### PR TITLE
infrastructure: kro backend — author RGDs from Templates (+ in-graph secret gen, status)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,6 +434,14 @@ TILT_KCP_DIR ?= /Users/mjudeikis/go/src/github.com/kcp-dev/kcp
 
 ## Full multi-shard kcp in a kind cluster + kedge-hub in-cluster, against a local kcp checkout
 tilt-cluster: ## Run Tiltfile.cluster against a local kcp tree (override with KCP_DIR=...)
+	@# Create the kind cluster + context BEFORE `tilt up`. If the cluster is
+	@# created from inside the Tiltfile, Tilt initializes its deploy client
+	@# before the kind-kcp-tilt context exists and caches an empty config,
+	@# leaving every native k8s_yaml resource stuck on "could not set up
+	@# kubernetes client: no configuration has been provided". Guaranteeing the
+	@# cluster+context up front avoids that race.
+	@kind get clusters 2>/dev/null | grep -qx kcp-tilt || kind create cluster --name kcp-tilt
+	@kind export kubeconfig --name kcp-tilt
 	tilt up -f Tiltfile.cluster -- --kcp-dir=$(TILT_KCP_DIR)
 
 # --- Provider quickstart (local dev) ---

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -138,6 +138,25 @@ load('ext://restart_process', 'docker_build_with_restart')
 hub_namespace = 'kedge-system'
 hub_image = 'ghcr.io/faroshq/kedge-hub'
 
+# The kedge-hub chart deploys namespaced objects (TLS Certificate + Secret,
+# selfsigned Issuer, StatefulSet) into hub_namespace but ships NO Namespace
+# object. The namespace is otherwise only created by the hub-kcp-secrets
+# local_resource via kubectl — which is gated on `kcp-admin extract` and so
+# runs much later. Without the namespace up front, Tilt's apply of the chart's
+# cert/secret objects fails with `namespaces "kedge-system" not found`. Create
+# it as a Tilt-managed object so Tilt applies it FIRST. We deliberately leave it
+# UNGROUPED so it lands in the same "uncategorized" apply batch as the chart's
+# cert/secret/issuer objects; within a single batch Tilt kind-sorts Namespaces
+# ahead of namespaced kinds, guaranteeing the namespace exists before they apply.
+# (Giving it its own k8s_resource would deploy it in parallel with uncategorized
+# with no ordering guarantee between the two.)
+k8s_yaml(blob('''
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+'''.strip() % hub_namespace))
+
 # Envoy gateway ClusterIP that *.kcp.localhost resolves to (see kcp's
 # gateway.yaml addresses + the hostAliases in its shard/front-proxy manifests).
 gateway_ip = '10.96.2.2'

--- a/providers/infrastructure/backend/kro/backend.go
+++ b/providers/infrastructure/backend/kro/backend.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Package kro implements the backend.Backend that turns a Template into a
+// kro ResourceGraphDefinition on the runtime cluster.
+//
+// The Template is the source of truth (it lives in the provider's kcp
+// workspace; the Template controller publishes its CRD/APIResourceSchema so
+// tenants can create instances). This backend derives the matching RGD from
+// the same Template and writes it to the kro runtime cluster — the cluster
+// kro's controller-runtime manager watches RGDs on (a kind cluster in dev),
+// NOT kcp. Once the RGD exists, kro registers the dynamic watch and
+// reconciles instances; instance workloads land on the runtime cluster while
+// the instance object + status stay in the tenant's kcp workspace (see the
+// kro fork's --deploy-to-local-runtime split).
+//
+// This backend does NOT reconcile instances itself — the kro controller does
+// that. Run() therefore just blocks: the RGD authoring happens in
+// SetupTemplate/TeardownTemplate, driven by the Template controller.
+package kro
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
+)
+
+// Name is the backend identifier operators put in Template.spec.backend.
+const Name = "kro"
+
+// Backend authors kro ResourceGraphDefinitions on the runtime cluster from
+// Templates. It implements backend.Backend.
+type Backend struct {
+	// runtime is a dynamic client scoped to the kro runtime cluster (where
+	// the kro controller watches RGDs). In dev this is the kind cluster
+	// pointed at by KRO_KUBECONFIG.
+	runtime dynamic.Interface
+}
+
+var _ backend.Backend = (*Backend)(nil)
+
+// New constructs the kro backend against the runtime cluster's dynamic
+// client. The caller (controller_manager) builds it from KRO_KUBECONFIG.
+func New(runtime dynamic.Interface) *Backend {
+	return &Backend{runtime: runtime}
+}
+
+// Name returns "kro".
+func (b *Backend) Name() string { return Name }
+
+// SetupTemplate derives the RGD from the Template and applies it to the
+// runtime cluster. Idempotent: re-applies on every reconcile pass. A build
+// error (malformed schema/backendConfig) is returned so the Template
+// controller surfaces BackendError; a successful apply reports Ready=true.
+func (b *Backend) SetupTemplate(ctx context.Context, tmpl *infrav1alpha1.Template) (backend.TemplateStatus, error) {
+	rgd, err := buildRGD(tmpl)
+	if err != nil {
+		return backend.TemplateStatus{Ready: false, Message: err.Error()}, err
+	}
+	if err := b.applyRGD(ctx, rgd); err != nil {
+		return backend.TemplateStatus{Ready: false, Message: "applying RGD: " + err.Error()}, err
+	}
+	klog.FromContext(ctx).WithName("backend.kro").Info("applied ResourceGraphDefinition to runtime cluster",
+		"template", tmpl.Name, "rgd", tmpl.Name)
+	return backend.TemplateStatus{Ready: true, Message: "RGD applied to runtime cluster"}, nil
+}
+
+// TeardownTemplate removes the Template's RGD from the runtime cluster. kro
+// then garbage-collects the generated CRD + stops the dynamic watch. 404 is
+// success (already gone). Idempotent.
+func (b *Backend) TeardownTemplate(ctx context.Context, tmpl *infrav1alpha1.Template) error {
+	err := b.runtime.Resource(rgdGVR).Delete(ctx, tmpl.Name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting RGD %q: %w", tmpl.Name, err)
+	}
+	return nil
+}
+
+// Run blocks until ctx is cancelled. Instance reconciliation is owned by the
+// kro controller (which watches the RGDs this backend writes), so there is
+// no per-process loop to run here. vwConfig is unused for the same reason.
+func (b *Backend) Run(ctx context.Context, _ *rest.Config) error {
+	klog.FromContext(ctx).WithName("backend.kro").Info("kro backend ready (RGDs authored on the runtime cluster; reconciliation handled by the kro controller)")
+	<-ctx.Done()
+	return nil
+}
+
+// applyRGD creates or updates the RGD on the runtime cluster, preserving the
+// server-assigned resourceVersion on update so it's a compare-and-set.
+func (b *Backend) applyRGD(ctx context.Context, rgd *unstructured.Unstructured) error {
+	existing, err := b.runtime.Resource(rgdGVR).Get(ctx, rgd.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := b.runtime.Resource(rgdGVR).Create(ctx, rgd, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get: %w", err)
+	}
+	rgd.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := b.runtime.Resource(rgdGVR).Update(ctx, rgd, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+	return nil
+}

--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kro
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+)
+
+func TestOpenAPIToSimpleSchema(t *testing.T) {
+	raw := []byte(`{
+		"type": "object",
+		"properties": {
+			"name":       {"type": "string", "description": "logical name"},
+			"size":       {"type": "string", "enum": ["small","medium","large"], "default": "small"},
+			"replicas":   {"type": "integer", "default": 1, "minimum": 1, "maximum": 10},
+			"persistent": {"type": "boolean", "default": false}
+		},
+		"required": ["name"]
+	}`)
+
+	got, err := openAPIToSimpleSchema(raw)
+	if err != nil {
+		t.Fatalf("openAPIToSimpleSchema: %v", err)
+	}
+
+	want := map[string]string{
+		"name":       `string | required=true description="logical name"`,
+		"size":       `string | enum="small,medium,large" default="small"`,
+		"replicas":   `integer | default=1 minimum=1 maximum=10`,
+		"persistent": `boolean | default=false`,
+	}
+	for field, exp := range want {
+		gotStr, ok := got[field].(string)
+		if !ok {
+			t.Errorf("field %q: not a string leaf: %#v", field, got[field])
+			continue
+		}
+		if gotStr != exp {
+			t.Errorf("field %q:\n  got:  %s\n  want: %s", field, gotStr, exp)
+		}
+	}
+}
+
+func TestOpenAPIToSimpleSchemaNested(t *testing.T) {
+	raw := []byte(`{
+		"type": "object",
+		"properties": {
+			"tls": {"type": "object", "properties": {"enabled": {"type": "boolean", "default": true}}}
+		}
+	}`)
+	got, err := openAPIToSimpleSchema(raw)
+	if err != nil {
+		t.Fatalf("openAPIToSimpleSchema: %v", err)
+	}
+	nested, ok := got["tls"].(map[string]any)
+	if !ok {
+		t.Fatalf("tls: expected nested map, got %#v", got["tls"])
+	}
+	if nested["enabled"] != `boolean | default=true` {
+		t.Errorf("tls.enabled: got %v", nested["enabled"])
+	}
+}
+
+func TestBuildRGD(t *testing.T) {
+	tmpl := &infrav1alpha1.Template{}
+	tmpl.Name = "redis-cache"
+	tmpl.Spec.Version = "0.1.0"
+	tmpl.Spec.InstanceCRD = infrav1alpha1.TemplateInstanceCRD{
+		Group:    "infrastructure.kedge.faros.sh",
+		Version:  "v1alpha1",
+		Resource: "rediscaches",
+		Kind:     "RedisCache",
+	}
+	tmpl.Spec.Schema = &runtime.RawExtension{Raw: []byte(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`)}
+	tmpl.Spec.BackendConfig = &runtime.RawExtension{Raw: []byte(`{"resources":[{"id":"statefulset","template":{"apiVersion":"apps/v1","kind":"StatefulSet"}}]}`)}
+
+	rgd, err := buildRGD(tmpl)
+	if err != nil {
+		t.Fatalf("buildRGD: %v", err)
+	}
+
+	if rgd.GetAPIVersion() != rgdAPIVersion || rgd.GetKind() != rgdKind {
+		t.Errorf("GVK = %s/%s", rgd.GetAPIVersion(), rgd.GetKind())
+	}
+	if rgd.GetName() != "redis-cache" {
+		t.Errorf("name = %q", rgd.GetName())
+	}
+	if lbl := rgd.GetLabels()["kedge.faros.sh/template"]; lbl != "redis-cache" {
+		t.Errorf("template label = %q", lbl)
+	}
+
+	assertNested := func(want string, fields ...string) {
+		got, found, err := unstructured.NestedString(rgd.Object, fields...)
+		if err != nil || !found {
+			t.Errorf("%v: not found (err=%v)", fields, err)
+			return
+		}
+		if got != want {
+			t.Errorf("%v = %q, want %q", fields, got, want)
+		}
+	}
+	assertNested("v1alpha1", "spec", "schema", "apiVersion")
+	assertNested("infrastructure.kedge.faros.sh", "spec", "schema", "group")
+	assertNested("RedisCache", "spec", "schema", "kind")
+	assertNested("Cluster", "spec", "schema", "scope")
+
+	resources, found, err := unstructured.NestedSlice(rgd.Object, "spec", "resources")
+	if err != nil || !found || len(resources) != 1 {
+		t.Fatalf("spec.resources: found=%v len=%d err=%v", found, len(resources), err)
+	}
+}
+
+func TestBuildRGDRequiresBackendConfig(t *testing.T) {
+	tmpl := &infrav1alpha1.Template{}
+	tmpl.Name = "no-config"
+	tmpl.Spec.InstanceCRD = infrav1alpha1.TemplateInstanceCRD{Group: "g", Version: "v1alpha1", Resource: "rs", Kind: "R"}
+	tmpl.Spec.Schema = &runtime.RawExtension{Raw: []byte(`{"type":"object","properties":{"name":{"type":"string"}}}`)}
+	// no BackendConfig
+	if _, err := buildRGD(tmpl); err == nil {
+		t.Fatal("expected error when backendConfig is missing")
+	}
+}

--- a/providers/infrastructure/backend/kro/rgd.go
+++ b/providers/infrastructure/backend/kro/rgd.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kro
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+)
+
+const (
+	rgdAPIVersion = "kro.run/v1alpha1"
+	rgdKind       = "ResourceGraphDefinition"
+
+	// instanceScope mirrors the per-template CRD scope the Template
+	// controller publishes (ClusterScoped — see
+	// controller/template/controller.go and the portal's api.ts note).
+	// The RGD's generated CRD must agree or kro and the API surface would
+	// disagree on whether instances are namespaced.
+	instanceScope = "Cluster"
+)
+
+// rgdGVR is the ResourceGraphDefinition resource on the kro runtime cluster.
+var rgdGVR = schema.GroupVersionResource{
+	Group:    "kro.run",
+	Version:  "v1alpha1",
+	Resource: "resourcegraphdefinitions",
+}
+
+// buildRGD projects a Template into the kro ResourceGraphDefinition that
+// drives reconciliation of its instances. The Template is the source of
+// truth; the RGD is derived, 1:1:
+//
+//   - metadata.name           = Template.name
+//   - spec.schema.{group,apiVersion,kind,scope} = Template.spec.instanceCRD (+ Cluster)
+//   - spec.schema.spec        = Template.spec.schema (OpenAPI) → kro SimpleSchema
+//   - spec.schema.status      = Template.spec.backendConfig.status (optional)
+//   - spec.resources          = Template.spec.backendConfig.resources (verbatim)
+func buildRGD(tmpl *infrav1alpha1.Template) (*unstructured.Unstructured, error) {
+	if tmpl.Spec.Schema == nil || len(tmpl.Spec.Schema.Raw) == 0 {
+		return nil, fmt.Errorf("template %q: spec.schema is required", tmpl.Name)
+	}
+	simpleSpec, err := openAPIToSimpleSchema(tmpl.Spec.Schema.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("template %q: %w", tmpl.Name, err)
+	}
+
+	resources, status, err := backendConfig(tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaBlock := map[string]any{
+		"apiVersion": tmpl.Spec.InstanceCRD.Version,
+		"group":      tmpl.Spec.InstanceCRD.Group,
+		"kind":       tmpl.Spec.InstanceCRD.Kind,
+		"scope":      instanceScope,
+		"spec":       simpleSpec,
+	}
+	if status != nil {
+		schemaBlock["status"] = status
+	}
+
+	rgd := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": rgdAPIVersion,
+		"kind":       rgdKind,
+		"metadata": map[string]any{
+			"name": tmpl.Name,
+			// Trace the RGD back to its Template + version, and mark it
+			// kedge-authored so a human (or a future GC) can tell these
+			// apart from hand-applied RGDs on the runtime cluster.
+			"labels": map[string]any{
+				"kedge.faros.sh/template":         tmpl.Name,
+				"kedge.faros.sh/template-version": tmpl.Spec.Version,
+				"app.kubernetes.io/managed-by":    "kedge-infrastructure",
+			},
+		},
+		"spec": map[string]any{
+			"schema":    schemaBlock,
+			"resources": resources,
+		},
+	}}
+	return rgd, nil
+}
+
+// backendConfig decodes Template.spec.backendConfig and extracts the kro
+// resource graph (required) and an optional status-mapping block. The
+// backendConfig is opaque to the platform; only this backend interprets it.
+func backendConfig(tmpl *infrav1alpha1.Template) (resources []any, status map[string]any, err error) {
+	if tmpl.Spec.BackendConfig == nil || len(tmpl.Spec.BackendConfig.Raw) == 0 {
+		return nil, nil, fmt.Errorf("template %q: spec.backendConfig is required for the kro backend", tmpl.Name)
+	}
+	var bc map[string]any
+	if err := json.Unmarshal(tmpl.Spec.BackendConfig.Raw, &bc); err != nil {
+		return nil, nil, fmt.Errorf("template %q: decode spec.backendConfig: %w", tmpl.Name, err)
+	}
+	res, ok := bc["resources"].([]any)
+	if !ok || len(res) == 0 {
+		return nil, nil, fmt.Errorf("template %q: spec.backendConfig.resources must be a non-empty list", tmpl.Name)
+	}
+	if st, ok := bc["status"].(map[string]any); ok {
+		status = st
+	}
+	return res, status, nil
+}

--- a/providers/infrastructure/backend/kro/simpleschema.go
+++ b/providers/infrastructure/backend/kro/simpleschema.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kro
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// openAPISchema is a minimal subset of OpenAPI v3 / JSONSchemaProps — just
+// the fields the Template author uses in spec.schema and that kro's
+// SimpleSchema can express. Anything richer is ignored (lossy by design;
+// SimpleSchema is deliberately a small surface).
+type openAPISchema struct {
+	Type        string                   `json:"type"`
+	Description string                   `json:"description"`
+	Properties  map[string]openAPISchema `json:"properties"`
+	Required    []string                 `json:"required"`
+	Enum        []any                    `json:"enum"`
+	Default     any                      `json:"default"`
+	Minimum     *float64                 `json:"minimum"`
+	Maximum     *float64                 `json:"maximum"`
+	Pattern     string                   `json:"pattern"`
+	Items       *openAPISchema           `json:"items"`
+}
+
+// openAPIToSimpleSchema converts a Template's spec.schema (OpenAPI JSON
+// Schema for the instance's spec) into the map shape kro expects at
+// ResourceGraphDefinition.spec.schema.spec, where each field is a kro
+// SimpleSchema string ("string | required=true default=...") or, for
+// nested objects, a nested map. See
+// https://kro.run/docs/concepts/simple-schema/.
+//
+// The raw input is the object schema for the instance spec (type: object
+// with properties). Returns the properties projected to SimpleSchema.
+func openAPIToSimpleSchema(raw []byte) (map[string]any, error) {
+	var s openAPISchema
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("decode spec.schema as OpenAPI object: %w", err)
+	}
+	if len(s.Properties) == 0 {
+		// A schema with no properties yields an empty instance spec; kro
+		// accepts that, but it almost certainly signals a malformed
+		// Template, so surface it rather than emitting a useless RGD.
+		return nil, fmt.Errorf("spec.schema has no properties")
+	}
+	return objectToSimpleSchema(s)
+}
+
+// objectToSimpleSchema projects an object schema's properties into the
+// SimpleSchema map. Nested objects recurse; leaves become marker strings.
+func objectToSimpleSchema(s openAPISchema) (map[string]any, error) {
+	required := make(map[string]struct{}, len(s.Required))
+	for _, r := range s.Required {
+		required[r] = struct{}{}
+	}
+	out := make(map[string]any, len(s.Properties))
+	for name, prop := range s.Properties {
+		if prop.Type == "object" && len(prop.Properties) > 0 {
+			nested, err := objectToSimpleSchema(prop)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", name, err)
+			}
+			out[name] = nested
+			continue
+		}
+		_, req := required[name]
+		out[name] = leafToSimpleSchema(prop, req)
+	}
+	return out, nil
+}
+
+// leafToSimpleSchema renders one scalar/array field as a kro SimpleSchema
+// string: "<type> | marker=value marker=value ...". Markers are emitted in
+// a fixed order so the output is deterministic (stable RGD spec → no
+// spurious revisions on re-reconcile).
+func leafToSimpleSchema(p openAPISchema, required bool) string {
+	typ := openAPIToKROType(p)
+
+	var markers []string
+	if required {
+		markers = append(markers, "required=true")
+	}
+	if len(p.Enum) > 0 {
+		vals := make([]string, 0, len(p.Enum))
+		for _, e := range p.Enum {
+			vals = append(vals, fmt.Sprintf("%v", e))
+		}
+		markers = append(markers, "enum="+quote(strings.Join(vals, ",")))
+	}
+	if p.Default != nil {
+		markers = append(markers, "default="+formatScalar(p.Default))
+	}
+	if p.Minimum != nil {
+		markers = append(markers, fmt.Sprintf("minimum=%v", *p.Minimum))
+	}
+	if p.Maximum != nil {
+		markers = append(markers, fmt.Sprintf("maximum=%v", *p.Maximum))
+	}
+	if p.Pattern != "" {
+		markers = append(markers, "pattern="+quote(p.Pattern))
+	}
+	if p.Description != "" {
+		// description last: it's free-form and the longest marker.
+		markers = append(markers, "description="+quote(p.Description))
+	}
+
+	if len(markers) == 0 {
+		return typ
+	}
+	return typ + " | " + strings.Join(markers, " ")
+}
+
+// openAPIToKROType maps an OpenAPI type to kro's SimpleSchema type token.
+// Arrays render as "[]<elem>" using the items type (defaulting to string).
+func openAPIToKROType(p openAPISchema) string {
+	switch p.Type {
+	case "integer":
+		return "integer"
+	case "number":
+		return "number"
+	case "boolean":
+		return "boolean"
+	case "array":
+		elem := "string"
+		if p.Items != nil && p.Items.Type != "" {
+			elem = openAPIToKROType(*p.Items)
+		}
+		return "[]" + elem
+	case "object":
+		return "object"
+	case "string":
+		return "string"
+	default:
+		return "string"
+	}
+}
+
+// formatScalar renders a default value: strings are quoted; numbers and
+// bools are emitted bare so kro coerces them to the right type. JSON numbers
+// arrive as float64, so an integer default like 1 prints as "1".
+func formatScalar(v any) string {
+	switch t := v.(type) {
+	case string:
+		return quote(t)
+	case bool:
+		return fmt.Sprintf("%v", t)
+	case float64:
+		// Print integers without a trailing ".0".
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%v", t)
+	default:
+		return quote(fmt.Sprintf("%v", t))
+	}
+}
+
+// quote wraps a marker value in double quotes for kro's tokenizer, which
+// treats a bare double quote as a delimiter and does not understand
+// backslash escapes — so any inner double quote is downgraded to a single
+// quote rather than risking a malformed token.
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `'`) + `"`
+}

--- a/providers/infrastructure/controller/template/apiexport.go
+++ b/providers/infrastructure/controller/template/apiexport.go
@@ -189,14 +189,23 @@ func (r *Reconciler) removeAPIExportEntry(ctx context.Context, resource, group s
 // changes (annotations, labels) are intentionally excluded.
 func schemaPrefix(crd *apiextensionsv1.CustomResourceDefinition) string {
 	h := sha256.New()
-	fmt.Fprintln(h, crd.Spec.Group, crd.Spec.Names.Kind)
+	_, _ = fmt.Fprintln(h, crd.Spec.Group, crd.Spec.Names.Kind)
 	for _, v := range crd.Spec.Versions {
-		fmt.Fprintln(h, v.Name)
+		_, _ = fmt.Fprintln(h, v.Name)
 		if v.Schema != nil && v.Schema.OpenAPIV3Schema != nil {
-			// Stringify via fmt to avoid pulling encoding/json + a
-			// stable serializer here — the SHA over the format output
-			// is good enough for a content fingerprint.
-			fmt.Fprintf(h, "%v\n", v.Schema.OpenAPIV3Schema)
+			// Hash a deterministic JSON serialization. JSON sorts object
+			// keys and renders pointer fields (e.g.
+			// x-kubernetes-preserve-unknown-fields, a *bool) by value, so
+			// the digest is stable across processes — unlike fmt %v, which
+			// prints pointer addresses for the schema's *bool fields and
+			// would make the prefix (and thus the APIResourceSchema name)
+			// non-deterministic.
+			data, err := crdsJSONMarshal(v.Schema.OpenAPIV3Schema)
+			if err != nil {
+				_, _ = fmt.Fprintf(h, "%v\n", v.Schema.OpenAPIV3Schema)
+				continue
+			}
+			_, _ = h.Write(data)
 		}
 	}
 	digest := hex.EncodeToString(h.Sum(nil))
@@ -327,8 +336,8 @@ func resourcesEqual(a, b []apisv1alpha2.ResourceSchema) bool {
 // accessors. Kept tiny so the package's behavior stays auditable in
 // one file.
 
-func jsonMarshal(v any) ([]byte, error)       { return jsonMarshalImpl(v) }
-func jsonUnmarshal(b []byte, v any) error      { return jsonUnmarshalImpl(b, v) }
+func jsonMarshal(v any) ([]byte, error)   { return jsonMarshalImpl(v) }
+func jsonUnmarshal(b []byte, v any) error { return jsonUnmarshalImpl(b, v) }
 func unstructuredNested(obj map[string]any, fields ...string) (any, bool, error) {
 	return unstructured.NestedFieldNoCopy(obj, fields...)
 }
@@ -346,8 +355,8 @@ var (
 
 // Forward-decl-style anchors; the actual implementations live in
 // crds_json.go so the controller.go + apiexport.go split stays clean.
-func jsonMarshalRef(v any) ([]byte, error)    { return crdsJSONMarshal(v) }
-func jsonUnmarshalRef(b []byte, v any) error  { return crdsJSONUnmarshal(b, v) }
+func jsonMarshalRef(v any) ([]byte, error)   { return crdsJSONMarshal(v) }
+func jsonUnmarshalRef(b []byte, v any) error { return crdsJSONUnmarshal(b, v) }
 
 // _ keeps the infra package's reference live in the import section
 // even when ensureAPIResourceSchema is the only consumer; PR B's

--- a/providers/infrastructure/controller/template/controller.go
+++ b/providers/infrastructure/controller/template/controller.go
@@ -378,12 +378,24 @@ func buildPerTemplateCRD(tmpl *infrav1alpha1.Template) (*apiextensionsv1.CustomR
 	return crd, nil
 }
 
-// templateInstanceStatusSchema is the fixed status shape every
-// per-template CRD gets. Lets backends report a consistent
-// {phase, message, conditions} set regardless of backend.
+// templateInstanceStatusSchema is the status shape every per-template CRD
+// gets: a platform-guaranteed {phase, message, conditions} baseline PLUS
+// whatever the backend projects.
+//
+// Backends own their instance status: the kro backend's RGD maps runtime
+// fields onto the instance (endpoints, readiness, a connection-Secret
+// reference — see install/templates/redis-cache.yaml). Those fields aren't
+// known to the platform, so the status object preserves unknown fields;
+// without that the apiserver's structural pruning would strip every
+// backend-projected field on the status subresource write, and the user
+// would only ever see the baseline. Sensitive values are never projected —
+// the backend exposes a Secret *reference*, and the Secret itself stays on
+// the runtime cluster.
 func templateInstanceStatusSchema() apiextensionsv1.JSONSchemaProps {
+	preserveUnknown := true
 	return apiextensionsv1.JSONSchemaProps{
-		Type: "object",
+		Type:                   "object",
+		XPreserveUnknownFields: &preserveUnknown,
 		Properties: map[string]apiextensionsv1.JSONSchemaProps{
 			"phase":   {Type: "string"},
 			"message": {Type: "string"},

--- a/providers/infrastructure/controller_manager.go
+++ b/providers/infrastructure/controller_manager.go
@@ -33,6 +33,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
+	krobackend "github.com/faroshq/faros-kedge/providers/infrastructure/backend/kro"
 	"github.com/faroshq/faros-kedge/providers/infrastructure/backend/stub"
 	"github.com/faroshq/faros-kedge/providers/infrastructure/controller/template"
 	"github.com/faroshq/faros-kedge/providers/infrastructure/install"
@@ -93,7 +94,28 @@ func startControllerManager(ctx context.Context) error {
 	if err := registry.Register(stub.New()); err != nil {
 		return fmt.Errorf("register stub backend: %w", err)
 	}
-	// PR C: registry.Register(kro.New())
+
+	// kro backend: authors RGDs on the runtime cluster (where the kro
+	// controller watches RGDs — a kind cluster in dev), NOT this provider's
+	// kcp workspace. It needs a separate client; KRO_KUBECONFIG points at
+	// that cluster (the same kubeconfig the legacy kro broker reads). When
+	// unset we run stub-only so dev/REST-only flows still boot.
+	if p := os.Getenv("KRO_KUBECONFIG"); p != "" {
+		kroCfg, err := clientcmd.BuildConfigFromFlags("", p)
+		if err != nil {
+			return fmt.Errorf("loading KRO_KUBECONFIG for kro backend: %w", err)
+		}
+		kroDyn, err := dynamic.NewForConfig(kroCfg)
+		if err != nil {
+			return fmt.Errorf("kro backend dynamic client: %w", err)
+		}
+		if err := registry.Register(krobackend.New(kroDyn)); err != nil {
+			return fmt.Errorf("register kro backend: %w", err)
+		}
+		log.Printf("controller manager: kro backend registered (RGD runtime cluster from KRO_KUBECONFIG=%s)", p)
+	} else {
+		log.Printf("controller manager: KRO_KUBECONFIG unset — kro backend not registered (stub-only)")
+	}
 
 	dyn, err := dynamic.NewForConfig(config)
 	if err != nil {

--- a/providers/infrastructure/install/templates/redis-cache.yaml
+++ b/providers/infrastructure/install/templates/redis-cache.yaml
@@ -7,7 +7,7 @@ spec:
   description: "A Redis instance for caching workloads. StatefulSet + Service; size knob picks the memory limit."
   category: Databases
   version: 0.1.0
-  backend: stub
+  backend: kro
   instanceCRD:
     group: infrastructure.kedge.faros.sh
     version: v1alpha1
@@ -33,14 +33,104 @@ spec:
         default: false
     required:
       - name
+  # backendConfig is interpreted by the kro backend. Every resource sets
+  # namespace: default — the control-plane/data-plane split materializes
+  # these on the runtime cluster and remaps that to a per-tenant namespace
+  # (<logicalcluster>-default), so a tenant's whole stack (redis + the apps
+  # that consume it) lands together and is isolated from other tenants.
   backendConfig:
     resources:
+      # The connection Secret. kro creates it with the non-sensitive
+      # connection details; the generator Job below fills in a random
+      # password + full URI. Lives on the runtime cluster next to the
+      # workload — its values never reach the control plane.
+      - id: credentials
+        template:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${schema.spec.name}-credentials
+            namespace: default
+          stringData:
+            host: ${schema.spec.name}
+            port: "6379"
+      # Password generation, in-graph (no external operator). A one-shot
+      # Job mints a random password and patches it (plus a complete
+      # redis://:<pw>@host:port URI) into the credentials Secret — once;
+      # it no-ops if the password key already exists, so re-reconciles
+      # don't rotate it. kro never sees the value (the Job runs the shell);
+      # status only ever references the Secret.
+      - id: pwgenAccount
+        template:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: ${schema.spec.name}-pwgen
+            namespace: default
+      - id: pwgenRole
+        template:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: ${schema.spec.name}-pwgen
+            namespace: default
+          rules:
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get", "patch"]
+      - id: pwgenBinding
+        template:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: ${schema.spec.name}-pwgen
+            namespace: default
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: ${pwgenRole.metadata.name}
+          subjects:
+            - kind: ServiceAccount
+              name: ${pwgenAccount.metadata.name}
+              namespace: default
+      - id: pwgen
+        template:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: ${schema.spec.name}-pwgen
+            namespace: default
+          spec:
+            backoffLimit: 5
+            ttlSecondsAfterFinished: 600
+            template:
+              spec:
+                serviceAccountName: ${pwgenAccount.metadata.name}
+                restartPolicy: OnFailure
+                containers:
+                  - name: pwgen
+                    image: bitnami/kubectl
+                    command:
+                      - /bin/sh
+                      - -c
+                      - |
+                        set -eu
+                        SECRET="${credentials.metadata.name}"
+                        if [ -z "$(kubectl get secret "$SECRET" -o jsonpath='{.data.password}' 2>/dev/null)" ]; then
+                          PW="$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 24)"
+                          kubectl patch secret "$SECRET" --type merge \
+                            -p "{\"stringData\":{\"password\":\"$PW\",\"uri\":\"redis://:$PW@${schema.spec.name}:6379\"}}"
+                          echo "generated credentials for $SECRET"
+                        else
+                          echo "credentials already present for $SECRET"
+                        fi
       - id: statefulset
         template:
           apiVersion: apps/v1
           kind: StatefulSet
           metadata:
             name: ${schema.spec.name}
+            namespace: default
           spec:
             serviceName: ${schema.spec.name}
             replicas: 1
@@ -55,6 +145,13 @@ spec:
                 containers:
                   - name: redis
                     image: redis:${schema.spec.version}
+                    command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
+                    env:
+                      - name: REDIS_PASSWORD
+                        valueFrom:
+                          secretKeyRef:
+                            name: ${credentials.metadata.name}
+                            key: password
                     ports:
                       - containerPort: 6379
       - id: service
@@ -63,6 +160,7 @@ spec:
           kind: Service
           metadata:
             name: ${schema.spec.name}
+            namespace: default
           spec:
             type: ClusterIP
             selector:
@@ -70,3 +168,14 @@ spec:
             ports:
               - port: 6379
                 targetPort: 6379
+    # status is projected onto the instance in the tenant's kcp workspace
+    # (via the split's instance client). Non-sensitive connection details +
+    # a reference to the credentials Secret — no credentials are ever
+    # surfaced to the user or an LLM.
+    status:
+      ready: ${statefulset.status.readyReplicas}
+      host: ${service.metadata.name}
+      port: ${service.spec.ports[0].port}
+      connectionSecretRef:
+        name: ${credentials.metadata.name}
+        namespace: ${credentials.metadata.namespace}

--- a/providers/infrastructure/install/templates/simple-webapp.yaml
+++ b/providers/infrastructure/install/templates/simple-webapp.yaml
@@ -7,7 +7,7 @@ spec:
   description: "A web application — Deployment + Service, nginx by default. Scales via the replicas input."
   category: Workloads
   version: 0.1.0
-  backend: stub
+  backend: kro
   instanceCRD:
     group: infrastructure.kedge.faros.sh
     version: v1alpha1


### PR DESCRIPTION
Stacked on #231 (depends on the Template CRD + backend interface there — base is `feat/infrastructure-template-crd`, not `main`).

## What

Makes **Templates the source of truth** and has the provider **seed the kro RGD automatically**, removing the last manual `kubectl apply` of an RGD. Creating a `Template` (with `backend: kro`) now produces its `ResourceGraphDefinition` on the kro runtime cluster.

## Changes

- **`backend/kro`** — `Backend.SetupTemplate` derives the RGD from the Template (`instanceCRD` → `spec.schema` GVK + `Cluster` scope; `spec.schema` OpenAPI → kro **SimpleSchema**; `backendConfig.resources` → `spec.resources`; optional `backendConfig.status`) and writes it to the runtime cluster. `TeardownTemplate` deletes it. `Run` is a no-op (the kro controller reconciles). + unit tests.
- **`controller_manager`** — registers the kro backend, building a runtime-cluster client from `KRO_KUBECONFIG` (stub-only when unset).
- **template controller** — per-template CRD `status` now preserves unknown fields so backend-projected status (endpoints, secret refs) survives apiserver pruning. Also fixes `schemaPrefix` to hash deterministic JSON (the new `*bool` status field exposed an `fmt %v` pointer-address non-determinism).
- **redis template** (`backend: kro`) — **in-graph password generation** via a Job (no external operator): mints a random password + full connection URI into a Secret on the runtime cluster; redis consumes it via `secretKeyRef`. `status` exposes only a **reference** — credentials never reach the control plane / user / LLM.
- **simple-webapp** — `backend: kro`.

## Design notes

- RGDs live on the **runtime cluster** (where kro's manager watches them), not kcp — so kro's own generated CRD never collides with the kcp APIResourceSchema the Template controller publishes.
- Pairs with the kro fork's `--deploy-to-local-runtime` split (`v0.0.1-mc.6`): instance + status in the tenant's kcp workspace, workloads + secrets on the runtime, per-tenant namespace isolation.

## Verification

`go build ./...`, `go test ./backend/... ./controller/...`, and `golangci-lint` on changed packages all pass. The CEL/status projection and the generator Job are validated by kro at runtime — a live re-seed + redeploy is the remaining end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)