### PR TITLE
portal: fix dead /edges link in FirstEdgeWizard footer

### DIFF
--- a/portal/src/components/FirstEdgeWizard.vue
+++ b/portal/src/components/FirstEdgeWizard.vue
@@ -492,7 +492,7 @@ function finish() {
       <button
         type="button"
         class="font-medium text-text-muted transition-colors hover:text-text-secondary"
-        @click="router.push('/edges')"
+        @click="router.push('/providers/kubernetes-edges')"
       >
         Already have an edge? Go to Edges →
       </button>


### PR DESCRIPTION
## Summary

The FirstEdgeWizard footer button "Already have an edge? Go to Edges →" still pushed `/edges`, which was removed when the kubernetes-edges provider became a micro-frontend. Same component already uses `/providers/kubernetes-edges/{name}` for per-edge links (lines 182, 425) — just align the footer button with the same root.

## Test plan
- [x] `npm run build` (vue-tsc + vite) clean
- [ ] Open the wizard, click "Already have an edge? Go to Edges →" — lands on the kubernetes-edges provider page

🤖 Generated with [Claude Code](https://claude.com/claude-code)