### PR TITLE
hub+portal: sync GraphQL cluster to active workspace on switch

### DIFF
--- a/pkg/hub/restapi/restapi.go
+++ b/pkg/hub/restapi/restapi.go
@@ -445,10 +445,20 @@ func projectOrg(o *tenancyv1alpha1.Organization) OrgView {
 }
 
 // WorkspaceView is the REST projection of a child Workspace.
+//
+// ClusterName is the kcp logical-cluster short hash backing this
+// workspace (Workspace.spec.cluster). The portal uses it to address
+// the GraphQL endpoint `/graphql/{clusterName}` for the active
+// workspace; without it, a workspace switch in the UI cannot retarget
+// per-workspace queries (MCP, edges, …) to the new cluster. May be
+// empty when the workspace has not yet reached Ready and kcp has not
+// assigned a cluster hash — callers should treat it as "not switchable
+// yet" rather than an error.
 type WorkspaceView struct {
 	UUID                string     `json:"uuid"`
 	OrgUUID             string     `json:"orgUUID"`
 	DisplayName         string     `json:"displayName,omitempty"`
+	ClusterName         string     `json:"clusterName,omitempty"`
 	DeletionRequestedAt *time.Time `json:"deletionRequestedAt,omitempty"`
 }
 

--- a/pkg/hub/restapi/workspaces.go
+++ b/pkg/hub/restapi/workspaces.go
@@ -161,9 +161,16 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, WorkspaceView{
-		UUID: wsUUID, OrgUUID: orgUUID, DisplayName: req.DisplayName,
-	})
+	// Project the freshly-created workspace through workspaceView so the
+	// response carries clusterName (EnsureChildWorkspace blocks on Ready,
+	// so spec.cluster is populated by now). Fall back to the partial
+	// view if the projection unexpectedly fails — the row still renders
+	// in the switcher and the user can retry the switch once it settles.
+	view, ok := h.workspaceView(r, orgUUID, wsUUID)
+	if !ok {
+		view = WorkspaceView{UUID: wsUUID, OrgUUID: orgUUID, DisplayName: req.DisplayName}
+	}
+	writeJSON(w, http.StatusCreated, view)
 }
 
 // getWorkspace returns one Workspace projection.
@@ -243,6 +250,14 @@ func (h *Handler) workspaceView(r *http.Request, orgUUID, wsUUID string) (Worksp
 		return WorkspaceView{}, false
 	}
 	view := WorkspaceView{UUID: wsUUID, OrgUUID: orgUUID, DisplayName: dn}
+	// Best-effort cluster-name lookup: omit when the workspace has not
+	// reached Ready (no spec.cluster yet) so the portal can show the row
+	// but skip retargeting GraphQL until it settles. The error case is
+	// indistinguishable from "not Ready" here and the row is still useful
+	// for display, so swallow it.
+	if cluster, err := h.mgr.bootstrapper.GetChildWorkspaceClusterName(r.Context(), orgUUID, wsUUID); err == nil && cluster != "" {
+		view.ClusterName = cluster
+	}
 	if t, found, err := h.mgr.bootstrapper.GetWorkspaceDeletionRequestedAt(r.Context(), orgUUID, wsUUID); err == nil && found && t != nil {
 		tt := *t
 		view.DeletionRequestedAt = &tt

--- a/portal/src/App.vue
+++ b/portal/src/App.vue
@@ -2,11 +2,13 @@
 import { onMounted, watch } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useProvidersStore } from '@/stores/providers'
+import { useTenantStore } from '@/stores/tenant'
 import { useRouter } from 'vue-router'
 import { registerProviderRoutes } from '@/router/providers'
 
 const auth = useAuthStore()
 const providers = useProvidersStore()
+const tenant = useTenantStore()
 const router = useRouter()
 
 // Register the dynamic provider route shape exactly once at app boot, before
@@ -26,6 +28,27 @@ watch(
   () => auth.isAuthenticated,
   (ok) => {
     if (ok && !providers.loaded) providers.load()
+  },
+)
+
+// Tenant → auth bridge: the sidebar TenantContextChip switches the active
+// org/workspace by mutating the tenant store, but every `/graphql/{cluster}`
+// query is built from auth.clusterName. Without this sync the user flips
+// workspace in the chip and the MCP/edges/workload pages keep showing data
+// from the login-time DefaultCluster. Mirror activeWorkspace.clusterName →
+// auth.clusterName so:
+//   1. useGraphQLQuery's watchEffect (which reads auth.isAuthenticated, a
+//      getter over s.clusterName) re-fires and re-queries the new cluster.
+//   2. ProviderFrame's watch on auth.clusterName pushes a fresh
+//      kedgeContext to the mounted provider element; its auth-adapter
+//      hydrates and its useGraphQLQuery re-fires the same way.
+// The hub omits clusterName until the workspace reports Ready, so guard on
+// a non-empty value to avoid clearing a working selection during the brief
+// window before fetchWorkspaces resolves on a hard refresh.
+watch(
+  () => tenant.activeWorkspace?.clusterName,
+  (cluster) => {
+    if (cluster) auth.setClusterName(cluster)
   },
 )
 </script>

--- a/portal/src/stores/auth.ts
+++ b/portal/src/stores/auth.ts
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import type { AuthMode, HealthzResponse, StoredAuth } from '@/auth/types'
 import { loadAuth, saveAuth, clearAuth, isExpired, refreshToken, parseClusterName } from '@/auth/token'
 import { fetchHealthz, loginWithToken } from '@/lib/api'
+import { STORAGE_KEYS } from '@/lib/constants'
 
 export const useAuthStore = defineStore('auth', () => {
   const stored = loadAuth()
@@ -91,6 +92,35 @@ export const useAuthStore = defineStore('auth', () => {
     clusterName.value = null
   }
 
+  // setClusterName retargets every `/graphql/{clusterName}` query to a
+  // different kcp logical cluster. Called from the tenant→auth sync in
+  // App.vue when the user picks a different workspace in the sidebar
+  // switcher (without this, MCP/edges/workload pages keep showing data
+  // from the login-time DefaultCluster regardless of the selection).
+  //
+  // Persists to StoredAuth so a hard refresh restores the same target
+  // instead of snapping back to DefaultCluster. The tenant store also
+  // persists the workspaceUUID; on reload App.vue re-syncs from
+  // workspace → clusterName once fetchWorkspaces resolves, keeping
+  // both sides consistent.
+  function setClusterName(name: string | null) {
+    if (clusterName.value === name) return
+    clusterName.value = name
+    try {
+      const raw = localStorage.getItem(STORAGE_KEYS.auth)
+      // Best-effort persist: skip when no StoredAuth exists yet (the
+      // setter can fire before login completes on a stale localStorage).
+      if (!raw) return
+      const parsed = JSON.parse(raw) as { clusterName?: string }
+      if (parsed && parsed.clusterName !== name) {
+        parsed.clusterName = name ?? ''
+        localStorage.setItem(STORAGE_KEYS.auth, JSON.stringify(parsed))
+      }
+    } catch {
+      /* ignore quota / parse errors — in-memory update is what matters */
+    }
+  }
+
   return {
     token,
     user,
@@ -105,5 +135,6 @@ export const useAuthStore = defineStore('auth', () => {
     loginFromOIDCResponse,
     getValidToken,
     logout,
+    setClusterName,
   }
 })

--- a/portal/src/stores/tenant.ts
+++ b/portal/src/stores/tenant.ts
@@ -52,6 +52,10 @@ export interface WorkspaceRow {
   // which has no display-name annotation yet. Callers must guard with
   // `?? ''` or `w.displayName || w.uuid` before reading.
   displayName?: string
+  // kcp logical-cluster short hash backing the workspace. Used to
+  // retarget `/graphql/{clusterName}` when the user switches workspace
+  // in the sidebar; omitted by the hub until the workspace reports Ready.
+  clusterName?: string
   deletionRequestedAt?: string | null
 }
 


### PR DESCRIPTION
## Summary

The sidebar TenantContextChip switcher only mutated `tenant.workspaceUUID`, but every `/graphql/{clusterName}` query (in the portal and in provider micro-frontends via the auth-adapter) is built from `auth.clusterName` — which stayed pinned to the login-time DefaultCluster. Result: switching org/workspace left the MCP, edges, and workload pages staring at the original cluster's data.

- **Hub** — `WorkspaceView` gains `clusterName`, populated from `bootstrapper.GetChildWorkspaceClusterName` (best-effort; omitted before the workspace reports Ready). `createWorkspace` now routes its response through `workspaceView()` so the freshly-created row is consistent.
- **Portal** — `WorkspaceRow` mirrors the field. Auth store gets a `setClusterName(name)` action that updates the ref and persists to `StoredAuth` so a hard refresh restores the same target. App.vue watches `tenant.activeWorkspace?.clusterName` and pipes it into `auth.setClusterName(...)`.
- **Providers, untouched** — `ProviderFrame`'s existing watch on `auth.clusterName` re-pushes `kedgeContext` to the mounted custom element; the provider-local auth-adapter re-hydrates, and `useGraphQLQuery`'s `watchEffect` (which reads `s.clusterName` via the `isAuthenticated` getter) re-fires with the new URL. No provider source changes — the propagation pipeline was already wired; it just had nothing to propagate.

## Test plan
- [x] `go build ./pkg/hub/...`
- [x] `go test ./pkg/hub/restapi/...`
- [x] `npm run build` in `portal/` (vue-tsc + vite, clean)
- [ ] Manual: switch workspace in the chip → MCP/edges list refresh against the new cluster
- [ ] Manual: hard refresh after switching → same workspace remains active

🤖 Generated with [Claude Code](https://claude.com/claude-code)