### PR TITLE
Portal nav fix + shorter asset cache

### DIFF
--- a/pkg/hub/providers/proxy.go
+++ b/pkg/hub/providers/proxy.go
@@ -17,8 +17,10 @@ limitations under the License.
 package providers
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
-	"io"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -26,6 +28,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -184,18 +187,26 @@ func (p *ProviderProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rp.ServeHTTP(w, r)
 }
 
+// localAssetCacheControl is what we serve on embedded provider assets.
+// `Cache-Control: no-cache` (the old value) is silently ignored by
+// Cloudflare for .js/.css under "Standard" caching — it falls back to
+// its 4h default, which once cached a 404 across every browser session
+// for hours after a fix shipped. An explicit short max-age is honored,
+// and the ETag below makes the post-expiry revalidation a cheap 304.
+const localAssetCacheControl = "public, max-age=60, must-revalidate"
+
 // serveLocalAsset writes the file at rest from the provider's embedded
 // LocalUIAssets FS to w. rest is the path after /ui/providers/{name} (so
 // "/main.js", "/icon.svg", "/assets/foo-abc.js"). 404s when the file
 // isn't present — the SPA-fallback branch upstream of this function
 // already handled non-asset paths, so 404 here is the right behavior:
 // the provider's bundle is missing an asset the portal asked for.
-func serveLocalAsset(w http.ResponseWriter, _ *http.Request, assets fs.FS, rest string, log logr.Logger) {
+func serveLocalAsset(w http.ResponseWriter, r *http.Request, assets fs.FS, rest string, log logr.Logger) {
 	name := strings.TrimPrefix(rest, "/")
 	if name == "" {
 		name = "index.html"
 	}
-	f, err := assets.Open(name)
+	data, err := fs.ReadFile(assets, name)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			log.Error(err, "open local asset", "name", name)
@@ -203,17 +214,20 @@ func serveLocalAsset(w http.ResponseWriter, _ *http.Request, assets fs.FS, rest 
 		http.NotFound(w, nil)
 		return
 	}
-	defer func() { _ = f.Close() }()
 
 	ct := mime.TypeByExtension(path.Ext(name))
 	if ct == "" {
 		ct = "application/octet-stream"
 	}
+	sum := sha256.Sum256(data)
+	etag := `"` + hex.EncodeToString(sum[:16]) + `"`
+
 	w.Header().Set("Content-Type", ct)
-	w.Header().Set("Cache-Control", "no-cache")
-	if _, err := io.Copy(w, f); err != nil {
-		log.Error(err, "write local asset", "name", name)
-	}
+	w.Header().Set("Cache-Control", localAssetCacheControl)
+	w.Header().Set("ETag", etag)
+	// ServeContent handles If-None-Match -> 304 and Content-Length for us.
+	// Zero ModTime skips Last-Modified so ETag alone drives revalidation.
+	http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(data))
 }
 
 // splitProviderPath parses "/ui/providers/foo/bar" given prefix

--- a/portal/src/pages/ProviderFrame.vue
+++ b/portal/src/pages/ProviderFrame.vue
@@ -49,10 +49,14 @@ watch(
   { immediate: true },
 )
 
-// Theme / token changes → push fresh context to the mounted element via
-// the property setter. The element's setter re-renders without remount.
+// Theme / token / sub-route changes → push fresh context to the mounted
+// element via the property setter. The element's setter recomputes
+// subPath from window.location and re-syncs its internal router, so a
+// portal-side nav (clicking a child like "Workloads") actually reaches
+// the micro-frontend. Without props.subPath in the dep list the element
+// stayed on its initial route until a hard refresh.
 watch(
-  () => [theme.mode, auth.token, auth.clusterName] as const,
+  () => [theme.mode, auth.token, auth.clusterName, props.subPath] as const,
   () => pushContext(),
 )
 

--- a/providers/kubernetesedges/portal/src/element.ts
+++ b/providers/kubernetesedges/portal/src/element.ts
@@ -5,6 +5,7 @@
 
 import { createApp, h, reactive, type App } from 'vue'
 import { createPinia } from 'pinia'
+import type { Router } from 'vue-router'
 
 import KubernetesEdgesHost from './KubernetesEdgesHost.vue'
 import { createInternalRouter } from './router'
@@ -19,11 +20,22 @@ interface ElementState {
 
 class KedgeProviderKubernetesEdges extends HTMLElement {
   private app: App | null = null
+  private router: Router | null = null
   private state: ElementState = reactive({ context: null, subPath: '' })
 
   set kedgeContext(v: KedgeContext) {
     this.state.context = v
-    this.state.subPath = computeSubPath(v?.basePath)
+    const next = computeSubPath(v?.basePath)
+    if (next === this.state.subPath) return
+    this.state.subPath = next
+    // Drive the internal memory-history router from portal-side
+    // navigation (side-nav clicks, browser back/forward). The afterEach
+    // guard below filters the re-entry: when paths already match it
+    // skips the kedge-navigate dispatch, so this won't loop.
+    const target = '/' + next.replace(/^\//, '')
+    if (this.router && this.router.currentRoute.value.path !== target) {
+      this.router.replace(target)
+    }
   }
   get kedgeContext(): KedgeContext | null {
     return this.state.context
@@ -32,7 +44,8 @@ class KedgeProviderKubernetesEdges extends HTMLElement {
   connectedCallback() {
     if (this.app) return
 
-    const router = createInternalRouter('/' + this.state.subPath.replace(/^\//, ''))
+    this.router = createInternalRouter('/' + this.state.subPath.replace(/^\//, ''))
+    const router = this.router
 
     router.afterEach((to) => {
       const path = to.path === '/' ? '' : to.path.replace(/^\//, '')
@@ -57,6 +70,7 @@ class KedgeProviderKubernetesEdges extends HTMLElement {
   disconnectedCallback() {
     this.app?.unmount()
     this.app = null
+    this.router = null
   }
 }
 

--- a/providers/mcp/portal/src/element.ts
+++ b/providers/mcp/portal/src/element.ts
@@ -11,6 +11,7 @@
 
 import { createApp, h, reactive, type App } from 'vue'
 import { createPinia } from 'pinia'
+import type { Router } from 'vue-router'
 
 import MCPHost from './MCPHost.vue'
 import { createInternalRouter } from './router'
@@ -28,6 +29,7 @@ interface ElementState {
 
 class KedgeProviderMCP extends HTMLElement {
   private app: App | null = null
+  private router: Router | null = null
   private state: ElementState = reactive({ context: null, subPath: '' })
 
   // The portal sets this AS A PROPERTY (not attribute) after appending
@@ -38,7 +40,16 @@ class KedgeProviderMCP extends HTMLElement {
     // basePath is the canonical /ui/providers/mcp prefix; anything past
     // that is the in-provider sub-route. We compute it from the
     // browser location since the portal doesn't push it explicitly.
-    this.state.subPath = computeSubPath(v?.basePath)
+    const next = computeSubPath(v?.basePath)
+    if (next === this.state.subPath) return
+    this.state.subPath = next
+    // Drive the internal memory-history router from portal-side nav.
+    // afterEach skips re-emit when paths already match, keeping this a
+    // one-way push and avoiding navigation loops.
+    const target = '/' + next.replace(/^\//, '')
+    if (this.router && this.router.currentRoute.value.path !== target) {
+      this.router.replace(target)
+    }
   }
   get kedgeContext(): KedgeContext | null {
     return this.state.context
@@ -47,7 +58,8 @@ class KedgeProviderMCP extends HTMLElement {
   connectedCallback() {
     if (this.app) return // double-mount guard for HMR
 
-    const router = createInternalRouter('/' + this.state.subPath.replace(/^\//, ''))
+    this.router = createInternalRouter('/' + this.state.subPath.replace(/^\//, ''))
+    const router = this.router
 
     // Bubble internal navigations up to the portal's SPA router via the
     // kedge-navigate CustomEvent ProviderFrame listens for. The portal
@@ -77,6 +89,7 @@ class KedgeProviderMCP extends HTMLElement {
   disconnectedCallback() {
     this.app?.unmount()
     this.app = null
+    this.router = null
   }
 }
 

--- a/providers/serveredges/portal/src/element.ts
+++ b/providers/serveredges/portal/src/element.ts
@@ -5,6 +5,7 @@
 
 import { createApp, h, reactive, type App } from 'vue'
 import { createPinia } from 'pinia'
+import type { Router } from 'vue-router'
 
 import ServerEdgesHost from './ServerEdgesHost.vue'
 import { createInternalRouter } from './router'
@@ -19,11 +20,21 @@ interface ElementState {
 
 class KedgeProviderServerEdges extends HTMLElement {
   private app: App | null = null
+  private router: Router | null = null
   private state: ElementState = reactive({ context: null, subPath: '' })
 
   set kedgeContext(v: KedgeContext) {
     this.state.context = v
-    this.state.subPath = computeSubPath(v?.basePath)
+    const next = computeSubPath(v?.basePath)
+    if (next === this.state.subPath) return
+    this.state.subPath = next
+    // Drive the internal memory-history router from portal-side
+    // navigation. afterEach below skips re-emit when paths already
+    // match, so this stays a one-way push.
+    const target = '/' + next.replace(/^\//, '')
+    if (this.router && this.router.currentRoute.value.path !== target) {
+      this.router.replace(target)
+    }
   }
   get kedgeContext(): KedgeContext | null {
     return this.state.context
@@ -32,7 +43,8 @@ class KedgeProviderServerEdges extends HTMLElement {
   connectedCallback() {
     if (this.app) return
 
-    const router = createInternalRouter('/' + this.state.subPath.replace(/^\//, ''))
+    this.router = createInternalRouter('/' + this.state.subPath.replace(/^\//, ''))
+    const router = this.router
 
     router.afterEach((to) => {
       const path = to.path === '/' ? '' : to.path.replace(/^\//, '')
@@ -57,6 +69,7 @@ class KedgeProviderServerEdges extends HTMLElement {
   disconnectedCallback() {
     this.app?.unmount()
     this.app = null
+    this.router = null
   }
 }
 


### PR DESCRIPTION
## Summary

- **Fix portal-side nav not updating the provider micro-frontend.** Clicking a child route (e.g. Workloads under kubernetes-edges) changed the URL but the rendered page stayed on the previous route until a hard refresh. `ProviderFrame.vue` now includes `props.subPath` in its context-push watch, and each provider's `element.ts` keeps a reference to its internal memory-history router so the `kedgeContext` setter can `router.replace()` when the sub-path changes. The existing `afterEach` guard short-circuits the re-entry path so the push stays one-way.
- **Shorter cache TTL on embedded provider assets.** `Cache-Control: no-cache` was silently overridden by Cloudflare's 4h default for `.js`/`.css`, which had pinned a stale 404 at the edge for hours after a fix shipped. Switched to `public, max-age=60, must-revalidate` plus an sha256-derived ETag served via `http.ServeContent`, so post-expiry revalidation collapses to a 304 instead of a full re-download.

## Test plan

- [ ] In dev portal: navigate from `/providers/kubernetes-edges` → `/providers/kubernetes-edges/workloads` via side nav. Workloads page renders without refresh.
- [ ] Reverse direction (Workloads → kubernetes-edges) also re-renders.
- [ ] Browser back/forward across the same pair works.
- [ ] Same checks for `server-edges` and `mcp` providers.
- [ ] `curl -I https://<host>/ui/providers/server-edges/main.js` shows `cache-control: public, max-age=60, must-revalidate` and an `ETag` header.
- [ ] Repeat with `If-None-Match: <etag>` returns `304 Not Modified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)