### PR TITLE
Provider-driven dashboard tiles

### DIFF
--- a/portal/src/components/DashboardTile.vue
+++ b/portal/src/components/DashboardTile.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch, nextTick } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { useThemeStore } from '@/stores/theme'
+import type { ProviderDTO } from '@/stores/providers'
+import { Puzzle, ChevronRight } from 'lucide-vue-next'
+
+// DashboardTile is the portal-side mount point for one provider's
+// dashboard summary. Mirrors ProviderFrame.vue's lifecycle but for the
+// tile element instead of the full-page element: each provider's
+// /main.js may register a second custom element
+// <kedge-dashboard-tile-{name}>; if it does we mount that here, push
+// the same kedgeContext shape, and proxy kedge-navigate events to the
+// portal router. If the provider has no tile (the tag never registers
+// within the timeout), we fall back to a static card linking to the
+// provider's page — so adding a tile is opt-in per provider.
+
+const props = defineProps<{ provider: ProviderDTO }>()
+
+const auth = useAuthStore()
+const theme = useThemeStore()
+const router = useRouter()
+
+const mountRef = ref<HTMLDivElement | null>(null)
+const elementRef = ref<HTMLElement | null>(null)
+const loadState = ref<'idle' | 'loading' | 'ready' | 'no-tile' | 'error'>('idle')
+const loadError = ref<string | null>(null)
+
+const tagFor = (name: string) => `kedge-dashboard-tile-${name}`
+
+watch(
+  () => props.provider,
+  async (p) => {
+    if (!p.ready) return
+    await loadAndMount(p.name, p.version)
+  },
+  { immediate: true },
+)
+
+watch(
+  () => [theme.mode, auth.token, auth.clusterName] as const,
+  () => pushContext(),
+)
+
+async function loadAndMount(name: string, version: string | undefined) {
+  loadState.value = 'loading'
+  loadError.value = null
+
+  // Reuse ProviderFrame's script id so we don't double-load the bundle
+  // when both the tile and the page are visible (e.g. user is on the
+  // provider page and the dashboard pre-fetches tiles). customElements
+  // is idempotent — second define() is a no-op.
+  const scriptID = `kedge-provider-script-${name}`
+  const tag = tagFor(name)
+
+  if (!customElements.get(tag) && !document.getElementById(scriptID)) {
+    const v = encodeURIComponent(version ?? '0')
+    const src = `/ui/providers/${name}/main.js?v=${v}`
+    await new Promise<void>((resolve, reject) => {
+      const s = document.createElement('script')
+      s.id = scriptID
+      s.src = src
+      s.async = true
+      s.onload = () => resolve()
+      s.onerror = () => reject(new Error(`failed to load ${src}`))
+      document.head.appendChild(s)
+    }).catch((e: Error) => {
+      loadState.value = 'error'
+      loadError.value = e.message
+      throw e
+    })
+  }
+
+  // Race whenDefined against a short timeout. A provider that doesn't
+  // ship a tile element is a normal case — fall through to the fallback
+  // card rather than treating it as an error.
+  const defined = await Promise.race([
+    customElements.whenDefined(tag).then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 1500)),
+  ])
+
+  if (!defined) {
+    loadState.value = 'no-tile'
+    return
+  }
+
+  await nextTick()
+  if (!mountRef.value) return
+  mountRef.value.replaceChildren()
+  const el = document.createElement(tag) as HTMLElement
+  mountRef.value.appendChild(el)
+  elementRef.value = el
+  pushContext()
+  loadState.value = 'ready'
+}
+
+function pushContext() {
+  const el = elementRef.value as HTMLElement & { kedgeContext?: unknown } | null
+  if (!el) return
+  el.kedgeContext = {
+    token: auth.token,
+    user: auth.user,
+    tenant: auth.clusterName,
+    theme: theme.mode,
+    basePath: `/ui/providers/${props.provider.name}`,
+  }
+}
+
+function onNavigate(e: Event) {
+  const ce = e as CustomEvent<{ path: string }>
+  const p = ce.detail?.path
+  if (typeof p !== 'string') return
+  router.push(`/providers/${props.provider.name}/${p.replace(/^\//, '')}`)
+}
+
+onMounted(() => mountRef.value?.addEventListener('kedge-navigate', onNavigate))
+onBeforeUnmount(() => {
+  mountRef.value?.removeEventListener('kedge-navigate', onNavigate)
+  if (elementRef.value && mountRef.value?.contains(elementRef.value)) {
+    mountRef.value.removeChild(elementRef.value)
+  }
+  elementRef.value = null
+})
+</script>
+
+<template>
+  <div class="rounded-2xl border border-border-subtle bg-surface-raised/80 p-5 backdrop-blur">
+    <!-- Tile header is portal chrome (icon, name, status) so a provider's
+         tile body never has to repeat the catalog metadata. -->
+    <div class="mb-4 flex items-center gap-3">
+      <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-surface-overlay">
+        <img
+          v-if="provider.iconURL"
+          :src="provider.iconURL"
+          alt=""
+          class="h-4 w-4 object-contain"
+          @error="(e) => ((e.target as HTMLImageElement).style.display = 'none')"
+        />
+        <Puzzle v-else class="h-3.5 w-3.5 text-text-muted" :stroke-width="1.75" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-[13px] font-medium text-text-primary">{{ provider.displayName }}</div>
+        <div class="truncate font-mono text-[10px] text-text-muted">{{ provider.name }}</div>
+      </div>
+      <router-link
+        :to="`/providers/${provider.name}`"
+        class="flex items-center gap-0.5 text-[11px] font-medium text-accent transition-colors hover:text-accent-hover"
+      >
+        Open <ChevronRight class="h-3 w-3" :stroke-width="2" />
+      </router-link>
+    </div>
+
+    <div v-if="loadState === 'loading'" class="text-[11px] text-text-muted">Loading&hellip;</div>
+    <div v-else-if="loadState === 'error'" class="text-[11px] text-danger">
+      Failed to load tile: <span class="font-mono">{{ loadError }}</span>
+    </div>
+    <div v-else-if="loadState === 'no-tile'" class="text-[11px] text-text-muted">
+      This provider doesn't expose a dashboard summary.
+    </div>
+    <!-- The provider's tile element mounts here. Always render the mount
+         node so the watch can attach to it before the script finishes
+         loading; visibility flips via the v-show above through loadState. -->
+    <div ref="mountRef" :class="loadState === 'ready' ? '' : 'hidden'" />
+  </div>
+</template>

--- a/portal/src/components/FirstEdgeWizard.vue
+++ b/portal/src/components/FirstEdgeWizard.vue
@@ -177,7 +177,9 @@ function formatElapsed(s: number) {
 }
 
 function viewEdge() {
-  router.push(`/edges/${trimmedName.value}`)
+  // /edges/:name was the legacy portal-level route; the kubernetes-edges
+  // micro-frontend now owns this URL space under /providers/.
+  router.push(`/providers/kubernetes-edges/${trimmedName.value}`)
 }
 
 function finish() {
@@ -420,7 +422,7 @@ function finish() {
             <button
               type="button"
               class="text-[11px] font-medium text-text-muted transition-colors hover:text-text-secondary"
-              @click="router.push(`/edges/${trimmedName}`)"
+              @click="router.push(`/providers/kubernetes-edges/${trimmedName}`)"
             >
               Skip — I'll come back later
             </button>

--- a/portal/src/pages/DashboardPage.vue
+++ b/portal/src/pages/DashboardPage.vue
@@ -1,29 +1,55 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import AppLayout from '@/components/AppLayout.vue'
-import StatusBadge from '@/components/StatusBadge.vue'
+import DashboardTile from '@/components/DashboardTile.vue'
 import FirstEdgeWizard from '@/components/FirstEdgeWizard.vue'
+import { useProvidersStore } from '@/stores/providers'
 import { useGraphQLQuery } from '@/composables/useGraphQL'
 import { LIST_EDGES, type ListEdgesResult } from '@/graphql/queries/edges'
-import { LIST_VIRTUAL_WORKLOADS, type ListVirtualWorkloadsResult } from '@/graphql/queries/workloads'
-import { formatAge } from '@/utils/time'
-import { Server, Wifi, WifiOff, ChevronRight, Activity, Gauge, Layers } from 'lucide-vue-next'
+import { Puzzle } from 'lucide-vue-next'
 
-const { data, loading, error, refetch } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 10000)
-const { data: workloadsData } = useGraphQLQuery<ListVirtualWorkloadsResult>(LIST_VIRTUAL_WORKLOADS, undefined, 10000)
+// The dashboard used to query LIST_EDGES directly and render fleet
+// health / connectivity / recent edges. That hardcoded "this hub is
+// about Kubernetes edges" into the portal, which the BYO-provider work
+// invalidated: server-edges, mcp, and any third-party provider deserve
+// equal billing on the dashboard, and the portal shouldn't need to
+// learn about each one's schema.
+//
+// Instead: iterate the catalog and mount one <DashboardTile> per
+// ready provider. Each provider may register a
+// <kedge-dashboard-tile-{name}> custom element in its main.js — that
+// element owns its own data fetch, summary rendering, and click-through
+// URLs. Providers without a tile get a fallback card linking to their
+// page.
+//
+// LIST_EDGES is still kept here for one job: deciding whether to show
+// FirstEdgeWizard on initial load. That's tenant-level onboarding (no
+// edges of any kind connected yet) and lives at the dashboard level
+// rather than inside any one provider's tile.
 
-const edges = computed(() => data.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? [])
-const workloads = computed(() => workloadsData.value?.kedge_faros_sh?.v1alpha1?.VirtualWorkloads?.items ?? [])
+const providers = useProvidersStore()
+const { data: edgesData, loading: edgesLoading, error: edgesError, refetch: refetchEdges } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 10000)
+const edges = computed(() => edgesData.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? [])
 
-// Latch the wizard decision on first load. Once the wizard is open, it stays open
-// (even after the new edge appears in LIST_EDGES) until the wizard itself completes.
+onMounted(() => {
+  if (!providers.loaded) providers.load()
+})
+
+const tiles = computed(() =>
+  providers.items
+    .filter((p) => p.ready && p.hasUI)
+    .sort((a, b) => a.displayName.localeCompare(b.displayName)),
+)
+
+// Latch the wizard on first load. Once open it stays open until the
+// wizard itself completes, even if LIST_EDGES updates underneath.
 const wizardOpen = ref<boolean | null>(null)
 watch(
-  [loading, error, edges],
+  [edgesLoading, edgesError, edges],
   () => {
     if (wizardOpen.value !== null) return
-    if (loading.value) return
-    if (error.value) return
+    if (edgesLoading.value) return
+    if (edgesError.value) return
     wizardOpen.value = edges.value.length === 0
   },
   { immediate: true },
@@ -32,45 +58,17 @@ const showWizard = computed(() => wizardOpen.value === true)
 
 function onWizardConnected() {
   wizardOpen.value = false
-  refetch()
+  refetchEdges()
 }
-
-const stats = computed(() => {
-  const items = edges.value
-  const total = items.length
-  const ready = items.filter((e) => e.status?.phase === 'Ready').length
-  const connected = items.filter((e) => e.status?.connected).length
-  return { total, ready, notReady: total - ready, connected, disconnected: total - connected }
-})
-
-const healthPct = computed(() => {
-  if (stats.value.total === 0) return 0
-  return Math.round((stats.value.ready / stats.value.total) * 100)
-})
-
-const recentEdges = computed(() =>
-  [...edges.value]
-    .sort((a, b) => (b.metadata.creationTimestamp ?? '').localeCompare(a.metadata.creationTimestamp ?? ''))
-    .slice(0, 8),
-)
-
-const workloadStats = computed(() => {
-  const total = workloads.value.length
-  const running = workloads.value.filter((w) => w.status?.phase === 'Running').length
-  const pending = workloads.value.filter((w) => w.status?.phase === 'Pending' || w.status?.phase === 'Scheduling').length
-  const failed = workloads.value.filter((w) => w.status?.phase === 'Failed').length
-  const totalEdges = workloads.value.reduce((sum, w) => sum + (w.status?.edges?.length ?? 0), 0)
-  return { total, running, pending, failed, totalEdges }
-})
 </script>
 
 <template>
   <AppLayout>
-    <div v-if="error" class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-4 text-[13px] text-danger">
-      {{ error }}
+    <div v-if="edgesError" class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-4 text-[13px] text-danger">
+      {{ edgesError }}
     </div>
 
-    <div v-else-if="loading && !data" class="mt-20 flex flex-col items-center justify-center">
+    <div v-else-if="(edgesLoading && !edgesData) || providers.loading" class="mt-20 flex flex-col items-center justify-center">
       <div class="shimmer h-8 w-8 rounded-xl" />
       <div class="shimmer mt-4 h-3 w-40 rounded" />
     </div>
@@ -80,174 +78,18 @@ const workloadStats = computed(() => {
     </div>
 
     <template v-else>
-      <div class="dashboard-grid">
-        <!-- Fleet health compact panel -->
-        <div
-          class="border-beam stagger-item rounded-xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur"
-          style="animation-delay: 0ms"
-        >
-          <div class="flex items-center gap-1.5">
-            <Gauge class="h-3.5 w-3.5 text-accent" :stroke-width="1.75" />
-            <span class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Fleet Health</span>
-          </div>
-          <div class="mt-1.5 flex items-baseline gap-1">
-            <span class="text-gradient text-2xl font-bold tabular-nums tracking-tight">{{ healthPct }}</span>
-            <span class="text-sm font-light text-text-muted">%</span>
-            <span class="ml-auto text-[11px] tabular-nums text-text-muted">{{ stats.ready }}/{{ stats.total }}</span>
-          </div>
-          <div class="mt-2 h-1 w-full overflow-hidden rounded-full bg-surface-overlay">
-            <div
-              class="h-full rounded-full transition-all duration-500"
-              :class="healthPct >= 80 ? 'bg-success' : healthPct >= 50 ? 'bg-warning' : 'bg-danger'"
-              :style="{ width: `${healthPct}%` }"
-            />
+      <div v-if="tiles.length === 0" class="flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-raised/60 p-4 text-[13px] text-text-muted">
+        <Puzzle class="mt-0.5 h-4 w-4 text-text-muted" :stroke-width="1.75" />
+        <div>
+          <div class="font-medium text-text-secondary">No providers ready</div>
+          <div class="mt-1 text-xs">
+            Enable a provider from the <router-link to="/providers" class="text-accent hover:text-accent-hover">catalog</router-link> to see a dashboard summary.
           </div>
         </div>
+      </div>
 
-        <!-- Edge status compact: ready/total -->
-        <div
-          class="tilt-card stagger-item rounded-xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur"
-          style="animation-delay: 60ms"
-        >
-          <div class="flex items-center gap-1.5">
-            <Server class="h-3.5 w-3.5 text-accent" :stroke-width="1.75" />
-            <span class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Edge Status</span>
-          </div>
-          <div class="mt-1.5 flex items-baseline gap-1">
-            <span class="text-2xl font-bold tabular-nums" :class="stats.notReady === 0 && stats.total > 0 ? 'text-success' : stats.ready === 0 ? 'text-danger' : 'text-warning'">
-              {{ stats.ready }}<span class="text-text-muted/60">/</span>{{ stats.total }}
-            </span>
-            <span class="ml-auto text-[11px] font-medium" :class="stats.notReady > 0 ? 'text-danger' : 'text-success'">
-              {{ stats.notReady > 0 ? `${stats.notReady} not ready` : 'All ready' }}
-            </span>
-          </div>
-          <div class="mt-2 flex h-1 w-full gap-0.5 overflow-hidden rounded-full bg-surface-overlay">
-            <div v-if="stats.ready > 0" class="h-full bg-success transition-all duration-500" :style="{ width: `${(stats.ready / Math.max(stats.total, 1)) * 100}%` }" />
-            <div v-if="stats.notReady > 0" class="h-full bg-danger transition-all duration-500" :style="{ width: `${(stats.notReady / Math.max(stats.total, 1)) * 100}%` }" />
-          </div>
-        </div>
-
-        <!-- Connectivity compact: online/total -->
-        <div
-          class="tilt-card stagger-item rounded-xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur"
-          style="animation-delay: 120ms"
-        >
-          <div class="flex items-center gap-1.5">
-            <Wifi class="h-3.5 w-3.5 text-accent" :stroke-width="1.75" />
-            <span class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Connectivity</span>
-          </div>
-          <div class="mt-1.5 flex items-baseline gap-1">
-            <span class="text-2xl font-bold tabular-nums" :class="stats.disconnected === 0 && stats.total > 0 ? 'text-success' : stats.connected === 0 ? 'text-danger' : 'text-warning'">
-              {{ stats.connected }}<span class="text-text-muted/60">/</span>{{ stats.total }}
-            </span>
-            <span class="ml-auto text-[11px] font-medium" :class="stats.disconnected > 0 ? 'text-danger' : 'text-success'">
-              {{ stats.disconnected > 0 ? `${stats.disconnected} offline` : 'All online' }}
-            </span>
-          </div>
-          <div class="mt-2 flex h-1 w-full gap-0.5 overflow-hidden rounded-full bg-surface-overlay">
-            <div v-if="stats.connected > 0" class="h-full bg-success transition-all duration-500" :style="{ width: `${(stats.connected / Math.max(stats.total, 1)) * 100}%` }" />
-            <div v-if="stats.disconnected > 0" class="h-full bg-danger transition-all duration-500" :style="{ width: `${(stats.disconnected / Math.max(stats.total, 1)) * 100}%` }" />
-          </div>
-        </div>
-
-        <!-- Workloads compact: running/total -->
-        <div
-          class="tilt-card stagger-item rounded-xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur"
-          style="animation-delay: 180ms"
-        >
-          <div class="flex items-center gap-1.5">
-            <Layers class="h-3.5 w-3.5 text-accent" :stroke-width="1.75" />
-            <span class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Workloads</span>
-            <router-link to="/workloads" class="ml-auto text-[10px] font-medium text-accent transition-colors hover:text-accent-hover">
-              View all &rarr;
-            </router-link>
-          </div>
-          <div class="mt-1.5 flex items-baseline gap-1">
-            <span class="text-2xl font-bold tabular-nums" :class="workloadStats.total === 0 ? 'text-text-muted' : workloadStats.running === workloadStats.total ? 'text-success' : 'text-warning'">
-              {{ workloadStats.running }}<span class="text-text-muted/60">/</span>{{ workloadStats.total }}
-            </span>
-            <span class="ml-auto flex items-center gap-2 text-[11px] tabular-nums">
-              <span v-if="workloadStats.pending > 0" class="text-warning">{{ workloadStats.pending }} pending</span>
-              <span class="text-text-muted">{{ workloadStats.totalEdges }} placements</span>
-            </span>
-          </div>
-          <div class="mt-2 flex h-1 w-full gap-0.5 overflow-hidden rounded-full bg-surface-overlay">
-            <div v-if="workloadStats.running > 0" class="h-full bg-success transition-all duration-500" :style="{ width: `${(workloadStats.running / Math.max(workloadStats.total, 1)) * 100}%` }" />
-            <div v-if="workloadStats.pending > 0" class="h-full bg-warning transition-all duration-500" :style="{ width: `${(workloadStats.pending / Math.max(workloadStats.total, 1)) * 100}%` }" />
-            <div v-if="workloadStats.failed > 0" class="h-full bg-danger transition-all duration-500" :style="{ width: `${(workloadStats.failed / Math.max(workloadStats.total, 1)) * 100}%` }" />
-          </div>
-        </div>
-
-        <!-- Recent edges (full width) -->
-        <div
-          v-if="edges.length > 0"
-          class="stagger-item col-span-full rounded-2xl border border-border-subtle bg-surface-raised/80 p-5 backdrop-blur"
-          style="animation-delay: 240ms"
-        >
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2">
-              <Activity class="h-3.5 w-3.5 text-accent" :stroke-width="1.75" />
-              <span class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Recent Edges</span>
-              <span class="text-[10px] tabular-nums text-text-muted/60">({{ recentEdges.length }}/{{ edges.length }})</span>
-            </div>
-            <router-link to="/edges" class="text-[11px] font-medium text-accent transition-colors hover:text-accent-hover">
-              View all &rarr;
-            </router-link>
-          </div>
-
-          <!-- Column headers (lg+ only; below that the rows just stack key info) -->
-          <div class="mt-4 hidden lg:grid grid-cols-[minmax(0,1fr)_140px_130px_80px_70px_100px_16px] items-center gap-4 px-4 pb-2 text-[9px] font-semibold uppercase tracking-[0.15em] text-text-muted/60">
-            <span>Edge</span>
-            <span>Connection</span>
-            <span>Agent</span>
-            <span>Heartbeat</span>
-            <span>Age</span>
-            <span class="text-right">Status</span>
-            <span aria-hidden="true" />
-          </div>
-
-          <div class="mt-1 space-y-1 lg:mt-0">
-            <router-link
-              v-for="(edge, i) in recentEdges"
-              :key="edge.metadata.name"
-              :to="`/edges/${edge.metadata.name}`"
-              class="card-glow stagger-item group flex items-center justify-between gap-4 rounded-xl border border-border-subtle bg-surface-overlay/50 px-4 py-2.5 transition-all duration-150 hover:bg-accent/[0.03] lg:grid lg:grid-cols-[minmax(0,1fr)_140px_130px_80px_70px_100px_16px]"
-              :style="{ animationDelay: `${(i + 5) * 40}ms` }"
-            >
-              <!-- Identity: name + type subtitle -->
-              <div class="flex min-w-0 items-center gap-3">
-                <Server class="h-3.5 w-3.5 shrink-0 text-text-muted transition-colors group-hover:text-accent" :stroke-width="1.75" />
-                <div class="min-w-0 leading-tight">
-                  <div class="truncate text-[13px] font-medium text-text-primary">{{ edge.metadata.name }}</div>
-                  <div class="font-mono text-[10px] text-text-muted">{{ edge.spec?.type ?? '—' }}</div>
-                </div>
-              </div>
-
-              <!-- Connection -->
-              <div class="hidden items-center gap-1.5 text-[11px] lg:flex" :class="edge.status?.connected ? 'text-success' : 'text-danger'">
-                <component :is="edge.status?.connected ? Wifi : WifiOff" class="h-3 w-3 shrink-0" :stroke-width="1.75" />
-                <span>{{ edge.status?.connected ? 'Connected' : 'Disconnected' }}</span>
-              </div>
-
-              <!-- Agent version -->
-              <span class="hidden truncate font-mono text-[11px] text-text-muted lg:inline">{{ edge.status?.agentVersion || '—' }}</span>
-
-              <!-- Last heartbeat -->
-              <span class="hidden tabular-nums text-[11px] text-text-muted lg:inline">{{ edge.status?.lastHeartbeatTime ? formatAge(edge.status.lastHeartbeatTime) : '—' }}</span>
-
-              <!-- Age -->
-              <span class="hidden tabular-nums text-[11px] text-text-muted lg:inline">{{ formatAge(edge.metadata.creationTimestamp) }}</span>
-
-              <!-- Status badge -->
-              <div class="flex justify-end">
-                <StatusBadge :status="edge.status?.phase" :connected="edge.status?.connected" />
-              </div>
-
-              <!-- Chevron -->
-              <ChevronRight class="h-3.5 w-3.5 shrink-0 text-text-muted/20 transition-all group-hover:translate-x-0.5 group-hover:text-accent/50" :stroke-width="1.75" />
-            </router-link>
-          </div>
-        </div>
+      <div v-else class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <DashboardTile v-for="p in tiles" :key="p.name" :provider="p" />
       </div>
     </template>
   </AppLayout>

--- a/providers/kubernetesedges/portal/src/DashboardTile.vue
+++ b/providers/kubernetesedges/portal/src/DashboardTile.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+// Tile content for the kubernetes-edges dashboard summary. Mounted by
+// the <kedge-dashboard-tile-kubernetes-edges> custom element, which
+// owns the Vue app and auth-store hydration the same way
+// KubernetesEdgesHost does for the full-page element.
+//
+// Renders a compact summary (count, connectivity, recent edges) plus
+// click-throughs that bubble kedge-navigate events the portal SPA
+// catches and turns into /providers/kubernetes-edges/{path} pushes.
+
+import { computed, watch, inject } from 'vue'
+import { useAuthStore, type KedgeContext } from './auth-adapter'
+import { useGraphQLQuery } from '@/composables/useGraphQL'
+import { LIST_EDGES, type ListEdgesResult } from '@/graphql/queries/edges'
+import { Server, Wifi, WifiOff, ChevronRight } from 'lucide-vue-next'
+
+const props = defineProps<{ context: KedgeContext | null }>()
+const auth = useAuthStore()
+
+// Hydrate the provider-local auth store from the kedgeContext property
+// the portal sets on the element. Same shape as KubernetesEdgesHost.
+watch(() => props.context, (ctx) => auth.hydrate(ctx), { immediate: true })
+
+const { data, loading, error } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 30000)
+
+const items = computed(() =>
+  (data.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? []).filter((e) => e.spec?.type === 'kubernetes'),
+)
+
+const stats = computed(() => {
+  const total = items.value.length
+  const ready = items.value.filter((e) => e.status?.phase === 'Ready').length
+  const connected = items.value.filter((e) => e.status?.connected).length
+  return { total, ready, connected }
+})
+
+const recent = computed(() =>
+  [...items.value]
+    .sort((a, b) => (b.metadata.creationTimestamp ?? '').localeCompare(a.metadata.creationTimestamp ?? ''))
+    .slice(0, 3),
+)
+
+// dispatchNavigate is provided by dashboard-tile.ts so we don't have
+// to thread the host element down through props.
+const dispatchNavigate = inject<(path: string) => void>('dispatchNavigate', () => {})
+</script>
+
+<template>
+  <div v-if="error" class="text-[11px] text-danger">{{ error }}</div>
+  <div v-else-if="loading && !data" class="text-[11px] text-text-muted">Loading clusters&hellip;</div>
+  <div v-else-if="items.length === 0" class="text-[11px] text-text-muted">
+    No Kubernetes clusters connected yet.
+  </div>
+  <div v-else class="space-y-3">
+    <div class="flex items-baseline gap-3">
+      <div class="flex items-baseline gap-1">
+        <span class="text-2xl font-bold tabular-nums text-text-primary">{{ stats.total }}</span>
+        <span class="text-[11px] text-text-muted">clusters</span>
+      </div>
+      <span class="text-[11px] text-text-muted">
+        <span :class="stats.ready === stats.total ? 'text-success' : 'text-warning'">{{ stats.ready }} ready</span>
+        <span class="mx-1 text-text-muted/50">·</span>
+        <span :class="stats.connected === stats.total ? 'text-success' : 'text-warning'">{{ stats.connected }} connected</span>
+      </span>
+    </div>
+
+    <ul class="space-y-1">
+      <li v-for="edge in recent" :key="edge.metadata.name">
+        <button
+          type="button"
+          class="group flex w-full items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2 text-left transition-colors hover:bg-accent/[0.04]"
+          @click="dispatchNavigate(edge.metadata.name)"
+        >
+          <Server class="h-3 w-3 shrink-0 text-text-muted" :stroke-width="1.75" />
+          <span class="min-w-0 flex-1 truncate text-[12px] text-text-primary">{{ edge.metadata.name }}</span>
+          <component
+            :is="edge.status?.connected ? Wifi : WifiOff"
+            class="h-3 w-3 shrink-0"
+            :class="edge.status?.connected ? 'text-success' : 'text-text-muted/60'"
+            :stroke-width="1.75"
+          />
+          <ChevronRight class="h-3 w-3 shrink-0 text-text-muted/30 transition-all group-hover:translate-x-0.5 group-hover:text-accent/60" :stroke-width="1.75" />
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/providers/kubernetesedges/portal/src/WorkloadDetailPage.vue
+++ b/providers/kubernetesedges/portal/src/WorkloadDetailPage.vue
@@ -346,7 +346,7 @@ const edgeSelectorLabels = computed(() => {
             <div class="flex items-center gap-3">
               <Server class="h-3.5 w-3.5 text-text-muted" :stroke-width="1.75" />
               <router-link
-                :to="`/edges/${edge.edgeName}`"
+                :to="`/${edge.edgeName}`"
                 class="text-[13px] font-medium text-text-primary hover:text-accent transition-colors"
               >
                 {{ edge.edgeName }}

--- a/providers/kubernetesedges/portal/src/dashboard-tile.ts
+++ b/providers/kubernetesedges/portal/src/dashboard-tile.ts
@@ -1,0 +1,60 @@
+// Custom-element shell for the kubernetes-edges dashboard tile. Mirror
+// of element.ts but smaller: no internal router, just a Vue app
+// rendering DashboardTile.vue. The portal's DashboardTile.vue mounts
+// this element on the dashboard page, sets kedgeContext, and listens
+// for kedge-navigate CustomEvents to drive vue-router pushes.
+
+import { createApp, h, reactive, type App } from 'vue'
+import { createPinia } from 'pinia'
+
+import DashboardTile from './DashboardTile.vue'
+import type { KedgeContext } from './auth-adapter'
+
+const TAG = 'kedge-dashboard-tile-kubernetes-edges'
+
+interface ElementState {
+  context: KedgeContext | null
+}
+
+class KedgeDashboardTileKubernetesEdges extends HTMLElement {
+  private app: App | null = null
+  private state: ElementState = reactive({ context: null })
+
+  set kedgeContext(v: KedgeContext) {
+    this.state.context = v
+  }
+  get kedgeContext(): KedgeContext | null {
+    return this.state.context
+  }
+
+  connectedCallback() {
+    if (this.app) return
+
+    const dispatch = (path: string) => {
+      this.dispatchEvent(
+        new CustomEvent('kedge-navigate', {
+          detail: { path: path.replace(/^\//, '') },
+          bubbles: true,
+        }),
+      )
+    }
+
+    this.app = createApp({
+      render: () => h(DashboardTile, { context: this.state.context }),
+    })
+    this.app.use(createPinia())
+    // provide() so DashboardTile.vue can `inject('dispatchNavigate')`
+    // without threading a callback prop down through templates.
+    this.app.provide('dispatchNavigate', dispatch)
+    this.app.mount(this)
+  }
+
+  disconnectedCallback() {
+    this.app?.unmount()
+    this.app = null
+  }
+}
+
+if (!customElements.get(TAG)) {
+  customElements.define(TAG, KedgeDashboardTileKubernetesEdges)
+}

--- a/providers/kubernetesedges/portal/src/main.ts
+++ b/providers/kubernetesedges/portal/src/main.ts
@@ -1,5 +1,7 @@
-// IIFE entry — registers <kedge-provider-kubernetes-edges> as a side
-// effect when the portal's ProviderFrame loads this bundle. See
-// element.ts for the actual class.
+// IIFE entry — registers <kedge-provider-kubernetes-edges> (full page)
+// and <kedge-dashboard-tile-kubernetes-edges> (dashboard summary tile)
+// as side effects when the portal loads this bundle. See element.ts
+// and dashboard-tile.ts for the actual classes.
 
 import './element'
+import './dashboard-tile'

--- a/providers/serveredges/portal/src/DashboardTile.vue
+++ b/providers/serveredges/portal/src/DashboardTile.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+// Tile content for the server-edges dashboard summary. Same shape as
+// kubernetesedges' DashboardTile but filters edges to type="server"
+// and uses "servers" labeling.
+
+import { computed, watch, inject } from 'vue'
+import { useAuthStore, type KedgeContext } from './auth-adapter'
+import { useGraphQLQuery } from '@/composables/useGraphQL'
+import { LIST_EDGES, type ListEdgesResult } from '@/graphql/queries/edges'
+import { Server, Wifi, WifiOff, ChevronRight } from 'lucide-vue-next'
+
+const props = defineProps<{ context: KedgeContext | null }>()
+const auth = useAuthStore()
+
+watch(() => props.context, (ctx) => auth.hydrate(ctx), { immediate: true })
+
+const { data, loading, error } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 30000)
+
+const items = computed(() =>
+  (data.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? []).filter((e) => e.spec?.type === 'server'),
+)
+
+const stats = computed(() => {
+  const total = items.value.length
+  const ready = items.value.filter((e) => e.status?.phase === 'Ready').length
+  const connected = items.value.filter((e) => e.status?.connected).length
+  return { total, ready, connected }
+})
+
+const recent = computed(() =>
+  [...items.value]
+    .sort((a, b) => (b.metadata.creationTimestamp ?? '').localeCompare(a.metadata.creationTimestamp ?? ''))
+    .slice(0, 3),
+)
+
+const dispatchNavigate = inject<(path: string) => void>('dispatchNavigate', () => {})
+</script>
+
+<template>
+  <div v-if="error" class="text-[11px] text-danger">{{ error }}</div>
+  <div v-else-if="loading && !data" class="text-[11px] text-text-muted">Loading servers&hellip;</div>
+  <div v-else-if="items.length === 0" class="text-[11px] text-text-muted">
+    No servers connected yet.
+  </div>
+  <div v-else class="space-y-3">
+    <div class="flex items-baseline gap-3">
+      <div class="flex items-baseline gap-1">
+        <span class="text-2xl font-bold tabular-nums text-text-primary">{{ stats.total }}</span>
+        <span class="text-[11px] text-text-muted">servers</span>
+      </div>
+      <span class="text-[11px] text-text-muted">
+        <span :class="stats.ready === stats.total ? 'text-success' : 'text-warning'">{{ stats.ready }} ready</span>
+        <span class="mx-1 text-text-muted/50">·</span>
+        <span :class="stats.connected === stats.total ? 'text-success' : 'text-warning'">{{ stats.connected }} connected</span>
+      </span>
+    </div>
+
+    <ul class="space-y-1">
+      <li v-for="edge in recent" :key="edge.metadata.name">
+        <button
+          type="button"
+          class="group flex w-full items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2 text-left transition-colors hover:bg-accent/[0.04]"
+          @click="dispatchNavigate(edge.metadata.name)"
+        >
+          <Server class="h-3 w-3 shrink-0 text-text-muted" :stroke-width="1.75" />
+          <span class="min-w-0 flex-1 truncate text-[12px] text-text-primary">{{ edge.metadata.name }}</span>
+          <component
+            :is="edge.status?.connected ? Wifi : WifiOff"
+            class="h-3 w-3 shrink-0"
+            :class="edge.status?.connected ? 'text-success' : 'text-text-muted/60'"
+            :stroke-width="1.75"
+          />
+          <ChevronRight class="h-3 w-3 shrink-0 text-text-muted/30 transition-all group-hover:translate-x-0.5 group-hover:text-accent/60" :stroke-width="1.75" />
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/providers/serveredges/portal/src/dashboard-tile.ts
+++ b/providers/serveredges/portal/src/dashboard-tile.ts
@@ -1,0 +1,55 @@
+// Custom-element shell for the server-edges dashboard tile. Mirror of
+// kubernetes-edges' dashboard-tile.ts.
+
+import { createApp, h, reactive, type App } from 'vue'
+import { createPinia } from 'pinia'
+
+import DashboardTile from './DashboardTile.vue'
+import type { KedgeContext } from './auth-adapter'
+
+const TAG = 'kedge-dashboard-tile-server-edges'
+
+interface ElementState {
+  context: KedgeContext | null
+}
+
+class KedgeDashboardTileServerEdges extends HTMLElement {
+  private app: App | null = null
+  private state: ElementState = reactive({ context: null })
+
+  set kedgeContext(v: KedgeContext) {
+    this.state.context = v
+  }
+  get kedgeContext(): KedgeContext | null {
+    return this.state.context
+  }
+
+  connectedCallback() {
+    if (this.app) return
+
+    const dispatch = (path: string) => {
+      this.dispatchEvent(
+        new CustomEvent('kedge-navigate', {
+          detail: { path: path.replace(/^\//, '') },
+          bubbles: true,
+        }),
+      )
+    }
+
+    this.app = createApp({
+      render: () => h(DashboardTile, { context: this.state.context }),
+    })
+    this.app.use(createPinia())
+    this.app.provide('dispatchNavigate', dispatch)
+    this.app.mount(this)
+  }
+
+  disconnectedCallback() {
+    this.app?.unmount()
+    this.app = null
+  }
+}
+
+if (!customElements.get(TAG)) {
+  customElements.define(TAG, KedgeDashboardTileServerEdges)
+}

--- a/providers/serveredges/portal/src/main.ts
+++ b/providers/serveredges/portal/src/main.ts
@@ -1,4 +1,6 @@
-// IIFE entry — registers <kedge-provider-server-edges> as a side
-// effect when the portal's ProviderFrame loads this bundle.
+// IIFE entry — registers <kedge-provider-server-edges> (full page) and
+// <kedge-dashboard-tile-server-edges> (dashboard summary tile) as side
+// effects when the portal loads this bundle.
 
 import './element'
+import './dashboard-tile'


### PR DESCRIPTION
## Summary

Refactor the dashboard from a hardcoded edges-aware page into a provider-aggregated layout, so the portal stops knowing about edge schemas and BYO providers get equal billing.

- **Portal**: new `DashboardTile.vue` that mounts a per-provider custom element `<kedge-dashboard-tile-{name}>`, pushes the same `kedgeContext` shape as `ProviderFrame`, and proxies `kedge-navigate` events to vue-router. `DashboardPage.vue` strips fleet health / edge status / connectivity / recent-edges / workload-stats panels and iterates `providers.items.filter(ready && hasUI)` instead. Providers without a tile fall through to a static card linking to their page (opt-in per provider).
- **kubernetes-edges**: new `dashboard-tile.ts` registering `kedge-dashboard-tile-kubernetes-edges`; `DashboardTile.vue` shows cluster count, ready/connected counts, top 3 recent clusters, click → `/providers/kubernetes-edges/{name}`.
- **server-edges**: mirror tile filtered to `spec.type=server`.
- **Stale links fixed**: `FirstEdgeWizard` and `WorkloadDetailPage` were pushing `/edges/{name}` (the legacy route that was removed when providers took over the URL space) and returning 404. Wizard now routes to `/providers/kubernetes-edges/{name}`; workload→edge link uses the in-provider `/{name}` form.
- `FirstEdgeWizard` stays at the dashboard level — it's tenant-level onboarding (no edges of any kind connected) rather than a per-provider concern, and it deep-links into kubernetes-edges once the first cluster joins.

## Test plan

- [ ] Dashboard with both providers ready: two tiles render, each with its own count + recent items.
- [ ] Click an edge name in kubernetes-edges tile → `/providers/kubernetes-edges/{name}` opens (no 404).
- [ ] Click an edge name in server-edges tile → `/providers/server-edges/{name}` opens.
- [ ] Click "Open →" on either tile header → provider root page renders.
- [ ] Provider without a registered tile element shows the fallback card (\"This provider doesn't expose a dashboard summary.\").
- [ ] Fresh tenant with zero edges: `FirstEdgeWizard` still appears; completing it routes to `/providers/kubernetes-edges/{name}` (not the old 404).
- [ ] WorkloadDetailPage's edge backlink resolves to the kube edge detail page (no 404).

## Follow-ups (not in this PR)

- mcp provider could expose a tile listing connected `MCPServer` CRs; currently falls through to the static fallback card.
- The wizard's edges-presence check still queries `LIST_EDGES` from the portal level; could move into a generic providers-have-items signal so providers without edges (e.g. mcp-only) don't fire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)