### PR TITLE
ci: bump e2e-ssh job timeout to 60m

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -80,7 +80,7 @@ jobs:
   e2e-ssh:
     name: SSH Server-Mode (hub-only cluster)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

`e2e-ssh` had `timeout-minutes: 30` while its test step called `make e2e-ssh E2E_TIMEOUT=30m` — after the ~7m build the test step only had ~23m before the job-level timeout terminated it mid-run. That left the suite flaking on most PRs (seen on #218 reruns and several recent main pushes).

Bumps to 60m to match the `e2e-standalone` budget (60m job / 50m test) which has consistently passed.

## Test plan
- [ ] CI green