### PR TITLE
providers: quickstart Helm chart + CI image/chart publishing for both providers

### DIFF
--- a/.github/workflows/helm-images.yaml
+++ b/.github/workflows/helm-images.yaml
@@ -62,11 +62,14 @@ jobs:
             APP_VERSION="${CHART_VERSION}"
           fi
 
-          # Package and push each chart in deploy/charts/
-          for chart_dir in deploy/charts/*/; do
+          # Package and push each platform chart in deploy/charts/ plus every
+          # per-provider chart in providers/*/deploy/chart/. The provider chart
+          # dirs are all named "chart", so the chart name is read from the
+          # Chart.yaml name: field rather than the directory basename.
+          for chart_dir in deploy/charts/*/ providers/*/deploy/chart/; do
             if [ -f "${chart_dir}Chart.yaml" ]; then
-              chart_name=$(basename "$chart_dir")
-              echo "Processing chart: $chart_name"
+              chart_name=$(grep -E '^name:' "${chart_dir}Chart.yaml" | head -1 | awk '{print $2}')
+              echo "Processing chart: $chart_name ($chart_dir)"
 
               # Update chart version and appVersion in Chart.yaml
               sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}Chart.yaml"

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - 'v*'
+  # On PRs, the jobs below run in build-only mode (push: false, single-arch)
+  # so a broken Dockerfile or build context is caught before a release tag.
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
@@ -30,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -50,8 +55,9 @@ jobs:
         with:
           context: .
           file: ./deploy/Dockerfile.hub
-          platforms: linux/amd64,linux/arm64
-          push: true
+          # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -69,6 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -89,8 +96,9 @@ jobs:
         with:
           context: .
           file: ./deploy/Dockerfile.agent
-          platforms: linux/amd64,linux/arm64
-          push: true
+          # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -108,6 +116,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -130,8 +139,9 @@ jobs:
           # the provider directory, so the build context is that directory.
           context: ./providers/infrastructure
           file: ./providers/infrastructure/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -145,6 +155,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -167,7 +178,8 @@ jobs:
           # the provider directory, so the build context is that directory.
           context: ./providers/quickstart
           file: ./providers/quickstart/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -16,6 +16,8 @@ env:
   REGISTRY: ghcr.io
   HUB_IMAGE_NAME: ${{ github.repository }}-hub
   AGENT_IMAGE_NAME: ${{ github.repository }}-agent
+  INFRASTRUCTURE_PROVIDER_IMAGE_NAME: ${{ github.repository }}-infrastructure-provider
+  QUICKSTART_PROVIDER_IMAGE_NAME: ${{ github.repository }}-quickstart-provider
 
 jobs:
   build-and-push-hub-image:
@@ -95,3 +97,77 @@ jobs:
             VERSION=${{ github.ref_name }}
             GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.release.created_at }}
+
+  build-and-push-infrastructure-provider-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.INFRASTRUCTURE_PROVIDER_IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          # The provider Dockerfile COPYs portal/ and the Go module relative to
+          # the provider directory, so the build context is that directory.
+          context: ./providers/infrastructure
+          file: ./providers/infrastructure/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-quickstart-provider-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.QUICKSTART_PROVIDER_IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          # The provider Dockerfile COPYs portal/ and the Go module relative to
+          # the provider directory, so the build context is that directory.
+          context: ./providers/quickstart
+          file: ./providers/quickstart/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/providers/infrastructure/Dockerfile
+++ b/providers/infrastructure/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 #    crds/ + templates/), controller/, backend/, kro/, tenant/, mcpserver/,
 #    server/, apis/. assets.go //go:embeds portal/dist, which is overlaid from
 #    the node stage below so the bundle is fresh.
-FROM golang:1.24-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/providers/quickstart/deploy/chart/Chart.yaml
+++ b/providers/quickstart/deploy/chart/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: kedge-quickstart-provider
+description: |
+  Reference kedge provider demonstrating the platform's extension surface
+  end-to-end. Ships the provider Deployment, ClusterIP Service, and the
+  CatalogEntry that registers the provider (UI + backend + a sample
+  greetings APIExport) with the kedge hub. Pure broker — no kcp or kro
+  kubeconfig wiring; useful as a copy-from template for new providers.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: https://example.com/kedge-icon.png
+keywords:
+  - kedge
+  - provider
+  - quickstart
+  - reference
+home: https://github.com/faroshq/kedge
+sources:
+  - https://github.com/faroshq/kedge/tree/main/providers/quickstart
+maintainers:
+  - name: kedge maintainers

--- a/providers/quickstart/deploy/chart/templates/_helpers.tpl
+++ b/providers/quickstart/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Shared helpers. fullName follows the standard
+{{ release-name }}-{{ chart-name }} pattern unless the user overrides
+.Values.fullnameOverride.
+*/}}
+
+{{- define "quickstart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "quickstart.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "quickstart.labels" -}}
+app.kubernetes.io/name: {{ include "quickstart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "quickstart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "quickstart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "quickstart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "quickstart.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/providers/quickstart/deploy/chart/templates/catalogentry.yaml
+++ b/providers/quickstart/deploy/chart/templates/catalogentry.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.catalogEntry.enabled -}}
+# CatalogEntry registers this provider with the kedge hub. The hub's catalog
+# controller materializes root:kedge:providers:quickstart, mints
+# kedge-provider-kubeconfig into our serviceAccountNamespace, applies the
+# inline APIResourceSchema(s), and creates the APIExport tenants APIBind to.
+#
+# This mirrors providers/quickstart/manifest.yaml, but the ui/backend URLs
+# point at the in-cluster Service DNS (the manifest defaults to localhost for
+# host-side dev). See manifest.yaml for the full field-by-field reference.
+apiVersion: providers.kedge.faros.sh/v1alpha1
+kind: CatalogEntry
+metadata:
+  name: quickstart
+  labels:
+    {{- include "quickstart.labels" . | nindent 4 }}
+spec:
+  displayName: "Quickstart"
+  description: "Reference provider demonstrating the kedge plugin surface."
+  vendor: "kedge"
+  version: {{ .Chart.AppVersion | quote }}
+  category: "Demo"
+  iconURL: "/ui/providers/quickstart/icon.svg"
+  serviceAccountNamespace: {{ .Release.Namespace }}
+  ui:
+    url: "http://{{ include "quickstart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+    indexPath: "/"
+  backend:
+    url: "http://{{ include "quickstart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+    healthPath: "/healthz"
+  apiExport:
+    name: "quickstart.providers.kedge.faros.sh"
+    # Sample permission claim so the portal's Enable dialog has something to
+    # render. The quickstart provider does not actually read configmaps —
+    # this is purely for demonstration. Marked tenantScoped so the dialog
+    # pre-checks it as safe-to-accept.
+    permissionClaims:
+      - resource: configmaps
+        verbs: [get, list, watch]
+        tenantScoped: true
+    schemas:
+      - groupResource: "greetings.quickstart.providers.kedge.faros.sh"
+        # Schema body is applied verbatim into the sub-workspace. The name
+        # must include a content-version segment because kcp treats
+        # APIResourceSchemas as immutable; a body change requires a new name.
+        body: |
+          apiVersion: apis.kcp.io/v1alpha1
+          kind: APIResourceSchema
+          metadata:
+            name: v260522-001.greetings.quickstart.providers.kedge.faros.sh
+          spec:
+            group: quickstart.providers.kedge.faros.sh
+            names:
+              kind: Greeting
+              listKind: GreetingList
+              plural: greetings
+              singular: greeting
+            scope: Namespaced
+            versions:
+              - name: v1alpha1
+                served: true
+                storage: true
+                subresources:
+                  status: {}
+                schema:
+                  type: object
+                  properties:
+                    apiVersion: { type: string }
+                    kind: { type: string }
+                    metadata: { type: object }
+                    spec:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+                          maxLength: 256
+                    status:
+                      type: object
+                      properties:
+                        observedAt:
+                          type: string
+                          format: date-time
+{{- end }}

--- a/providers/quickstart/deploy/chart/templates/deployment.yaml
+++ b/providers/quickstart/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quickstart.fullname" . }}
+  labels:
+    {{- include "quickstart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "quickstart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "quickstart.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "quickstart.serviceAccountName" . }}
+      containers:
+        - name: provider
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 5
+          env:
+            - name: PORT
+              value: "8081"
+            - name: KEDGE_HUB_URL
+              value: {{ .Values.hub.url | quote }}
+            - name: KEDGE_PROVIDER_NAME
+              value: "quickstart"
+            {{- if .Values.hub.insecure }}
+            - name: KEDGE_HUB_INSECURE
+              value: "true"
+            {{- end }}
+            {{- if .Values.hub.tokenSecretRef.name }}
+            - name: KEDGE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hub.tokenSecretRef.name }}
+                  key: {{ .Values.hub.tokenSecretRef.key }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/providers/quickstart/deploy/chart/templates/service.yaml
+++ b/providers/quickstart/deploy/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quickstart.fullname" . }}
+  labels:
+    {{- include "quickstart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "quickstart.selectorLabels" . | nindent 4 }}

--- a/providers/quickstart/deploy/chart/templates/serviceaccount.yaml
+++ b/providers/quickstart/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "quickstart.serviceAccountName" . }}
+  labels:
+    {{- include "quickstart.labels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
## What

Adds a Helm chart for the **quickstart** provider (it had none) and wires both the **infrastructure** and **quickstart** providers into release CI for container images and OCI Helm charts.

## Changes

**New chart — `providers/quickstart/deploy/chart/`**
- Modeled on the infrastructure chart but trimmed to what quickstart actually is: a pure UI+backend broker. No kcp/kro kubeconfig, no bootstrap init container.
- Templates: Deployment, Service, ServiceAccount, CatalogEntry, `_helpers.tpl`.
- The CatalogEntry mirrors the provider's `manifest.yaml` (configmaps permission claim + greetings APIResourceSchema) but points ui/backend URLs at in-cluster Service DNS instead of localhost.

**Container images — `.github/workflows/images.yaml`**
- Two new jobs build+push each provider to `ghcr.io/faroshq/kedge-{infrastructure,quickstart}-provider`.
- Build context is the provider directory (the Dockerfiles `COPY portal/` + the Go module relative to it). Infra image name matches what its `values.yaml` already references.

**Helm charts — `.github/workflows/helm-images.yaml`**
- Packaging loop extended to `providers/*/deploy/chart/`.
- Chart name now read from `Chart.yaml` `name:` rather than the directory basename (the provider chart dirs are all named `chart`).

## Verification
- `helm lint` + `helm template` pass on both charts (default and variant values).
- Simulated the CI packaging loop locally — produces all four `.tgz` with correct names (`kedge-hub`, `kedge-agent`, `kedge-infrastructure-provider`, `kedge-quickstart-provider`).
- Both workflow YAMLs parse cleanly.

## Note
Both workflows publish on the existing triggers (`v*` tags / releases; `helm-images.yaml` also on `main` pushes) — the provider artifacts ride the same trigger as hub/agent. No PR-time smoke build added; can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)