### PR TITLE
Richer provider dashboard tiles

### DIFF
--- a/providers/kubernetesedges/portal/src/DashboardTile.vue
+++ b/providers/kubernetesedges/portal/src/DashboardTile.vue
@@ -1,87 +1,183 @@
 <script setup lang="ts">
 // Tile content for the kubernetes-edges dashboard summary. Mounted by
 // the <kedge-dashboard-tile-kubernetes-edges> custom element, which
-// owns the Vue app and auth-store hydration the same way
+// owns the Vue app + auth-store hydration the same way
 // KubernetesEdgesHost does for the full-page element.
 //
-// Renders a compact summary (count, connectivity, recent edges) plus
-// click-throughs that bubble kedge-navigate events the portal SPA
-// catches and turns into /providers/kubernetes-edges/{path} pushes.
+// Aims to give an at-a-glance picture of what the user has:
+//   - cluster trio (total / ready / connected) + a health bar
+//   - workload trio (running / pending / failed) for what's deployed
+//   - top recent clusters, each click-through bubbles kedge-navigate.
+//
+// Click handlers dispatch through the provided `dispatchNavigate` so
+// the portal catches them and pushes /providers/kubernetes-edges/{path}.
 
 import { computed, watch, inject } from 'vue'
 import { useAuthStore, type KedgeContext } from './auth-adapter'
 import { useGraphQLQuery } from '@/composables/useGraphQL'
 import { LIST_EDGES, type ListEdgesResult } from '@/graphql/queries/edges'
-import { Server, Wifi, WifiOff, ChevronRight } from 'lucide-vue-next'
+import { LIST_VIRTUAL_WORKLOADS, type ListVirtualWorkloadsResult } from '@/graphql/queries/workloads'
+import { Server, Layers, Wifi, WifiOff, ChevronRight, CheckCircle2, AlertCircle, Clock } from 'lucide-vue-next'
 
 const props = defineProps<{ context: KedgeContext | null }>()
 const auth = useAuthStore()
 
-// Hydrate the provider-local auth store from the kedgeContext property
-// the portal sets on the element. Same shape as KubernetesEdgesHost.
 watch(() => props.context, (ctx) => auth.hydrate(ctx), { immediate: true })
 
-const { data, loading, error } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 30000)
+const { data: edgesData, loading: edgesLoading, error: edgesError } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 30000)
+const { data: workloadsData } = useGraphQLQuery<ListVirtualWorkloadsResult>(LIST_VIRTUAL_WORKLOADS, undefined, 30000)
 
-const items = computed(() =>
-  (data.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? []).filter((e) => e.spec?.type === 'kubernetes'),
+const clusters = computed(() =>
+  (edgesData.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? []).filter((e) => e.spec?.type === 'kubernetes'),
 )
+const workloads = computed(() => workloadsData.value?.kedge_faros_sh?.v1alpha1?.VirtualWorkloads?.items ?? [])
 
-const stats = computed(() => {
-  const total = items.value.length
-  const ready = items.value.filter((e) => e.status?.phase === 'Ready').length
-  const connected = items.value.filter((e) => e.status?.connected).length
-  return { total, ready, connected }
+const clusterStats = computed(() => {
+  const total = clusters.value.length
+  const ready = clusters.value.filter((e) => e.status?.phase === 'Ready').length
+  const connected = clusters.value.filter((e) => e.status?.connected).length
+  const healthPct = total === 0 ? 0 : Math.round((ready / total) * 100)
+  return { total, ready, connected, healthPct }
+})
+
+const workloadStats = computed(() => {
+  const total = workloads.value.length
+  const running = workloads.value.filter((w) => w.status?.phase === 'Running').length
+  const pending = workloads.value.filter((w) => w.status?.phase === 'Pending' || w.status?.phase === 'Scheduling').length
+  const failed = workloads.value.filter((w) => w.status?.phase === 'Failed').length
+  return { total, running, pending, failed }
 })
 
 const recent = computed(() =>
-  [...items.value]
+  [...clusters.value]
     .sort((a, b) => (b.metadata.creationTimestamp ?? '').localeCompare(a.metadata.creationTimestamp ?? ''))
     .slice(0, 3),
 )
 
-// dispatchNavigate is provided by dashboard-tile.ts so we don't have
-// to thread the host element down through props.
 const dispatchNavigate = inject<(path: string) => void>('dispatchNavigate', () => {})
+
+// Color the health bar by ready/total ratio. The same thresholds the
+// old central dashboard used so the visual ranking stays consistent.
+const healthColor = computed(() => {
+  const p = clusterStats.value.healthPct
+  if (p >= 80) return 'bg-success'
+  if (p >= 50) return 'bg-warning'
+  return 'bg-danger'
+})
 </script>
 
 <template>
-  <div v-if="error" class="text-[11px] text-danger">{{ error }}</div>
-  <div v-else-if="loading && !data" class="text-[11px] text-text-muted">Loading clusters&hellip;</div>
-  <div v-else-if="items.length === 0" class="text-[11px] text-text-muted">
-    No Kubernetes clusters connected yet.
+  <div v-if="edgesError" class="text-[11px] text-danger">{{ edgesError }}</div>
+  <div v-else-if="edgesLoading && !edgesData" class="text-[11px] text-text-muted">Loading clusters&hellip;</div>
+  <div v-else-if="clusters.length === 0" class="space-y-2">
+    <div class="text-[11px] text-text-muted">No Kubernetes clusters connected yet.</div>
+    <button
+      type="button"
+      class="text-[11px] font-medium text-accent hover:text-accent-hover"
+      @click="dispatchNavigate('')"
+    >
+      Connect your first cluster &rarr;
+    </button>
   </div>
-  <div v-else class="space-y-3">
-    <div class="flex items-baseline gap-3">
-      <div class="flex items-baseline gap-1">
-        <span class="text-2xl font-bold tabular-nums text-text-primary">{{ stats.total }}</span>
-        <span class="text-[11px] text-text-muted">clusters</span>
+
+  <div v-else class="space-y-4">
+    <!-- Cluster stat trio + health bar. The bar gives a fast "is the
+         fleet OK" read; the numbers carry exact state. -->
+    <div>
+      <div class="mb-2 flex items-center gap-1.5">
+        <Server class="h-3 w-3 text-text-muted" :stroke-width="1.75" />
+        <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Clusters</span>
       </div>
-      <span class="text-[11px] text-text-muted">
-        <span :class="stats.ready === stats.total ? 'text-success' : 'text-warning'">{{ stats.ready }} ready</span>
-        <span class="mx-1 text-text-muted/50">·</span>
-        <span :class="stats.connected === stats.total ? 'text-success' : 'text-warning'">{{ stats.connected }} connected</span>
-      </span>
+      <div class="grid grid-cols-3 gap-2">
+        <div class="rounded-lg border border-border-subtle bg-surface-overlay/40 p-2">
+          <div class="text-[9px] uppercase tracking-wider text-text-muted/70">Total</div>
+          <div class="mt-0.5 text-lg font-bold tabular-nums text-text-primary">{{ clusterStats.total }}</div>
+        </div>
+        <div class="rounded-lg border border-border-subtle bg-surface-overlay/40 p-2">
+          <div class="text-[9px] uppercase tracking-wider text-text-muted/70">Ready</div>
+          <div
+            class="mt-0.5 text-lg font-bold tabular-nums"
+            :class="clusterStats.ready === clusterStats.total ? 'text-success' : 'text-warning'"
+          >
+            {{ clusterStats.ready }}
+          </div>
+        </div>
+        <div class="rounded-lg border border-border-subtle bg-surface-overlay/40 p-2">
+          <div class="text-[9px] uppercase tracking-wider text-text-muted/70">Online</div>
+          <div
+            class="mt-0.5 text-lg font-bold tabular-nums"
+            :class="clusterStats.connected === clusterStats.total ? 'text-success' : 'text-warning'"
+          >
+            {{ clusterStats.connected }}
+          </div>
+        </div>
+      </div>
+      <div class="mt-2 flex items-center gap-2">
+        <div class="h-1 flex-1 overflow-hidden rounded-full bg-surface-overlay">
+          <div class="h-full rounded-full transition-all duration-500" :class="healthColor" :style="{ width: `${clusterStats.healthPct}%` }" />
+        </div>
+        <span class="text-[10px] tabular-nums text-text-muted">{{ clusterStats.healthPct }}% healthy</span>
+      </div>
     </div>
 
-    <ul class="space-y-1">
-      <li v-for="edge in recent" :key="edge.metadata.name">
+    <!-- Workload stats. Hidden when there are no workloads at all,
+         to keep the empty state quiet rather than nagging. -->
+    <div v-if="workloadStats.total > 0">
+      <div class="mb-2 flex items-center gap-1.5">
+        <Layers class="h-3 w-3 text-text-muted" :stroke-width="1.75" />
+        <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Workloads</span>
+        <span class="text-[10px] tabular-nums text-text-muted/60">({{ workloadStats.total }})</span>
         <button
           type="button"
-          class="group flex w-full items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2 text-left transition-colors hover:bg-accent/[0.04]"
-          @click="dispatchNavigate(edge.metadata.name)"
+          class="ml-auto text-[10px] font-medium text-accent transition-colors hover:text-accent-hover"
+          @click="dispatchNavigate('workloads')"
         >
-          <Server class="h-3 w-3 shrink-0 text-text-muted" :stroke-width="1.75" />
-          <span class="min-w-0 flex-1 truncate text-[12px] text-text-primary">{{ edge.metadata.name }}</span>
-          <component
-            :is="edge.status?.connected ? Wifi : WifiOff"
-            class="h-3 w-3 shrink-0"
-            :class="edge.status?.connected ? 'text-success' : 'text-text-muted/60'"
-            :stroke-width="1.75"
-          />
-          <ChevronRight class="h-3 w-3 shrink-0 text-text-muted/30 transition-all group-hover:translate-x-0.5 group-hover:text-accent/60" :stroke-width="1.75" />
+          View all &rarr;
         </button>
-      </li>
-    </ul>
+      </div>
+      <div class="flex items-center gap-3 text-[11px]">
+        <span class="inline-flex items-center gap-1 text-success">
+          <CheckCircle2 class="h-3 w-3" :stroke-width="1.75" />
+          <span class="tabular-nums">{{ workloadStats.running }}</span>
+          <span class="text-text-muted">running</span>
+        </span>
+        <span v-if="workloadStats.pending > 0" class="inline-flex items-center gap-1 text-warning">
+          <Clock class="h-3 w-3" :stroke-width="1.75" />
+          <span class="tabular-nums">{{ workloadStats.pending }}</span>
+          <span class="text-text-muted">pending</span>
+        </span>
+        <span v-if="workloadStats.failed > 0" class="inline-flex items-center gap-1 text-danger">
+          <AlertCircle class="h-3 w-3" :stroke-width="1.75" />
+          <span class="tabular-nums">{{ workloadStats.failed }}</span>
+          <span class="text-text-muted">failed</span>
+        </span>
+      </div>
+    </div>
+
+    <!-- Recent clusters with click-through. Three lines max so the tile
+         stays scannable; "View all" is in the tile header (the portal-
+         supplied chrome). -->
+    <div>
+      <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Recent</div>
+      <ul class="space-y-1">
+        <li v-for="edge in recent" :key="edge.metadata.name">
+          <button
+            type="button"
+            class="group flex w-full items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-2.5 py-1.5 text-left transition-colors hover:bg-accent/[0.04]"
+            @click="dispatchNavigate(edge.metadata.name)"
+          >
+            <Server class="h-3 w-3 shrink-0 text-text-muted" :stroke-width="1.75" />
+            <span class="min-w-0 flex-1 truncate text-[12px] text-text-primary">{{ edge.metadata.name }}</span>
+            <component
+              :is="edge.status?.connected ? Wifi : WifiOff"
+              class="h-3 w-3 shrink-0"
+              :class="edge.status?.connected ? 'text-success' : 'text-text-muted/60'"
+              :stroke-width="1.75"
+            />
+            <ChevronRight class="h-3 w-3 shrink-0 text-text-muted/30 transition-all group-hover:translate-x-0.5 group-hover:text-accent/60" :stroke-width="1.75" />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>

--- a/providers/serveredges/portal/src/DashboardTile.vue
+++ b/providers/serveredges/portal/src/DashboardTile.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // Tile content for the server-edges dashboard summary. Same shape as
-// kubernetesedges' DashboardTile but filters edges to type="server"
-// and uses "servers" labeling.
+// kubernetes-edges' tile minus the workloads section (workloads are
+// kube-only today). Mounted by <kedge-dashboard-tile-server-edges>.
 
 import { computed, watch, inject } from 'vue'
 import { useAuthStore, type KedgeContext } from './auth-adapter'
@@ -16,63 +16,132 @@ watch(() => props.context, (ctx) => auth.hydrate(ctx), { immediate: true })
 
 const { data, loading, error } = useGraphQLQuery<ListEdgesResult>(LIST_EDGES, undefined, 30000)
 
-const items = computed(() =>
+const servers = computed(() =>
   (data.value?.kedge_faros_sh?.v1alpha1?.Edges?.items ?? []).filter((e) => e.spec?.type === 'server'),
 )
 
 const stats = computed(() => {
-  const total = items.value.length
-  const ready = items.value.filter((e) => e.status?.phase === 'Ready').length
-  const connected = items.value.filter((e) => e.status?.connected).length
-  return { total, ready, connected }
+  const total = servers.value.length
+  const ready = servers.value.filter((e) => e.status?.phase === 'Ready').length
+  const connected = servers.value.filter((e) => e.status?.connected).length
+  const healthPct = total === 0 ? 0 : Math.round((ready / total) * 100)
+  return { total, ready, connected, healthPct }
 })
 
 const recent = computed(() =>
-  [...items.value]
+  [...servers.value]
     .sort((a, b) => (b.metadata.creationTimestamp ?? '').localeCompare(a.metadata.creationTimestamp ?? ''))
     .slice(0, 3),
 )
 
 const dispatchNavigate = inject<(path: string) => void>('dispatchNavigate', () => {})
+
+const healthColor = computed(() => {
+  const p = stats.value.healthPct
+  if (p >= 80) return 'bg-success'
+  if (p >= 50) return 'bg-warning'
+  return 'bg-danger'
+})
+
+// Agent version distribution as a quick "do I have stragglers" signal.
+// Sorts by count desc so the dominant version surfaces first.
+const versionDist = computed(() => {
+  const m = new Map<string, number>()
+  for (const s of servers.value) {
+    const v = s.status?.agentVersion || 'unknown'
+    m.set(v, (m.get(v) ?? 0) + 1)
+  }
+  return [...m.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3)
+})
 </script>
 
 <template>
   <div v-if="error" class="text-[11px] text-danger">{{ error }}</div>
   <div v-else-if="loading && !data" class="text-[11px] text-text-muted">Loading servers&hellip;</div>
-  <div v-else-if="items.length === 0" class="text-[11px] text-text-muted">
-    No servers connected yet.
+  <div v-else-if="servers.length === 0" class="space-y-2">
+    <div class="text-[11px] text-text-muted">No servers connected yet.</div>
+    <button
+      type="button"
+      class="text-[11px] font-medium text-accent hover:text-accent-hover"
+      @click="dispatchNavigate('')"
+    >
+      Connect your first server &rarr;
+    </button>
   </div>
-  <div v-else class="space-y-3">
-    <div class="flex items-baseline gap-3">
-      <div class="flex items-baseline gap-1">
-        <span class="text-2xl font-bold tabular-nums text-text-primary">{{ stats.total }}</span>
-        <span class="text-[11px] text-text-muted">servers</span>
+
+  <div v-else class="space-y-4">
+    <!-- Stat trio + health bar — same shape as kubernetes-edges' tile
+         so the user reads both at a glance with the same mental model. -->
+    <div>
+      <div class="mb-2 flex items-center gap-1.5">
+        <Server class="h-3 w-3 text-text-muted" :stroke-width="1.75" />
+        <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Servers</span>
       </div>
-      <span class="text-[11px] text-text-muted">
-        <span :class="stats.ready === stats.total ? 'text-success' : 'text-warning'">{{ stats.ready }} ready</span>
-        <span class="mx-1 text-text-muted/50">·</span>
-        <span :class="stats.connected === stats.total ? 'text-success' : 'text-warning'">{{ stats.connected }} connected</span>
-      </span>
+      <div class="grid grid-cols-3 gap-2">
+        <div class="rounded-lg border border-border-subtle bg-surface-overlay/40 p-2">
+          <div class="text-[9px] uppercase tracking-wider text-text-muted/70">Total</div>
+          <div class="mt-0.5 text-lg font-bold tabular-nums text-text-primary">{{ stats.total }}</div>
+        </div>
+        <div class="rounded-lg border border-border-subtle bg-surface-overlay/40 p-2">
+          <div class="text-[9px] uppercase tracking-wider text-text-muted/70">Ready</div>
+          <div
+            class="mt-0.5 text-lg font-bold tabular-nums"
+            :class="stats.ready === stats.total ? 'text-success' : 'text-warning'"
+          >
+            {{ stats.ready }}
+          </div>
+        </div>
+        <div class="rounded-lg border border-border-subtle bg-surface-overlay/40 p-2">
+          <div class="text-[9px] uppercase tracking-wider text-text-muted/70">Online</div>
+          <div
+            class="mt-0.5 text-lg font-bold tabular-nums"
+            :class="stats.connected === stats.total ? 'text-success' : 'text-warning'"
+          >
+            {{ stats.connected }}
+          </div>
+        </div>
+      </div>
+      <div class="mt-2 flex items-center gap-2">
+        <div class="h-1 flex-1 overflow-hidden rounded-full bg-surface-overlay">
+          <div class="h-full rounded-full transition-all duration-500" :class="healthColor" :style="{ width: `${stats.healthPct}%` }" />
+        </div>
+        <span class="text-[10px] tabular-nums text-text-muted">{{ stats.healthPct }}% healthy</span>
+      </div>
     </div>
 
-    <ul class="space-y-1">
-      <li v-for="edge in recent" :key="edge.metadata.name">
-        <button
-          type="button"
-          class="group flex w-full items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2 text-left transition-colors hover:bg-accent/[0.04]"
-          @click="dispatchNavigate(edge.metadata.name)"
-        >
-          <Server class="h-3 w-3 shrink-0 text-text-muted" :stroke-width="1.75" />
-          <span class="min-w-0 flex-1 truncate text-[12px] text-text-primary">{{ edge.metadata.name }}</span>
-          <component
-            :is="edge.status?.connected ? Wifi : WifiOff"
-            class="h-3 w-3 shrink-0"
-            :class="edge.status?.connected ? 'text-success' : 'text-text-muted/60'"
-            :stroke-width="1.75"
-          />
-          <ChevronRight class="h-3 w-3 shrink-0 text-text-muted/30 transition-all group-hover:translate-x-0.5 group-hover:text-accent/60" :stroke-width="1.75" />
-        </button>
-      </li>
-    </ul>
+    <!-- Agent version distribution — quick visibility into upgrade lag.
+         Hidden when only one distinct version (the normal case). -->
+    <div v-if="versionDist.length > 1">
+      <div class="mb-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Agent versions</div>
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+        <span v-for="[ver, count] in versionDist" :key="ver" class="text-text-muted">
+          <span class="font-mono text-text-secondary">{{ ver }}</span>
+          <span class="ml-1 tabular-nums">×{{ count }}</span>
+        </span>
+      </div>
+    </div>
+
+    <div>
+      <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Recent</div>
+      <ul class="space-y-1">
+        <li v-for="edge in recent" :key="edge.metadata.name">
+          <button
+            type="button"
+            class="group flex w-full items-center gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-2.5 py-1.5 text-left transition-colors hover:bg-accent/[0.04]"
+            @click="dispatchNavigate(edge.metadata.name)"
+          >
+            <Server class="h-3 w-3 shrink-0 text-text-muted" :stroke-width="1.75" />
+            <span class="min-w-0 flex-1 truncate text-[12px] text-text-primary">{{ edge.metadata.name }}</span>
+            <component
+              :is="edge.status?.connected ? Wifi : WifiOff"
+              class="h-3 w-3 shrink-0"
+              :class="edge.status?.connected ? 'text-success' : 'text-text-muted/60'"
+              :stroke-width="1.75"
+            />
+            <ChevronRight class="h-3 w-3 shrink-0 text-text-muted/30 transition-all group-hover:translate-x-0.5 group-hover:text-accent/60" :stroke-width="1.75" />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

The first-cut tiles from #202 only showed a small count and a few recent items. Make both first-party tiles actually informative:

**kubernetes-edges tile**
- Cluster stat trio (Total / Ready / Online) in mini-cards
- Colored health bar (≥80% green, ≥50% amber, else red) with percent
- Workloads section: running / pending / failed counts, plus a "View all →" deep-link to the in-provider workloads page (only shown when there are workloads)
- Top 3 recent clusters, click-through to the cluster detail page

**server-edges tile**
- Same Total / Ready / Online trio + health bar
- Agent-version distribution row (top 3 versions with counts) — surfaces upgrade lag in one glance; hidden when the fleet is homogeneous
- Top 3 recent servers with click-through

Both empty states now offer a "Connect your first cluster/server →" CTA that deep-links into the provider page instead of just stating the absence.

## Test plan

- [ ] Dashboard with a healthy fleet: green health bar, all numbers match `/providers/{name}` counts.
- [ ] Disconnect one edge: Online count drops, bar turns amber/red, color update is immediate.
- [ ] Deploy a workload: kubernetes-edges tile shows it in the running count; "View all" links to `/providers/kubernetes-edges/workloads`.
- [ ] Empty server-edges: tile shows "Connect your first server →"; clicking goes to `/providers/server-edges`.
- [ ] Mixed agent versions on server-edges: distribution row shows up; single-version cluster hides it.
- [ ] Click a recent item: lands at `/providers/{name}/{edgeName}` (kubernetes-edges or server-edges accordingly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)