### PR TITLE
dev: add edge-kube, edge-server, and ssh-server to Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,4 +1,4 @@
-# Tiltfile — local dev for kedge hub + portal
+# Tiltfile — local dev for kedge hub + portal + edges
 # Replaces: make run-hub-embedded-static (terminal 1) + make dev-portal (terminal 2)
 # Usage: tilt up
 
@@ -20,6 +20,7 @@ local_resource(
         'providers/kubernetesedges/portal/src',
         'providers/serveredges/portal/src',
     ],
+    labels=['hub'],
 )
 
 # ---------------------------------------------------------------------------
@@ -59,4 +60,62 @@ go build -o bin/kedge-hub ./cmd/kedge-hub
         'providers/serveredges',
     ],
     resource_deps=['portal'],
+    labels=['hub'],
+)
+
+# ---------------------------------------------------------------------------
+# edges — kubernetes & server agents. All manual triggers (click ▶ in Tilt UI).
+#
+# Workflow:
+#   1. Click ▶ on `edge-{kube,server}-create` to log in via static token,
+#      register the Edge with the hub, and write .env.edge.<type>.
+#   2. Click ▶ on `edge-{kube,server}-agent` to run the agent.
+#        - kubernetes: also spins up a `kedge-agent` kind cluster on first run.
+#        - server: also click ▶ on `ssh-server` so the agent has an SSH target.
+# ---------------------------------------------------------------------------
+local_resource(
+    'edge-kube-create',
+    cmd='make dev-login-static && make dev-edge-create TYPE=kubernetes',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['edges'],
+)
+
+local_resource(
+    'edge-kube-agent',
+    serve_cmd='make dev-run-edge TYPE=kubernetes',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['edges'],
+)
+
+local_resource(
+    'edge-server-create',
+    cmd='make dev-login-static && make dev-edge-create TYPE=server',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['edges'],
+)
+
+local_resource(
+    'edge-server-agent',
+    serve_cmd='make dev-run-edge TYPE=server',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['edges'],
+)
+
+# openssh-server container — target for the server-edge agent.
+# Pre-step removes any stale container left from a previous run so the
+# named --name=openssh-server doesn't collide.
+local_resource(
+    'ssh-server',
+    serve_cmd='docker rm -f openssh-server >/dev/null 2>&1; make dev-run-ssh-server',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=['edges'],
 )


### PR DESCRIPTION
## Summary
- `tilt up` only ran hub + portal — spinning up an edge meant dropping to a terminal for `make dev-edge-create TYPE=...` and `make dev-run-edge TYPE=...`. Adds five manual-trigger resources under an `edges` label so the whole loop stays in the Tilt UI.
- Two `*-create` resources chain `dev-login-static` so kubectl is wired before the edge resource is registered; two `*-agent` resources run the existing make targets; `ssh-server` wraps `dev-run-ssh-server` with a pre-step that removes any stale openssh container so re-triggers don't collide on `--name`.
- All five are `TRIGGER_MODE_MANUAL` with `auto_init=False`, so `tilt up` still only brings up hub + portal automatically. The `*-create` resources `resource_deps` on `hub` so they wait for it to serve before calling kubectl. `hub` and `portal` get a separate `hub` label so the UI splits cleanly into the two groups.

## Test plan
- [ ] `tilt up` → only `hub`, `portal` start automatically.
- [ ] Click ▶ on `edge-kube-create` → Edge resource registered, `.env.edge.kubernetes` written.
- [ ] Click ▶ on `edge-kube-agent` → kind cluster `kedge-agent` comes up, agent connects.
- [ ] Click ▶ on `ssh-server` → openssh-server container running on :2222. Re-trigger → no `--name` collision.
- [ ] Click ▶ on `edge-server-create` then `edge-server-agent` → server-edge agent connects via SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)