### PR TITLE
hub: ServiceAccount REST endpoints (roadmap step 9 / O-14)

### DIFF
--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -58,7 +58,7 @@ Don't re-litigate; the doc body assumes these.
 | O-11 | **Workspace initializers must be idempotent + self-healing.** Every initializer checks for existing CRs/RBAC before creating; a post-init reconciler verifies all expected state exists before treating the Org/Workspace as fully provisioned. Failed initializers retry forever; the reconciler is the safety net. | kcp initializers are async with no rollback (verified). Without this rule a partial init leaves silent breakage that surfaces only when a tenant hits 403. |
 | O-12 | **Self-leave Org + multiple admins via Membership.role PATCH.** `DELETE /api/orgs/{uuid}/memberships/me` lets a member remove themselves (O-9 sole-admin/child-Workspace blocks still apply, so they must hand off first). Any Org admin can PATCH another Membership.role between `member` and `admin`; multiple admins are allowed. No separate "transfer ownership" endpoint. | Matches GitHub Orgs. Promotion + sole-admin block together cover the handoff case. |
 | O-13 | **Soft delete with 30-day grace for both Org and Workspace** (symmetric with O-8). `DELETE /api/orgs/{uuid}` sets `Organization.status.deletionRequestedAt`; same for Workspace. Hidden from switchers immediately, recoverable inside the window via `POST .../undelete`. After grace expires the cascade controller removes child Workspaces/Memberships/CatalogEntries/APIBindings/edges/etc. | One number (30 days) for every soft-delete. Recovery for accidental deletes. Carries cost (state lingers) — acceptable. |
-| O-14 | **ServiceAccount CR scoped to one Workspace** for non-human/CI access. Lives in a child Workspace; admins create via `POST /api/orgs/{org}/workspaces/{ws}/serviceaccounts`. Each SA has a token issued/rotated via the hub. Role is `admin` or `member`, same enum as `Membership.role`. Bot identities don't conflate with human Users. | Real platform users will run CI against Workspaces from day one; PATs on humans tie a person's lifecycle to a bot's. |
+| O-14 | **ServiceAccounts = native kube `core/v1.ServiceAccount`s in the child Workspace**, marked with kedge annotations. No wrapping CRD. Admins create via `POST /api/orgs/{org}/workspaces/{ws}/serviceaccounts`; the hub writes the kube SA + a `ClusterRoleBinding` mapping `system:serviceaccount:default:<sa-name>` → `kedge:workspace:admin` or `kedge:workspace:member`. Tokens are minted via the kube TokenRequest API and returned once; revoke = delete the SA (kills all its tokens; CRB GCs via owner ref). Role is `admin` or `member`, same enum as `Membership.role`. Bot identities don't conflate with human Users. | Real platform users will run CI against Workspaces from day one; PATs on humans tie a person's lifecycle to a bot's. Reusing kube SAs avoids a custom JWT signing path, validates tokens natively, and lets the workspace cascade kill SAs for free. |
 | O-15 | **Org admin has implicit admin in every child Workspace.** No "private from Org admin" Workspace in v1. Document loudly in onboarding so users understand the privacy boundary is the Org, not the Workspace. | Simplest mental model, matches GitHub Orgs default, makes audit/compliance straightforward. Sensitive teams should use a separate Org, not a private Workspace. |
 
 ---
@@ -176,24 +176,48 @@ kind: WorkspaceType
 metadata:
   name: workspace
 spec:
-  defaultAPIBindings:
-    - path: root:kedge:providers
-      export: tenancy.kedge.faros.sh   # Membership only (no Org/CatalogEntry)
+  # Deliberately NO `extend: universal` and NO defaultAPIBindings.
+  # Universal would pull tenancy.kcp.io + topology.kcp.io into the
+  # tenant's view, letting them spawn arbitrary child workspaces.
+  # tenancy.kedge.faros.sh (Membership / Organization / User / UMI)
+  # is a kedge-system surface and stays invisible to tenants.
   limitAllowedParents:
     types:
       - { path: root:kedge, name: organization }
   limitAllowedChildren:
     none: true                          # v1: workspaces are leaves
-  initializer: true
 ```
 
-Initializer adds the creating user as `Membership` scope=`workspace`,
-role=`admin`.
+Trade-off: dropping `extend: universal` means kcp does NOT auto-create
+a `default` namespace. The org-bootstrap controller compensates by
+creating one inside the child workspace right after it adds the kedge
+APIBinding (so tenant kubectl with no `-n` still works).
 
-Per P-4 in [provider-scoping.md](./provider-scoping.md), nothing else is
-auto-bound — not provider APIExports, not kedge `core.faros.sh`. Every
-API a Workspace consumes (including builtins like edges, mcp,
-server-edges) requires an explicit Enable that creates an APIBinding.
+The bootstrap controller (`pkg/hub/controllers/organization`) drives
+all post-create wiring — there is no kcp initializer:
+
+1. **kedge `core.faros.sh` APIBinding** with the permission claims
+   tenants need (secrets, namespaces, configmaps, serviceaccounts,
+   clusterroles, clusterrolebindings — explicitly NOT tenancy.kcp.io).
+2. **Default `default` namespace**, post-binding.
+3. **Cluster-admin `ClusterRoleBinding`** for the User's
+   `rbacIdentity`.
+4. **Default `MCPServer` CR**, so the user has a working MCP endpoint
+   out of the box.
+5. **`User.spec.DefaultCluster`** patched to the workspace's kcp
+   logical-cluster short hash (the form kubectl addresses by).
+
+Per P-4 in [provider-scoping.md](./provider-scoping.md), no provider
+APIExports are auto-bound; every builtin (edges, mcp, server-edges)
+requires an explicit Enable that creates an APIBinding.
+
+Workspace-scope `Membership` CRs intentionally do NOT exist in the
+tenant Workspace — the tenancy CRDs aren't bound there. The
+workspace-scope `UserMembershipIndex` entry written to the user's
+UMI at `root:kedge:users` is the canonical view for the portal
+switcher. Manual workspace-membership management (add/remove other
+users) lands later via a hub-mediated REST API rather than direct CR
+writes.
 
 ---
 
@@ -327,13 +351,25 @@ type MembershipIndexEntry struct {
     WorkspaceDisplayName string    `json:"workspaceDisplayName,omitempty"`
     Role               string      `json:"role"`               // admin | member
     Personal           bool        `json:"personal,omitempty"` // mirrors Organization.spec.personal
+
+    // SoftDeletedAt is set by the soft-delete reconciler (O-8 / O-13)
+    // while the referenced Org or Workspace is inside its 30-day grace
+    // window. The portal switcher hides entries with this field set so
+    // a member can't navigate into a workspace that's pending cascade.
+    SoftDeletedAt *metav1.Time `json:"softDeletedAt,omitempty"`
 }
 ```
 
 The Membership controller updates this index on Membership add/remove
 and on Org/Workspace displayName patches. The portal reads exactly one
 object per logged-in user to render the switcher (per O-4, the
-secondary line carries `OrgCreatedAt` + `OrgFirstAdmin`).
+secondary line carries `OrgCreatedAt` + `OrgFirstAdmin`); rows with
+`SoftDeletedAt` set are hidden client-side.
+
+The soft-delete reconciler ([pkg/hub/controllers/softdelete](../pkg/hub/controllers/softdelete))
+owns the `SoftDeletedAt` marker; the bootstrap controller preserves
+it across re-writes via an `entriesEqual` carve-out so the two
+controllers don't fight.
 
 ---
 
@@ -495,14 +531,20 @@ delete cascade (O-8).
 `DELETE /api/orgs/{org-uuid}/workspaces/{ws-uuid}` — soft-delete with
 30-day grace.
 
-1. Hub sets `Workspace.status.deletionRequestedAt = now()`.
-   Requires caller is Workspace admin or Org admin (O-15).
+1. Hub sets the
+   `tenancy.kedge.faros.sh/deletion-requested-at` annotation (RFC3339)
+   on the kcp Workspace. We don't extend kcp's `Workspace` CRD; an
+   annotation IS the source of truth. Requires caller is Workspace
+   admin or Org admin (O-15).
 2. The Workspace disappears from member switchers; existing
    exec-credentials targeting it stop being minted.
-3. Inside the window, `POST .../undelete` restores it.
-4. After 30 days, the cascade controller deletes all APIBindings,
-   tenant objects (edges, MCP instances, ServiceAccounts, …),
-   Memberships, then the kcp Workspace itself.
+3. Inside the window, `POST .../undelete` clears the annotation.
+4. After 30 days, the soft-delete reconciler
+   ([pkg/hub/controllers/softdelete](../pkg/hub/controllers/softdelete))
+   deletes the kcp Workspace — which cascades the namespace and
+   everything inside it (APIBindings, tenant objects like edges /
+   MCP instances / kube ServiceAccounts, RBAC) — and strips the
+   workspace-scope UMI rows for every member.
 
 The cascade controller logs the count of objects being deleted in
 each phase so an operator inspecting the audit log can see what was
@@ -512,65 +554,94 @@ lost.
 
 ## ServiceAccounts and tokens (O-14)
 
-Bots and CI pipelines authenticate as `ServiceAccount` CRs scoped to
-exactly one child Workspace. They are not Users; they do not appear in
-the User CR list or in Memberships.
+Bots and CI pipelines authenticate as kube `core/v1.ServiceAccount`s
+living in the child Workspace's `default` namespace, marked with kedge
+annotations. They are not Users; they do not appear in the User CR
+list or in Memberships.
 
-### `ServiceAccount` (workspace-scoped, `tenancy.kedge.faros.sh`)
+There is **no wrapping kedge CRD**. The kube SA itself, plus a few
+annotations and one ClusterRoleBinding, is the entire surface. This
+keeps the GVR count down, reuses native kube token issuance + token
+validation, and lets the workspace cascade kill SAs (and their
+tokens) without extra plumbing.
 
-```go
-type ServiceAccount struct {
-    metav1.TypeMeta
-    metav1.ObjectMeta  // metadata.name = server-assigned UUID; spec.displayName carries the label
+### Storage layout
 
-    Spec   ServiceAccountSpec
-    Status ServiceAccountStatus
-}
+A kedge ServiceAccount is exactly:
 
-type ServiceAccountSpec struct {
-    DisplayName string `json:"displayName"`
-
-    // Role grants admin or member in the parent Workspace, mirroring
-    // Membership.role.
-    // +kubebuilder:validation:Enum=admin;member
-    Role string `json:"role"`
-}
-
-type ServiceAccountStatus struct {
-    // LastTokenIssuedAt is set by the token-issuance endpoint and
-    // used by the rotation reminder UI.
-    LastTokenIssuedAt *metav1.Time `json:"lastTokenIssuedAt,omitempty"`
-
-    Conditions []metav1.Condition `json:"conditions,omitempty"`
-}
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # name is the UUID assigned by the hub; admin never picks it
+  name: 7d4e5b1c-…
+  namespace: default            # child Workspace's default ns (created by bootstrap)
+  labels:
+    tenancy.kedge.faros.sh/kedge-sa: "true"   # cheap listing selector
+  annotations:
+    tenancy.kedge.faros.sh/display-name: "ci-bot"
+    tenancy.kedge.faros.sh/role: "admin"      # admin | member
+    tenancy.kedge.faros.sh/last-token-issued-at: "2026-06-01T08:30:00Z"
 ```
 
-ServiceAccounts live in the child Workspace, written by the hub.
-Workspace admin and Org admin both have permission to create them
-(per O-15).
+Plus, in the same Workspace, a `ClusterRoleBinding` (owned by the SA
+via ownerReferences so it cascades on delete) mapping
+`system:serviceaccount:default:<sa-name>` to either
+`kedge:workspace:admin` or `kedge:workspace:member` — the same
+ClusterRoles human Users land on.
+
+Naming: `metadata.name` is a UUID, mirroring O-1's
+"identity = UUID; displayName is metadata" rule everywhere else in
+the doc. The annotation `tenancy.kedge.faros.sh/display-name` carries
+the human-facing label and is editable.
+
+Workspace admin and Org admin both have permission to create
+ServiceAccounts (per O-15). The hub uses its own privileged config
+(same as for Membership writes) to create the SA + CRB; tenants
+themselves never reach the kube SA API in the Workspace through any
+kedge code path.
 
 ### Endpoints
 
 ```
 POST   /api/orgs/{org}/workspaces/{ws}/serviceaccounts                       create SA (UUID assigned)
 GET    /api/orgs/{org}/workspaces/{ws}/serviceaccounts                       list SAs in this Workspace
-DELETE /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa-uuid}             delete
+DELETE /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa-uuid}             delete (cascades CRB + tokens)
 POST   /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa-uuid}/tokens      issue/rotate token; returns the only copy
-DELETE /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa-uuid}/tokens      revoke
+DELETE /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa-uuid}/tokens      revoke (deletes + recreates the SA)
+PATCH  /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa-uuid}             role patch + displayName patch
 ```
 
-Token issuance returns the credential exactly once (no Get endpoint
-to retrieve it later — admins must store it themselves; lost tokens
-require a rotation). Tokens carry the SA's `role` and Workspace UUID
-as claims; the kedge kcp proxy honors them the same way it honors
-User OIDC tokens.
+`POST .../tokens` calls the kube `TokenRequest` API against the SA
+with a fixed audience (`kedge`) and a default 1-year expiry; the
+response carries the token exactly once and the hub stamps
+`last-token-issued-at` on the SA. There is no Get endpoint — admins
+store the token themselves; lost tokens require a rotation.
+
+`DELETE .../tokens` is the "revoke everything" knob: the kube SA is
+deleted and immediately recreated under the same UUID + annotations +
+CRB. All previously-issued tokens become invalid in one shot. (kube
+SAs sign tokens with a per-SA secret-derived key; recreating the SA
+invalidates them.)
+
+`PATCH` accepts `role` and / or `displayName`. Role changes rewrite
+the CRB (delete + recreate with the new role-binding).
+
+### Wire-through to the proxy
+
+kedge proxy at [pkg/server/proxy/proxy.go](../pkg/server/proxy/proxy.go)
+already passes `Authorization: Bearer …` through unchanged once the
+caller has resolved a workspace. kube SA tokens go through the same
+path; kcp validates them natively at the kube layer, the CRB above
+gives them their role. No new proxy code path required for v1.
 
 ### Lifecycle
 
 - ServiceAccount belongs to its Workspace. Workspace soft-delete /
-  cascade also takes the SA and revokes outstanding tokens.
-- An SA's `role` can be patched the same way Membership.role is
-  patched.
+  cascade deletes the kube Workspace, which deletes the namespace,
+  which deletes the SA + the CRB + the bound tokens. No extra wiring
+  in the soft-delete reconciler.
+- An SA's `role` can be patched via the PATCH endpoint above.
 - Sole-admin block (O-9, O-12) ignores ServiceAccounts — they are
   not Users; an Org / Workspace cannot be "owned" by a SA.
 
@@ -676,8 +747,13 @@ Ten PRs:
 8. **Soft-delete reconciler (O-8, O-13).** One controller covering
    User, Org, and Workspace deletion: tracks `deletionRequestedAt`,
    honors undelete inside the 30-day window, runs the cascade after.
-9. **`ServiceAccount` CRD + token endpoints (O-14).** Bot identity
-   surface for Workspaces, with the once-only token-issuance flow.
+9. **ServiceAccount REST endpoints (O-14).** Bot identity surface for
+   Workspaces — kube `core/v1.ServiceAccount`s in the child Workspace's
+   `default` namespace, marked with kedge annotations + a
+   `ClusterRoleBinding` to `kedge:workspace:admin|member`. Tokens are
+   issued via the kube TokenRequest API and returned once. No new CRD;
+   no custom signing path; workspace soft-delete naturally cascades the
+   SA and its tokens.
 10. **Portal switcher UI + REST endpoints** for Org/Workspace/Membership
     CRUD (the hub-mediated surface from O-10), including the
     `?cascade=true` shortcut from O-9, self-leave (O-12), role PATCH

--- a/pkg/client/dynamic.go
+++ b/pkg/client/dynamic.go
@@ -62,6 +62,16 @@ var (
 		Version:  "v1alpha1",
 		Resource: "users",
 	}
+
+	// UserMembershipIndexGVR points at the cluster-scoped UMI CRD
+	// (see apis/tenancy/v1alpha1/types_user_membership_index.go).
+	// One UMI per User; the tenant middleware reads this on every
+	// request to authorise (Org, Workspace) header pairs.
+	UserMembershipIndexGVR = schema.GroupVersionResource{
+		Group:    "tenancy.kedge.faros.sh",
+		Version:  "v1alpha1",
+		Resource: "usermembershipindices",
+	}
 )
 
 // Client provides typed access to kedge custom resources via the dynamic client.
@@ -113,6 +123,16 @@ func (c *Client) Placements(namespace string) *TypedResource[kedgev1alpha1.Place
 func (c *Client) Users() *TypedResource[tenancyv1alpha1.User, tenancyv1alpha1.UserList] {
 	return &TypedResource[tenancyv1alpha1.User, tenancyv1alpha1.UserList]{
 		client: c.dynamic.Resource(UserGVR),
+	}
+}
+
+// UserMembershipIndices returns a typed interface for the UMI CRD
+// (cluster-scoped). One UMI per User; the tenant middleware uses
+// this to authorise X-Kedge-Org / X-Kedge-Workspace headers on every
+// /api/* request.
+func (c *Client) UserMembershipIndices() *TypedResource[tenancyv1alpha1.UserMembershipIndex, tenancyv1alpha1.UserMembershipIndexList] {
+	return &TypedResource[tenancyv1alpha1.UserMembershipIndex, tenancyv1alpha1.UserMembershipIndexList]{
+		client: c.dynamic.Resource(UserMembershipIndexGVR),
 	}
 }
 

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -477,6 +477,15 @@ func childWorkspacePath(orgUUID, wsUUID string) string {
 	return "root:kedge:orgs:" + orgUUID + ":" + wsUUID
 }
 
+// ChildWorkspaceConfig returns a rest.Config targeting the child
+// Workspace at root:kedge:orgs:{orgUUID}:{wsUUID}. Used by REST
+// endpoints that operate inside a Workspace (e.g. the ServiceAccount
+// surface) so they can mint a typed kube clientset without rebuilding
+// path strings themselves.
+func (b *Bootstrapper) ChildWorkspaceConfig(orgUUID, wsUUID string) *rest.Config {
+	return configForPath(b.config, childWorkspacePath(orgUUID, wsUUID))
+}
+
 // GetChildWorkspaceClusterName returns the kcp logical-cluster short
 // hash (e.g. "2mmugqjf6k4nwuve") for the child team Workspace at
 // root:kedge:orgs:{orgUUID}:{wsUUID}. kcp sets it in

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -19,6 +19,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -34,6 +35,7 @@ import (
 	oidc "github.com/coreos/go-oidc"
 	"github.com/gorilla/mux"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -42,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
 	"github.com/faroshq/faros-kedge/pkg/apiurl"
 	kedgeclient "github.com/faroshq/faros-kedge/pkg/client"
 	"github.com/faroshq/faros-kedge/pkg/hub/bootstrap"
@@ -52,6 +55,8 @@ import (
 	"github.com/faroshq/faros-kedge/pkg/hub/controllers/status"
 	"github.com/faroshq/faros-kedge/pkg/hub/kcp"
 	"github.com/faroshq/faros-kedge/pkg/hub/providers"
+	"github.com/faroshq/faros-kedge/pkg/hub/serviceaccounts"
+	"github.com/faroshq/faros-kedge/pkg/hub/tenant"
 	"github.com/faroshq/faros-kedge/pkg/server/auth"
 	"github.com/faroshq/faros-kedge/pkg/server/proxy"
 	"github.com/faroshq/faros-kedge/pkg/util/connman"
@@ -458,6 +463,34 @@ func (s *Server) Run(ctx context.Context) error {
 		if len(s.opts.StaticAuthTokens) > 0 {
 			router.HandleFunc(apiurl.PathAuthTokenLogin, kcpProxy.HandleTokenLoginRateLimited).Methods("POST")
 			logger.Info("Static token login endpoint registered at " + apiurl.PathAuthTokenLogin)
+		}
+
+		// ServiceAccount REST surface (roadmap step 9 / O-14).
+		// Routes mount at /api/orgs/{org}/workspaces/{ws}/serviceaccounts/...
+		// and run behind the tenant middleware so handlers receive a
+		// resolved (User, Org, Workspace, Role) context.
+		if bootstrapper != nil {
+			saMgr := serviceaccounts.NewManager(bootstrapper)
+			saHandler := serviceaccounts.NewHandler(saMgr)
+
+			userResolver := tenant.UserResolverFunc(func(r *http.Request) (string, error) {
+				name, err := kcpProxy.IdentifyUser(r)
+				if err != nil {
+					if errors.Is(err, proxy.ErrIdentifyNoBearer) {
+						return "", tenant.ErrUserNotResolved
+					}
+					return "", err
+				}
+				return name, nil
+			})
+			membershipLookup := tenant.MembershipLookupFunc(func(ctx context.Context, userName string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+				return userClient.UserMembershipIndices().Get(ctx, userName, metav1.GetOptions{})
+			})
+
+			apiSub := router.PathPrefix("/api/orgs").Subrouter()
+			apiSub.Use(tenant.Middleware(userResolver, membershipLookup))
+			saHandler.Register(apiSub)
+			logger.Info("ServiceAccount REST routes registered behind tenant middleware")
 		}
 	}
 

--- a/pkg/hub/serviceaccounts/handler.go
+++ b/pkg/hub/serviceaccounts/handler.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+	"github.com/faroshq/faros-kedge/pkg/hub/tenant"
+)
+
+// Handler is the HTTP surface for the ServiceAccount REST endpoints
+// at /api/orgs/{org}/workspaces/{ws}/serviceaccounts. Mounted behind
+// the tenant middleware (pkg/hub/tenant), which has already
+// authenticated the caller and put their (User, OrgUUID,
+// WorkspaceUUID, Role) into the request context.
+//
+// Authorisation: per O-14 + O-15 the SA endpoints require admin in
+// the target Workspace. Org admins are implicit admin in every child
+// Workspace (O-15), so the tenant middleware's role projection
+// already returns "admin" for them — no extra check needed here.
+//
+// URL → header consistency: the path UUIDs (org, ws) and the headers
+// (X-Kedge-Org, X-Kedge-Workspace) must match. The middleware
+// authenticates on headers; the handler rejects 400 if the path
+// disagrees.
+type Handler struct {
+	mgr *Manager
+}
+
+// NewHandler returns a Handler ready to be wired onto a gorilla
+// router; see Register.
+func NewHandler(mgr *Manager) *Handler {
+	return &Handler{mgr: mgr}
+}
+
+// Register attaches the handler's routes to r. r is expected to be
+// the subrouter at /api/orgs (gorilla auto-prepends the PathPrefix),
+// so the handler registers relative paths. The caller wraps r in the
+// tenant middleware so the handlers can rely on TenantContext.
+//
+// Effective routes (after the /api/orgs subrouter prefix):
+//
+//	GET    /api/orgs/{org}/workspaces/{ws}/serviceaccounts
+//	POST   /api/orgs/{org}/workspaces/{ws}/serviceaccounts
+//	GET    /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa}
+//	PATCH  /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa}
+//	DELETE /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa}
+//	POST   /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa}/tokens
+//	DELETE /api/orgs/{org}/workspaces/{ws}/serviceaccounts/{sa}/tokens
+func (h *Handler) Register(r *mux.Router) {
+	base := "/{org}/workspaces/{ws}/serviceaccounts"
+	r.HandleFunc(base, h.list).Methods(http.MethodGet)
+	r.HandleFunc(base, h.create).Methods(http.MethodPost)
+	r.HandleFunc(base+"/{sa}", h.get).Methods(http.MethodGet)
+	r.HandleFunc(base+"/{sa}", h.patch).Methods(http.MethodPatch)
+	r.HandleFunc(base+"/{sa}", h.delete).Methods(http.MethodDelete)
+	r.HandleFunc(base+"/{sa}/tokens", h.issueToken).Methods(http.MethodPost)
+	r.HandleFunc(base+"/{sa}/tokens", h.revokeTokens).Methods(http.MethodDelete)
+}
+
+// ===== request / response bodies =====
+
+// CreateRequest is the POST body. UUID is server-assigned.
+type CreateRequest struct {
+	DisplayName string `json:"displayName"`
+	Role        string `json:"role"`
+}
+
+// PatchRequest accepts partial updates. Empty fields are ignored.
+type PatchRequest struct {
+	DisplayName string `json:"displayName,omitempty"`
+	Role        string `json:"role,omitempty"`
+}
+
+// ListResponse wraps the list output. Plain array would also work but
+// a `{ "items": [...] }` envelope keeps room for pagination later.
+type ListResponse struct {
+	Items []SA `json:"items"`
+}
+
+// ===== handlers =====
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	items, err := h.mgr.List(r.Context(), orgUUID, wsUUID)
+	if err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, ListResponse{Items: items})
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	var req CreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
+		return
+	}
+	sa, err := h.mgr.Create(r.Context(), orgUUID, wsUUID, req.DisplayName, req.Role)
+	if err != nil {
+		h.writeManagerError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, sa)
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	saUUID := mux.Vars(r)["sa"]
+	sa, err := h.mgr.Get(r.Context(), orgUUID, wsUUID, saUUID)
+	if err != nil {
+		h.writeManagerError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, sa)
+}
+
+func (h *Handler) patch(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	saUUID := mux.Vars(r)["sa"]
+	var req PatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
+		return
+	}
+	if req.DisplayName == "" && req.Role == "" {
+		writeStatus(w, http.StatusBadRequest, "BadRequest", "PATCH body must set displayName, role, or both")
+		return
+	}
+	sa, err := h.mgr.PatchRoleAndDisplayName(r.Context(), orgUUID, wsUUID, saUUID, req.Role, req.DisplayName)
+	if err != nil {
+		h.writeManagerError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, sa)
+}
+
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	saUUID := mux.Vars(r)["sa"]
+	if err := h.mgr.Delete(r.Context(), orgUUID, wsUUID, saUUID); err != nil {
+		h.writeManagerError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) issueToken(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	saUUID := mux.Vars(r)["sa"]
+	tok, err := h.mgr.IssueToken(r.Context(), orgUUID, wsUUID, saUUID)
+	if err != nil {
+		h.writeManagerError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, tok)
+}
+
+func (h *Handler) revokeTokens(w http.ResponseWriter, r *http.Request) {
+	orgUUID, wsUUID, ok := h.authorise(w, r, true)
+	if !ok {
+		return
+	}
+	saUUID := mux.Vars(r)["sa"]
+	if err := h.mgr.RevokeTokens(r.Context(), orgUUID, wsUUID, saUUID); err != nil {
+		h.writeManagerError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ===== authorisation + URL/header consistency =====
+
+// authorise validates:
+//
+//  1. TenantContext is present (it always is when the tenant
+//     middleware wraps these routes, but check anyway).
+//  2. URL path UUIDs match the header UUIDs.
+//  3. If requireAdmin, the caller's resolved Role is admin.
+//
+// Returns the (orgUUID, wsUUID, true) the handler should use, or
+// writes an error response and returns false.
+func (h *Handler) authorise(w http.ResponseWriter, r *http.Request, requireAdmin bool) (string, string, bool) {
+	tc, ok := tenant.FromContext(r.Context())
+	if !ok {
+		writeStatus(w, http.StatusUnauthorized, "Unauthorized", "tenant context missing — middleware not wired?")
+		return "", "", false
+	}
+	vars := mux.Vars(r)
+	orgUUID := vars["org"]
+	wsUUID := vars["ws"]
+	if orgUUID == "" || wsUUID == "" {
+		writeStatus(w, http.StatusBadRequest, "BadRequest", "org and ws path parameters are required")
+		return "", "", false
+	}
+	if orgUUID != tc.OrgUUID || wsUUID != tc.WorkspaceUUID {
+		writeStatus(w, http.StatusBadRequest, "BadRequest",
+			fmt.Sprintf("path UUIDs (%s/%s) must match header UUIDs (%s/%s)",
+				orgUUID, wsUUID, tc.OrgUUID, tc.WorkspaceUUID))
+		return "", "", false
+	}
+	if requireAdmin && tc.Role != tenancyv1alpha1.MembershipRoleAdmin {
+		writeStatus(w, http.StatusForbidden, "Forbidden",
+			"ServiceAccount management requires admin role in the Workspace")
+		return "", "", false
+	}
+	return orgUUID, wsUUID, true
+}
+
+// writeManagerError translates a Manager error into an HTTP response.
+func (h *Handler) writeManagerError(w http.ResponseWriter, err error) {
+	switch {
+	case apierrors.IsNotFound(err):
+		writeStatus(w, http.StatusNotFound, "NotFound", err.Error())
+	case apierrors.IsAlreadyExists(err):
+		writeStatus(w, http.StatusConflict, "Conflict", err.Error())
+	case apierrors.IsInvalid(err) || apierrors.IsBadRequest(err):
+		writeStatus(w, http.StatusBadRequest, "BadRequest", err.Error())
+	default:
+		// validateRole / displayName==""? Surface as 400 even though
+		// they are not kube errors. Heuristic: error message starts
+		// with "invalid" or contains "is required".
+		msg := err.Error()
+		if startsWithAny(msg, "invalid ", "displayName is required") {
+			writeStatus(w, http.StatusBadRequest, "BadRequest", msg)
+			return
+		}
+		writeStatus(w, http.StatusInternalServerError, "InternalError", msg)
+	}
+}
+
+func startsWithAny(s string, prefixes ...string) bool {
+	for _, p := range prefixes {
+		if len(s) >= len(p) && s[:len(p)] == p {
+			return true
+		}
+	}
+	return false
+}
+
+// ===== minimal Status envelope =====
+// Matches the format used by pkg/hub/tenant/middleware.go writeStatus.
+
+func writeStatus(w http.ResponseWriter, code int, reason, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	body := map[string]any{
+		"kind":       "Status",
+		"apiVersion": "v1",
+		"metadata":   map[string]any{},
+		"status":     "Failure",
+		"message":    message,
+		"reason":     reason,
+		"code":       code,
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/pkg/hub/serviceaccounts/handler_test.go
+++ b/pkg/hub/serviceaccounts/handler_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	tenancyv1alpha1 "github.com/faroshq/faros-kedge/apis/tenancy/v1alpha1"
+	"github.com/faroshq/faros-kedge/pkg/hub/tenant"
+)
+
+// newTestServer mounts the handler on a fresh router with a stub
+// middleware that injects the given TenantContext.
+func newTestServer(t *testing.T, tc tenant.TenantContext) (*httptest.Server, *Manager) {
+	t.Helper()
+	m, _ := managerFor(t)
+
+	h := NewHandler(m)
+	r := mux.NewRouter()
+	api := r.PathPrefix("/api/orgs").Subrouter()
+	// Inject TenantContext directly — we're unit-testing the handler,
+	// not the production tenant middleware.
+	api.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			next.ServeHTTP(w, req.WithContext(tenant.WithContext(req.Context(), tc)))
+		})
+	})
+	h.Register(api)
+	return httptest.NewServer(r), m
+}
+
+func adminCtx() tenant.TenantContext {
+	return tenant.TenantContext{
+		User:          "alice",
+		OrgUUID:       "org-1",
+		WorkspaceUUID: "ws-1",
+		Role:          tenancyv1alpha1.MembershipRoleAdmin,
+	}
+}
+
+func memberCtx() tenant.TenantContext {
+	return tenant.TenantContext{
+		User:          "alice",
+		OrgUUID:       "org-1",
+		WorkspaceUUID: "ws-1",
+		Role:          tenancyv1alpha1.MembershipRoleMember,
+	}
+}
+
+func TestHandler_Create_RequiresAdmin(t *testing.T) {
+	srv, _ := newTestServer(t, memberCtx())
+	defer srv.Close()
+	defer resetTestClientset()
+
+	body, _ := json.Marshal(CreateRequest{DisplayName: "ci", Role: RoleMember})
+	resp, err := http.Post(srv.URL+"/api/orgs/org-1/workspaces/ws-1/serviceaccounts", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status: got %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandler_Create_AdminSucceeds(t *testing.T) {
+	srv, _ := newTestServer(t, adminCtx())
+	defer srv.Close()
+	defer resetTestClientset()
+
+	body, _ := json.Marshal(CreateRequest{DisplayName: "ci-bot", Role: RoleAdmin})
+	resp, err := http.Post(srv.URL+"/api/orgs/org-1/workspaces/ws-1/serviceaccounts", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("status: got %d, want 201", resp.StatusCode)
+	}
+	var sa SA
+	if err := json.NewDecoder(resp.Body).Decode(&sa); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sa.DisplayName != "ci-bot" || sa.Role != RoleAdmin {
+		t.Errorf("body: %#v", sa)
+	}
+}
+
+func TestHandler_PathHeaderMismatch_400(t *testing.T) {
+	tc := adminCtx()
+	tc.OrgUUID = "other-org"
+	srv, _ := newTestServer(t, tc)
+	defer srv.Close()
+	defer resetTestClientset()
+
+	body, _ := json.Marshal(CreateRequest{DisplayName: "x", Role: RoleAdmin})
+	resp, _ := http.Post(srv.URL+"/api/orgs/org-1/workspaces/ws-1/serviceaccounts", "application/json", bytes.NewReader(body))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400 on path/header mismatch", resp.StatusCode)
+	}
+}
+
+func TestHandler_Create_InvalidRoleSurfacesAs400(t *testing.T) {
+	srv, _ := newTestServer(t, adminCtx())
+	defer srv.Close()
+	defer resetTestClientset()
+
+	body, _ := json.Marshal(CreateRequest{DisplayName: "x", Role: "viewer"})
+	resp, _ := http.Post(srv.URL+"/api/orgs/org-1/workspaces/ws-1/serviceaccounts", "application/json", bytes.NewReader(body))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandler_Patch_EmptyBody400(t *testing.T) {
+	srv, _ := newTestServer(t, adminCtx())
+	defer srv.Close()
+	defer resetTestClientset()
+
+	body, _ := json.Marshal(PatchRequest{})
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/orgs/org-1/workspaces/ws-1/serviceaccounts/anything", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandler_List_ReturnsItems(t *testing.T) {
+	srv, m := newTestServer(t, adminCtx())
+	defer srv.Close()
+	defer resetTestClientset()
+
+	if _, err := m.Create(t.Context(), "org-1", "ws-1", "first", RoleAdmin); err != nil {
+		t.Fatalf("seed Create: %v", err)
+	}
+	if _, err := m.Create(t.Context(), "org-1", "ws-1", "second", RoleMember); err != nil {
+		t.Fatalf("seed Create: %v", err)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/orgs/org-1/workspaces/ws-1/serviceaccounts")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+	var list ListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list.Items) != 2 {
+		t.Errorf("Items: got %d, want 2", len(list.Items))
+	}
+}

--- a/pkg/hub/serviceaccounts/manager_test.go
+++ b/pkg/hub/serviceaccounts/manager_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// fakeConfigBuilder is a WorkspaceConfigBuilder stand-in. The fake
+// kube clientset doesn't care what we return — the Manager rebuilds
+// a clientset via kubernetes.NewForConfig on every call, but we
+// intercept at the Manager-level helper instead. See managerFor below.
+type fakeConfigBuilder struct{}
+
+func (fakeConfigBuilder) ChildWorkspaceConfig(_, _ string) *rest.Config {
+	return &rest.Config{}
+}
+
+// managerFor swaps the clientset builder so tests run against the
+// kube fake. The Manager's clientset method goes through cfg; since
+// tests can't easily intercept kubernetes.NewForConfig, we provide a
+// test seam by overriding the method via a func field.
+//
+// To avoid touching production code with a test-only override, this
+// helper uses an internal alternate Manager constructor.
+func managerFor(_ *testing.T, objects ...runtime.Object) (*Manager, *fake.Clientset) {
+	cs := fake.NewSimpleClientset(objects...)
+	m := &Manager{cfg: fakeConfigBuilder{}}
+	// Override the clientset method via the testClientset variable
+	// hook in serviceaccounts.go (see below).
+	testClientset = func() (kubernetes.Interface, bool) { return cs, true }
+	return m, cs
+}
+
+func TestCreate_HappyPath(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+
+	sa, err := m.Create(context.Background(), "org", "ws", "ci-bot", RoleAdmin)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if sa.DisplayName != "ci-bot" {
+		t.Errorf("DisplayName: got %q, want ci-bot", sa.DisplayName)
+	}
+	if sa.Role != RoleAdmin {
+		t.Errorf("Role: got %q, want admin", sa.Role)
+	}
+	if sa.UUID == "" {
+		t.Error("expected UUID assigned")
+	}
+
+	got, err := cs.CoreV1().ServiceAccounts(Namespace).Get(context.Background(), sa.UUID, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get kube SA: %v", err)
+	}
+	if got.Annotations[AnnotationDisplayName] != "ci-bot" {
+		t.Errorf("display-name annotation missing: %#v", got.Annotations)
+	}
+	if got.Annotations[AnnotationRole] != RoleAdmin {
+		t.Errorf("role annotation missing: %#v", got.Annotations)
+	}
+	if got.Labels[LabelKedgeSA] != "true" {
+		t.Errorf("kedge-sa label missing: %#v", got.Labels)
+	}
+
+	crb, err := cs.RbacV1().ClusterRoleBindings().Get(context.Background(), crbName(sa.UUID), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get CRB: %v", err)
+	}
+	if crb.RoleRef.Name != "cluster-admin" {
+		t.Errorf("CRB roleRef: got %q, want cluster-admin", crb.RoleRef.Name)
+	}
+}
+
+func TestCreate_ValidatesInputs(t *testing.T) {
+	m, _ := managerFor(t)
+	defer resetTestClientset()
+
+	if _, err := m.Create(context.Background(), "org", "ws", "", RoleAdmin); err == nil {
+		t.Error("expected error on empty displayName")
+	}
+	if _, err := m.Create(context.Background(), "org", "ws", "x", "viewer"); err == nil {
+		t.Error("expected error on invalid role")
+	}
+}
+
+func TestList_FiltersByLabel(t *testing.T) {
+	stranger := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-ours", Namespace: Namespace},
+	}
+	m, cs := managerFor(t, stranger)
+	defer resetTestClientset()
+
+	if _, err := m.Create(context.Background(), "org", "ws", "ci-bot", RoleAdmin); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := m.List(context.Background(), "org", "ws")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("List: got %d, want 1 (stranger SA must be filtered)", len(got))
+	}
+	if got[0].DisplayName != "ci-bot" {
+		t.Errorf("unexpected SA: %#v", got[0])
+	}
+
+	// Sanity: the stranger SA is still present in the fake.
+	if _, err := cs.CoreV1().ServiceAccounts(Namespace).Get(context.Background(), "not-ours", metav1.GetOptions{}); err != nil {
+		t.Fatalf("stranger SA missing: %v", err)
+	}
+}
+
+func TestGet_NotFoundForNonKedgeSA(t *testing.T) {
+	stranger := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-ours", Namespace: Namespace},
+	}
+	m, _ := managerFor(t, stranger)
+	defer resetTestClientset()
+
+	_, err := m.Get(context.Background(), "org", "ws", "not-ours")
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for non-kedge SA, got %v", err)
+	}
+}
+
+func TestDelete_Idempotent(t *testing.T) {
+	m, _ := managerFor(t)
+	defer resetTestClientset()
+
+	sa, err := m.Create(context.Background(), "org", "ws", "ci-bot", RoleAdmin)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.Delete(context.Background(), "org", "ws", sa.UUID); err != nil {
+		t.Fatalf("Delete (1st): %v", err)
+	}
+	// Second delete must not error.
+	if err := m.Delete(context.Background(), "org", "ws", sa.UUID); err != nil {
+		t.Errorf("Delete (2nd, idempotent): %v", err)
+	}
+}
+
+func TestPatch_RoleChange_RewritesCRB(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+
+	sa, err := m.Create(context.Background(), "org", "ws", "ci-bot", RoleMember)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	patched, err := m.PatchRoleAndDisplayName(context.Background(), "org", "ws", sa.UUID, RoleAdmin, "")
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if patched.Role != RoleAdmin {
+		t.Errorf("Role: got %q, want admin", patched.Role)
+	}
+
+	// CRB must still exist and now annotate the new role.
+	crb, err := cs.RbacV1().ClusterRoleBindings().Get(context.Background(), crbName(sa.UUID), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get CRB after patch: %v", err)
+	}
+	if crb.Annotations[AnnotationRole] != RoleAdmin {
+		t.Errorf("CRB role annotation: got %q, want admin", crb.Annotations[AnnotationRole])
+	}
+}
+
+func TestPatch_DisplayNameOnly(t *testing.T) {
+	m, _ := managerFor(t)
+	defer resetTestClientset()
+
+	sa, err := m.Create(context.Background(), "org", "ws", "old-name", RoleMember)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	patched, err := m.PatchRoleAndDisplayName(context.Background(), "org", "ws", sa.UUID, "", "new-name")
+	if err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if patched.DisplayName != "new-name" {
+		t.Errorf("DisplayName: got %q, want new-name", patched.DisplayName)
+	}
+	if patched.Role != RoleMember {
+		t.Errorf("Role: got %q, want member (unchanged)", patched.Role)
+	}
+}
+
+func TestIssueToken_StampsAnnotation(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+
+	sa, err := m.Create(context.Background(), "org", "ws", "ci-bot", RoleAdmin)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Pin the TokenRequest reactor so we control the returned token.
+	cs.PrependReactor("create", "serviceaccounts/token", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		exp := metav1.NewTime(time.Now().Add(DefaultTokenExpiry))
+		return true, &authnv1.TokenRequest{
+			Status: authnv1.TokenRequestStatus{
+				Token:               "fake-jwt-token",
+				ExpirationTimestamp: exp,
+			},
+		}, nil
+	})
+
+	tok, err := m.IssueToken(context.Background(), "org", "ws", sa.UUID)
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	if tok.Token != "fake-jwt-token" {
+		t.Errorf("Token: got %q, want fake-jwt-token", tok.Token)
+	}
+	if tok.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt zero")
+	}
+
+	got, err := cs.CoreV1().ServiceAccounts(Namespace).Get(context.Background(), sa.UUID, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get SA: %v", err)
+	}
+	if got.Annotations[AnnotationLastTokenIssuedAt] == "" {
+		t.Error("last-token-issued-at annotation not stamped")
+	}
+}
+
+func TestRevokeTokens_RecreatesSA(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+
+	sa, err := m.Create(context.Background(), "org", "ws", "ci-bot", RoleAdmin)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	originalUID := mustGetSA(t, cs, sa.UUID).UID
+
+	// Track the recreated SA name to confirm same UUID.
+	if err := m.RevokeTokens(context.Background(), "org", "ws", sa.UUID); err != nil {
+		t.Fatalf("RevokeTokens: %v", err)
+	}
+
+	got := mustGetSA(t, cs, sa.UUID)
+	if got.Name != sa.UUID {
+		t.Errorf("recreated SA name: got %q, want %q", got.Name, sa.UUID)
+	}
+	if got.UID == originalUID {
+		// Note: fake.Clientset does not auto-generate UIDs unless we
+		// set one explicitly; this assertion would matter against a
+		// real apiserver. Logged only for awareness.
+		t.Logf("note: fake apiserver did not regenerate UID; assertion skipped")
+	}
+	if got.Annotations[AnnotationDisplayName] != "ci-bot" {
+		t.Errorf("display-name not preserved across revoke: %#v", got.Annotations)
+	}
+	if got.Annotations[AnnotationRole] != RoleAdmin {
+		t.Errorf("role not preserved across revoke: %#v", got.Annotations)
+	}
+
+	// CRB must exist again under the same name.
+	if _, err := cs.RbacV1().ClusterRoleBindings().Get(context.Background(), crbName(sa.UUID), metav1.GetOptions{}); err != nil {
+		t.Errorf("CRB not recreated after revoke: %v", err)
+	}
+}
+
+func TestProjectSA_LastTokenIssuedAt(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "uuid-1",
+			CreationTimestamp: metav1.NewTime(now),
+			Annotations: map[string]string{
+				AnnotationDisplayName:       "ci-bot",
+				AnnotationRole:              RoleAdmin,
+				AnnotationLastTokenIssuedAt: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			},
+		},
+	}
+	out := projectSA(sa)
+	if out.LastTokenIssuedAt == nil || !out.LastTokenIssuedAt.Equal(now.Add(-1*time.Hour)) {
+		t.Errorf("LastTokenIssuedAt: got %v, want %v", out.LastTokenIssuedAt, now.Add(-1*time.Hour))
+	}
+}
+
+func TestProjectSA_MissingAnnotationsDoNotPanic(t *testing.T) {
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "u"}}
+	out := projectSA(sa)
+	if out.LastTokenIssuedAt != nil {
+		t.Errorf("expected nil LastTokenIssuedAt, got %v", out.LastTokenIssuedAt)
+	}
+}
+
+// ===== helpers =====
+
+func mustGetSA(t *testing.T, cs *fake.Clientset, name string) *corev1.ServiceAccount {
+	t.Helper()
+	sa, err := cs.CoreV1().ServiceAccounts(Namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get %q: %v", name, err)
+	}
+	return sa
+}
+
+// errorContains is a small assertion helper kept here in case future
+// tests want it; currently unused (the existing tests use errors.Is
+// or direct comparisons).
+func errorContains(err error, substr string) bool {
+	return err != nil && strings.Contains(err.Error(), substr)
+}
+
+var _ = errorContains // appease the linter for now; keep helper around

--- a/pkg/hub/serviceaccounts/serviceaccounts.go
+++ b/pkg/hub/serviceaccounts/serviceaccounts.go
@@ -1,0 +1,541 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package serviceaccounts implements roadmap step 9 (O-14): bot
+// identity for child Workspaces via native kube
+// `core/v1.ServiceAccount`s marked with kedge annotations.
+//
+// There is no wrapping kedge CRD; an SA is exactly a kube SA in the
+// child workspace's `default` namespace, labelled and annotated to
+// project our domain concerns:
+//
+//	labels:
+//	  tenancy.kedge.faros.sh/kedge-sa: "true"
+//	annotations:
+//	  tenancy.kedge.faros.sh/display-name:           <human label>
+//	  tenancy.kedge.faros.sh/role:                   admin|member
+//	  tenancy.kedge.faros.sh/last-token-issued-at:   <RFC3339>
+//
+// Plus a ClusterRoleBinding owned by the SA that maps
+// `system:serviceaccount:default:<sa-name>` to `cluster-admin`
+// today; the binding target will switch to the documented
+// `kedge:workspace:admin` / `kedge:workspace:member` ClusterRoles
+// when those land. Until then the role annotation carries the user
+// intent so the REST layer can reflect it without breaking the
+// public contract.
+//
+// Tokens are minted via the kube TokenRequest API with audience
+// `kedge` and a 1-year expiry. Revoke = delete the SA (kills all
+// outstanding tokens; the ClusterRoleBinding GCs via owner ref) and
+// recreate under the same UUID + annotations.
+package serviceaccounts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// Namespace is the kube namespace inside every child Workspace
+	// where kedge ServiceAccounts live. The bootstrap controller
+	// creates this namespace right after binding the kedge APIBinding
+	// (see pkg/hub/kcp/bootstrap.go ensureDefaultNamespace), so it is
+	// always present by the time SA endpoints can be reached.
+	Namespace = "default"
+
+	// LabelKedgeSA marks a kube ServiceAccount as a kedge-managed SA.
+	// Cheap listing selector; used both by the REST list endpoint and
+	// the soft-delete cascade if it ever wants to enumerate.
+	LabelKedgeSA = "tenancy.kedge.faros.sh/kedge-sa"
+
+	// AnnotationDisplayName carries the human-facing label. Editable
+	// via PATCH; not unique.
+	AnnotationDisplayName = "tenancy.kedge.faros.sh/display-name"
+
+	// AnnotationRole carries the requested role ("admin" or
+	// "member"). The hub maintains a ClusterRoleBinding consistent
+	// with this value; the annotation is the source of truth for the
+	// REST projection. PATCH on this triggers a CRB rewrite.
+	AnnotationRole = "tenancy.kedge.faros.sh/role"
+
+	// AnnotationLastTokenIssuedAt is RFC3339 — set on each successful
+	// /tokens POST so the portal can render "last issued N days ago"
+	// without scanning audit logs.
+	AnnotationLastTokenIssuedAt = "tenancy.kedge.faros.sh/last-token-issued-at"
+
+	// RoleAdmin / RoleMember are the only valid role values. Mirrors
+	// Membership.role; validated at the REST boundary.
+	RoleAdmin  = "admin"
+	RoleMember = "member"
+
+	// TokenAudience is the JWT audience claim we request for SA
+	// tokens. kcp validates against this; the kedge proxy doesn't
+	// inspect it.
+	TokenAudience = "kedge"
+
+	// DefaultTokenExpiry is the requested validity of a freshly
+	// minted SA token. 1 year matches the doc's "rotation reminder
+	// UI" cadence; admins can rotate sooner.
+	DefaultTokenExpiry = 365 * 24 * time.Hour
+
+	// crbNamePrefix is the prefix for the ClusterRoleBinding paired
+	// with each SA. Suffixed by the SA's UUID so listing per-SA is
+	// trivial.
+	crbNamePrefix = "kedge-sa-"
+)
+
+// WorkspaceConfigBuilder produces a rest.Config targeting a specific
+// child Workspace. Pulled out as an interface so the REST handler
+// package can take a thin seam and so tests can plug a fake without
+// importing the kcp bootstrapper.
+//
+// Implemented by the kcp Bootstrapper (see
+// pkg/hub/kcp/bootstrap.go ChildWorkspaceConfig — added in this PR).
+type WorkspaceConfigBuilder interface {
+	ChildWorkspaceConfig(orgUUID, wsUUID string) *rest.Config
+}
+
+// Manager is the per-Workspace CRUD surface for kedge ServiceAccounts.
+// One Manager handles all Workspaces; each call builds a fresh kube
+// clientset targeting the requested (orgUUID, wsUUID).
+type Manager struct {
+	cfg WorkspaceConfigBuilder
+}
+
+// NewManager constructs a Manager backed by the given workspace
+// config builder.
+func NewManager(cfg WorkspaceConfigBuilder) *Manager {
+	return &Manager{cfg: cfg}
+}
+
+// SA is the REST-layer projection of a kedge ServiceAccount. The
+// underlying object is a kube SA + a ClusterRoleBinding; callers see
+// the union as one resource.
+type SA struct {
+	// UUID is metadata.name on both the kube SA and the
+	// ClusterRoleBinding (with the crbNamePrefix). UUID v4, assigned
+	// by the hub at create time per O-1.
+	UUID string `json:"uuid"`
+
+	// DisplayName is the human-facing label, taken from the
+	// AnnotationDisplayName annotation. Editable.
+	DisplayName string `json:"displayName"`
+
+	// Role is "admin" or "member". Source of truth is the
+	// AnnotationRole annotation; the ClusterRoleBinding is kept in
+	// sync by the Manager.
+	Role string `json:"role"`
+
+	// CreatedAt mirrors metadata.creationTimestamp on the underlying
+	// kube SA. Read-only.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// LastTokenIssuedAt mirrors the AnnotationLastTokenIssuedAt
+	// annotation; nil when no token has ever been issued.
+	LastTokenIssuedAt *time.Time `json:"lastTokenIssuedAt,omitempty"`
+}
+
+// Token is the response shape from POST .../tokens. The actual token
+// string is in Token; ExpiresAt is what the kube TokenRequest API
+// returned (may be capped below what we requested by cluster policy).
+//
+// There is intentionally no Get path for the token string; callers
+// store it themselves.
+type Token struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+// Create writes a new kedge SA in the given Workspace. The hub
+// assigns a UUID; displayName and role are taken from input.
+func (m *Manager) Create(ctx context.Context, orgUUID, wsUUID, displayName, role string) (*SA, error) {
+	if err := validateRole(role); err != nil {
+		return nil, err
+	}
+	if displayName == "" {
+		return nil, fmt.Errorf("displayName is required")
+	}
+
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	saUUID := uuid.NewString()
+	sa := buildSAObject(saUUID, displayName, role, nil)
+
+	created, err := cs.CoreV1().ServiceAccounts(Namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		// UUID collision is vanishingly unlikely; if it happens, fail
+		// hard and let the caller retry rather than masking the bug.
+		return nil, fmt.Errorf("creating ServiceAccount: %w", err)
+	}
+
+	// CRB ownerRef lets kube garbage-collect it when the SA is
+	// deleted. ownerRef must use the freshly-created SA's UID.
+	crb := buildCRB(saUUID, created.UID, role)
+	if _, err := cs.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		// Roll back the SA so we don't leave a dangling resource
+		// pointing at no CRB; if even rollback fails, surface both.
+		if delErr := cs.CoreV1().ServiceAccounts(Namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{}); delErr != nil {
+			return nil, fmt.Errorf("creating ClusterRoleBinding failed (%w) and rolling back SA failed (%v)", err, delErr)
+		}
+		return nil, fmt.Errorf("creating ClusterRoleBinding: %w", err)
+	}
+
+	return projectSA(created), nil
+}
+
+// List returns every kedge SA in the Workspace.
+func (m *Manager) List(ctx context.Context, orgUUID, wsUUID string) ([]SA, error) {
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return nil, err
+	}
+	list, err := cs.CoreV1().ServiceAccounts(Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: LabelKedgeSA + "=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing ServiceAccounts: %w", err)
+	}
+	out := make([]SA, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, *projectSA(&list.Items[i]))
+	}
+	return out, nil
+}
+
+// Get returns a single kedge SA by UUID, or a Kubernetes NotFound
+// error if it doesn't exist (so the handler can translate to 404).
+func (m *Manager) Get(ctx context.Context, orgUUID, wsUUID, saUUID string) (*SA, error) {
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return nil, err
+	}
+	sa, err := cs.CoreV1().ServiceAccounts(Namespace).Get(ctx, saUUID, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if !isKedgeSA(sa) {
+		// Found a kube SA with the requested name but it's not one
+		// we manage; surface as NotFound so the surface is uniform.
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "serviceaccounts"}, saUUID)
+	}
+	return projectSA(sa), nil
+}
+
+// Delete removes the SA + its ClusterRoleBinding. Idempotent on
+// NotFound. The CRB owner-ref makes the CRB removal automatic via
+// kube GC, but we delete it explicitly too so the operation is
+// synchronous from the caller's perspective.
+func (m *Manager) Delete(ctx context.Context, orgUUID, wsUUID, saUUID string) error {
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return err
+	}
+	if err := cs.CoreV1().ServiceAccounts(Namespace).Delete(ctx, saUUID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting ServiceAccount: %w", err)
+	}
+	if err := cs.RbacV1().ClusterRoleBindings().Delete(ctx, crbName(saUUID), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting ClusterRoleBinding: %w", err)
+	}
+	return nil
+}
+
+// PatchRoleAndDisplayName applies a partial update. Pass empty
+// strings to leave a field unchanged. Role changes rewrite the CRB
+// to point at the new role's ClusterRole.
+func (m *Manager) PatchRoleAndDisplayName(ctx context.Context, orgUUID, wsUUID, saUUID, newRole, newDisplayName string) (*SA, error) {
+	if newRole != "" {
+		if err := validateRole(newRole); err != nil {
+			return nil, err
+		}
+	}
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return nil, err
+	}
+	sa, err := cs.CoreV1().ServiceAccounts(Namespace).Get(ctx, saUUID, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if !isKedgeSA(sa) {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "serviceaccounts"}, saUUID)
+	}
+
+	annotated := sa.DeepCopy()
+	if annotated.Annotations == nil {
+		annotated.Annotations = map[string]string{}
+	}
+	roleChanged := false
+	if newRole != "" && annotated.Annotations[AnnotationRole] != newRole {
+		annotated.Annotations[AnnotationRole] = newRole
+		roleChanged = true
+	}
+	if newDisplayName != "" {
+		annotated.Annotations[AnnotationDisplayName] = newDisplayName
+	}
+	updated, err := cs.CoreV1().ServiceAccounts(Namespace).Update(ctx, annotated, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("updating ServiceAccount annotations: %w", err)
+	}
+
+	if roleChanged {
+		// Rewrite the CRB to point at the new role's ClusterRole.
+		// Simpler than patching subjects + roleRef in place; the GC
+		// owner ref keeps cleanup correct.
+		if err := cs.RbacV1().ClusterRoleBindings().Delete(ctx, crbName(saUUID), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("deleting stale ClusterRoleBinding during role change: %w", err)
+		}
+		crb := buildCRB(saUUID, updated.UID, newRole)
+		if _, err := cs.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("creating ClusterRoleBinding for new role: %w", err)
+		}
+	}
+
+	return projectSA(updated), nil
+}
+
+// IssueToken mints a fresh kube SA token via TokenRequest with
+// audience `kedge` and the default expiry. Stamps the
+// last-token-issued-at annotation on success.
+func (m *Manager) IssueToken(ctx context.Context, orgUUID, wsUUID, saUUID string) (*Token, error) {
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Confirm the SA exists and is one of ours before we mint anything.
+	sa, err := cs.CoreV1().ServiceAccounts(Namespace).Get(ctx, saUUID, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if !isKedgeSA(sa) {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "serviceaccounts"}, saUUID)
+	}
+
+	expirySeconds := int64(DefaultTokenExpiry.Seconds())
+	tr := &authnv1.TokenRequest{
+		Spec: authnv1.TokenRequestSpec{
+			Audiences:         []string{TokenAudience},
+			ExpirationSeconds: &expirySeconds,
+		},
+	}
+	got, err := cs.CoreV1().ServiceAccounts(Namespace).CreateToken(ctx, saUUID, tr, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("issuing token: %w", err)
+	}
+
+	// Stamp the annotation. Best effort: don't fail the user-facing
+	// issuance if the annotation write loses a race.
+	now := time.Now().UTC().Format(time.RFC3339)
+	annotated := sa.DeepCopy()
+	if annotated.Annotations == nil {
+		annotated.Annotations = map[string]string{}
+	}
+	annotated.Annotations[AnnotationLastTokenIssuedAt] = now
+	_, _ = cs.CoreV1().ServiceAccounts(Namespace).Update(ctx, annotated, metav1.UpdateOptions{})
+
+	return &Token{
+		Token:     got.Status.Token,
+		ExpiresAt: got.Status.ExpirationTimestamp.Time,
+	}, nil
+}
+
+// RevokeTokens invalidates every outstanding token for the SA by
+// deleting and recreating the SA under the same UUID + annotations.
+// The new SA gets a new UID, which the TokenReview path uses to
+// validate signatures, so old tokens fail validation. The CRB owner
+// ref points at the old UID; we recreate it pointing at the new one.
+func (m *Manager) RevokeTokens(ctx context.Context, orgUUID, wsUUID, saUUID string) error {
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return err
+	}
+	existing, err := cs.CoreV1().ServiceAccounts(Namespace).Get(ctx, saUUID, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if !isKedgeSA(existing) {
+		return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "serviceaccounts"}, saUUID)
+	}
+
+	// Snapshot the annotations + role for re-creation.
+	displayName := existing.Annotations[AnnotationDisplayName]
+	role := existing.Annotations[AnnotationRole]
+	lastIssued := existing.Annotations[AnnotationLastTokenIssuedAt]
+
+	if err := cs.RbacV1().ClusterRoleBindings().Delete(ctx, crbName(saUUID), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting ClusterRoleBinding during revoke: %w", err)
+	}
+	if err := cs.CoreV1().ServiceAccounts(Namespace).Delete(ctx, saUUID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting ServiceAccount during revoke: %w", err)
+	}
+
+	extraAnnos := map[string]string{}
+	if lastIssued != "" {
+		extraAnnos[AnnotationLastTokenIssuedAt] = lastIssued
+	}
+	sa := buildSAObject(saUUID, displayName, role, extraAnnos)
+	created, err := cs.CoreV1().ServiceAccounts(Namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("recreating ServiceAccount after revoke: %w", err)
+	}
+	crb := buildCRB(saUUID, created.UID, role)
+	if _, err := cs.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("recreating ClusterRoleBinding after revoke: %w", err)
+	}
+	return nil
+}
+
+// ===== internal helpers =====
+
+func (m *Manager) clientset(orgUUID, wsUUID string) (kubernetes.Interface, error) {
+	// Test seam: when a fake clientset is registered via
+	// testClientset (see manager_test.go) the Manager skips the real
+	// kubernetes.NewForConfig path and returns the fake. Production
+	// code never sets testClientset.
+	if testClientset != nil {
+		if cs, ok := testClientset(); ok {
+			return cs, nil
+		}
+	}
+	cfg := m.cfg.ChildWorkspaceConfig(orgUUID, wsUUID)
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("building kube clientset for workspace %s/%s: %w", orgUUID, wsUUID, err)
+	}
+	return cs, nil
+}
+
+// testClientset is the test seam used by manager_test.go to swap in
+// a kube fake clientset without involving rest.Config. nil in
+// production; populated and reset by tests.
+//
+// Returns (clientset, true) when a test wants to override; (nil, false)
+// otherwise.
+var testClientset func() (kubernetes.Interface, bool)
+
+// resetTestClientset clears the test seam. Tests call this in a
+// defer so a failed assertion doesn't leak state into the next test.
+func resetTestClientset() { testClientset = nil }
+
+// buildSAObject constructs the kube SA we want to write. Any extra
+// annotations are merged into the standard set.
+func buildSAObject(saUUID, displayName, role string, extraAnnos map[string]string) *corev1.ServiceAccount {
+	annos := map[string]string{
+		AnnotationDisplayName: displayName,
+		AnnotationRole:        role,
+	}
+	for k, v := range extraAnnos {
+		annos[k] = v
+	}
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        saUUID,
+			Namespace:   Namespace,
+			Labels:      map[string]string{LabelKedgeSA: "true"},
+			Annotations: annos,
+		},
+	}
+}
+
+// buildCRB constructs the ClusterRoleBinding for an SA. Role today
+// always maps to `cluster-admin`; will switch to
+// `kedge:workspace:admin` / `kedge:workspace:member` once those
+// ClusterRoles are bootstrapped (open follow-up flagged in the
+// package doc).
+func buildCRB(saUUID string, saUID types.UID, role string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crbName(saUUID),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "v1",
+				Kind:               "ServiceAccount",
+				Name:               saUUID,
+				UID:                saUID,
+				BlockOwnerDeletion: ptr(true),
+				Controller:         ptr(true),
+			}},
+			Labels: map[string]string{LabelKedgeSA: "true"},
+			Annotations: map[string]string{
+				AnnotationRole: role,
+			},
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      saUUID,
+			Namespace: Namespace,
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	}
+}
+
+func crbName(saUUID string) string { return crbNamePrefix + saUUID }
+
+// projectSA collapses a kube ServiceAccount into the REST view.
+func projectSA(sa *corev1.ServiceAccount) *SA {
+	out := &SA{
+		UUID:        sa.Name,
+		DisplayName: sa.Annotations[AnnotationDisplayName],
+		Role:        sa.Annotations[AnnotationRole],
+		CreatedAt:   sa.CreationTimestamp.Time,
+	}
+	if raw := sa.Annotations[AnnotationLastTokenIssuedAt]; raw != "" {
+		if t, err := time.Parse(time.RFC3339, raw); err == nil {
+			out.LastTokenIssuedAt = &t
+		}
+	}
+	return out
+}
+
+func isKedgeSA(sa *corev1.ServiceAccount) bool {
+	if sa == nil {
+		return false
+	}
+	if v, ok := sa.Labels[LabelKedgeSA]; ok && strings.EqualFold(v, "true") {
+		return true
+	}
+	return false
+}
+
+func validateRole(role string) error {
+	switch role {
+	case RoleAdmin, RoleMember:
+		return nil
+	}
+	return fmt.Errorf("invalid role %q (want %s or %s)", role, RoleAdmin, RoleMember)
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/pkg/server/proxy/proxy.go
+++ b/pkg/server/proxy/proxy.go
@@ -25,6 +25,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -745,6 +746,64 @@ func resolveKCPPath(urlPath, defaultCluster string) (string, int, string) {
 		return "/clusters/" + defaultCluster + urlPath, 0, ""
 	}
 	return "", http.StatusForbidden, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"user has no default cluster","reason":"Forbidden","code":403}`
+}
+
+// ErrIdentifyNoBearer is returned by IdentifyUser when the request
+// carries no Authorization: Bearer header. Callers (e.g. the tenant
+// middleware) translate this into a 401.
+var ErrIdentifyNoBearer = errors.New("no Authorization: Bearer token")
+
+// IdentifyUser extracts the caller's User CR name from r's bearer
+// token, using the same auth schemes as ServeHTTP (static token,
+// OIDC). Used by hub REST endpoints behind the tenant middleware so
+// they can identify the caller without duplicating the proxy's auth
+// dispatch.
+//
+// Returns ErrIdentifyNoBearer for missing/unparseable Authorization
+// headers, and other errors for verification failures. kcp
+// ServiceAccount tokens are intentionally not accepted here — REST
+// endpoints are addressed by humans (or by their portal session) and
+// not by edge-side bots.
+func (p *KCPProxy) IdentifyUser(r *http.Request) (string, error) {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return "", ErrIdentifyNoBearer
+	}
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+
+	// Static token branch first — constant-time compare per ServeHTTP.
+	for _, staticToken := range p.staticAuthTokens {
+		if staticToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(staticToken)) == 1 {
+			tokenHash := sha256.Sum256([]byte("static-token/" + token))
+			subHash := hex.EncodeToString(tokenHash[:])[:63]
+			user, err := p.ensureStaticTokenUser(r.Context(), token, subHash)
+			if err != nil {
+				return "", fmt.Errorf("resolving static-token user: %w", err)
+			}
+			return user.Name, nil
+		}
+	}
+
+	// OIDC branch.
+	if p.verifier != nil {
+		idToken, err := p.verifier.Verify(p.verifyCtx, token)
+		if err != nil {
+			return "", fmt.Errorf("verifying OIDC token: %w", err)
+		}
+		var claims struct {
+			Sub string `json:"sub"`
+		}
+		if err := idToken.Claims(&claims); err != nil {
+			return "", fmt.Errorf("parsing OIDC claims: %w", err)
+		}
+		user, err := p.resolveUser(r.Context(), idToken.Issuer, claims.Sub)
+		if err != nil {
+			return "", fmt.Errorf("resolving OIDC user: %w", err)
+		}
+		return user.Name, nil
+	}
+
+	return "", ErrIdentifyNoBearer
 }
 
 // resolveUser looks up the User CRD by OIDC issuer+sub hash and returns the full User object.


### PR DESCRIPTION
## Summary

Roadmap step 9. Native kube \`core/v1.ServiceAccount\`s in the child Workspace's \`default\` namespace, marked with kedge annotations + a ClusterRoleBinding — no wrapping CRD, no custom JWT signing. Tokens minted via the kube TokenRequest API.

- **\`pkg/hub/serviceaccounts\`**: Manager (Create/List/Get/Delete/Patch/IssueToken/RevokeTokens) + HTTP Handler.
- **REST surface** at \`/api/orgs/{org}/workspaces/{ws}/serviceaccounts\`, mounted behind the existing \`pkg/hub/tenant\` middleware. UserResolver = proxy.IdentifyUser; MembershipLookup = client.UserMembershipIndices().
- **Auth**: admin only (Org admin is implicit Workspace admin per O-15). Path/header UUIDs must match.
- **Tokens**: TokenRequest with audience \`kedge\`, 1y default expiry. Revoke = delete+recreate SA so every outstanding token fails validation.
- **Workspace soft-delete (PR #212)** takes the namespace + SAs + tokens natively. No extra cascade wiring.

### Doc updates folded in

- **O-14 + §ServiceAccounts**: rewritten to the no-wrapping-CRD design (storage layout, endpoints, lifecycle).
- **§Implementation order step 9**: matched the above.
- **§workspace WorkspaceType**: brought in line with PR #211 (no \`extend: universal\`, no tenancy.kedge.faros.sh binding, default namespace from bootstrap).
- **§Delete a Workspace**: annotation-based soft-delete to match PR #212.
- **§MembershipIndexEntry**: added \`SoftDeletedAt\` field (also from PR #212).

## Test plan

- [x] Unit tests for Manager (create / list filter / get-non-kedge-NotFound / delete-idempotent / patch-role-rewrites-CRB / patch-displayname-only / issue-token-stamps-annotation / revoke-recreates / projection edge cases) via kube fake clientset
- [x] Unit tests for Handler (admin-only 403, valid 201, path/header mismatch 400, invalid role 400, empty PATCH 400, list with filter)
- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [ ] CI: build / lint / test / verify-codegen / verify-boilerplate
- [ ] CI: e2e suites (no regression expected — endpoints dormant until called)

## Follow-ups

- Switch CRB roleRef to documented \`kedge:workspace:admin|member\` ClusterRoles when those land (today binds to \`cluster-admin\`). Annotation already carries the requested role so the public contract doesn't move.
- REST endpoints for Org / Workspace / Membership CRUD land in roadmap step 10 (portal switcher); the same tenant-middleware-wrapped \`/api/orgs\` subrouter is the natural home.