### PR TITLE
tenancy: workspace WorkspaceType + restore org defaultChildWorkspaceType (PR #3)

### DIFF
--- a/config/kcp/embed.go
+++ b/config/kcp/embed.go
@@ -42,12 +42,13 @@ var ProvidersFS embed.FS
 
 // PostProvidersFS contains workspace-scoped objects that must be applied in
 // root:kedge AFTER ProvidersFS has populated root:kedge:providers with the
-// APIExports they reference. Today it ships the `organization` WorkspaceType
-// (defaultAPIBindings references root:kedge:providers.tenancy.kedge.faros.sh).
-// kcp's WorkspaceType admission validates bind permission on every APIExport
-// in defaultAPIBindings; the referenced export has to exist by the time the
-// WT is applied, otherwise the LogicalCluster lookup fails and admission
-// returns 403 forbidden.
+// APIExports they reference. Ships the `organization` + `workspace`
+// WorkspaceTypes, both of which carry a defaultAPIBinding to
+// root:kedge:providers.tenancy.kedge.faros.sh. kcp's WorkspaceType admission
+// validates bind permission on every APIExport in defaultAPIBindings; the
+// referenced export has to exist by the time the WT is applied, otherwise
+// the LogicalCluster lookup fails and admission returns 403 forbidden (see
+// PR #205 / commit 3d2d277 for the failure shape).
 //
-//go:embed workspacetype-organization.yaml
+//go:embed workspacetype-organization.yaml workspacetype-workspace.yaml
 var PostProvidersFS embed.FS

--- a/config/kcp/workspacetype-organization.yaml
+++ b/config/kcp/workspacetype-organization.yaml
@@ -16,12 +16,6 @@ spec:
     with:
     - name: universal
       path: root
-  # NOTE: docs/organizations.md mandates that child workspaces inside an
-  # Organization are of type `workspace`. `defaultChildWorkspaceType` is
-  # intentionally omitted in PR #2 because the referenced WorkspaceType
-  # is created by PR #3; the dangling reference would fail kcp's
-  # admission check. PR #3 fills it in.
-  #
   # tenancy.kcp.io (Workspace, WorkspaceType, etc.) is NOT redeclared
   # here — it is inherited from root:universal via the `extend` above,
   # which is also how the existing `tenant` WorkspaceType picks it up.
@@ -29,3 +23,12 @@ spec:
   defaultAPIBindings:
   - path: root:kedge:providers
     export: tenancy.kedge.faros.sh
+  # Child workspaces inside an Organization are the team / project
+  # spaces where tenant work (APIBindings, edges, MCP instances)
+  # actually lives. v1 caps the allowed child type to a single value
+  # so a tenant attempting to create a child of any other type fails
+  # at kcp admission. PR #3 brought the `workspace` WorkspaceType into
+  # the same PostProvidersFS bootstrap so this reference resolves.
+  defaultChildWorkspaceType:
+    name: workspace
+    path: root:kedge

--- a/config/kcp/workspacetype-workspace.yaml
+++ b/config/kcp/workspacetype-workspace.yaml
@@ -1,0 +1,44 @@
+apiVersion: tenancy.kcp.io/v1alpha1
+kind: WorkspaceType
+metadata:
+  name: workspace
+  annotations:
+    bootstrap.kcp.io/create-only: "true"
+spec:
+  # Extend root:universal so workspace workspaces inherit the universal
+  # initializer that bootstraps the "default" namespace (same reason the
+  # `tenant` and `organization` types extend universal). Without it,
+  # namespaced kubectl operations would fail with `namespaces "default"
+  # not found`.
+  extend:
+    with:
+    - name: universal
+      path: root
+  # Workspaces ("team" workspaces) are leaves in v1; they hold APIBindings,
+  # edges, mcp instances, and any other tenant work. Nested child
+  # workspaces are deferred to v2 per docs/organizations.md §Open questions.
+  # Without this constraint a tenant kubectl-apply could create arbitrary
+  # children inside their workspace.
+  limitAllowedChildren:
+    none: true
+  # workspace workspaces must be children of an `organization` workspace —
+  # they only make sense as a team inside an Org. The kcp WorkspaceType
+  # admission rejects an attempt to create one at any other path.
+  limitAllowedParents:
+    types:
+    - name: organization
+      path: root:kedge
+  # Default bindings the hub + tenant rely on inside a workspace:
+  #   - tenancy.kedge.faros.sh provides Membership (PR #4 lands the CRD
+  #     and the initializer that adds the creator as Membership{scope:
+  #     workspace, role: admin}). Organization and CatalogEntry CRDs come
+  #     in via the same APIExport but are not used inside a workspace —
+  #     CatalogEntries live one level up at the Org workspace, and
+  #     Organization is cluster-scoped at root:kedge:users.
+  # Provider APIExports (mcp, kubernetes-edges, etc.) are deliberately
+  # NOT in defaultAPIBindings per docs/provider-scoping.md P-4: every
+  # provider, including builtins, requires explicit Enable in the
+  # workspace.
+  defaultAPIBindings:
+  - path: root:kedge:providers
+    export: tenancy.kedge.faros.sh


### PR DESCRIPTION
**Roadmap step 3** of the multi-org tenancy roadmap (docs/organizations.md). Builds on #205.

Adds the `workspace` WorkspaceType so child "team" workspaces become creatable inside an Organization, and fills in the `defaultChildWorkspaceType` on the `organization` WT that roadmap step 2 deferred because the referenced type didn't exist yet.

## Summary

- **`config/kcp/workspacetype-workspace.yaml`** — extends `root:universal`; `limitAllowedChildren: none` (v1 leaves nested workspaces to v2); `limitAllowedParents: organization` (only valid as a child of an Org); `defaultAPIBindings: root:kedge:providers.tenancy.kedge.faros.sh` for Membership (roadmap step 4). Provider APIExports (mcp, edges, etc.) are deliberately **not** in defaultAPIBindings per `provider-scoping.md` P-4 — every provider, including builtins, requires explicit Enable.
- **`config/kcp/embed.go`** — `PostProvidersFS` now embeds both `workspacetype-organization.yaml` and `workspacetype-workspace.yaml`. Both ride the same post-providers bootstrap step established in roadmap step 2 because both reference the kedge-owned APIExport whose `bind` permission only exists after `ensureProvidersSelfBinding`.
- **`config/kcp/workspacetype-organization.yaml`** — `defaultChildWorkspaceType: {name: workspace, path: root:kedge}` restored. Both types now live in the same `PostProvidersFS` bootstrap so the reference resolves at admission time.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean (`0 issues.`)
- [x] `go test ./pkg/hub/...` — no regressions
- [ ] Manual smoke against a real kcp: confirm `kubectl create workspace foo --type=workspace.tenancy.kcp.io --workspace-type-path=root:kedge` succeeds inside an Org-typed workspace and is rejected anywhere else.

## Out of scope (continues in roadmap step 4+)

- Initializer flag + post-init reconciler that adds the creator as `Membership{scope: workspace, role: admin}` — roadmap step 4 with the Membership CRD.
- Hub-side REST endpoint `POST /api/orgs/{org}/workspaces` — roadmap step 10 with the portal switcher UI.
- kcp-proxy gate that enforces O-10 on Org workspaces — roadmap step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
