### PR TITLE
proxy: enforce O-10 — refuse direct access to Org workspaces (PR #5)

### DIFF
--- a/pkg/server/proxy/proxy.go
+++ b/pkg/server/proxy/proxy.go
@@ -332,6 +332,14 @@ func (p *KCPProxy) serveOIDC(w http.ResponseWriter, r *http.Request, token strin
 		return
 	}
 
+	// O-10 gate: refuse direct access to Organization workspaces.
+	// Tenants must use the hub REST surface for Org-scoped operations.
+	if clusterPath := extractClusterPathFromKCPPath(kcpPath); isOrgWorkspacePath(clusterPath) {
+		p.logger.Info("org workspace access denied (O-10)", "user", user.Name, "cluster", clusterPath)
+		writeOrgWorkspaceForbidden(w)
+		return
+	}
+
 	target := *p.kcpTarget
 	logger := p.logger
 
@@ -389,6 +397,14 @@ func (p *KCPProxy) serveStaticToken(w http.ResponseWriter, r *http.Request, toke
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(errStatus)
 		_, _ = fmt.Fprint(w, errBody)
+		return
+	}
+
+	// O-10 gate: refuse direct access to Organization workspaces.
+	// Tenants must use the hub REST surface for Org-scoped operations.
+	if clusterPath := extractClusterPathFromKCPPath(kcpPath); isOrgWorkspacePath(clusterPath) {
+		p.logger.Info("org workspace access denied (O-10)", "user", user.Name, "cluster", clusterPath)
+		writeOrgWorkspaceForbidden(w)
 		return
 	}
 
@@ -588,6 +604,17 @@ func (p *KCPProxy) serveServiceAccount(w http.ResponseWriter, r *http.Request, t
 		return
 	}
 
+	// O-10 gate: refuse direct access to Organization workspaces even when
+	// authenticated as a kcp ServiceAccount. SA tokens bound at the Org
+	// workspace shouldn't exist in v1, but defense-in-depth: the structural
+	// check here costs nothing and stops a misconfigured token from
+	// reaching the Org workspace's API server.
+	if isOrgWorkspacePath(clusterName) {
+		p.logger.Info("SA: org workspace access denied (O-10)", "cluster", clusterName)
+		writeOrgWorkspaceForbidden(w)
+		return
+	}
+
 	target := *p.kcpTarget
 	logger := p.logger
 
@@ -659,6 +686,69 @@ func writeUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}`)
+}
+
+// orgWorkspacePathPrefix is the kcp logical-cluster path under which every
+// Organization workspace lives (root:kedge:orgs:{org-uuid}). The proxy
+// uses this prefix together with the structural rule "an Organization
+// workspace has exactly one segment after orgs:" to decide whether a
+// requested target is an Org workspace.
+const orgWorkspacePathPrefix = "root:kedge:orgs:"
+
+// orgWorkspaceForbiddenBody is the JSON the proxy returns when refusing a
+// direct request to an Organization workspace per docs/organizations.md
+// decision O-10 ("Org workspaces are hub-mediated only"). The body uses
+// the standard Kubernetes Status envelope so kubectl renders the message
+// nicely while also carrying a kedge-specific reason + a pointer at the
+// hub REST surface so CLI tooling can suggest the right endpoint.
+const orgWorkspaceForbiddenBody = `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Organization workspaces are hub-mediated and not directly accessible — use the hub REST endpoints at /api/orgs/{org-uuid}/... instead.","reason":"OrgWorkspaceNotDirectlyAccessible","code":403,"details":{"kind":"OrganizationWorkspace","group":"tenancy.kedge.faros.sh"}}`
+
+// isOrgWorkspacePath reports whether clusterPath addresses a kcp
+// Organization workspace (path root:kedge:orgs:{single-segment}). Child
+// "team" workspaces under an Org, which look like
+// root:kedge:orgs:{org-uuid}:{ws-uuid}, do NOT match — those remain
+// tenant-accessible per the design.
+//
+// The check is structural rather than annotation-based on purpose: every
+// Organization workspace lives at exactly this path shape by the
+// invariant established in PR #2 (workspacetype-organization.yaml +
+// Bootstrapper.EnsureOrgWorkspace). Using the path keeps the proxy hot
+// path free of kcp lookups and avoids a cache layer.
+func isOrgWorkspacePath(clusterPath string) bool {
+	if !strings.HasPrefix(clusterPath, orgWorkspacePathPrefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(clusterPath, orgWorkspacePathPrefix)
+	if rest == "" {
+		return false
+	}
+	// Exactly one segment after `orgs:` ⇒ an Org workspace. A second
+	// colon ⇒ child team Workspace (root:kedge:orgs:{org}:{ws}).
+	return !strings.Contains(rest, ":")
+}
+
+// extractClusterPathFromKCPPath returns the logical-cluster path portion
+// of a kcp-syntax URL path like `/clusters/{cluster}/api/...`. Returns
+// the empty string if the input doesn't carry a /clusters/ prefix
+// (i.e. it has already been resolved by resolveKCPPath, which would
+// have prepended the default cluster). The proxy calls this AFTER
+// resolveKCPPath so kcpPath is always /clusters/-prefixed.
+func extractClusterPathFromKCPPath(kcpPath string) string {
+	if !strings.HasPrefix(kcpPath, "/clusters/") {
+		return ""
+	}
+	rest := strings.TrimPrefix(kcpPath, "/clusters/")
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// writeOrgWorkspaceForbidden writes the O-10 403 response.
+func writeOrgWorkspaceForbidden(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = fmt.Fprint(w, orgWorkspaceForbiddenBody)
 }
 
 // resolveKCPPath computes the target kcp path for the given request URL path.

--- a/pkg/server/proxy/proxy_test.go
+++ b/pkg/server/proxy/proxy_test.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -122,5 +123,92 @@ func TestResolveKCPPath(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestIsOrgWorkspacePath covers the structural rule that decides whether
+// a kcp logical-cluster path targets an Organization workspace (which the
+// proxy rejects per O-10) or a child team Workspace under one (which
+// remains tenant-accessible).
+func TestIsOrgWorkspacePath(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		wantOK bool
+	}{
+		{"org workspace UUID", "root:kedge:orgs:7f3a91d2-aaaa-bbbb-cccc-1111", true},
+		{"org workspace short", "root:kedge:orgs:acme", true},
+		{"child team workspace", "root:kedge:orgs:7f3a:9c4b", false},
+		{"child team workspace nested", "root:kedge:orgs:acme:platform", false},
+		{"tenants workspace", "root:kedge:tenants:alice", false},
+		{"providers workspace", "root:kedge:providers", false},
+		{"root", "root", false},
+		{"empty", "", false},
+		{"orgs parent (no org)", "root:kedge:orgs:", false},
+		{"orgs parent (no trailing colon)", "root:kedge:orgs", false},
+		{"random workspace under root", "root:other", false},
+		{"path traversal attempt", "root:kedge:orgs:foo/etc/passwd", true /* path has no colon → structural match; caller's regex strips traversal earlier */},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOrgWorkspacePath(tc.path); got != tc.wantOK {
+				t.Errorf("isOrgWorkspacePath(%q) = %v, want %v", tc.path, got, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestExtractClusterPathFromKCPPath covers the helper that pulls the
+// logical-cluster portion out of a kcp-syntax URL path.
+func TestExtractClusterPathFromKCPPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clusters with subpath", "/clusters/root:kedge:orgs:7f3a/api/v1/pods", "root:kedge:orgs:7f3a"},
+		{"clusters with mount suffix", "/clusters/root:tenant:abc:mount1/api/v1/pods", "root:tenant:abc:mount1"},
+		{"clusters bare (no subpath)", "/clusters/root:kedge:orgs:7f3a", "root:kedge:orgs:7f3a"},
+		{"non-clusters path", "/api/v1/pods", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractClusterPathFromKCPPath(tc.in); got != tc.want {
+				t.Errorf("extractClusterPathFromKCPPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteOrgWorkspaceForbidden verifies the 403 envelope is a valid
+// Kubernetes Status object so kubectl renders it nicely, and carries the
+// kedge-specific reason + a pointer at the hub REST surface for CLI tooling.
+func TestWriteOrgWorkspaceForbidden(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeOrgWorkspaceForbidden(w)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", got)
+	}
+	var status map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+		t.Fatalf("body is not valid JSON: %v — %q", err, w.Body.String())
+	}
+	if status["kind"] != "Status" || status["apiVersion"] != "v1" {
+		t.Errorf("body is not a v1.Status envelope: %v", status)
+	}
+	if status["code"] != float64(403) {
+		t.Errorf("code: got %v, want 403", status["code"])
+	}
+	if status["reason"] != "OrgWorkspaceNotDirectlyAccessible" {
+		t.Errorf("reason: got %v, want OrgWorkspaceNotDirectlyAccessible", status["reason"])
+	}
+	msg, _ := status["message"].(string)
+	if msg == "" {
+		t.Error("message should be a non-empty hint about the hub REST surface")
 	}
 }


### PR DESCRIPTION
**Roadmap step 5** of the multi-org tenancy roadmap (docs/organizations.md). Builds on #207.

Wires the kcp-proxy gate that makes decision O-10 ("Org workspaces are hub-mediated only") network-level enforced: any request whose target cluster resolves to `root:kedge:orgs:{org-uuid}` now gets a 403 instead of being proxied to kcp.

This closes the loop opened by PRs #1–#4: the bootstrap controller materializes Organization workspaces, creates the admin Membership, and indexes it; from this PR on, tenants **physically cannot** kubectl into those workspaces. Org-scoped CRUD has to flow through the hub REST endpoints (roadmap step 6+).

## Implementation

- **`isOrgWorkspacePath`** uses a structural rule: the path matches `root:kedge:orgs:{single-segment}` (no second colon). Child team workspaces (`root:kedge:orgs:{org}:{ws}`) are explicitly **not** matched and remain tenant-accessible per design. Structural is cheaper than an annotation read on the hot path and correct because roadmap step 2 pins the invariant via `workspacetype-organization.yaml` + `Bootstrapper.EnsureOrgWorkspace`.
- **`extractClusterPathFromKCPPath`** pulls the cluster portion out of a `/clusters/{path}/...` URL so the gate can be applied after `resolveKCPPath` without re-parsing.
- **`writeOrgWorkspaceForbidden`** returns the standard `v1.Status` envelope (so kubectl renders the message nicely) with reason `OrgWorkspaceNotDirectlyAccessible` and a hint pointing at the hub REST surface so CLI tools can suggest the right endpoint.

### Gate insertion

| Serve path | Hook point |
|---|---|
| `serveOIDC` | After `resolveKCPPath`, before the ReverseProxy is built |
| `serveStaticToken` | Same shape, same point |
| `serveServiceAccount` | Directly after the clusterName regex check (no `resolveKCPPath` step). Defense in depth — SA tokens bound to an Org workspace shouldn't exist in v1, but the check costs nothing |

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean (`0 issues.`)
- [x] `go test ./pkg/server/proxy/...` — passes, 4 tests / 30+ sub-cases:
  - `TestIsOrgWorkspacePath` — 12 sub-cases (org matches, child non-matches, sibling workspaces, root, empty, degenerate).
  - `TestExtractClusterPathFromKCPPath` — 5 sub-cases for the `/clusters/{cluster}/{subpath}` variants.
  - `TestWriteOrgWorkspaceForbidden` — asserts 403, JSON envelope, reason, non-empty message.
  - Existing `TestResolveKCPPath` untouched.
- [ ] Manual smoke: `kubectl --server=https://kedge.example.com/clusters/root:kedge:orgs/abc-... get organization` should return the new 403 status with the OrgWorkspaceNotDirectlyAccessible reason.

## Out of scope (continues in roadmap step 6+)

- Tenant middleware (`X-Kedge-Org` / `X-Kedge-Workspace` header resolution) — roadmap step 6.
- Hub REST endpoints for Org / Membership / CatalogEntry CRUD — roadmap step 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
