### PR TITLE
providers: ship distinct icon.svg for kubernetes-edges, server-edges, and mcp

### DIFF
--- a/providers/kubernetesedges/portal/public/icon.svg
+++ b/providers/kubernetesedges/portal/public/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+  stroke="#326CE5" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hexagonal frame evokes the Kubernetes logo without copying it. -->
+  <path d="M12 2.5l8.5 4.75v9.5L12 21.5l-8.5-4.75v-9.5z"/>
+  <!-- Inner control-plane node with four worker pods radiating off it. -->
+  <circle cx="12" cy="12" r="2.25"/>
+  <path d="M12 6.5v3.25M12 14.25v3.25M5.75 9.25l2.75 1.5M18.25 9.25l-2.75 1.5M5.75 14.75l2.75-1.5M18.25 14.75l-2.75-1.5"/>
+</svg>

--- a/providers/mcp/portal/public/icon.svg
+++ b/providers/mcp/portal/public/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+  stroke="#f59e0b" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Bot head with antenna — reads as "AI tool surface" at small sizes. -->
+  <path d="M12 2v2.5"/>
+  <circle cx="12" cy="2" r="0.75" fill="#f59e0b" stroke="none"/>
+  <rect x="4" y="6" width="16" height="13" rx="2.5"/>
+  <!-- Eye dots + speaker grille bridge the bot motif and the protocol idea. -->
+  <circle cx="9" cy="12" r="1.1" fill="#f59e0b" stroke="none"/>
+  <circle cx="15" cy="12" r="1.1" fill="#f59e0b" stroke="none"/>
+  <path d="M9 16h6"/>
+</svg>

--- a/providers/serveredges/portal/public/icon.svg
+++ b/providers/serveredges/portal/public/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+  stroke="#10b981" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Stacked 1U-style server units. Reads as "rack" at 14x14 px. -->
+  <rect x="3.5" y="4" width="17" height="5.5" rx="1"/>
+  <rect x="3.5" y="14.5" width="17" height="5.5" rx="1"/>
+  <!-- LED + slot rows hint at hardware without crowding the silhouette. -->
+  <circle cx="6.25" cy="6.75" r="0.5" fill="#10b981" stroke="none"/>
+  <circle cx="6.25" cy="17.25" r="0.5" fill="#10b981" stroke="none"/>
+  <path d="M8.5 6.75h8M8.5 17.25h8"/>
+</svg>


### PR DESCRIPTION
## Summary

The portal already has per-provider icon support (`iconURL` on the catalog, with [`pkg/hub/providers/api.go:125`](pkg/hub/providers/api.go#L125) auto-defaulting to `/ui/providers/{name}/icon.svg` for any provider with a UI). But none of the three built-in providers actually ship an SVG, so the portal falls back to the `Puzzle` Lucide icon for all of them. Result: kubernetes-edges, server-edges, and mcp are visually identical everywhere — sidebar, dashboard tiles, provider frame header.

Each provider now has a `public/icon.svg` that Vite copies into `dist/` on build. The existing `//go:embed all:portal/dist` directive picks them up; the URL `/ui/providers/{name}/icon.svg` resolves automatically.

- **kubernetes-edges** — hexagonal frame with central node + radial pods (Kubernetes blue, `#326CE5`).
- **server-edges** — stacked 1U rack units with LEDs (emerald green, `#10b981`).
- **mcp** — bot head with antenna, eyes, speaker grille (amber, `#f59e0b`).

All three keep the 24×24 viewBox + `stroke-width 1.75` posture the existing quickstart icon established, so the chrome stays consistent.

## Test plan
- [x] `make build-kubernetes-edges-provider-portal build-server-edges-provider-portal build-mcp-provider-portal` — each rebuilds, `dist/icon.svg` appears.
- [x] `go build ./providers/... ./pkg/hub/...` — embed picks up the new files cleanly.
- [ ] Manual: sidebar, dashboard tiles, and provider-frame header show three distinct icons instead of three puzzle pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)