### PR TITLE
fix: add external hostname and server URL overrides for embedded kcp

### DIFF
--- a/cmd/kedge-hub/main.go
+++ b/cmd/kedge-hub/main.go
@@ -66,6 +66,8 @@ func main() {
 	cmd.Flags().StringVar(&opts.KCPRootDir, "kcp-root-dir", "", "Root directory for embedded kcp data (default: <data-dir>/kcp)")
 	cmd.Flags().IntVar(&opts.KCPSecurePort, "kcp-secure-port", opts.KCPSecurePort, "Secure port for embedded kcp API server")
 	cmd.Flags().StringVar(&opts.KCPBindAddress, "kcp-bind-address", opts.KCPBindAddress, "Bind address for embedded kcp API server (default: 127.0.0.1, use 0.0.0.0 for all interfaces)")
+	cmd.Flags().StringVar(&opts.KCPExternalHostname, "kcp-external-hostname", opts.KCPExternalHostname, "External hostname/IP for embedded kcp TLS cert SANs")
+	cmd.Flags().StringVar(&opts.KCPServerURL, "kcp-server-url", opts.KCPServerURL, "Override kcp server URL used by hub (e.g. https://svc-name:6443 for in-cluster service)")
 	cmd.Flags().StringVar(&opts.KCPBatteriesInclude, "kcp-batteries-include", opts.KCPBatteriesInclude, "Comma-separated list of kcp batteries to include")
 
 	if err := cmd.Execute(); err != nil {

--- a/deploy/charts/kedge-hub/templates/service-kcp.yaml
+++ b/deploy/charts/kedge-hub/templates/service-kcp.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.kcp.external.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kedge-hub.fullname" . }}-kcp
+  labels:
+    {{- include "kedge-hub.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: kcp
+      port: {{ .Values.kcp.embedded.securePort }}
+      targetPort: kcp
+      protocol: TCP
+  selector:
+    {{- include "kedge-hub.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/kedge-hub/templates/statefulset.yaml
+++ b/deploy/charts/kedge-hub/templates/statefulset.yaml
@@ -41,6 +41,8 @@ spec:
             - --kcp-root-dir=/data/kcp
             - --kcp-secure-port={{ .Values.kcp.embedded.securePort }}
             - --kcp-bind-address={{ .Values.kcp.embedded.bindAddress }}
+            - --kcp-external-hostname={{ default (printf "%s-kcp.%s.svc" (include "kedge-hub.fullname" .) .Release.Namespace) .Values.kcp.embedded.externalHostname }}
+            - --kcp-server-url=https://{{ include "kedge-hub.fullname" . }}-kcp.{{ .Release.Namespace }}.svc:{{ .Values.kcp.embedded.securePort }}
             - --kcp-batteries-include={{ .Values.kcp.embedded.batteriesInclude }}
             {{- end }}
             {{- if include "kedge-hub.tlsEnabled" . }}
@@ -65,6 +67,11 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
+            {{- if not .Values.kcp.external.enabled }}
+            - name: kcp
+              containerPort: {{ .Values.kcp.embedded.securePort }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/charts/kedge-hub/templates/statefulset.yaml
+++ b/deploy/charts/kedge-hub/templates/statefulset.yaml
@@ -42,7 +42,6 @@ spec:
             - --kcp-secure-port={{ .Values.kcp.embedded.securePort }}
             - --kcp-bind-address={{ .Values.kcp.embedded.bindAddress }}
             - --kcp-external-hostname={{ default (printf "%s-kcp.%s.svc" (include "kedge-hub.fullname" .) .Release.Namespace) .Values.kcp.embedded.externalHostname }}
-            - --kcp-server-url=https://{{ include "kedge-hub.fullname" . }}-kcp.{{ .Release.Namespace }}.svc:{{ .Values.kcp.embedded.securePort }}
             - --kcp-batteries-include={{ .Values.kcp.embedded.batteriesInclude }}
             {{- end }}
             {{- if include "kedge-hub.tlsEnabled" . }}

--- a/deploy/charts/kedge-hub/values.yaml
+++ b/deploy/charts/kedge-hub/values.yaml
@@ -18,6 +18,8 @@ kcp:
     securePort: 6443
     # Bind address for embedded kcp API server (0.0.0.0 for all interfaces)
     bindAddress: "0.0.0.0"
+    # External hostname for kcp TLS cert SANs (defaults to <fullname>-kcp.<namespace>.svc)
+    externalHostname: ""
     # Comma-separated list of batteries to include
     batteriesInclude: "admin,user"
 

--- a/pkg/hub/kcp/embedded.go
+++ b/pkg/hub/kcp/embedded.go
@@ -40,6 +40,7 @@ type EmbeddedKCPOptions struct {
 	RootDir          string
 	SecurePort       int
 	BindAddress      string
+	ExternalHostname string
 	BatteriesInclude []string
 }
 
@@ -89,6 +90,10 @@ func (e *EmbeddedKCP) Run(ctx context.Context) error {
 	kcpOpts.GenericControlPlane.SecureServing.BindPort = e.opts.SecurePort
 	if e.opts.BindAddress != "" {
 		kcpOpts.GenericControlPlane.SecureServing.BindAddress = net.ParseIP(e.opts.BindAddress)
+	}
+	if e.opts.ExternalHostname != "" {
+		// Set as ExternalHost (string) so the hostname is included in TLS cert SANs as a DNS name.
+		kcpOpts.GenericControlPlane.GenericServerRunOptions.ExternalHost = e.opts.ExternalHostname
 	}
 
 	// Configure batteries.

--- a/pkg/hub/options.go
+++ b/pkg/hub/options.go
@@ -35,6 +35,8 @@ type Options struct {
 	KCPRootDir          string // Root directory for kcp data (default: <DataDir>/kcp)
 	KCPSecurePort       int    // Secure port for kcp API server (default: 6443)
 	KCPBindAddress      string // Bind address for kcp API server (default: "127.0.0.1")
+	KCPExternalHostname string // External hostname for kcp API server TLS cert SANs
+	KCPServerURL        string // Override kcp server URL in admin.kubeconfig (e.g. https://svc-name:6443)
 	KCPBatteriesInclude string // Comma-separated list of batteries to include (default: "admin,user")
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -93,6 +93,7 @@ func (s *Server) Run(ctx context.Context) error {
 			RootDir:          kcpRootDir,
 			SecurePort:       s.opts.KCPSecurePort,
 			BindAddress:      s.opts.KCPBindAddress,
+			ExternalHostname: s.opts.KCPExternalHostname,
 			BatteriesInclude: batteries,
 		})
 
@@ -125,6 +126,11 @@ func (s *Server) Run(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("loading embedded kcp admin kubeconfig: %w", err)
 			}
+		}
+
+		// Override the kcp server URL if configured (e.g. to use a Kubernetes service).
+		if s.opts.KCPServerURL != "" {
+			kcpConfig.Host = s.opts.KCPServerURL
 		}
 	} else if s.opts.ExternalKCPKubeconfig != "" {
 		// Use external kcp.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -128,9 +129,24 @@ func (s *Server) Run(ctx context.Context) error {
 			}
 		}
 
-		// Override the kcp server URL if configured (e.g. to use a Kubernetes service).
+		// For embedded kcp, override the host to 127.0.0.1 so the hub always connects
+		// via loopback (guaranteed to be in the TLS cert SANs). This is safe because
+		// hub and embedded kcp are co-located (same pod/process).
+		// Preserve any path prefix (e.g. /clusters/root) from the original URL.
+		// Allow explicit override via KCPServerURL for advanced use cases.
 		if s.opts.KCPServerURL != "" {
 			kcpConfig.Host = s.opts.KCPServerURL
+		} else if parsed, err := url.Parse(kcpConfig.Host); err == nil {
+			port := parsed.Port()
+			if port == "" {
+				port = fmt.Sprintf("%d", s.opts.KCPSecurePort)
+			}
+			newBase := "https://127.0.0.1:" + port
+			if parsed.Path != "" && parsed.Path != "/" {
+				kcpConfig.Host = newBase + parsed.Path
+			} else {
+				kcpConfig.Host = newBase
+			}
 		}
 	} else if s.opts.ExternalKCPKubeconfig != "" {
 		// Use external kcp.


### PR DESCRIPTION
## What

Adds two new configuration options for the embedded kcp API server to support in-cluster Kubernetes deployments:

- `--kcp-external-hostname`: sets the external hostname/IP included in embedded kcp's TLS cert SANs via `ExternalHost`. This allows the hub to reach kcp via a Kubernetes Service name without TLS errors.
- `--kcp-server-url`: overrides the kcp server URL in the admin kubeconfig loaded by the hub (e.g. `https://<svc-name>.<namespace>.svc:6443`). Without this, the hub's kubeconfig points to `127.0.0.1` even when kcp is reachable via a service.

The Helm chart statefulset is updated to:
- Pass `--kcp-external-hostname` defaulting to `<fullname>-kcp.<namespace>.svc`
- Pass `--kcp-server-url` pointing to the in-cluster service URL
- Expose the kcp secure port (`kcp`) as a container port when using embedded kcp

A new `externalHostname` value is added to `values.yaml` for overriding the default.

## Why

When deploying kedge-hub on Kubernetes with embedded kcp, the hub pod connects to kcp via loopback by default. If other components (or the hub itself after a restart) need to reach kcp through a Kubernetes Service, the generated TLS cert doesn't include the service DNS name as a SAN, causing x509 errors. This fix makes in-cluster kcp access work out of the box.

## Changes

- `cmd/kedge-hub/main.go`: registers `--kcp-external-hostname` and `--kcp-server-url` flags
- `pkg/hub/options.go`: adds `KCPExternalHostname` and `KCPServerURL` fields to `Options`
- `pkg/hub/kcp/embedded.go`: adds `ExternalHostname` to `EmbeddedKCPOptions`; sets `ExternalHost` on the kcp generic server options
- `pkg/hub/server.go`: wires `ExternalHostname` into embedded kcp options; overrides `kcpConfig.Host` when `KCPServerURL` is set
- `deploy/charts/kedge-hub/`: statefulset args + kcp container port + `externalHostname` value