### PR TITLE
hub: quota library for O-5 / O-6 (roadmap step 7)

### DIFF
--- a/pkg/hub/controllers/organization/controller.go
+++ b/pkg/hub/controllers/organization/controller.go
@@ -69,6 +69,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+	"github.com/faroshq/faros-kedge/pkg/hub/quota"
 )
 
 const (
@@ -236,6 +237,13 @@ func (r *Reconciler) createPersonalOrg(ctx context.Context, user *tenancyv1alpha
 			Name: orgUUID,
 			Labels: map[string]string{
 				labelPersonalOwner: user.Name,
+				// quota.LabelCreatedBy lets roadmap step 7's Org quota check
+				// (CheckOrgQuota) count Orgs by creator. Personal Orgs
+				// carry spec.personal=true and are filtered out at the
+				// Counter level, so labelling them here keeps the data
+				// model consistent across personal and non-personal Orgs
+				// without affecting the count.
+				quota.LabelCreatedBy: user.Name,
 			},
 		},
 		Spec: tenancyv1alpha1.OrganizationSpec{

--- a/pkg/hub/controllers/organization/controller_test.go
+++ b/pkg/hub/controllers/organization/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+	"github.com/faroshq/faros-kedge/pkg/hub/quota"
 )
 
 // fakeProvisioner is the test double for WorkspaceProvisioner. By default
@@ -133,6 +134,9 @@ func TestReconciler_CreatesPersonalOrgForNewUser(t *testing.T) {
 	}
 	if org.Labels[labelPersonalOwner] != "alice" {
 		t.Errorf("expected personal-owner label = alice, got %q", org.Labels[labelPersonalOwner])
+	}
+	if org.Labels[quota.LabelCreatedBy] != "alice" {
+		t.Errorf("expected created-by label = alice (for roadmap step 7 Org-quota counting), got %q", org.Labels[quota.LabelCreatedBy])
 	}
 	if want := orgWorkspaceParent + ":" + org.Name; org.Status.WorkspacePath != want {
 		t.Errorf("workspacePath: got %q, want %q", org.Status.WorkspacePath, want)

--- a/pkg/hub/quota/quota.go
+++ b/pkg/hub/quota/quota.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package quota implements the quota checks pinned by decisions O-5
+// (Org quota = soft cap, admin-overridable per User; default 10) and
+// O-6 (Workspace quota = soft cap, admin-overridable per Org; default 50)
+// in docs/organizations.md. The package is library-only: it exposes
+// constants, helpers, and a Counter interface so REST handlers
+// (roadmap step 10) and any future controller-side admission can run
+// the same check.
+//
+// Quota counting deliberately ignores Organizations created by the
+// hub's personal-Org bootstrap (spec.personal=true). Those are
+// auto-provisioned per User and shouldn't burn the user's
+// admin-overridable cap.
+package quota
+
+import (
+	"context"
+	"fmt"
+
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+)
+
+const (
+	// DefaultOrgsPerUser is the platform-wide soft cap on the number
+	// of Organizations a single User may create. Per O-5; overridable
+	// per User via User.spec.orgQuota (0 means use this default).
+	DefaultOrgsPerUser int32 = 10
+
+	// DefaultWorkspacesPerOrg is the platform-wide soft cap on the
+	// number of child Workspaces an Organization may hold. Per O-6;
+	// overridable per Org via Organization.spec.workspaceQuota (0
+	// means use this default).
+	DefaultWorkspacesPerOrg int32 = 50
+
+	// LabelCreatedBy records which User CR created a given Organization.
+	// Set at create time by the hub's Org-create endpoint (roadmap step 10)
+	// and by the personal-Org bootstrap controller (roadmap step 1+). Used
+	// here to count Orgs against the user's quota.
+	LabelCreatedBy = "tenancy.kedge.faros.sh/created-by"
+)
+
+// EffectiveOrgsPerUser returns the effective Org quota for the given
+// User. spec.orgQuota of 0 (the zero value) defers to the platform
+// default; a non-zero value overrides it.
+func EffectiveOrgsPerUser(user *tenancyv1alpha1.User) int32 {
+	if user == nil || user.Spec.OrgQuota == 0 {
+		return DefaultOrgsPerUser
+	}
+	return user.Spec.OrgQuota
+}
+
+// EffectiveWorkspacesPerOrg returns the effective Workspace quota for
+// the given Organization. spec.workspaceQuota of 0 defers to the
+// platform default; a non-zero value overrides it.
+func EffectiveWorkspacesPerOrg(org *tenancyv1alpha1.Organization) int32 {
+	if org == nil || org.Spec.WorkspaceQuota == 0 {
+		return DefaultWorkspacesPerOrg
+	}
+	return org.Spec.WorkspaceQuota
+}
+
+// Counter is the minimal interface the quota checks consume. The
+// caller supplies a Counter whose Count method returns the current
+// usage; the quota check compares against the cap and returns
+// QuotaExceededError when usage >= cap.
+//
+// Pulling the count behind an interface keeps the package
+// dependency-free of the kedge / kcp clientsets so the helpers can be
+// unit-tested with a literal fakeCounter (see quota_test.go) and the
+// production wiring picks the appropriate listing strategy at the
+// call site.
+type Counter interface {
+	Count(ctx context.Context) (int32, error)
+}
+
+// CounterFunc adapts a function to the Counter interface.
+type CounterFunc func(ctx context.Context) (int32, error)
+
+// Count implements Counter.
+func (f CounterFunc) Count(ctx context.Context) (int32, error) { return f(ctx) }
+
+// QuotaExceededError is returned by the Check* helpers when the
+// supplied Counter reports usage at or above the effective cap. Carries
+// structured fields so REST handlers (roadmap step 10) can map it to
+// a 409 Conflict (or 4xx of choice) with a machine-readable hint.
+//
+// The kind field describes what is being capped ("Organization" or
+// "Workspace"). Owner identifies the parent (User name for Org quota;
+// Organization UUID for Workspace quota).
+type QuotaExceededError struct {
+	Kind  string
+	Owner string
+	Count int32
+	Cap   int32
+}
+
+// Error implements the error interface.
+func (e *QuotaExceededError) Error() string {
+	return fmt.Sprintf("quota exceeded: %s for %q at %d/%d", e.Kind, e.Owner, e.Count, e.Cap)
+}
+
+// CheckOrgQuota verifies the User has not reached their Org-creation
+// cap. It calls counter.Count(ctx) to read current usage, then
+// compares against EffectiveOrgsPerUser(user).
+//
+//   - Returns nil when usage < cap.
+//   - Returns a *QuotaExceededError when usage >= cap.
+//   - Returns the Counter's error verbatim on count failure.
+//
+// Personal Organizations created by the bootstrap controller are
+// expected to be excluded by the Counter implementation (the Counter
+// caller filters by spec.personal=false). The package does not enforce
+// that filter on its own to keep the abstraction tight; the
+// "Organizations counted exclude spec.personal=true" rule is part of
+// the Counter contract.
+func CheckOrgQuota(ctx context.Context, user *tenancyv1alpha1.User, counter Counter) error {
+	if counter == nil {
+		return fmt.Errorf("quota: counter is required")
+	}
+	count, err := counter.Count(ctx)
+	if err != nil {
+		return fmt.Errorf("quota: counting Organizations: %w", err)
+	}
+	cap := EffectiveOrgsPerUser(user)
+	if count >= cap {
+		ownerName := ""
+		if user != nil {
+			ownerName = user.Name
+		}
+		return &QuotaExceededError{
+			Kind:  "Organization",
+			Owner: ownerName,
+			Count: count,
+			Cap:   cap,
+		}
+	}
+	return nil
+}
+
+// CheckWorkspaceQuota verifies the Organization has not reached its
+// Workspace-creation cap. Same contract as CheckOrgQuota.
+func CheckWorkspaceQuota(ctx context.Context, org *tenancyv1alpha1.Organization, counter Counter) error {
+	if counter == nil {
+		return fmt.Errorf("quota: counter is required")
+	}
+	count, err := counter.Count(ctx)
+	if err != nil {
+		return fmt.Errorf("quota: counting Workspaces: %w", err)
+	}
+	cap := EffectiveWorkspacesPerOrg(org)
+	if count >= cap {
+		ownerName := ""
+		if org != nil {
+			ownerName = org.Name
+		}
+		return &QuotaExceededError{
+			Kind:  "Workspace",
+			Owner: ownerName,
+			Count: count,
+			Cap:   cap,
+		}
+	}
+	return nil
+}

--- a/pkg/hub/quota/quota_test.go
+++ b/pkg/hub/quota/quota_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+)
+
+func TestEffectiveOrgsPerUser(t *testing.T) {
+	cases := []struct {
+		name string
+		user *tenancyv1alpha1.User
+		want int32
+	}{
+		{"nil user uses default", nil, DefaultOrgsPerUser},
+		{"zero override uses default", &tenancyv1alpha1.User{Spec: tenancyv1alpha1.UserSpec{OrgQuota: 0}}, DefaultOrgsPerUser},
+		{"override of 1 wins", &tenancyv1alpha1.User{Spec: tenancyv1alpha1.UserSpec{OrgQuota: 1}}, 1},
+		{"override of 25 wins", &tenancyv1alpha1.User{Spec: tenancyv1alpha1.UserSpec{OrgQuota: 25}}, 25},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EffectiveOrgsPerUser(tc.user); got != tc.want {
+				t.Errorf("EffectiveOrgsPerUser: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveWorkspacesPerOrg(t *testing.T) {
+	cases := []struct {
+		name string
+		org  *tenancyv1alpha1.Organization
+		want int32
+	}{
+		{"nil org uses default", nil, DefaultWorkspacesPerOrg},
+		{"zero override uses default", &tenancyv1alpha1.Organization{Spec: tenancyv1alpha1.OrganizationSpec{WorkspaceQuota: 0}}, DefaultWorkspacesPerOrg},
+		{"override of 5 wins", &tenancyv1alpha1.Organization{Spec: tenancyv1alpha1.OrganizationSpec{WorkspaceQuota: 5}}, 5},
+		{"override of 200 wins", &tenancyv1alpha1.Organization{Spec: tenancyv1alpha1.OrganizationSpec{WorkspaceQuota: 200}}, 200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EffectiveWorkspacesPerOrg(tc.org); got != tc.want {
+				t.Errorf("EffectiveWorkspacesPerOrg: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckOrgQuota(t *testing.T) {
+	user := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice"},
+	}
+	overrideUser := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "bob"},
+		Spec:       tenancyv1alpha1.UserSpec{OrgQuota: 3},
+	}
+
+	t.Run("under default cap permits create", func(t *testing.T) {
+		err := CheckOrgQuota(context.Background(), user, CounterFunc(func(_ context.Context) (int32, error) { return 9, nil }))
+		if err != nil {
+			t.Errorf("under cap: got error %v, want nil", err)
+		}
+	})
+	t.Run("at default cap rejects with quota-exceeded", func(t *testing.T) {
+		err := CheckOrgQuota(context.Background(), user, CounterFunc(func(_ context.Context) (int32, error) { return DefaultOrgsPerUser, nil }))
+		var qe *QuotaExceededError
+		if !errors.As(err, &qe) {
+			t.Fatalf("at cap: got error %v, want *QuotaExceededError", err)
+		}
+		if qe.Kind != "Organization" || qe.Owner != "alice" || qe.Count != DefaultOrgsPerUser || qe.Cap != DefaultOrgsPerUser {
+			t.Errorf("error fields: %#v", qe)
+		}
+		if !strings.Contains(qe.Error(), "Organization") || !strings.Contains(qe.Error(), `"alice"`) {
+			t.Errorf("error message: %q", qe.Error())
+		}
+	})
+	t.Run("at admin override rejects", func(t *testing.T) {
+		err := CheckOrgQuota(context.Background(), overrideUser, CounterFunc(func(_ context.Context) (int32, error) { return 3, nil }))
+		var qe *QuotaExceededError
+		if !errors.As(err, &qe) {
+			t.Fatalf("override at cap: got error %v, want *QuotaExceededError", err)
+		}
+		if qe.Cap != 3 {
+			t.Errorf("override cap: got %d, want 3", qe.Cap)
+		}
+	})
+	t.Run("counter error propagates", func(t *testing.T) {
+		boom := errors.New("kcp unreachable")
+		err := CheckOrgQuota(context.Background(), user, CounterFunc(func(_ context.Context) (int32, error) { return 0, boom }))
+		if !errors.Is(err, boom) {
+			t.Errorf("counter error: got %v, want wrapping %v", err, boom)
+		}
+		var qe *QuotaExceededError
+		if errors.As(err, &qe) {
+			t.Errorf("counter error should not be classified as QuotaExceeded")
+		}
+	})
+	t.Run("nil counter rejected", func(t *testing.T) {
+		err := CheckOrgQuota(context.Background(), user, nil)
+		if err == nil {
+			t.Error("nil counter: expected error, got nil")
+		}
+	})
+	t.Run("nil user uses default cap", func(t *testing.T) {
+		err := CheckOrgQuota(context.Background(), nil, CounterFunc(func(_ context.Context) (int32, error) { return DefaultOrgsPerUser, nil }))
+		var qe *QuotaExceededError
+		if !errors.As(err, &qe) {
+			t.Fatalf("nil user at cap: got %v, want *QuotaExceededError", err)
+		}
+		if qe.Owner != "" {
+			t.Errorf("nil user owner: got %q, want empty", qe.Owner)
+		}
+	})
+}
+
+func TestCheckWorkspaceQuota(t *testing.T) {
+	org := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "7f3a-acme"},
+	}
+
+	t.Run("under default cap permits create", func(t *testing.T) {
+		err := CheckWorkspaceQuota(context.Background(), org, CounterFunc(func(_ context.Context) (int32, error) { return 0, nil }))
+		if err != nil {
+			t.Errorf("under cap: got %v, want nil", err)
+		}
+	})
+	t.Run("at default cap rejects", func(t *testing.T) {
+		err := CheckWorkspaceQuota(context.Background(), org, CounterFunc(func(_ context.Context) (int32, error) { return DefaultWorkspacesPerOrg, nil }))
+		var qe *QuotaExceededError
+		if !errors.As(err, &qe) {
+			t.Fatalf("at cap: got %v, want *QuotaExceededError", err)
+		}
+		if qe.Kind != "Workspace" || qe.Owner != "7f3a-acme" {
+			t.Errorf("error fields: %#v", qe)
+		}
+	})
+	t.Run("counter error propagates", func(t *testing.T) {
+		boom := errors.New("listing failed")
+		err := CheckWorkspaceQuota(context.Background(), org, CounterFunc(func(_ context.Context) (int32, error) { return 0, boom }))
+		if !errors.Is(err, boom) {
+			t.Errorf("counter error: got %v, want wrapping %v", err, boom)
+		}
+	})
+	t.Run("nil counter rejected", func(t *testing.T) {
+		if err := CheckWorkspaceQuota(context.Background(), org, nil); err == nil {
+			t.Error("expected nil-counter error")
+		}
+	})
+}
+
+func TestQuotaExceededError_AsTarget(t *testing.T) {
+	// Demonstrates the intended usage pattern: handlers use errors.As
+	// to switch on the structured fields. Guards against future
+	// refactors that might change the error's pointer receiver.
+	err := error(&QuotaExceededError{Kind: "Organization", Owner: "alice", Count: 10, Cap: 10})
+	var qe *QuotaExceededError
+	if !errors.As(err, &qe) {
+		t.Fatal("errors.As failed on a literal QuotaExceededError")
+	}
+	if qe.Kind != "Organization" || qe.Cap != 10 {
+		t.Errorf("As-target fields: %#v", qe)
+	}
+}


### PR DESCRIPTION
**Roadmap step 7** of the multi-org tenancy roadmap in [docs/organizations.md §Implementation order](docs/organizations.md). Builds on #209 (step 6).

Ships the **quota library** that backs decisions O-5 (Orgs/User: default 10, admin-overridable via `User.spec.orgQuota`) and O-6 (Workspaces/Org: default 50, overridable via `Organization.spec.workspaceQuota`).

**Library-only scope.** No quota gate is wired into the personal-Org bootstrap path (it only ever creates 1 Org per User and personal Orgs are exempt from the cap anyway). The first consumer is **roadmap step 10**'s `POST /api/orgs` and `POST /api/orgs/{uuid}/workspaces` endpoints, which run `CheckOrgQuota` / `CheckWorkspaceQuota` before creating.

## Package layout

- **`pkg/hub/quota/quota.go`**:
  - `DefaultOrgsPerUser = 10`, `DefaultWorkspacesPerOrg = 50` (O-5, O-6 platform defaults).
  - `LabelCreatedBy = "tenancy.kedge.faros.sh/created-by"` — recorded on every Organization at create time so the future Counter can count Orgs by creator.
  - `EffectiveOrgsPerUser(*User)` / `EffectiveWorkspacesPerOrg(*Organization)` — return the effective cap (override if non-zero, default otherwise; nil-safe).
  - `Counter` interface + `CounterFunc` adapter — the only dependency the package takes. Callers supply a Counter that does the appropriate List + filter; the package stays dependency-free of the kedge / kcp clientsets.
  - `CheckOrgQuota` / `CheckWorkspaceQuota` — compute the effective cap, call `Counter.Count`, return `*QuotaExceededError` when usage ≥ cap or the wrapped Counter error on count failure.
  - `QuotaExceededError` — `{Kind, Owner, Count, Cap}` structured so step 10's REST handlers can map it to a 409 Conflict with a machine-readable hint.

## Bootstrap controller bump

The personal-Org create path in `pkg/hub/controllers/organization/controller.go` now stamps `tenancy.kedge.faros.sh/created-by: {userName}` on every personal Organization. Personal Orgs carry `spec.personal=true` and are filtered out at the Counter level (the "Organizations counted exclude `spec.personal=true`" rule is part of the Counter contract), so labeling them here doesn't burn the user's cap — it just keeps the data model uniform across personal and non-personal Orgs so step 10's REST endpoint can use a single Counter implementation.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean (`0 issues.`)
- [x] `go test ./pkg/hub/quota/...` — **5 test funcs / 18 sub-cases, all passing**:
  - `TestEffectiveOrgsPerUser` / `TestEffectiveWorkspacesPerOrg` — table-driven, 4 sub-cases each (nil receiver, zero override, two non-zero overrides).
  - `TestCheckOrgQuota` — 6 sub-cases (under cap, at default cap, at admin override, counter error propagation, nil counter, nil user with default cap).
  - `TestCheckWorkspaceQuota` — 4 sub-cases (under cap, at cap, counter error, nil counter).
  - `TestQuotaExceededError_AsTarget` — guards `errors.As` usability.
- [x] `go test ./pkg/hub/controllers/organization/...` — the existing happy-path test now also asserts the new `created-by` label.

## Out of scope (continues in subsequent roadmap steps)

| Roadmap step | What |
|---|---|
| 8 | Soft-delete reconciler (O-8 / O-13) |
| 9 | ServiceAccount CRD + token endpoints (O-14) |
| 10 | Portal switcher UI + REST endpoints; wires `CheckOrgQuota` into `POST /api/orgs` and `CheckWorkspaceQuota` into `POST /api/orgs/{uuid}/workspaces` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
