### PR TITLE
hub: tenant middleware library (PR #6)

### DIFF
--- a/pkg/hub/tenant/context.go
+++ b/pkg/hub/tenant/context.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tenant implements the hub-side tenant middleware described in
+// docs/organizations.md §Switch the active context. It resolves the active
+// Organization + Workspace from request headers (X-Kedge-Org and
+// X-Kedge-Workspace), validates them against the caller's
+// UserMembershipIndex, and stuffs the resolved (user, orgUUID,
+// workspaceUUID, role) tuple into the request context for downstream
+// handlers to consume.
+//
+// PR #6 ships the middleware as a library only: the package exposes the
+// middleware + context helpers + the UserResolver / MembershipLookup
+// interfaces. Wiring it into actual /api/* routes lands in PR #10 when
+// the hub-mediated REST surface goes in.
+package tenant
+
+import (
+	"context"
+)
+
+// TenantContext captures the result of a successful pass through the
+// tenant middleware: the caller's User CR name plus the
+// Organization-Workspace-Role triple they're claiming via headers.
+//
+// WorkspaceUUID is empty for Org-scoped requests (the caller sent
+// X-Kedge-Org without X-Kedge-Workspace — valid for org-management
+// endpoints).
+type TenantContext struct {
+	// User is the metadata.name (UUID) of the caller's User CR.
+	User string
+
+	// OrgUUID is the metadata.name (UUID) of the caller's active
+	// Organization, taken from X-Kedge-Org. Always set in a successful
+	// TenantContext.
+	OrgUUID string
+
+	// WorkspaceUUID is the metadata.name (UUID) of the caller's active
+	// child Workspace, taken from X-Kedge-Workspace. Empty for
+	// Org-scoped requests.
+	WorkspaceUUID string
+
+	// Role is the granted role for the matching Membership: "admin" or
+	// "member". For Workspace-scoped requests this is the role from the
+	// workspace-scope Membership; for Org-scoped requests it is the
+	// role from the org-scope Membership. Validated against
+	// MembershipRole* constants in apis/tenancy/v1alpha1.
+	Role string
+}
+
+// contextKey is unexported so callers must use the helpers below to
+// read/write the TenantContext; this keeps the key namespace clean and
+// prevents accidental shadowing by other packages.
+type contextKey struct{}
+
+// WithContext returns a copy of ctx that carries tc. Used by the
+// middleware to attach the resolved triple before invoking the next
+// handler, and by tests to inject a synthetic TenantContext.
+func WithContext(ctx context.Context, tc TenantContext) context.Context {
+	return context.WithValue(ctx, contextKey{}, tc)
+}
+
+// FromContext returns the TenantContext attached to ctx by the
+// middleware, or (zero, false) if none is present. Handlers downstream
+// of the middleware can rely on ok=true. Handlers reachable without the
+// middleware should treat ok=false as "anonymous or unscoped" and
+// behave accordingly.
+func FromContext(ctx context.Context) (TenantContext, bool) {
+	tc, ok := ctx.Value(contextKey{}).(TenantContext)
+	return tc, ok
+}

--- a/pkg/hub/tenant/context_test.go
+++ b/pkg/hub/tenant/context_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenant
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithContext_RoundTrip(t *testing.T) {
+	tc := TenantContext{
+		User:          "alice",
+		OrgUUID:       "7f3a91d2",
+		WorkspaceUUID: "9c4b8e1f",
+		Role:          "admin",
+	}
+	ctx := WithContext(context.Background(), tc)
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("FromContext returned ok=false after WithContext")
+	}
+	if got != tc {
+		t.Errorf("FromContext: got %#v, want %#v", got, tc)
+	}
+}
+
+func TestFromContext_Absent(t *testing.T) {
+	got, ok := FromContext(context.Background())
+	if ok {
+		t.Errorf("FromContext on a bare ctx should return ok=false, got %#v", got)
+	}
+	if got != (TenantContext{}) {
+		t.Errorf("FromContext on a bare ctx should return zero value, got %#v", got)
+	}
+}
+
+// TestContextKey_Isolated ensures the context key is private to this
+// package: a value stored under a foreign key with the same content
+// shape doesn't satisfy FromContext, and vice-versa.
+func TestContextKey_Isolated(t *testing.T) {
+	type otherKey struct{}
+	ctx := context.WithValue(context.Background(), otherKey{}, TenantContext{User: "alice"})
+
+	if _, ok := FromContext(ctx); ok {
+		t.Errorf("FromContext should not return a TenantContext stored under a foreign key")
+	}
+}

--- a/pkg/hub/tenant/middleware.go
+++ b/pkg/hub/tenant/middleware.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+)
+
+const (
+	// HeaderKedgeOrg carries the active Organization UUID. Required for
+	// any endpoint mounted behind this middleware.
+	HeaderKedgeOrg = "X-Kedge-Org"
+
+	// HeaderKedgeWorkspace carries the active child Workspace UUID.
+	// Optional: Org-scoped endpoints can omit it; Workspace-scoped
+	// endpoints must include it (callers downstream of the middleware
+	// can branch on tc.WorkspaceUUID == "").
+	HeaderKedgeWorkspace = "X-Kedge-Workspace"
+)
+
+// ErrUserNotResolved is returned by a UserResolver when the request
+// carries no authenticated identity. The middleware translates this
+// into a 401 Unauthorized response.
+var ErrUserNotResolved = errors.New("tenant: caller is not authenticated")
+
+// UserResolver extracts the caller's User CR name from the request.
+// Implementations are typically thin wrappers over the hub's existing
+// auth layer (OIDC bearer-token validation, static-token lookups, or
+// kcp ServiceAccount claims).
+//
+// Returning ErrUserNotResolved signals "no authenticated identity"; the
+// middleware turns that into a 401. Any other error is treated as a
+// 500 because it indicates a backend failure rather than a missing
+// caller.
+type UserResolver interface {
+	ResolveUser(r *http.Request) (string, error)
+}
+
+// UserResolverFunc adapts a function to the UserResolver interface.
+type UserResolverFunc func(r *http.Request) (string, error)
+
+// ResolveUser implements UserResolver.
+func (f UserResolverFunc) ResolveUser(r *http.Request) (string, error) { return f(r) }
+
+// MembershipLookup reads the UserMembershipIndex CR for the named user.
+// Implementations typically wrap a Kubernetes/kcp dynamic or typed
+// client targeting root:kedge:users.
+//
+// Returning a Kubernetes "not found" error (apierrors.IsNotFound) is
+// the convention for "this user has no memberships yet" — the
+// middleware turns that into a 403 because the caller is authenticated
+// but holds no Memberships, which is functionally the same as "you
+// can't access this Org". Any other error is treated as a 500.
+type MembershipLookup interface {
+	GetUserMembershipIndex(ctx context.Context, userName string) (*tenancyv1alpha1.UserMembershipIndex, error)
+}
+
+// MembershipLookupFunc adapts a function to the MembershipLookup interface.
+type MembershipLookupFunc func(ctx context.Context, userName string) (*tenancyv1alpha1.UserMembershipIndex, error)
+
+// GetUserMembershipIndex implements MembershipLookup.
+func (f MembershipLookupFunc) GetUserMembershipIndex(ctx context.Context, userName string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+	return f(ctx, userName)
+}
+
+// Middleware returns the tenant-context HTTP middleware. The returned
+// function wraps an http.Handler chain so handlers downstream of it can
+// trust TenantContext from r.Context().
+//
+// The middleware performs these steps in order:
+//
+//  1. Calls userResolver to identify the caller. 401 on
+//     ErrUserNotResolved; 500 on any other error.
+//  2. Reads X-Kedge-Org; 400 if missing.
+//  3. Reads X-Kedge-Workspace (optional).
+//  4. Calls lookup to fetch UserMembershipIndex for the user. 403 on
+//     "not found"; 500 on other errors.
+//  5. Walks index.spec.entries looking for a (OrgUUID, WorkspaceUUID)
+//     match where WorkspaceUUID can be empty (org-scope request) or
+//     equal to the header value (workspace-scope request).
+//  6. On match, attaches a TenantContext via WithContext and invokes
+//     next; on no match, returns 403.
+//
+// The middleware is intentionally side-effect-free aside from setting
+// the request context. It does not mutate response headers (other than
+// on error) and does not impose a content-type.
+func Middleware(userResolver UserResolver, lookup MembershipLookup) func(next http.Handler) http.Handler {
+	if userResolver == nil {
+		panic("tenant.Middleware: userResolver is required")
+	}
+	if lookup == nil {
+		panic("tenant.Middleware: lookup is required")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Step 1: identify the caller.
+			user, err := userResolver.ResolveUser(r)
+			if err != nil {
+				if errors.Is(err, ErrUserNotResolved) {
+					writeStatus(w, http.StatusUnauthorized, "Unauthorized", "Unauthorized")
+					return
+				}
+				writeStatus(w, http.StatusInternalServerError, "InternalError", "failed to resolve caller identity: "+err.Error())
+				return
+			}
+
+			// Step 2: read X-Kedge-Org.
+			orgUUID := r.Header.Get(HeaderKedgeOrg)
+			if orgUUID == "" {
+				writeStatus(w, http.StatusBadRequest, "BadRequest", fmt.Sprintf("missing required header %q", HeaderKedgeOrg))
+				return
+			}
+			// Step 3: read X-Kedge-Workspace (optional).
+			workspaceUUID := r.Header.Get(HeaderKedgeWorkspace)
+
+			// Step 4: fetch UserMembershipIndex.
+			index, err := lookup.GetUserMembershipIndex(r.Context(), user)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					writeStatus(w, http.StatusForbidden, "Forbidden", "caller has no memberships")
+					return
+				}
+				writeStatus(w, http.StatusInternalServerError, "InternalError", "failed to look up memberships: "+err.Error())
+				return
+			}
+
+			// Step 5: find the matching entry.
+			role, ok := matchEntry(index, orgUUID, workspaceUUID)
+			if !ok {
+				if workspaceUUID == "" {
+					writeStatus(w, http.StatusForbidden, "Forbidden",
+						fmt.Sprintf("no membership found for user %q in Organization %q", user, orgUUID))
+				} else {
+					writeStatus(w, http.StatusForbidden, "Forbidden",
+						fmt.Sprintf("no membership found for user %q in Organization %q / Workspace %q", user, orgUUID, workspaceUUID))
+				}
+				return
+			}
+
+			// Step 6: attach context, invoke next.
+			tc := TenantContext{
+				User:          user,
+				OrgUUID:       orgUUID,
+				WorkspaceUUID: workspaceUUID,
+				Role:          role,
+			}
+			next.ServeHTTP(w, r.WithContext(WithContext(r.Context(), tc)))
+		})
+	}
+}
+
+// matchEntry walks index.spec.entries looking for the entry that
+// satisfies the request's (OrgUUID, WorkspaceUUID) combination. For
+// org-scope requests (WorkspaceUUID == "") it returns the role of the
+// org-scope Membership entry (the one with empty WorkspaceUUID); for
+// workspace-scope requests it returns the role of the matching
+// workspace-scope entry.
+//
+// Returns ("", false) when no entry matches.
+func matchEntry(index *tenancyv1alpha1.UserMembershipIndex, orgUUID, workspaceUUID string) (string, bool) {
+	if index == nil {
+		return "", false
+	}
+	for _, e := range index.Spec.Entries {
+		if e.OrgUUID != orgUUID {
+			continue
+		}
+		if e.WorkspaceUUID == workspaceUUID {
+			return e.Role, true
+		}
+	}
+	return "", false
+}
+
+// writeStatus emits a minimal Kubernetes Status envelope so kubectl /
+// other Kubernetes-aware tooling renders the error nicely while plain
+// HTTP clients still see a sensible JSON body. Reason follows the
+// existing kedge convention from pkg/server/proxy/proxy.go.
+func writeStatus(w http.ResponseWriter, code int, reason, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, _ = fmt.Fprintf(w,
+		`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":%q,"reason":%q,"code":%d}`,
+		message, reason, code,
+	)
+}

--- a/pkg/hub/tenant/middleware_test.go
+++ b/pkg/hub/tenant/middleware_test.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+)
+
+// fakeIndex is a small fixture builder for UserMembershipIndex.
+func fakeIndex(user string, entries ...tenancyv1alpha1.MembershipIndexEntry) *tenancyv1alpha1.UserMembershipIndex {
+	return &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: user},
+		Spec:       tenancyv1alpha1.UserMembershipIndexSpec{Entries: entries},
+	}
+}
+
+// captureNext returns an http.Handler that records the TenantContext
+// from the request and signals via the channel that it was reached.
+func captureNext(got *TenantContext, reached chan<- struct{}) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tc, ok := FromContext(r.Context()); ok {
+			*got = tc
+		}
+		close(reached)
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMiddleware_OrgScopeHappyPath(t *testing.T) {
+	user := "alice"
+	orgUUID := "org-uuid"
+	index := fakeIndex(user,
+		tenancyv1alpha1.MembershipIndexEntry{
+			OrgUUID: orgUUID,
+			Role:    tenancyv1alpha1.MembershipRoleAdmin,
+		},
+	)
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return user, nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, name string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		if name != user {
+			t.Fatalf("lookup called with %q, want %q", name, user)
+		}
+		return index, nil
+	})
+
+	var got TenantContext
+	reached := make(chan struct{}, 1)
+	h := Middleware(resolver, lookup)(captureNext(&got, reached))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/orgs/x/anything", nil)
+	req.Header.Set(HeaderKedgeOrg, orgUUID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-reached:
+	default:
+		t.Fatal("next handler was not invoked")
+	}
+	want := TenantContext{User: user, OrgUUID: orgUUID, Role: tenancyv1alpha1.MembershipRoleAdmin}
+	if got != want {
+		t.Errorf("TenantContext: got %#v, want %#v", got, want)
+	}
+}
+
+func TestMiddleware_WorkspaceScopeHappyPath(t *testing.T) {
+	user := "bob"
+	orgUUID := "org-uuid"
+	wsUUID := "ws-uuid"
+	index := fakeIndex(user,
+		tenancyv1alpha1.MembershipIndexEntry{
+			OrgUUID: orgUUID,
+			Role:    tenancyv1alpha1.MembershipRoleAdmin,
+		},
+		tenancyv1alpha1.MembershipIndexEntry{
+			OrgUUID:       orgUUID,
+			WorkspaceUUID: wsUUID,
+			Role:          tenancyv1alpha1.MembershipRoleMember,
+		},
+	)
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return user, nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return index, nil
+	})
+
+	var got TenantContext
+	reached := make(chan struct{}, 1)
+	h := Middleware(resolver, lookup)(captureNext(&got, reached))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/orgs/x/workspaces/y/anything", nil)
+	req.Header.Set(HeaderKedgeOrg, orgUUID)
+	req.Header.Set(HeaderKedgeWorkspace, wsUUID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-reached:
+	default:
+		t.Fatal("next handler was not invoked")
+	}
+	want := TenantContext{
+		User:          user,
+		OrgUUID:       orgUUID,
+		WorkspaceUUID: wsUUID,
+		Role:          tenancyv1alpha1.MembershipRoleMember,
+	}
+	if got != want {
+		t.Errorf("TenantContext: got %#v, want %#v", got, want)
+	}
+}
+
+func TestMiddleware_MissingOrgHeader(t *testing.T) {
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		t.Fatal("lookup should not be called when X-Kedge-Org is missing")
+		return nil, nil
+	})
+
+	nextCalled := false
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rec.Code)
+	}
+	if nextCalled {
+		t.Error("next handler should not be called on missing header")
+	}
+	assertStatusEnvelope(t, rec, "BadRequest", HeaderKedgeOrg)
+}
+
+func TestMiddleware_NoMatchingMembership(t *testing.T) {
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		// Index exists, but only carries an entry for a different Org.
+		return fakeIndex("alice",
+			tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "other-org", Role: tenancyv1alpha1.MembershipRoleAdmin},
+		), nil
+	})
+
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called on no-match")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set(HeaderKedgeOrg, "asked-for-org")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want 403", rec.Code)
+	}
+	assertStatusEnvelope(t, rec, "Forbidden", "asked-for-org")
+}
+
+func TestMiddleware_IndexNotFound(t *testing.T) {
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "tenancy.kedge.faros.sh", Resource: "usermembershipindices"}, "alice")
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return nil, notFound
+	})
+
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next should not be called when the index is not found")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set(HeaderKedgeOrg, "org")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want 403", rec.Code)
+	}
+	assertStatusEnvelope(t, rec, "Forbidden", "no memberships")
+}
+
+func TestMiddleware_LookupError(t *testing.T) {
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return nil, fmt.Errorf("kcp unreachable")
+	})
+
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next should not be called on lookup error")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set(HeaderKedgeOrg, "org")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status: got %d, want 500", rec.Code)
+	}
+	assertStatusEnvelope(t, rec, "InternalError", "kcp unreachable")
+}
+
+func TestMiddleware_Unauthenticated(t *testing.T) {
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "", ErrUserNotResolved })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		t.Fatal("lookup should not be called when caller is unauthenticated")
+		return nil, nil
+	})
+
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next should not be called when caller is unauthenticated")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set(HeaderKedgeOrg, "org") // header present but irrelevant
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", rec.Code)
+	}
+	assertStatusEnvelope(t, rec, "Unauthorized", "")
+}
+
+func TestMiddleware_ResolverInternalError(t *testing.T) {
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) {
+		return "", errors.New("kcp unreachable")
+	})
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		t.Fatal("lookup should not be called on resolver error")
+		return nil, nil
+	})
+
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next should not be called on resolver error")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set(HeaderKedgeOrg, "org")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status: got %d, want 500", rec.Code)
+	}
+}
+
+func TestMiddleware_NilResolverPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected Middleware(nil, lookup) to panic")
+		}
+	}()
+	_ = Middleware(nil, MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) { return nil, nil }))
+}
+
+func TestMiddleware_NilLookupPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected Middleware(resolver, nil) to panic")
+		}
+	}()
+	_ = Middleware(UserResolverFunc(func(_ *http.Request) (string, error) { return "a", nil }), nil)
+}
+
+func TestMatchEntry(t *testing.T) {
+	idx := fakeIndex("alice",
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "o1", Role: "admin"},
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "o2", WorkspaceUUID: "w1", Role: "member"},
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "o2", WorkspaceUUID: "w2", Role: "admin"},
+	)
+
+	cases := []struct {
+		name     string
+		orgUUID  string
+		wsUUID   string
+		wantRole string
+		wantOK   bool
+	}{
+		{"org-scope match (admin)", "o1", "", "admin", true},
+		{"org-scope on wrong org", "o2", "", "", false},
+		{"workspace-scope match (member)", "o2", "w1", "member", true},
+		{"workspace-scope match (admin)", "o2", "w2", "admin", true},
+		{"workspace-scope on wrong workspace", "o2", "w999", "", false},
+		{"unknown org", "ghost", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRole, gotOK := matchEntry(idx, tc.orgUUID, tc.wsUUID)
+			if gotOK != tc.wantOK || gotRole != tc.wantRole {
+				t.Errorf("matchEntry(_, %q, %q) = (%q, %v), want (%q, %v)", tc.orgUUID, tc.wsUUID, gotRole, gotOK, tc.wantRole, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestMatchEntry_NilIndex(t *testing.T) {
+	if _, ok := matchEntry(nil, "o", ""); ok {
+		t.Error("matchEntry(nil, _, _) should return ok=false")
+	}
+}
+
+// assertStatusEnvelope verifies the response body is a valid v1.Status
+// envelope and (optionally) that its message carries the expected
+// substring.
+func assertStatusEnvelope(t *testing.T, rec *httptest.ResponseRecorder, wantReason, wantMsgSubstr string) {
+	t.Helper()
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", got)
+	}
+	var status map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("body is not valid JSON: %v — body: %s", err, rec.Body.String())
+	}
+	if status["kind"] != "Status" || status["apiVersion"] != "v1" {
+		t.Errorf("envelope: got %#v, want v1.Status", status)
+	}
+	if wantReason != "" && status["reason"] != wantReason {
+		t.Errorf("reason: got %v, want %q", status["reason"], wantReason)
+	}
+	if wantMsgSubstr != "" {
+		msg, _ := status["message"].(string)
+		if !strings.Contains(msg, wantMsgSubstr) {
+			t.Errorf("message: %q does not contain %q", msg, wantMsgSubstr)
+		}
+	}
+}


### PR DESCRIPTION
**Roadmap step 6** of the multi-org tenancy roadmap in [docs/organizations.md §Implementation order](docs/organizations.md). Builds on #208 (step 5).

Ships the tenant-context middleware described in `§Switch the active context` + `§Tenant middleware`: it resolves the active Organization + Workspace from request headers, validates them against the caller's `UserMembershipIndex`, and attaches a `TenantContext` to `r.Context()` for downstream handlers.

**Library-only scope.** No `/api/*` routes are wired behind it yet — that lands in roadmap step 10 (portal switcher + REST endpoints). The "ship infrastructure, wire it later" split keeps this PR small and trivially reviewable, matching the #204 (step 1) pattern where the Organization controller landed before any consumers existed.

## Package layout

- **`pkg/hub/tenant/context.go`** — `TenantContext` struct + `WithContext` / `FromContext` helpers + a private context-key type so foreign values can't be confused for ours (covered by `TestContextKey_Isolated`).
- **`pkg/hub/tenant/middleware.go`** — `Middleware` factory + `UserResolver` and `MembershipLookup` interfaces. The interfaces are tiny so step 10 can plug in the hub's existing auth resolver + a kedgeclient-backed UMI lookup while tests use `UserResolverFunc` / `MembershipLookupFunc` adapters.

## Middleware semantics

1. `ResolveUser` → 401 on `ErrUserNotResolved`, 500 on other errors.
2. `X-Kedge-Org` → 400 if missing.
3. `X-Kedge-Workspace` → optional (org-scope vs. workspace-scope).
4. `GetUserMembershipIndex` → 403 on `apierrors.IsNotFound`, 500 on others.
5. `matchEntry` walks `index.spec.entries` looking for the matching `(OrgUUID, WorkspaceUUID)` pair. Workspace-scope requests require a workspace-scope entry; org-scope requests require an org-scope entry (empty `WorkspaceUUID`).
6. On match: attach `TenantContext`, invoke next. On miss: 403.

Error envelopes follow the `v1.Status` convention already in use across the codebase.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean (`0 issues.`)
- [x] `go test ./pkg/hub/tenant/...` — **13 tests / 19 sub-cases, all passing**:
  - Context plumbing round-trip + isolation.
  - Happy paths for org-scope and workspace-scope, asserting the attached `TenantContext`.
  - 400 on missing `X-Kedge-Org`; 403 on no matching membership.
  - 403 on `apierrors.IsNotFound` index lookup; 500 on other lookup errors.
  - 401 on `ErrUserNotResolved`; 500 on other resolver errors.
  - Constructor fail-fast on nil resolver / nil lookup.
  - `matchEntry` table-driven with 6 sub-cases.
- [ ] No production wiring to smoke yet — that lands in roadmap step 10.

## Out of scope (continues in subsequent roadmap steps)

| Roadmap step | What |
|---|---|
| 7 | Quota controllers (O-5 / O-6) |
| 8 | Soft-delete reconciler (O-8 / O-13) |
| 9 | ServiceAccount CRD + token endpoints (O-14) |
| 10 | Portal switcher UI + REST endpoints for Org/Workspace/Membership CRUD; wires this middleware on `/api/orgs/{org-uuid}/...` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
