### PR TITLE
infrastructure(redis): generate password via init container, not a Job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -724,9 +724,9 @@ helm-undeploy-provider-infrastructure: ## (experimental) helm uninstall the infr
 KRO_KIND_NAME ?= kedge-kro
 KRO_KIND_KUBECONFIG ?= $(CURDIR)/.kedge-kro.kubeconfig
 KRO_CHART ?= oci://ghcr.io/faroshq/kro-multicluster/charts/kro/kro
-KRO_CHART_VERSION ?= v0.0.1-mc.6
+KRO_CHART_VERSION ?= v0.0.1-mc.7
 KRO_IMAGE_REPO ?= ghcr.io/faroshq/kro-multicluster/kro
-KRO_IMAGE_TAG ?= v0.0.1-mc.6
+KRO_IMAGE_TAG ?= v0.0.1-mc.7
 KRO_NAMESPACE ?= kro-system
 KRO_SEED_DIR ?= providers/infrastructure/examples/rgds
 

--- a/providers/infrastructure/install/templates/redis-cache.yaml
+++ b/providers/infrastructure/install/templates/redis-cache.yaml
@@ -54,12 +54,14 @@ spec:
           stringData:
             host: ${schema.spec.name}
             port: "6379"
-      # Password generation, in-graph (no external operator). A one-shot
-      # Job mints a random password and patches it (plus a complete
-      # redis://:<pw>@host:port URI) into the credentials Secret — once;
-      # it no-ops if the password key already exists, so re-reconciles
-      # don't rotate it. kro never sees the value (the Job runs the shell);
-      # status only ever references the Secret.
+      # Password generation runs as an init container on the redis pod
+      # itself (see statefulset below), NOT a standalone Job. Co-locating it
+      # with the consumer makes ordering deterministic: the init container
+      # mints + patches the password before the redis container starts, so
+      # redis never comes up against a credentials Secret missing its
+      # password key (a standalone Job races the StatefulSet and wedges redis
+      # if it fails). The SA/Role/RoleBinding below grant that init container
+      # get+patch on the Secret; kro never sees the value.
       - id: pwgenAccount
         template:
           apiVersion: v1
@@ -93,37 +95,6 @@ spec:
             - kind: ServiceAccount
               name: ${pwgenAccount.metadata.name}
               namespace: default
-      - id: pwgen
-        template:
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: ${schema.spec.name}-pwgen
-            namespace: default
-          spec:
-            backoffLimit: 5
-            ttlSecondsAfterFinished: 600
-            template:
-              spec:
-                serviceAccountName: ${pwgenAccount.metadata.name}
-                restartPolicy: OnFailure
-                containers:
-                  - name: pwgen
-                    image: bitnami/kubectl
-                    command:
-                      - /bin/sh
-                      - -c
-                      - |
-                        set -eu
-                        SECRET="${credentials.metadata.name}"
-                        if [ -z "$(kubectl get secret "$SECRET" -o jsonpath='{.data.password}' 2>/dev/null)" ]; then
-                          PW="$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 24)"
-                          kubectl patch secret "$SECRET" --type merge \
-                            -p "{\"stringData\":{\"password\":\"$PW\",\"uri\":\"redis://:$PW@${schema.spec.name}:6379\"}}"
-                          echo "generated credentials for $SECRET"
-                        else
-                          echo "credentials already present for $SECRET"
-                        fi
       - id: statefulset
         template:
           apiVersion: apps/v1
@@ -141,7 +112,36 @@ spec:
               metadata:
                 labels:
                   app: ${schema.spec.name}
+                annotations:
+                  # Force kro to apply the RoleBinding (and the SA/Role it
+                  # references) before this pod: the reference makes the
+                  # StatefulSet a DAG-dependent of pwgenBinding, so the init
+                  # container always has get+patch on the Secret when it runs.
+                  kedge.faros.sh/rbac: ${pwgenBinding.metadata.name}
               spec:
+                serviceAccountName: ${pwgenAccount.metadata.name}
+                initContainers:
+                  # Mint the password in-graph, before redis starts. Idempotent:
+                  # no-ops if the password key is already set, so pod restarts
+                  # and re-reconciles don't rotate it. Patches a complete
+                  # redis://:<pw>@host:port URI alongside the password so
+                  # consumers get a ready-to-use connection string.
+                  - name: pwgen
+                    image: bitnami/kubectl
+                    command:
+                      - /bin/sh
+                      - -c
+                      - |
+                        set -eu
+                        SECRET="${credentials.metadata.name}"
+                        if [ -z "$(kubectl get secret "$SECRET" -o jsonpath='{.data.password}' 2>/dev/null)" ]; then
+                          PW="$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 24)"
+                          kubectl patch secret "$SECRET" --type merge \
+                            -p "{\"stringData\":{\"password\":\"$PW\",\"uri\":\"redis://:$PW@${schema.spec.name}:6379\"}}"
+                          echo "generated credentials for $SECRET"
+                        else
+                          echo "credentials already present for $SECRET"
+                        fi
                 containers:
                   - name: redis
                     image: redis:${schema.spec.version}


### PR DESCRIPTION
## What

Replaces the standalone `pwgen` Job in the `redis-cache` Template with an **init container** on the redis StatefulSet, and bumps the kro fork chart/image to `v0.0.1-mc.7`.

## Why

The standalone Job was an independent graph node racing the StatefulSet. redis's `secretKeyRef` on the credentials Secret's `password` key blocks the pod until the Job patches it, so:

- if the Job ever fails, redis is wedged indefinitely with no ordering guarantee;
- a recent RBAC bug (RoleBinding subject namespace not remapped by the data-plane split) made the Job's `kubectl get secret` 403, leaving redis stuck.

Moving generation into an init container makes ordering deterministic via the pod lifecycle (init → app): redis never starts against a Secret missing its password, and a generation failure only back-offs the init container instead of leaving a half-provisioned instance.

## Changes

- **`providers/infrastructure/install/templates/redis-cache.yaml`**
  - Remove the `pwgen` Job node.
  - Keep the SA / Role (get+patch secrets) / RoleBinding — the init container still patches the Secret.
  - StatefulSet gains `serviceAccountName`, an `initContainers[0]` running the same idempotent generate-and-patch script, and a `kedge.faros.sh/rbac: ${pwgenBinding.metadata.name}` annotation so kro applies RBAC before the pod (DAG dependency).
- **`Makefile`** — `KRO_CHART_VERSION`/`KRO_IMAGE_TAG` → `v0.0.1-mc.7` (carries the kro-multicluster RoleBinding subject-namespace remap fix the split needs).

## Notes

- Tradeoff unchanged: the init container still needs RBAC to patch the Secret — inherent to minting a random secret in the data plane without the control plane seeing the value.
- Rollout: re-seed the Template into the provider workspace (`make init-provider-infrastructure`) and recreate the existing RedisCache instance so kro applies the init-container StatefulSet and prunes the old Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)