### PR TITLE
portal: remount active page on workspace/org switch to reset state

### DIFF
--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -620,7 +620,21 @@ const layoutInsetsStyle = computed<Record<string, string>>(() => {
       :style="mainPaddingBottom ? { paddingBottom: mainPaddingBottom } : undefined"
     >
       <div class="dot-grid pointer-events-none absolute inset-0 opacity-40" />
-      <div class="relative z-10">
+      <!--
+        Keying the slot on auth.clusterName forces the active page to
+        unmount + remount when the user switches workspace or org. The
+        v0.0.63 fix retargets /graphql/{cluster} so new queries hit the
+        right shard, but pages keep displaying the previous workspace's
+        payload until the next poll fires (10s+ for MCP/edges), and
+        provider micro-frontends carry their own Pinia/URQL caches the
+        URL change never invalidates. Unmounting here propagates through
+        ProviderFrame: its onBeforeUnmount removes the custom element,
+        the element's disconnectedCallback tears down the inner Vue app,
+        and the next render boots a fresh provider with empty state.
+        The chrome above (sidebar, TenantContextChip, popover) stays
+        mounted because the key is on the slot wrapper, not the layout.
+      -->
+      <div :key="auth.clusterName ?? 'unauth'" class="relative z-10">
         <slot />
       </div>
     </main>


### PR DESCRIPTION
## Summary

Followup to v0.0.63 + #220. The GraphQL URL retarget works — new queries hit the new cluster — but each page keeps rendering the previous workspace's payload until its next poll fires (10s+ on MCP/edges), and provider micro-frontends carry their own Pinia/URQL caches the URL change can't invalidate. Symptom reported: switch workspace, edge/server/MCP lists stay stale until manual refresh.

### Fix

One-line key on the slot wrapper inside `AppLayout` — `:key="auth.clusterName ?? 'unauth'"`. When the cluster changes, the active page unmounts and remounts cleanly. The propagation works as follows:

- **Host pages** (`DashboardPage`, `ProvidersPage`, `TenantSettingsPage`, etc.): every `useGraphQLQuery` instance re-runs setup with `data.value = null`, kicks off an immediate first fetch — no stale flash.
- **Provider micro-frontends**: `ProviderFrame` unmounts → `onBeforeUnmount` removes the custom element from the DOM → element's `disconnectedCallback` tears down the inner Vue app + Pinia → on remount, `loadAndMount` creates a fresh element with the new context. No provider-side code change required.
- **Chrome stays put**: sidebar, `TenantContextChip` popover, header — all outside the keyed wrapper, so they don't flicker.

### Why not other options

- Per-provider explicit reset signal: would require every provider to implement reset hooks for every Pinia store, easy to miss new state.
- `useGraphQLQuery` clears `data` on cluster change: doesn't help provider micro-frontends' internal caches or anything outside that composable.

The remount approach handles everything uniformly because Vue's unmount lifecycle already wires through to the provider's `disconnectedCallback`.

## Test plan
- [x] `npm run build` clean (vue-tsc + vite)
- [ ] Manual: open dashboard with edges/MCP visible, switch workspace in the chip, confirm tiles immediately reflect new workspace (no stale rows)
- [ ] Manual: navigate to a provider page (e.g. `/providers/kubernetes-edges`), switch workspace, confirm the page reloads with the new workspace's edges
- [ ] Manual: chip popover stays open with selection visible during the switch — no flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)