### PR TITLE
Add GCP Cloud Run infrastructure template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ _artifacts/
 pkg/hub/portal/
 portal/dist/
 portal/node_modules/
+providers/infrastructure/portal/dist/
+providers/infrastructure/portal/node_modules/
 
 # Data dirs
 data/
@@ -68,3 +70,4 @@ edge-kubeconfig
 .env.edge.server
 .env.edge.kubernetes
 values.yaml
+.secrets/

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ _artifacts/
 pkg/hub/portal/
 portal/dist/
 portal/node_modules/
-providers/infrastructure/portal/dist/
-providers/infrastructure/portal/node_modules/
+providers/*/portal/dist/
+providers/*/portal/node_modules
 
 # Data dirs
 data/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
+.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self dev-config-connector-up dev-config-connector-down dev-config-connector-status e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
 
 BINDIR ?= bin
 GOFLAGS ?=
@@ -660,6 +660,10 @@ KRO_IMAGE_REPO ?= ghcr.io/faroshq/kro-multicluster/kro
 KRO_IMAGE_TAG ?= v0.0.1-mc.6
 KRO_NAMESPACE ?= kro-system
 KRO_SEED_DIR ?= providers/infrastructure/examples/rgds
+CONFIG_CONNECTOR_BUNDLE_URI ?= gs://configconnector-operator/latest/release-bundle.tar.gz
+CONFIG_CONNECTOR_KUBECONFIG ?= $(if $(KRO_TARGET_KUBECONFIG),$(KRO_TARGET_KUBECONFIG),$(KRO_KIND_KUBECONFIG))
+CONFIG_CONNECTOR_NAMESPACE ?= cnrm-system
+CONFIG_CONNECTOR_SECRET_NAME ?= kcc-gcp-key
 
 ## Bring up the management kro cluster + install kro (fork w/ multicluster) +
 ## register the cluster as a self-member + seed RGDs. Idempotent: re-running
@@ -822,6 +826,76 @@ dev-kro-down-into: ## Helm-uninstall kro from $KRO_TARGET_KUBECONFIG cluster
 	@test -n "$(KRO_TARGET_KUBECONFIG)" || { echo "KRO_TARGET_KUBECONFIG not set"; exit 1; }
 	-KUBECONFIG=$(KRO_TARGET_KUBECONFIG) helm uninstall kro -n $(KRO_NAMESPACE)
 	-KUBECONFIG=$(KRO_TARGET_KUBECONFIG) kubectl delete namespace $(KRO_NAMESPACE) --wait=false
+
+## Install Config Connector into the kro runtime cluster. This is manual in
+## Tilt because it imports a local GCP service-account key into the cluster.
+dev-config-connector-up: ## Install Config Connector; requires CONFIG_CONNECTOR_KEY_FILE=/path/to/key.json
+	@command -v gcloud >/dev/null || { echo "gcloud not found; install the Google Cloud SDK"; exit 1; }
+	@command -v kubectl >/dev/null || { echo "kubectl not found"; exit 1; }
+	@test -n "$(CONFIG_CONNECTOR_KUBECONFIG)" || { echo "CONFIG_CONNECTOR_KUBECONFIG not set"; exit 1; }
+	@test -f "$(CONFIG_CONNECTOR_KUBECONFIG)" || { echo "no kubeconfig at $(CONFIG_CONNECTOR_KUBECONFIG)"; exit 1; }
+	@test -n "$(CONFIG_CONNECTOR_KEY_FILE)" || { echo "CONFIG_CONNECTOR_KEY_FILE must point at a local service-account key named/imported as key.json"; exit 1; }
+	@test -f "$(CONFIG_CONNECTOR_KEY_FILE)" || { echo "no key file at $(CONFIG_CONNECTOR_KEY_FILE)"; exit 1; }
+	@echo ">>> ensuring $(CONFIG_CONNECTOR_NAMESPACE) namespace"
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl create namespace $(CONFIG_CONNECTOR_NAMESPACE) \
+		--dry-run=client -o yaml | KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl apply -f -
+	@echo ">>> importing Config Connector service-account key into $(CONFIG_CONNECTOR_NAMESPACE)/$(CONFIG_CONNECTOR_SECRET_NAME)"
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl -n $(CONFIG_CONNECTOR_NAMESPACE) create secret generic $(CONFIG_CONNECTOR_SECRET_NAME) \
+		--from-file=key.json="$(CONFIG_CONNECTOR_KEY_FILE)" \
+		--dry-run=client -o yaml | KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl apply -f -
+	@echo ">>> downloading and applying Config Connector operator"
+	@tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	gcloud storage cp $(CONFIG_CONNECTOR_BUNDLE_URI) "$$tmpdir/release-bundle.tar.gz"; \
+	tar -xzf "$$tmpdir/release-bundle.tar.gz" -C "$$tmpdir"; \
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl apply -f "$$tmpdir/operator-system/configconnector-operator.yaml"
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl wait --for=condition=Established crd/configconnectors.core.cnrm.cloud.google.com --timeout=120s
+	@echo ">>> configuring Config Connector in cluster mode"
+	@printf '%s\n' \
+		'apiVersion: core.cnrm.cloud.google.com/v1beta1' \
+		'kind: ConfigConnector' \
+		'metadata:' \
+		'  name: configconnector.core.cnrm.cloud.google.com' \
+		'spec:' \
+		'  mode: cluster' \
+		'  credentialSecretName: $(CONFIG_CONNECTOR_SECRET_NAME)' \
+		'  stateIntoSpec: Absent' | KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl apply -f -
+	@echo ">>> waiting for Config Connector pods and Google Cloud CRDs"
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl wait -n $(CONFIG_CONNECTOR_NAMESPACE) --for=condition=Ready pod --all --timeout=300s
+	@for crd in runservices.run.cnrm.cloud.google.com iampolicymembers.iam.cnrm.cloud.google.com; do \
+		for i in $$(seq 1 60); do \
+			if KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl get crd $$crd >/dev/null 2>&1; then \
+				break; \
+			fi; \
+			if [ "$$i" -eq 60 ]; then \
+				echo "timed out waiting for $$crd"; \
+				exit 1; \
+			fi; \
+			sleep 5; \
+		done; \
+		KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl wait --for=condition=Established crd/$$crd --timeout=300s; \
+	done
+	@echo ">>> Config Connector ready"
+
+dev-config-connector-status: ## Show Config Connector status in the kro runtime cluster
+	@test -n "$(CONFIG_CONNECTOR_KUBECONFIG)" || { echo "CONFIG_CONNECTOR_KUBECONFIG not set"; exit 1; }
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl get configconnector configconnector.core.cnrm.cloud.google.com -o wide
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl -n $(CONFIG_CONNECTOR_NAMESPACE) get pods
+	KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl get crd runservices.run.cnrm.cloud.google.com iampolicymembers.iam.cnrm.cloud.google.com
+
+dev-config-connector-down: ## Uninstall Config Connector from the kro runtime cluster
+	@test -n "$(CONFIG_CONNECTOR_KUBECONFIG)" || { echo "CONFIG_CONNECTOR_KUBECONFIG not set"; exit 1; }
+	-KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl delete ConfigConnector configconnector.core.cnrm.cloud.google.com --wait=true
+	@if command -v gcloud >/dev/null; then \
+		tmpdir=$$(mktemp -d); \
+		trap 'rm -rf "$$tmpdir"' EXIT; \
+		gcloud storage cp $(CONFIG_CONNECTOR_BUNDLE_URI) "$$tmpdir/release-bundle.tar.gz" && \
+		tar -xzf "$$tmpdir/release-bundle.tar.gz" -C "$$tmpdir" && \
+		KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl delete -f "$$tmpdir/operator-system/configconnector-operator.yaml" --wait=true || true; \
+	else \
+		echo "gcloud not found; skipping operator manifest delete"; \
+	fi
+	-KUBECONFIG=$(CONFIG_CONNECTOR_KUBECONFIG) kubectl delete namespace $(CONFIG_CONNECTOR_NAMESPACE) --wait=false
 
 dev-status: ## Show status of dev services (dex, kcp)
 	@source $(SERVICE_HOOKS) && list_services

--- a/Tiltfile
+++ b/Tiltfile
@@ -152,6 +152,32 @@ local_resource(
 )
 
 local_resource(
+    'config-connector-up',
+    cmd='make dev-config-connector-up',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kro-mgmt-up'],
+    labels=['providers-kro'],
+)
+
+local_resource(
+    'config-connector-status',
+    cmd='make dev-config-connector-status',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kro-mgmt-up'],
+    labels=['providers-kro'],
+)
+
+local_resource(
+    'config-connector-down',
+    cmd='make dev-config-connector-down',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=['providers-kro'],
+)
+
+local_resource(
     'infrastructure',
     cmd='make build-infrastructure-provider',
     serve_cmd='make run-provider-infrastructure',

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -528,6 +528,35 @@ local_resource(
 )
 
 local_resource(
+    'config-connector-up',
+    cmd='CONFIG_CONNECTOR_KUBECONFIG={kc} make dev-config-connector-up'.format(
+        kc=KIND_HOST_KUBECONFIG),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kro-mgmt-up'],
+    labels=['providers-kro'],
+)
+
+local_resource(
+    'config-connector-status',
+    cmd='CONFIG_CONNECTOR_KUBECONFIG={kc} make dev-config-connector-status'.format(
+        kc=KIND_HOST_KUBECONFIG),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kro-mgmt-up'],
+    labels=['providers-kro'],
+)
+
+local_resource(
+    'config-connector-down',
+    cmd='CONFIG_CONNECTOR_KUBECONFIG={kc} make dev-config-connector-down'.format(
+        kc=KIND_HOST_KUBECONFIG),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=['providers-kro'],
+)
+
+local_resource(
     'infrastructure',
     cmd='make build-infrastructure-provider',
     # Point KRO_KUBECONFIG at the same kind cluster's host kubeconfig (where

--- a/providers/infrastructure/apis/v1alpha1/types_template.go
+++ b/providers/infrastructure/apis/v1alpha1/types_template.go
@@ -93,6 +93,14 @@ type TemplateSpec struct {
 	// +kubebuilder:validation:MaxLength=64
 	Category string `json:"category,omitempty"`
 
+	// Cloud identifies the target environment for catalog filtering
+	// (for example "k8s", "gcp", "aws", or "azure"). Empty means
+	// the template is not cloud-specific.
+	// +optional
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[a-z][a-z0-9-]*$`
+	Cloud string `json:"cloud,omitempty"`
+
 	// Version pins the Template definition's revision. Required by
 	// the per-template CRD's served version selection and by
 	// instance-create-time consistency checks.

--- a/providers/infrastructure/apis/v1alpha1/types_template_test.go
+++ b/providers/infrastructure/apis/v1alpha1/types_template_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTemplateCloudJSONRoundTrip(t *testing.T) {
+	tmpl := Template{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloud-run"},
+		Spec: TemplateSpec{
+			DisplayName: "Cloud Run",
+			Category:    "Serverless",
+			Cloud:       "gcp",
+			Version:     "0.1.0",
+			Backend:     "kro",
+			InstanceCRD: TemplateInstanceCRD{
+				Group:    GroupName,
+				Version:  Version,
+				Resource: "cloudrunservices",
+				Kind:     "CloudRunService",
+			},
+		},
+	}
+
+	data, err := json.Marshal(tmpl)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got Template
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Spec.Cloud != "gcp" {
+		t.Fatalf("cloud = %q, want gcp", got.Spec.Cloud)
+	}
+}

--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -11,10 +11,15 @@ You may obtain a copy of the License at
 package kro
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
 )
@@ -132,4 +137,109 @@ func TestBuildRGDRequiresBackendConfig(t *testing.T) {
 	if _, err := buildRGD(tmpl); err == nil {
 		t.Fatal("expected error when backendConfig is missing")
 	}
+}
+
+func TestBuildRGDFromCloudRunSeedTemplate(t *testing.T) {
+	tmpl := loadSeedTemplate(t, "../../install/templates/gcp-cloud-run-service.yaml")
+	rgd, err := buildRGD(tmpl)
+	if err != nil {
+		t.Fatalf("buildRGD: %v", err)
+	}
+
+	assertNested := func(want string, fields ...string) {
+		got, found, err := unstructured.NestedString(rgd.Object, fields...)
+		if err != nil || !found {
+			t.Fatalf("%v: not found (err=%v)", fields, err)
+		}
+		if got != want {
+			t.Fatalf("%v = %q, want %q", fields, got, want)
+		}
+	}
+	assertNested("CloudRunService", "spec", "schema", "kind")
+	assertNested("infrastructure.kedge.faros.sh", "spec", "schema", "group")
+
+	resources, found, err := unstructured.NestedSlice(rgd.Object, "spec", "resources")
+	if err != nil || !found {
+		t.Fatalf("spec.resources: found=%v err=%v", found, err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resources len = %d, want 2", len(resources))
+	}
+
+	kinds := map[string]bool{}
+	for _, res := range resources {
+		rm, ok := res.(map[string]any)
+		if !ok {
+			t.Fatalf("resource is %T, want map", res)
+		}
+		tm, ok := rm["template"].(map[string]any)
+		if !ok {
+			t.Fatalf("template is %T, want map", rm["template"])
+		}
+		apiVersion, _ := tm["apiVersion"].(string)
+		kind, _ := tm["kind"].(string)
+		kinds[apiVersion+"/"+kind] = true
+	}
+	if !kinds["run.cnrm.cloud.google.com/v1beta1/RunService"] {
+		t.Fatalf("missing RunService resource: %v", kinds)
+	}
+	if !kinds["iam.cnrm.cloud.google.com/v1beta1/IAMPolicyMember"] {
+		t.Fatalf("missing IAMPolicyMember resource: %v", kinds)
+	}
+	assertNested("${service.status.url}", "spec", "schema", "status", "url")
+}
+
+func loadSeedTemplate(t *testing.T, path string) *infrav1alpha1.Template {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read seed template: %v", err)
+	}
+	var obj map[string]any
+	if err := utilyaml.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal seed template: %v", err)
+	}
+	name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+	if name == "" {
+		t.Fatal("seed template missing metadata.name")
+	}
+	schemaRaw, err := marshalNested(obj, "spec", "schema")
+	if err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	backendConfigRaw, err := marshalNested(obj, "spec", "backendConfig")
+	if err != nil {
+		t.Fatalf("backendConfig: %v", err)
+	}
+	group, _, _ := unstructured.NestedString(obj, "spec", "instanceCRD", "group")
+	version, _, _ := unstructured.NestedString(obj, "spec", "instanceCRD", "version")
+	resource, _, _ := unstructured.NestedString(obj, "spec", "instanceCRD", "resource")
+	kind, _, _ := unstructured.NestedString(obj, "spec", "instanceCRD", "kind")
+	templateVersion, _, _ := unstructured.NestedString(obj, "spec", "version")
+
+	return &infrav1alpha1.Template{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: infrav1alpha1.TemplateSpec{
+			Version: templateVersion,
+			InstanceCRD: infrav1alpha1.TemplateInstanceCRD{
+				Group:    group,
+				Version:  version,
+				Resource: resource,
+				Kind:     kind,
+			},
+			Schema:        &runtime.RawExtension{Raw: schemaRaw},
+			BackendConfig: &runtime.RawExtension{Raw: backendConfigRaw},
+		},
+	}
+}
+
+func marshalNested(obj map[string]any, fields ...string) ([]byte, error) {
+	nested, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("missing %v", fields)
+	}
+	return json.Marshal(nested)
 }

--- a/providers/infrastructure/config/crds/infrastructure.kedge.faros.sh_templates.yaml
+++ b/providers/infrastructure/config/crds/infrastructure.kedge.faros.sh_templates.yaml
@@ -108,6 +108,14 @@ spec:
                   "Other" bucket.
                 maxLength: 64
                 type: string
+              cloud:
+                description: |-
+                  Cloud identifies the target environment for catalog filtering
+                  (for example "k8s", "gcp", "aws", or "azure"). Empty means
+                  the template is not cloud-specific.
+                maxLength: 64
+                pattern: ^[a-z][a-z0-9-]*$
+                type: string
               description:
                 description: |-
                   Description is one to three sentences shown beneath the

--- a/providers/infrastructure/docs/config-connector.md
+++ b/providers/infrastructure/docs/config-connector.md
@@ -1,0 +1,44 @@
+# Config Connector for local Cloud Run templates
+
+The `gcp-cloud-run-service` Template generates a kro ResourceGraphDefinition
+that creates Config Connector resources on the kro runtime cluster. Install
+Config Connector before provisioning the template, otherwise the generated
+RunService and IAMPolicyMember resources have no controller.
+
+## Local Tilt setup
+
+The Tilt resources `config-connector-up`, `config-connector-status`, and
+`config-connector-down` wrap the Make targets below. They are manual because
+`config-connector-up` imports Google Cloud credentials into the local runtime
+cluster.
+
+```sh
+export CONFIG_CONNECTOR_KEY_FILE=/absolute/path/to/key.json
+tilt trigger config-connector-up
+```
+
+`CONFIG_CONNECTOR_KEY_FILE` must point to an existing service-account JSON key.
+Keep that file outside the repository, or place it under `.secrets/`, which is
+ignored. The Make target imports it as a Kubernetes Secret in `cnrm-system` with
+the required key name `key.json`; it does not print the key or write it to disk.
+
+Optional settings:
+
+```sh
+export CONFIG_CONNECTOR_KUBECONFIG=/absolute/path/to/runtime.kubeconfig
+export CONFIG_CONNECTOR_SECRET_NAME=kcc-gcp-key
+```
+
+If `CONFIG_CONNECTOR_KUBECONFIG` is unset, the Make target uses the active kro
+runtime kubeconfig: `KRO_TARGET_KUBECONFIG` when set by `Tiltfile.cluster`, or
+`.kedge-kro.kubeconfig` in the embedded-kcp Tiltfile.
+
+## Google Cloud prerequisites
+
+Create the service account, grant the minimum roles needed for the resources you
+plan to reconcile, enable the required Google APIs, and create the key yourself.
+For the first Cloud Run template, enable `run.googleapis.com` and grant access
+to manage Cloud Run plus the public invoker IAM binding.
+
+Service-account keys are a local-dev compromise. Prefer Workload Identity or
+another keyless identity mechanism for production clusters.

--- a/providers/infrastructure/install/crds/infrastructure.kedge.faros.sh_templates.yaml
+++ b/providers/infrastructure/install/crds/infrastructure.kedge.faros.sh_templates.yaml
@@ -108,6 +108,14 @@ spec:
                   "Other" bucket.
                 maxLength: 64
                 type: string
+              cloud:
+                description: |-
+                  Cloud identifies the target environment for catalog filtering
+                  (for example "k8s", "gcp", "aws", or "azure"). Empty means
+                  the template is not cloud-specific.
+                maxLength: 64
+                pattern: ^[a-z][a-z0-9-]*$
+                type: string
               description:
                 description: |-
                   Description is one to three sentences shown beneath the

--- a/providers/infrastructure/install/seedtemplates_test.go
+++ b/providers/infrastructure/install/seedtemplates_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package install
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func TestEmbeddedSeedTemplatesAreValid(t *testing.T) {
+	entries, err := fs.ReadDir(seedTemplatesFS, "templates")
+	if err != nil {
+		t.Fatalf("read templates: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one embedded template")
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		t.Run(entry.Name(), func(t *testing.T) {
+			raw, err := fs.ReadFile(seedTemplatesFS, "templates/"+entry.Name())
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var obj map[string]any
+			if err := utilyaml.Unmarshal(raw, &obj); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+			if name == "" {
+				t.Fatal("metadata.name is required")
+			}
+			for _, field := range []string{"version", "backend", "category", "cloud"} {
+				got, _, _ := unstructured.NestedString(obj, "spec", field)
+				if got == "" {
+					t.Fatalf("spec.%s is required for seed templates", field)
+				}
+			}
+			resources, found, err := unstructured.NestedSlice(obj, "spec", "backendConfig", "resources")
+			if err != nil {
+				t.Fatalf("spec.backendConfig.resources: %v", err)
+			}
+			if !found || len(resources) == 0 {
+				t.Fatal("spec.backendConfig.resources must be non-empty")
+			}
+		})
+	}
+}

--- a/providers/infrastructure/install/templates/gcp-cloud-run-service.yaml
+++ b/providers/infrastructure/install/templates/gcp-cloud-run-service.yaml
@@ -1,0 +1,84 @@
+apiVersion: infrastructure.kedge.faros.sh/v1alpha1
+kind: Template
+metadata:
+  name: gcp-cloud-run-service
+spec:
+  displayName: "Cloud Run service"
+  description: "A public Google Cloud Run service reconciled by Config Connector."
+  category: Serverless
+  cloud: gcp
+  version: 0.1.0
+  backend: kro
+  instanceCRD:
+    group: infrastructure.kedge.faros.sh
+    version: v1alpha1
+    resource: cloudrunservices
+    kind: CloudRunService
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: "Cloud Run service name."
+        pattern: "^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$"
+      projectID:
+        type: string
+        description: "Google Cloud project ID."
+      region:
+        type: string
+        default: "us-central1"
+      image:
+        type: string
+        default: "gcr.io/cloudrun/hello"
+      port:
+        type: integer
+        default: 8080
+        minimum: 1
+        maximum: 65535
+      ingress:
+        type: string
+        enum: ["INGRESS_TRAFFIC_ALL", "INGRESS_TRAFFIC_INTERNAL_ONLY", "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"]
+        default: "INGRESS_TRAFFIC_ALL"
+    required:
+      - name
+      - projectID
+  backendConfig:
+    resources:
+      - id: service
+        template:
+          apiVersion: run.cnrm.cloud.google.com/v1beta1
+          kind: RunService
+          metadata:
+            name: ${schema.spec.name}
+            namespace: default
+          spec:
+            ingress: ${schema.spec.ingress}
+            launchStage: GA
+            location: ${schema.spec.region}
+            projectRef:
+              external: projects/${schema.spec.projectID}
+            template:
+              containers:
+                - image: ${schema.spec.image}
+                  ports:
+                    - containerPort: ${schema.spec.port}
+            traffic:
+              - percent: 100
+                type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
+      - id: publicInvoker
+        template:
+          apiVersion: iam.cnrm.cloud.google.com/v1beta1
+          kind: IAMPolicyMember
+          metadata:
+            name: ${schema.spec.name}-public-invoker
+            namespace: default
+          spec:
+            member: allUsers
+            role: roles/run.invoker
+            resourceRef:
+              apiVersion: run.cnrm.cloud.google.com/v1beta1
+              kind: RunService
+              name: ${service.metadata.name}
+    status:
+      url: ${service.status.url}
+      conditions: ${service.status.conditions}

--- a/providers/infrastructure/install/templates/redis-cache.yaml
+++ b/providers/infrastructure/install/templates/redis-cache.yaml
@@ -6,6 +6,7 @@ spec:
   displayName: "Redis cache"
   description: "A Redis instance for caching workloads. StatefulSet + Service; size knob picks the memory limit."
   category: Databases
+  cloud: k8s
   version: 0.1.0
   backend: kro
   instanceCRD:

--- a/providers/infrastructure/install/templates/simple-webapp.yaml
+++ b/providers/infrastructure/install/templates/simple-webapp.yaml
@@ -6,6 +6,7 @@ spec:
   displayName: "Simple webapp"
   description: "A web application — Deployment + Service, nginx by default. Scales via the replicas input."
   category: Workloads
+  cloud: k8s
   version: 0.1.0
   backend: kro
   instanceCRD:


### PR DESCRIPTION
## Summary

  Adds a GCP Cloud Run infrastructure template backed by kro and Config Connector.

  - Adds `Template.spec.cloud` for cloud/runtime catalog metadata and regenerates the Template CRDs.
  - Adds a `gcp-cloud-run-service` seed Template that generates a kro RGD composing Config Connector `RunService` and
  `IAMPolicyMember` resources.
  - Marks existing seed templates as `cloud: k8s`.
  - Adds manual Tilt + Make targets for installing, checking, and uninstalling Config Connector in the kro runtime
  cluster.
  - Documents local Config Connector setup and safe handling of GCP service-account keys.
  - Adds tests for `spec.cloud`, embedded seed template validity, and Cloud Run RGD generation.