### PR TITLE
hub+cli: harden OIDC token cache + krew install variant for kubeconfig download

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	golang.org/x/time v0.15.0
 	helm.sh/helm/v3 v3.20.0
@@ -276,7 +277,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/pkg/cli/auth/token_cache.go
+++ b/pkg/cli/auth/token_cache.go
@@ -61,14 +61,22 @@ func cacheKey(issuerURL, clientID string) string {
 	return hex.EncodeToString(h[:])[:32]
 }
 
+// cachePath returns the path to the cache file for the given OIDC config.
+func cachePath(issuerURL, clientID string) (string, error) {
+	dir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, cacheKey(issuerURL, clientID)+".json"), nil
+}
+
 // LoadTokenCache reads the cached token for the given OIDC config.
 func LoadTokenCache(issuerURL, clientID string) (*TokenCache, error) {
-	dir, err := cacheDir()
+	path, err := cachePath(issuerURL, clientID)
 	if err != nil {
 		return nil, err
 	}
 
-	path := filepath.Join(dir, cacheKey(issuerURL, clientID)+".json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading token cache: %w", err)
@@ -82,9 +90,12 @@ func LoadTokenCache(issuerURL, clientID string) (*TokenCache, error) {
 	return &cache, nil
 }
 
-// SaveTokenCache writes the token cache to disk.
+// SaveTokenCache writes the token cache to disk atomically (tmp file + rename).
+// Atomicity matters because a partial write that survives can leave the cache
+// holding a refresh token that the IdP has already rotated, permanently
+// bricking the cache until the next interactive login.
 func SaveTokenCache(cache *TokenCache) error {
-	dir, err := cacheDir()
+	path, err := cachePath(cache.IssuerURL, cache.ClientID)
 	if err != nil {
 		return err
 	}
@@ -94,10 +105,50 @@ func SaveTokenCache(cache *TokenCache) error {
 		return fmt.Errorf("marshaling token cache: %w", err)
 	}
 
-	path := filepath.Join(dir, cacheKey(cache.IssuerURL, cache.ClientID)+".json")
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return fmt.Errorf("writing token cache: %w", err)
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tokencache-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
 	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
 
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("syncing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
 	return nil
+}
+
+// LockTokenCache takes an exclusive OS-level file lock on a sidecar lock file
+// for the given OIDC config. Returns an unlock function that the caller MUST
+// invoke (e.g. via defer) — typically wrapping load → expiry-check → refresh →
+// save so that concurrent `kedge get-token` invocations don't race on the
+// refresh-token rotation. On platforms where advisory locking isn't supported
+// the returned unlock is a no-op.
+func LockTokenCache(issuerURL, clientID string) (unlock func(), err error) {
+	dir, err := cacheDir()
+	if err != nil {
+		return nil, err
+	}
+	lockPath := filepath.Join(dir, cacheKey(issuerURL, clientID)+".lock")
+	return acquireFileLock(lockPath)
 }

--- a/pkg/cli/auth/token_cache_test.go
+++ b/pkg/cli/auth/token_cache_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSaveTokenCache_Atomic verifies a successful save is observable in full
+// (no half-written file). We round-trip through Save then Load and check
+// that every field survives — exercising both the temp-file write and the
+// rename step.
+func TestSaveTokenCache_Atomic(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	want := &TokenCache{
+		IDToken:      "id-token",
+		RefreshToken: "refresh-token",
+		ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+		IssuerURL:    "https://issuer.test",
+		ClientID:     "test-client",
+	}
+	if err := SaveTokenCache(want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadTokenCache(want.IssuerURL, want.ClientID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if *got != *want {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+// TestLockTokenCache_Serialises spawns N goroutines that all take the lock,
+// bump a shared counter under it, sleep briefly, and release. If the lock
+// works, no two goroutines hold it simultaneously, so the observed max
+// concurrency is 1. If the lock is broken, multiple goroutines overlap.
+func TestLockTokenCache_Serialises(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const goroutines = 8
+	const iterations = 10
+
+	var (
+		inCritical int32
+		maxSeen    int32
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				unlock, err := LockTokenCache("https://issuer.test", "test-client")
+				if err != nil {
+					t.Errorf("lock: %v", err)
+					return
+				}
+				cur := atomic.AddInt32(&inCritical, 1)
+				for {
+					seen := atomic.LoadInt32(&maxSeen)
+					if cur <= seen || atomic.CompareAndSwapInt32(&maxSeen, seen, cur) {
+						break
+					}
+				}
+				// Tiny pause so any broken locking has a chance to interleave.
+				time.Sleep(time.Millisecond)
+				atomic.AddInt32(&inCritical, -1)
+				unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxSeen); got > 1 {
+		t.Errorf("max concurrent holders = %d; want 1 (lock failed to serialise)", got)
+	}
+}

--- a/pkg/cli/auth/token_lock_unix.go
+++ b/pkg/cli/auth/token_lock_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
 Copyright 2026 The Faros Authors.
 
@@ -13,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build !windows
 
 package auth
 

--- a/pkg/cli/auth/token_lock_unix.go
+++ b/pkg/cli/auth/token_lock_unix.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build !windows
+
+package auth
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireFileLock takes a blocking exclusive flock(2) on lockPath and returns
+// an unlock function. The lock is released either by calling the returned
+// function or when the process exits (the kernel drops flocks on FD close).
+func acquireFileLock(lockPath string) (func(), error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("acquiring file lock: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/pkg/cli/auth/token_lock_windows.go
+++ b/pkg/cli/auth/token_lock_windows.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build windows
+
+package auth
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireFileLock takes a blocking exclusive byte-range lock on lockPath via
+// LockFileEx and returns an unlock function. The lock is released either by
+// calling the returned function or when the process exits.
+func acquireFileLock(lockPath string) (func(), error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file: %w", err)
+	}
+	ol := new(windows.Overlapped)
+	// Lock a single byte at offset 0 — that's enough to serialise writers.
+	if err := windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, ol); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("acquiring file lock: %w", err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+		_ = f.Close()
+	}, nil
+}

--- a/pkg/cli/auth/token_lock_windows.go
+++ b/pkg/cli/auth/token_lock_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /*
 Copyright 2026 The Faros Authors.
 
@@ -13,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build windows
 
 package auth
 

--- a/pkg/cli/cmd/get_token.go
+++ b/pkg/cli/cmd/get_token.go
@@ -72,9 +72,18 @@ func runGetToken(ctx context.Context, issuerURL, clientID string, insecure bool)
 		return fmt.Errorf("--oidc-issuer-url and --oidc-client-id are required")
 	}
 
-	// Try to load a cached token.
-	cache, err := cliauth.LoadTokenCache(issuerURL, clientID)
-	if err == nil && !cache.IsExpired() {
+	// Take an exclusive flock around the cache. OIDC refresh-token rotation is
+	// single-use, so two concurrent kubectl invocations racing here would burn
+	// one of the rotated tokens and brick the cache. With the lock the loser
+	// waits, re-reads the cache, and uses the IDToken the winner just stored.
+	unlock, err := cliauth.LockTokenCache(issuerURL, clientID)
+	if err != nil {
+		return fmt.Errorf("locking token cache: %w", err)
+	}
+	defer unlock()
+
+	cache, loadErr := cliauth.LoadTokenCache(issuerURL, clientID)
+	if loadErr == nil && !cache.IsExpired() {
 		return outputExecCredential(cache.IDToken, cache.ExpiresAt)
 	}
 
@@ -89,12 +98,15 @@ func runGetToken(ctx context.Context, issuerURL, clientID string, insecure bool)
 		return fmt.Errorf("token refresh failed (run 'kedge login' to re-authenticate): %w", err)
 	}
 
-	// Update cache.
+	// Persist BEFORE returning the token: a successful refresh has already
+	// rotated the refresh_token at the IdP, so silently failing the cache
+	// write would leave the cached refresh token consumed and the cache
+	// permanently bricked until the next interactive login.
 	cache.IDToken = newIDToken
 	cache.RefreshToken = newRefreshToken
 	cache.ExpiresAt = expiry.Unix()
 	if err := cliauth.SaveTokenCache(cache); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to save token cache: %v\n", err)
+		return fmt.Errorf("saving rotated token cache (run 'kedge login' to re-authenticate): %w", err)
 	}
 
 	return outputExecCredential(newIDToken, expiry.Unix())

--- a/pkg/hub/restapi/kubeconfig.go
+++ b/pkg/hub/restapi/kubeconfig.go
@@ -38,6 +38,11 @@ import (
 //   - Static-token mode: the caller's bearer token is embedded directly.
 //     The downloaded file behaves the same way the live REST call did.
 //
+// The OIDC variant accepts ?install=krew to swap the exec Command from
+// `kedge` to `kubectl-kedge`, matching the binary name the krew plugin
+// installs (the only release channel that ships `kubectl-kedge` without
+// a `kedge` symlink). Default is `kedge` for back-compat.
+//
 // Either way the cluster URL is HubExternalURL + /clusters/<clusterName>,
 // where clusterName is the kcp logical-cluster hash for the workspace
 // (resolved via the bootstrapper).
@@ -71,7 +76,19 @@ func (h *Handler) downloadKubeconfig(w http.ResponseWriter, r *http.Request) {
 		staticToken = strings.TrimPrefix(ah, "Bearer ")
 	}
 
-	cfg, err := h.mgr.buildWorkspaceKubeconfig(tc.User, clusterName, staticToken)
+	execCommand := "kedge"
+	switch strings.ToLower(r.URL.Query().Get("install")) {
+	case "", "kedge", "standalone":
+		// default
+	case "krew", "kubectl-kedge":
+		execCommand = "kubectl-kedge"
+	default:
+		writeStatus(w, http.StatusBadRequest, "BadRequest",
+			"unknown install variant; expected 'kedge' or 'krew'")
+		return
+	}
+
+	cfg, err := h.mgr.buildWorkspaceKubeconfig(tc.User, clusterName, staticToken, execCommand)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -106,7 +123,7 @@ func kubeconfigFilename(displayName, uuid string) string {
 
 var filenameSafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
-func (m *Manager) buildWorkspaceKubeconfig(userID, clusterName, staticToken string) ([]byte, error) {
+func (m *Manager) buildWorkspaceKubeconfig(userID, clusterName, staticToken, execCommand string) ([]byte, error) {
 	cfg := clientcmdapi.NewConfig()
 	serverURL := apiurl.HubServerURL(m.kubeconfig.HubExternalURL, clusterName)
 
@@ -117,6 +134,9 @@ func (m *Manager) buildWorkspaceKubeconfig(userID, clusterName, staticToken stri
 
 	authInfo := &clientcmdapi.AuthInfo{}
 	if m.kubeconfig.OIDCIssuerURL != "" {
+		if execCommand == "" {
+			execCommand = "kedge"
+		}
 		// PKCE public client — no --oidc-client-secret. Matches the args
 		// pkg/server/auth.Handler.generateKubeconfig writes on first login.
 		args := []string{
@@ -129,7 +149,7 @@ func (m *Manager) buildWorkspaceKubeconfig(userID, clusterName, staticToken stri
 		}
 		authInfo.Exec = &clientcmdapi.ExecConfig{
 			APIVersion: "client.authentication.k8s.io/v1beta1",
-			Command:    "kedge",
+			Command:    execCommand,
 			Args:       args,
 		}
 	} else {

--- a/pkg/hub/restapi/restapi_test.go
+++ b/pkg/hub/restapi/restapi_test.go
@@ -622,6 +622,56 @@ func TestDeleteSelfUser_StampsTimestamp(t *testing.T) {
 	}
 }
 
+// ===== Kubeconfig download tests =====
+
+func TestDownloadKubeconfig_InstallVariant(t *testing.T) {
+	mgr, ops, _ := newTestManager(t)
+	_ = ops.EnsureChildWorkspace(context.Background(), "org-a", "ws-1")
+	mgr.WithKubeconfig(KubeconfigConfig{
+		HubExternalURL: "https://hub.test",
+		OIDCIssuerURL:  "https://issuer.test",
+		OIDCClientID:   "test-client",
+	})
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", "ws-1"))
+	defer srv.Close()
+
+	cases := []struct {
+		name        string
+		query       string
+		wantStatus  int
+		wantCommand string // empty if status != 200
+	}{
+		{"default", "", http.StatusOK, "kedge"},
+		{"explicit kedge", "?install=kedge", http.StatusOK, "kedge"},
+		{"krew alias", "?install=krew", http.StatusOK, "kubectl-kedge"},
+		{"explicit kubectl-kedge", "?install=kubectl-kedge", http.StatusOK, "kubectl-kedge"},
+		{"unknown", "?install=bogus", http.StatusBadRequest, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + "/api/orgs/org-a/workspaces/ws-1/kubeconfig" + tc.query)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			if tc.wantStatus != http.StatusOK {
+				return
+			}
+			body, _ := io.ReadAll(resp.Body)
+			// We only assert on the substring; a YAML parse here would drag in
+			// clientcmd just to re-check what the handler already produces.
+			want := "command: " + tc.wantCommand
+			if !bytes.Contains(body, []byte(want)) {
+				t.Errorf("response missing %q\nbody:\n%s", want, body)
+			}
+		})
+	}
+}
+
 // ===== helpers =====
 
 // jsonBody wraps a []byte as a Reader for http.Post.

--- a/portal/src/components/TenantContextChip.vue
+++ b/portal/src/components/TenantContextChip.vue
@@ -86,11 +86,29 @@ function onWorkspaceChange(e: Event) {
 }
 
 const downloading = ref(false)
+// 'install' picks the exec credential plugin Command in the downloaded
+// kubeconfig: 'kedge' for the curl/tar.gz binary on PATH, 'krew' for
+// kubectl-kedge (the krew plugin, which never installs a `kedge`
+// symlink). Persisted so the user doesn't have to re-pick on every
+// download.
+const INSTALL_STORAGE_KEY = 'kedge:portal:kubeconfig:install'
+function loadInstall(): 'kedge' | 'krew' {
+  const v = localStorage.getItem(INSTALL_STORAGE_KEY)
+  return v === 'krew' ? 'krew' : 'kedge'
+}
+const installVariant = ref<'kedge' | 'krew'>(loadInstall())
+watch(installVariant, (v) => {
+  try {
+    localStorage.setItem(INSTALL_STORAGE_KEY, v)
+  } catch {
+    /* ignore quota / private-mode errors */
+  }
+})
 async function onDownloadKubeconfig() {
   if (!tenant.orgUUID || !tenant.workspaceUUID || downloading.value) return
   downloading.value = true
   try {
-    await tenant.downloadKubeconfig(tenant.orgUUID, tenant.workspaceUUID)
+    await tenant.downloadKubeconfig(tenant.orgUUID, tenant.workspaceUUID, installVariant.value)
   } finally {
     downloading.value = false
   }
@@ -183,17 +201,29 @@ onUnmounted(() => {
 
         <div class="mx-1 my-2 h-px bg-border-default/40" />
 
-        <button
-          type="button"
-          class="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted transition-colors hover:bg-surface-overlay/60 hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
-          :disabled="!tenant.workspaceUUID || downloading"
-          :title="tenant.workspaceUUID ? 'Download kubeconfig for the active workspace' : 'Select a workspace first'"
-          @click="onDownloadKubeconfig"
-        >
-          <Loader2 v-if="downloading" class="h-3 w-3 animate-spin" :stroke-width="2" />
-          <Download v-else class="h-3 w-3" :stroke-width="2" />
-          Download kubeconfig
-        </button>
+        <div class="flex items-stretch gap-1">
+          <button
+            type="button"
+            class="flex flex-1 items-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted transition-colors hover:bg-surface-overlay/60 hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="!tenant.workspaceUUID || downloading"
+            :title="tenant.workspaceUUID ? 'Download kubeconfig for the active workspace' : 'Select a workspace first'"
+            @click="onDownloadKubeconfig"
+          >
+            <Loader2 v-if="downloading" class="h-3 w-3 animate-spin" :stroke-width="2" />
+            <Download v-else class="h-3 w-3" :stroke-width="2" />
+            Download kubeconfig
+          </button>
+          <select
+            v-model="installVariant"
+            class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-1 py-1 text-[10px] text-text-muted focus:border-accent focus:outline-none"
+            :title="installVariant === 'krew'
+              ? 'Exec plugin will call kubectl-kedge (krew install)'
+              : 'Exec plugin will call kedge (curl/tar.gz install)'"
+          >
+            <option value="kedge">kedge</option>
+            <option value="krew">krew</option>
+          </select>
+        </div>
 
         <router-link
           to="/tenant"

--- a/portal/src/pages/TenantSettingsPage.vue
+++ b/portal/src/pages/TenantSettingsPage.vue
@@ -251,7 +251,11 @@ async function onDownloadKubeconfig(uuid: string) {
   const key = `kc:${uuid}`
   wsBusy.value = { ...wsBusy.value, [key]: true }
   try {
-    const ok = await tenant.downloadKubeconfig(tenant.orgUUID, uuid)
+    // Reuse the install variant the user picked in the TenantContextChip
+    // (persisted under the same key) so the per-row download in this
+    // page matches the chip's dropdown. Defaults to 'kedge'.
+    const install = (localStorage.getItem('kedge:portal:kubeconfig:install') === 'krew' ? 'krew' : 'kedge') as 'kedge' | 'krew'
+    const ok = await tenant.downloadKubeconfig(tenant.orgUUID, uuid, install)
     if (!ok) flash('error', tenant.error ?? 'Failed to download kubeconfig.')
   } finally {
     const next = { ...wsBusy.value }

--- a/portal/src/stores/tenant.ts
+++ b/portal/src/stores/tenant.ts
@@ -511,8 +511,20 @@ export const useTenantStore = defineStore('tenant', () => {
   // credential plugin (OIDC mode) or the caller's bearer token
   // (static-token mode); the portal just relays bytes. Returns true on
   // success — failures populate `error` and surface in the calling page.
-  async function downloadKubeconfig(targetOrgUUID: string, wsUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/kubeconfig`, {
+  //
+  // `install` selects the exec credential plugin Command in OIDC mode:
+  //   - 'kedge'         → Command="kedge" (curl/tar.gz install on PATH)
+  //   - 'krew'          → Command="kubectl-kedge" (krew install, no
+  //                       symlink). The same binary, just renamed by krew.
+  // Defaults to 'kedge' for back-compat with the v1 endpoint. Ignored in
+  // static-token mode (no exec plugin emitted).
+  async function downloadKubeconfig(
+    targetOrgUUID: string,
+    wsUUID: string,
+    install: 'kedge' | 'krew' = 'kedge',
+  ): Promise<boolean> {
+    const url = `/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/kubeconfig?install=${encodeURIComponent(install)}`
+    const resp = await fetch(url, {
       headers: {
         ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
@@ -530,14 +542,14 @@ export const useTenantStore = defineStore('tenant', () => {
     const cd = resp.headers.get('Content-Disposition') ?? ''
     const match = cd.match(/filename="?([^";]+)"?/i)
     const filename = match?.[1] ?? `kedge-${wsUUID}.kubeconfig`
-    const url = URL.createObjectURL(blob)
+    const blobURL = URL.createObjectURL(blob)
     const a = document.createElement('a')
-    a.href = url
+    a.href = blobURL
     a.download = filename
     document.body.appendChild(a)
     a.click()
     a.remove()
-    URL.revokeObjectURL(url)
+    URL.revokeObjectURL(blobURL)
     return true
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #217 that fixes two issues with the per-workspace kubeconfig download flow:

- **Token cache races / silent burns** — `kedge get-token` now wraps the load → expiry-check → refresh → save cycle under an exclusive `flock(2)` / `LockFileEx` so concurrent kubectl invocations can't both consume the cached single-use refresh token. A successful refresh that fails to persist is now a hard error rather than a `warning:` print, so we don't return success after silently rotating the IdP-side token but losing the new one locally. `SaveTokenCache` writes atomically (temp file + fsync + rename).
- **Krew install variant** — the release channel ships the binary as `kubectl-kedge` (no `kedge` symlink), but the downloaded kubeconfig hardcoded `Command: kedge`, so krew users hit `executable file not found`. The endpoint now accepts `?install=kedge|krew` and emits the matching Command. Portal's chip popover gets a small `kedge`/`krew` dropdown that persists to localStorage; the per-row download button on the Workspaces tab reuses the same choice.

## Test plan
- [x] `go build ./...` (darwin + `GOOS=windows`) — both lock variants compile
- [x] `go test ./pkg/cli/auth/... ./pkg/hub/restapi/... ./pkg/cli/cmd/...`
  - New `TestSaveTokenCache_Atomic` round-trips Save→Load
  - New `TestLockTokenCache_Serialises` runs 8 goroutines × 10 iterations under the lock and asserts max concurrent holders == 1
  - New `TestDownloadKubeconfig_InstallVariant` covers default, both aliases, and the 400 path
- [x] `vue-tsc -b` (portal type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)