### PR TITLE
hub: grant workspace RBAC on workspace create + membership add + reconciler backfill

### DIFF
--- a/pkg/hub/controllers/organization/controller.go
+++ b/pkg/hub/controllers/organization/controller.go
@@ -576,6 +576,22 @@ func (r *Reconciler) reconcileOrganizationStatus(ctx context.Context, user *tena
 		changed = true
 	}
 
+	// Step H-backfill: ensure cluster-admin in every other workspace the
+	// user belongs to in this Org. The original H step above only handled
+	// user.Status.DefaultWorkspace; workspaces created via the REST
+	// surface (POST /api/orgs/{org}/workspaces) historically skipped the
+	// RBAC grant, so a portal switch into one of them 403s from the
+	// GraphQL gateway. Walking the UMI is the canonical source of "what
+	// workspaces should this user have access to" — the REST handler now
+	// grants RBAC inline, but this reconciler step self-heals legacy
+	// state and survives any future drift. Best-effort: per-workspace
+	// failures log + continue rather than fail the whole reconcile.
+	if workspaceAdminOK && user.Spec.RBACIdentity != "" {
+		if err := r.backfillWorkspaceAdmins(ctx, user, org.Name, wsUUID, logger); err != nil {
+			logger.Error(err, "UMI workspace-admin backfill failed; will retry on next reconcile")
+		}
+	}
+
 	// Step I: default MCPServer (only after H succeeded — needs admin
 	// claims accepted via the kedge APIBinding).
 	var mcpCond metav1.Condition
@@ -787,6 +803,44 @@ func (r *Reconciler) reconcileWorkspace(ctx context.Context, org *tenancyv1alpha
 		Reason:  reasonWorkspaceProvisioned,
 		Message: "kcp Workspace " + desiredPath + " is Ready.",
 	}, true
+}
+
+// backfillWorkspaceAdmins walks the User's UMI workspace-scope entries
+// for the given org and ensures cluster-admin RBAC for the user's
+// rbacIdentity in each (excluding skipWsUUID, which the caller already
+// reconciled as Step H). Pre-PR fix the REST createWorkspace path
+// skipped EnsureChildWorkspaceAdmin entirely, leaving every
+// portal-created workspace without a kedge-cluster-admin
+// ClusterRoleBinding — switching to one of them surfaced as a GraphQL
+// 403 once the workspace switcher actually retargeted /graphql/{cluster}
+// in v0.0.63. This reconciler step self-heals that legacy state.
+//
+// Errors on individual workspaces are logged and skipped; one bad
+// workspace must not stall the whole Org reconcile. Idempotent —
+// EnsureChildWorkspaceAdmin handles the AlreadyExists / subject-rewrite
+// cases internally.
+func (r *Reconciler) backfillWorkspaceAdmins(ctx context.Context, user *tenancyv1alpha1.User, orgUUID, skipWsUUID string, logger logr.Logger) error {
+	var index tenancyv1alpha1.UserMembershipIndex
+	if err := r.client.Get(ctx, types.NamespacedName{Name: user.Name}, &index); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("loading UMI for workspace-admin backfill: %w", err)
+	}
+	for _, e := range index.Spec.Entries {
+		if e.OrgUUID != orgUUID || e.WorkspaceUUID == "" || e.WorkspaceUUID == skipWsUUID {
+			continue
+		}
+		if e.SoftDeletedAt != nil {
+			continue
+		}
+		if err := r.provisioner.EnsureChildWorkspaceAdmin(ctx, orgUUID, e.WorkspaceUUID, user.Spec.RBACIdentity); err != nil {
+			logger.Error(err, "Granting workspace-admin failed; will retry on next reconcile",
+				"workspaceUUID", e.WorkspaceUUID)
+			continue
+		}
+	}
+	return nil
 }
 
 // aggregateReady combines the seven step outcomes (workspace,

--- a/pkg/hub/restapi/memberships.go
+++ b/pkg/hub/restapi/memberships.go
@@ -275,6 +275,24 @@ func (h *Handler) addWorkspaceMembership(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	dn, _ := h.mgr.bootstrapper.GetWorkspaceDisplayName(r.Context(), tc.OrgUUID, tc.WorkspaceUUID)
+	// Grant the new member RBAC in the workspace's kcp cluster. The UMI
+	// row alone is portal metadata — without a matching kcp CRB the
+	// GraphQL gateway 403s the moment the member tries to switch to
+	// this workspace. SAs currently map both admin+member to
+	// cluster-admin (see serviceaccounts.buildCRB); we follow the same
+	// posture until the kedge:workspace:admin/member ClusterRoles are
+	// bootstrapped.
+	target, err := h.mgr.client.Users().Get(r.Context(), req.User, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if target.Spec.RBACIdentity != "" {
+		if err := h.mgr.bootstrapper.EnsureChildWorkspaceAdmin(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, target.Spec.RBACIdentity); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
 	if err := h.mgr.upsertUMIEntry(r.Context(), req.User, tenancyv1alpha1.MembershipIndexEntry{
 		OrgUUID:              tc.OrgUUID,
 		OrgDisplayName:       org.Spec.DisplayName,

--- a/pkg/hub/restapi/restapi.go
+++ b/pkg/hub/restapi/restapi.go
@@ -73,6 +73,13 @@ type WorkspaceOps interface {
 	EnsureChildWorkspace(ctx context.Context, orgUUID, wsUUID string) error
 	EnsureChildWorkspaceKedgeBinding(ctx context.Context, orgUUID, wsUUID string) error
 	EnsureChildWorkspaceDefaultMCPServer(ctx context.Context, orgUUID, wsUUID string) error
+	// EnsureChildWorkspaceAdmin grants cluster-admin in the child team
+	// Workspace to the given rbacIdentity. Idempotent. Used at workspace
+	// create time and when adding a member, since the kcp-side CRB is
+	// otherwise only seeded by the org bootstrap controller for the
+	// user's default workspace — every other workspace would 403 from
+	// the GraphQL gateway without this call.
+	EnsureChildWorkspaceAdmin(ctx context.Context, orgUUID, wsUUID, rbacIdentity string) error
 	ListChildWorkspaces(ctx context.Context, orgUUID string) ([]string, error)
 	GetWorkspaceDisplayName(ctx context.Context, orgUUID, wsUUID string) (string, error)
 	SetWorkspaceDisplayName(ctx context.Context, orgUUID, wsUUID, displayName string) error

--- a/pkg/hub/restapi/restapi_test.go
+++ b/pkg/hub/restapi/restapi_test.go
@@ -53,6 +53,7 @@ type fakeOps struct {
 	wsDeletionAnnos   map[wsKey]time.Time          // (org,ws) → timestamp
 	mcpServerCalls    map[wsKey]int                // (org,ws) → count
 	kedgeBindingCalls map[wsKey]int                // (org,ws) → count
+	workspaceAdmins   map[wsKey]map[string]bool    // (org,ws) → rbacIdentity set
 }
 
 type wsKey struct{ Org, WS string }
@@ -66,6 +67,7 @@ func newFakeOps() *fakeOps {
 		wsDeletionAnnos:   map[wsKey]time.Time{},
 		mcpServerCalls:    map[wsKey]int{},
 		kedgeBindingCalls: map[wsKey]int{},
+		workspaceAdmins:   map[wsKey]map[string]bool{},
 	}
 }
 
@@ -210,6 +212,23 @@ func (f *fakeOps) GetChildWorkspaceClusterName(_ context.Context, orgUUID, wsUUI
 	// Deterministic fake cluster name; the kubeconfig handler only needs a
 	// non-empty value to build a valid /clusters/<name> URL in tests.
 	return "fake-" + wsUUID, nil
+}
+
+func (f *fakeOps) EnsureChildWorkspaceAdmin(_ context.Context, orgUUID, wsUUID, rbacIdentity string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.childWorkspaces[orgUUID][wsUUID]; !ok {
+		return fmt.Errorf("workspace not found")
+	}
+	if f.workspaceAdmins == nil {
+		f.workspaceAdmins = map[wsKey]map[string]bool{}
+	}
+	key := wsKey{orgUUID, wsUUID}
+	if f.workspaceAdmins[key] == nil {
+		f.workspaceAdmins[key] = map[string]bool{}
+	}
+	f.workspaceAdmins[key][rbacIdentity] = true
+	return nil
 }
 
 // ===== test fixtures =====
@@ -453,7 +472,11 @@ func TestCreateWorkspace_HappyPath(t *testing.T) {
 			WorkspaceCreation: tenancyv1alpha1.WorkspaceCreationMembers,
 		},
 	}
-	mgr, ops, _ := newTestManager(t, org)
+	alice := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice"},
+		Spec:       tenancyv1alpha1.UserSpec{Email: "alice@example.com", RBACIdentity: "kedge:alice@example.com"},
+	}
+	mgr, ops, _ := newTestManager(t, org, alice)
 	srv := newTestServer(t, mgr, adminTC("alice", "org-a", ""))
 	defer srv.Close()
 
@@ -481,6 +504,14 @@ func TestCreateWorkspace_HappyPath(t *testing.T) {
 	}
 	if ops.wsDisplayNames[wsKey{"org-a", view.UUID}] != "platform" {
 		t.Errorf("display name not set: %v", ops.wsDisplayNames)
+	}
+	// Regression guard for the v0.0.63 workspace-switch 403: createWorkspace
+	// must seed the caller's cluster-admin CRB; without it the freshly-
+	// minted workspace 403s from the GraphQL gateway the moment the user
+	// switches into it.
+	if !ops.workspaceAdmins[wsKey{"org-a", view.UUID}]["kedge:alice@example.com"] {
+		t.Errorf("EnsureChildWorkspaceAdmin not called for caller; admins=%v",
+			ops.workspaceAdmins[wsKey{"org-a", view.UUID}])
 	}
 }
 

--- a/pkg/hub/restapi/workspaces.go
+++ b/pkg/hub/restapi/workspaces.go
@@ -143,6 +143,23 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+	// Grant cluster-admin to the caller in the freshly-minted workspace.
+	// Without this the workspace is unreachable from the portal (the
+	// GraphQL gateway calls into kcp on the caller's bearer token and
+	// kcp 403s without a matching ClusterRoleBinding). The org bootstrap
+	// controller only ever seeded the binding for the user's default
+	// workspace — any portal-created workspace stayed RBAC-less.
+	callerUser, err := h.mgr.client.Users().Get(r.Context(), tc.User, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if callerUser.Spec.RBACIdentity != "" {
+		if err := h.mgr.bootstrapper.EnsureChildWorkspaceAdmin(r.Context(), orgUUID, wsUUID, callerUser.Spec.RBACIdentity); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
 	if err := h.mgr.bootstrapper.EnsureChildWorkspaceDefaultMCPServer(r.Context(), orgUUID, wsUUID); err != nil {
 		writeError(w, err)
 		return


### PR DESCRIPTION
## Summary

Followup to #219 / v0.0.63. The new workspace switcher actually retargets `/graphql/{cluster}` to the active workspace, which exposed a long-standing gap: the only path that seeded a `kedge-cluster-admin` ClusterRoleBinding was the org bootstrap controller, and it only ever did so for `user.Status.DefaultWorkspace`. Workspaces created from the portal landed in the UMI but never got a CRB — the moment a user switched into one the GraphQL gateway 403'd:

```
[GraphQL] unable to list objects: edges.kedge.faros.sh is forbidden:
User "kedge:mangirdas@judeikis.lt" cannot list resource "edges" in API group
"kedge.faros.sh" at the cluster scope: access denied
```

`createWorkspace`'s comment claimed "grants admin RBAC" — the call was never wired. Same for `addWorkspaceMembership`. This PR closes the gap forward, and the reconciler self-heals legacy state.

### Changes

- **REST `createWorkspace`** (`pkg/hub/restapi/workspaces.go`) — resolve the caller's `User.spec.RBACIdentity` and call `EnsureChildWorkspaceAdmin` against the freshly-minted workspace.
- **REST `addWorkspaceMembership`** (`pkg/hub/restapi/memberships.go`) — same for the target user. Matches the existing SA RBAC posture (admin+member both → cluster-admin) until `kedge:workspace:admin/member` ClusterRoles are bootstrapped.
- **Organization reconciler** (`pkg/hub/controllers/organization/controller.go`) — new Step H-backfill walks the user's UMI workspace-scope entries for this org and `EnsureChildWorkspaceAdmin` on each non-default workspace. Idempotent, best-effort: per-workspace failures log + continue rather than fail the whole reconcile. Self-heals legacy state on next reconcile.
- **`WorkspaceOps` interface** (`pkg/hub/restapi/restapi.go`) — adds `EnsureChildWorkspaceAdmin`. Fake gains `workspaceAdmins` map.
- **`TestCreateWorkspace_HappyPath`** — asserts the caller's rbacIdentity ends up in the workspace's admin set.

### Prod hotfix already applied

Manually created the missing `kedge-cluster-admin` CRB in both affected workspace clusters (`2sllaz9gyoqedk2f`, `1hevtzkli36tfg02`) to unblock the user. This PR ensures the same can't recur and brings any other legacy workspaces into compliance the next time the org reconciles.

## Test plan
- [x] `go build ./pkg/hub/...`
- [x] `go test ./pkg/hub/restapi/... ./pkg/hub/controllers/organization/...`
- [ ] Deploy + manually create a fresh workspace in the portal, switch into it, confirm MCP/edges queries succeed without manual CRB intervention
- [ ] Confirm the reconciler back-fills any pre-existing workspace by deleting the CRB and watching it return

🤖 Generated with [Claude Code](https://claude.com/claude-code)