### PR TITLE
portal: fix empty view on workspace switch + add wizard for empty orgs

### DIFF
--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -3,10 +3,12 @@ import { ref, onMounted, onUnmounted, computed, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useTerminalSessionsStore } from '@/stores/terminalSessions'
+import { useTenantStore } from '@/stores/tenant'
 import TerminalDock from '@/components/TerminalDock.vue'
 import CliQuickstartModal from '@/components/CliQuickstartModal.vue'
 import TenantContextChip from '@/components/TenantContextChip.vue'
 import ThemeSwitch from '@/components/ThemeSwitch.vue'
+import FirstWorkspaceWizard from '@/components/FirstWorkspaceWizard.vue'
 import { Hexagon, LayoutDashboard, LogOut, Zap, GripHorizontal, GripVertical, Pin, Terminal, Puzzle, Dot, Settings } from 'lucide-vue-next'
 import { useProvidersStore } from '@/stores/providers'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
@@ -14,6 +16,33 @@ import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
 const auth = useAuthStore()
 const terminalStore = useTerminalSessionsStore()
 const providersStore = useProvidersStore()
+const tenantStore = useTenantStore()
+
+const route = useRoute()
+const router = useRouter()
+
+// Empty-org guard: when the active org has zero workspaces (after fetch
+// completes), every workspace-scoped page would try to query a cluster
+// that doesn't exist. Replace the slot with the create-workspace wizard
+// instead. Pages that don't need a workspace — the tenant settings page
+// and the providers catalog — render normally so the user keeps a
+// non-blocked path to manage orgs/workspaces.
+//
+// workspacesByOrg[uuid] is undefined while the initial fetch is in
+// flight; we only show the wizard once it lands as an empty array, so
+// the UI doesn't flash the wizard between an org switch and the fetch
+// resolving.
+const showWorkspaceWizard = computed(() => {
+  if (!auth.isAuthenticated) return false
+  const orgUUID = tenantStore.orgUUID
+  if (!orgUUID) return false
+  const list = tenantStore.workspacesByOrg[orgUUID]
+  if (!list || list.length > 0) return false
+  const path = route.path
+  if (path === '/tenant' || path.startsWith('/tenant/')) return false
+  if (path === '/providers') return false
+  return true
+})
 
 const mainPaddingBottom = computed(() => {
   if (!terminalStore.isVisible || terminalStore.sessions.length === 0) return undefined
@@ -21,9 +50,6 @@ const mainPaddingBottom = computed(() => {
   const h = terminalStore.panelState.isMinimized ? 40 : terminalStore.panelState.height
   return `${h + 16}px`
 })
-
-const route = useRoute()
-const router = useRouter()
 
 const now = ref(new Date())
 let timer: ReturnType<typeof setInterval>
@@ -627,15 +653,23 @@ const layoutInsetsStyle = computed<Record<string, string>>(() => {
         right shard, but pages keep displaying the previous workspace's
         payload until the next poll fires (10s+ for MCP/edges), and
         provider micro-frontends carry their own Pinia/URQL caches the
-        URL change never invalidates. Unmounting here propagates through
-        ProviderFrame: its onBeforeUnmount removes the custom element,
-        the element's disconnectedCallback tears down the inner Vue app,
-        and the next render boots a fresh provider with empty state.
-        The chrome above (sidebar, TenantContextChip, popover) stays
-        mounted because the key is on the slot wrapper, not the layout.
+        URL change never invalidates. Unmounting here resets every host
+        page's useGraphQLQuery state; ProviderFrame's own watch on
+        auth.clusterName re-creates its custom element post-flush so
+        the new mountRef div doesn't render empty after the slot
+        wrapper rebuilds. The chrome above (sidebar, TenantContextChip,
+        popover) stays mounted because the key sits on the slot
+        wrapper, not the layout shell.
+
+        When the active org has no workspaces we never get a clusterName,
+        so swap the slot out for the create-workspace wizard. The wizard
+        triggers tenant.createWorkspace, which selects the new workspace,
+        which sets auth.clusterName, which re-keys this wrapper and
+        restores the original page.
       -->
       <div :key="auth.clusterName ?? 'unauth'" class="relative z-10">
-        <slot />
+        <FirstWorkspaceWizard v-if="showWorkspaceWizard" />
+        <slot v-else />
       </div>
     </main>
 

--- a/portal/src/components/FirstWorkspaceWizard.vue
+++ b/portal/src/components/FirstWorkspaceWizard.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+// Shown when the active org has zero workspaces. Replaces the would-be
+// page slot in AppLayout so the user gets a guided "create your first
+// workspace" affordance instead of a broken edges/dashboard/provider view
+// pointing at a non-existent cluster. Picking an org via the
+// TenantContextChip clears workspaceUUID; without this guard the app
+// keeps the previous org's clusterName pinned and every GraphQL query
+// runs against the wrong shard.
+//
+// Switching to an org that does have workspaces will re-select one
+// automatically (tenant.selectOrg → first workspace), so this view is
+// only ever reached for genuinely empty orgs.
+
+import { computed, ref } from 'vue'
+import { useTenantStore } from '@/stores/tenant'
+import { ArrowRight, FolderTree, Loader2, Sparkles, AlertCircle, Settings } from 'lucide-vue-next'
+
+const tenant = useTenantStore()
+const name = ref('')
+const busy = ref(false)
+const error = ref<string | null>(null)
+
+const trimmed = computed(() => name.value.trim())
+const canSubmit = computed(() => trimmed.value.length > 0 && !busy.value && !!tenant.orgUUID)
+
+async function handleCreate() {
+  if (!canSubmit.value || !tenant.orgUUID) return
+  busy.value = true
+  error.value = null
+  try {
+    const created = await tenant.createWorkspace(tenant.orgUUID, trimmed.value)
+    if (!created) {
+      error.value = tenant.error ?? 'Failed to create workspace'
+    }
+    // On success the tenant store selects the new workspace, App.vue's
+    // watch on activeWorkspace.clusterName fires auth.setClusterName,
+    // AppLayout re-keys the slot, and the original page renders.
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to create workspace'
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto w-full max-w-xl pt-8">
+    <div class="mb-6 flex items-start gap-4">
+      <div class="relative flex h-12 w-12 shrink-0 items-center justify-center">
+        <div class="absolute inset-0 rounded-xl bg-accent/20 blur-md" />
+        <div class="relative flex h-12 w-12 items-center justify-center rounded-xl border border-accent/25 bg-surface-overlay">
+          <FolderTree class="h-6 w-6 text-accent" :stroke-width="1.5" />
+        </div>
+      </div>
+      <div class="flex-1">
+        <h1 class="flex items-center gap-2 text-[18px] font-bold text-text-primary">
+          Create your first workspace
+          <Sparkles class="h-4 w-4 text-accent" :stroke-width="1.75" />
+        </h1>
+        <p class="mt-1 text-[12px] text-text-muted">
+          <span class="font-mono text-text-secondary">{{ tenant.activeOrg?.displayName ?? 'This org' }}</span>
+          doesn't have a workspace yet. Workspaces are isolated kcp clusters where edges, MCP servers, and workloads live.
+        </p>
+      </div>
+    </div>
+
+    <div class="border-beam rounded-2xl">
+      <div class="space-y-5 rounded-2xl border border-border-subtle bg-surface-raised/80 p-6 backdrop-blur">
+        <div
+          v-if="error"
+          class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger"
+        >
+          <AlertCircle class="h-3.5 w-3.5 shrink-0" :stroke-width="1.75" />
+          {{ error }}
+        </div>
+
+        <div>
+          <label class="mb-1 block text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">
+            Workspace name
+          </label>
+          <input
+            v-model="name"
+            type="text"
+            placeholder="e.g. production"
+            class="w-full rounded-xl border border-border-default bg-surface-overlay/60 px-3 py-2.5 font-mono text-[12px] text-text-primary placeholder:text-text-muted/40 focus:border-accent/40 focus:outline-none"
+            autofocus
+            @keyup.enter="canSubmit && handleCreate()"
+          />
+          <p class="mt-1 text-[10px] text-text-muted">
+            A friendly name. The hub will allocate the underlying kcp cluster automatically.
+          </p>
+        </div>
+
+        <div class="flex items-center justify-between gap-3 pt-2">
+          <router-link
+            to="/tenant"
+            class="flex items-center gap-1.5 text-[11px] font-medium text-text-muted transition-colors hover:text-text-secondary"
+          >
+            <Settings class="h-3 w-3" :stroke-width="2" />
+            Manage workspaces in settings
+          </router-link>
+          <button
+            type="button"
+            class="group flex items-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[12px] font-semibold text-white transition-all hover:bg-accent-hover hover:shadow-lg hover:shadow-accent/20 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-40"
+            :disabled="!canSubmit"
+            @click="handleCreate"
+          >
+            <Loader2 v-if="busy" class="h-3.5 w-3.5 animate-spin" :stroke-width="2" />
+            <span>{{ busy ? 'Creating…' : 'Create workspace' }}</span>
+            <ArrowRight v-if="!busy" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" :stroke-width="2" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/portal/src/pages/ProviderFrame.vue
+++ b/portal/src/pages/ProviderFrame.vue
@@ -60,6 +60,41 @@ watch(
   () => pushContext(),
 )
 
+// Workspace/org switch: AppLayout keys its slot wrapper on auth.clusterName,
+// so the <div ref="mountRef" /> below is torn down and a new empty div is
+// mounted. The custom element that lived in the old div detaches from
+// DOM, its disconnectedCallback fires, and its Vue app + Pinia tear down
+// cleanly — but ProviderFrame itself stays mounted (it's the route
+// component above the slot), so elementRef still points at the orphan
+// and loadAndMount is never re-invoked. Symptom: switch workspace,
+// provider page reads as a blank panel instead of the new context's
+// list.
+//
+// flush: 'post' runs the effect after AppLayout's slot has finished
+// re-rendering, so mountRef.value already points at the new (empty) div
+// when we append the fresh element.
+watch(
+  () => auth.clusterName,
+  async () => {
+    if (!entry.value?.ready) return
+    await mountElement(entry.value.name)
+  },
+  { flush: 'post' },
+)
+
+// mountElement creates a fresh custom-element instance and appends it
+// into the current mountRef div. Split out from loadAndMount so the
+// workspace-switch watch above can re-mount without re-fetching the
+// provider's main.js script.
+async function mountElement(name: string) {
+  if (!mountRef.value) return
+  mountRef.value.replaceChildren()
+  const el = document.createElement(tagFor(name)) as HTMLElement
+  mountRef.value.appendChild(el)
+  elementRef.value = el
+  pushContext()
+}
+
 async function loadAndMount(name: string, version: string | undefined) {
   loadState.value = 'loading'
   loadError.value = null
@@ -106,12 +141,7 @@ async function loadAndMount(name: string, version: string | undefined) {
 
   // DOM is ready; create + mount the element.
   await nextTick()
-  if (!mountRef.value) return
-  mountRef.value.replaceChildren()
-  const el = document.createElement(tag) as HTMLElement
-  mountRef.value.appendChild(el)
-  elementRef.value = el
-  pushContext()
+  await mountElement(name)
   loadState.value = 'ready'
 }
 


### PR DESCRIPTION
## Summary
Two issues #222 left behind on workspace/org switch:

**1. Provider pages drop to a blank panel.** #222 keyed AppLayout's slot wrapper on `auth.clusterName` so the active page remounts. That works for host pages (resets every `useGraphQLQuery`) but not for `ProviderFrame`: it's the route component above AppLayout and doesn't unmount — only its slotted `<div ref="mountRef" />` does. The custom element appended to the old div detaches (disconnectedCallback tears down its Vue app + Pinia), the new mountRef div is empty, and `loadAndMount` is never re-invoked because `entry.value` didn't change. Split out `mountElement(name)` and add a `flush: 'post'` watch on `auth.clusterName` that re-mounts after AppLayout's slot has finished re-rendering. `loadAndMount` now ends with `mountElement` so first-mount and re-mount share one code path.

**2. Switching to an org with zero workspaces leaves `auth.clusterName` pointing at the previous org's cluster.** Every workspace-scoped page renders against the wrong (or non-existent) cluster. Adds `FirstWorkspaceWizard` and gates the AppLayout slot on it: when the active org's workspace list has been fetched and is empty, render the wizard instead of the slot. `/tenant` and `/providers` (catalog) bypass the gate. The wizard calls `tenant.createWorkspace`; the store selects the new workspace, App.vue's existing sync sets `auth.clusterName`, AppLayout re-keys, the original page renders.

`workspacesByOrg[uuid]` is undefined while the initial fetch is in flight, so the wizard only appears once the empty array lands — no flash between org switch and fetch resolving.

## Test plan
- [ ] Open an edge in `/providers/kubernetes-edges/`, switch workspace from the TenantContextChip → list reloads with the new workspace's edges (no blank panel).
- [ ] Same for `/providers/mcp/` and `/providers/server-edges/`.
- [ ] Switch to an org with no workspaces → wizard appears with the org name in the subtitle.
- [ ] Type a name + click Create → workspace is created, wizard goes away, original page renders against the new cluster.
- [ ] While on `/tenant` or `/providers`, switching to an empty org should NOT show the wizard (those routes bypass the gate).
- [ ] During the brief window between org switch and `fetchWorkspaces` resolving, no wizard flash.

## Caveat
The hub omits `clusterName` from a workspace until it reports Ready. Immediately after the wizard creates a workspace, `auth.clusterName` may stay empty for a short window — pages will show "No cluster selected" until the workspace becomes Ready. That's the existing newly-created-workspace edge case, not a regression. Worth a follow-up "workspace provisioning…" placeholder if it's frequent enough to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)