### PR TITLE
providers/code: portal views + Tilt/dev wiring — PR D

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
+.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
 
 BINDIR ?= bin
 GOFLAGS ?=
@@ -717,6 +717,28 @@ uninstall-provider-code: ## Delete the code CatalogEntry
 		--server=$(KROMC_KCP_SERVER)/clusters/root:kedge:providers \
 		--insecure-skip-tls-verify \
 		delete -f $(CODE_MANIFEST)
+
+CODE_WORKSPACE_PATH ?= root:kedge:providers:code
+## Dev bootstrap for the code provider. The hub mints a real provider
+## kubeconfig only when it runs with a host cluster (--kubeconfig); the
+## in-process dev hub does not, so we synthesize a static-token kubeconfig
+## pointed at the provider workspace and ensure the APIExportEndpointSlice the
+## controller manager needs. run-provider-code reads it via CODE_KUBECONFIG.
+## Order: install-provider-code (creates the workspace) → init-provider-code →
+## run-provider-code. Re-runnable.
+init-provider-code: build-code-provider ## Write the dev kubeconfig + ensure the code APIExportEndpointSlice
+	@test -f $(KROMC_KCP_KUBECONFIG) || { \
+		echo "kubeconfig not found at $(KROMC_KCP_KUBECONFIG)"; \
+		echo "start the hub first with: make run-hub-embedded-static"; \
+		exit 1; \
+	}
+	@mkdir -p $(KCP_DATA_DIR)
+	@echo "Writing dev kubeconfig $(CODE_RUNTIME_KUBECONFIG) (workspace $(CODE_WORKSPACE_PATH))"
+	@printf 'apiVersion: v1\nkind: Config\ncurrent-context: code\nclusters:\n- name: code\n  cluster:\n    server: %s/clusters/%s\n    insecure-skip-tls-verify: true\ncontexts:\n- name: code\n  context:\n    cluster: code\n    user: code\nusers:\n- name: code\n  user:\n    token: %s\n' \
+		"$(KROMC_KCP_SERVER)" "$(CODE_WORKSPACE_PATH)" "$(KROMC_TOKEN)" > $(CODE_RUNTIME_KUBECONFIG)
+	CODE_KUBECONFIG=$(CODE_RUNTIME_KUBECONFIG) \
+	CODE_WORKSPACE_PATH=$(CODE_WORKSPACE_PATH) \
+		$(BINDIR)/code-provider init
 
 # --- Experimental: run the infrastructure provider as a POD (init-container
 #     bootstrap) instead of a host binary. Exercises the full hub-minted

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,6 +19,7 @@ local_resource(
         'providers/mcp/portal/src',
         'providers/kubernetesedges/portal/src',
         'providers/serveredges/portal/src',
+        'providers/code/portal/src',
     ],
     labels=['hub'],
 )
@@ -30,7 +31,7 @@ local_resource(
     'hub',
     cmd='''
 make certs && \
-mkdir -p providers/mcp/portal/dist providers/kubernetesedges/portal/dist providers/serveredges/portal/dist portal/dist && \
+mkdir -p providers/mcp/portal/dist providers/kubernetesedges/portal/dist providers/serveredges/portal/dist providers/code/portal/dist portal/dist && \
 go build -o bin/kedge-hub ./cmd/kedge-hub
 ''',
     serve_cmd='''./bin/kedge-hub \
@@ -133,6 +134,75 @@ local_resource(
     auto_init=False,
     resource_deps=['hub'],
     labels=['providers-quickstart'],
+)
+
+# --- providers-code (git repository management) ---
+# Long-lived provider: serves the portal + MCP on :8083 and, once a kubeconfig
+# is present, runs the multicluster controller manager. run-provider-code reads
+# CODE_KUBECONFIG from .kcp/code-runtime.kubeconfig (written by code-init), and
+# falls back to portal/MCP-only when it's absent — so this can start before the
+# workspace exists.
+local_resource(
+    'code',
+    cmd='make build-code-provider',
+    serve_cmd='make run-provider-code',
+    deps=[
+        'providers/code/main.go',
+        'providers/code/heartbeat.go',
+        'providers/code/assets.go',
+        'providers/code/controller_manager.go',
+        'providers/code/init_cmd.go',
+        'providers/code/server',
+        'providers/code/tenant',
+        'providers/code/mcpserver',
+        'providers/code/controller',
+        'providers/code/backend',
+        'providers/code/install',
+        'providers/code/scheme',
+        'providers/code/portal/src',
+        'providers/code/portal/package.json',
+        'providers/code/go.mod',
+        'providers/code/go.sum',
+        '.kcp/code-runtime.kubeconfig',
+    ],
+    resource_deps=['hub'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=8083, path='/healthz'),
+    ),
+    labels=['providers-code'],
+)
+
+local_resource(
+    'code-register',
+    cmd='make install-provider-code',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['providers-code'],
+)
+
+# Writes the dev kubeconfig (.kcp/code-runtime.kubeconfig) and ensures the
+# APIExportEndpointSlice the controller manager watches. Order:
+#   code-register  → creates root:kedge:providers:code
+#   code-init      → writes kubeconfig + endpoint slice
+#   code (serve)   → Tilt restarts it when the kubeconfig dep appears
+local_resource(
+    'code-init',
+    cmd='make init-provider-code',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub', 'code-register'],
+    labels=['providers-code'],
+)
+
+local_resource(
+    'code-unregister',
+    cmd='make uninstall-provider-code',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['providers-code'],
 )
 
 # --- providers-kro ---

--- a/providers/code/portal/src/App.vue
+++ b/providers/code/portal/src/App.vue
@@ -1,25 +1,42 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import type { KedgeContext } from './types'
+import { setBasePath, setTenant, setToken } from './api'
+import ConnectionsView from './views/ConnectionsView.vue'
+import RepositoriesView from './views/RepositoriesView.vue'
+import RepoDetailView from './views/RepoDetailView.vue'
 
-// PR A ships a placeholder shell that routes on subPath. The real Connections
-// (connect GitHub, paste PAT, validation status) and Repositories
-// (list/create/delete + deploy keys + collaborators) views land in PR C.
-//
-//   ''  | 'connections'  → Connections
-//   'repositories'       → Repositories
+// Sub-path routing (the shell pushes the trailing /providers/code/<sub> segment):
+//   ''  | 'connections'        → Connections
+//   'repositories'             → Repositories
+//   'repositories/<name>'      → RepoDetail
 const props = defineProps<{ ctx: KedgeContext | null }>()
 
-type Page = 'connections' | 'repositories'
+interface Route {
+  page: 'connections' | 'repositories'
+  repo?: string
+}
 
-const page = computed<Page>(() => {
-  const s = (props.ctx?.subPath ?? '').replace(/^\/+|\/+$/g, '').split('/')[0]
-  return s === 'repositories' ? 'repositories' : 'connections'
-})
+function parse(sub: string | null | undefined): Route {
+  const s = (sub ?? '').replace(/^\/+|\/+$/g, '')
+  if (s === '' || s === 'connections') return { page: 'connections' }
+  const parts = s.split('/')
+  if (parts[0] === 'repositories') {
+    return parts.length > 1 ? { page: 'repositories', repo: decodeURIComponent(parts[1]) } : { page: 'repositories' }
+  }
+  return { page: 'connections' }
+}
 
-function navigate(sub: Page) {
-  // Mirror the infra provider: dispatch a bubbling kedge-navigate CustomEvent
-  // so the shell's ProviderFrame router keeps the browser URL in sync.
+const route = computed(() => parse(props.ctx?.subPath))
+
+// Feed identity into the api client whenever the shell re-pushes context.
+watch(() => props.ctx?.basePath, v => setBasePath(v), { immediate: true })
+watch(() => props.ctx?.token, v => setToken(v), { immediate: true })
+watch(() => props.ctx?.tenant, v => setTenant(v), { immediate: true })
+
+const hasTenant = computed(() => !!props.ctx?.tenant)
+
+function navigate(sub: string) {
   document.dispatchEvent(new CustomEvent('kedge-navigate', { bubbles: true, detail: { subPath: sub } }))
 }
 </script>
@@ -27,26 +44,16 @@ function navigate(sub: Page) {
 <template>
   <div class="code-shell">
     <nav class="code-tabs">
-      <button :class="{ active: page === 'connections' }" @click="navigate('connections')">Connections</button>
-      <button :class="{ active: page === 'repositories' }" @click="navigate('repositories')">Repositories</button>
+      <button :class="{ active: route.page === 'connections' }" @click="navigate('connections')">Connections</button>
+      <button :class="{ active: route.page === 'repositories' }" @click="navigate('repositories')">Repositories</button>
     </nav>
 
-    <section v-if="page === 'connections'" class="code-panel">
-      <h2>Connections</h2>
-      <p class="code-muted">
-        Connect a git account (GitHub) by pasting a personal access token. The
-        provider validates it and shows the authenticated login here.
-      </p>
-      <p class="code-todo">Connection management UI arrives in PR C.</p>
-    </section>
+    <p v-if="!hasTenant" class="code-empty">Select a workspace to manage code.</p>
 
-    <section v-else class="code-panel">
-      <h2>Repositories</h2>
-      <p class="code-muted">
-        Create and manage repositories under a connected account, plus deploy
-        keys and collaborators.
-      </p>
-      <p class="code-todo">Repository management UI arrives in PR C.</p>
-    </section>
+    <template v-else>
+      <ConnectionsView v-if="route.page === 'connections'" />
+      <RepoDetailView v-else-if="route.repo" :name="route.repo" @back="navigate('repositories')" />
+      <RepositoriesView v-else @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))" />
+    </template>
   </div>
 </template>

--- a/providers/code/portal/src/api.ts
+++ b/providers/code/portal/src/api.ts
@@ -1,0 +1,326 @@
+// kcp-native client for the code provider's portal.
+//
+// Talks to kcp directly through the hub's kcp REST proxy:
+//   /clusters/<tenant>/apis/code.kedge.faros.sh/v1alpha1/<resource>   (our CRDs)
+//   /clusters/<tenant>/api/v1/namespaces/default/secrets              (PAT secret)
+//
+// The shell pushes kedgeContext.tenant (kcp cluster name) and
+// kedgeContext.token (bearer). All four code CRDs are cluster-scoped, so their
+// CRs live at <cluster>/apis/<g>/<v>/<plural>/<name> with no namespace segment.
+
+import type {
+  Collaborator,
+  Connection,
+  DeployKey,
+  ErrorResponse,
+  Repository,
+} from './types'
+
+const GROUP = 'code.kedge.faros.sh'
+const VERSION = 'v1alpha1'
+const APIS_PREFIX = `/apis/${GROUP}/${VERSION}`
+const CRED_NAMESPACE = 'default'
+const TOKEN_KEY = 'token'
+
+let bearerToken: string | null = null
+let clusterName: string | null = null
+
+// setBasePath is a no-op: kcp paths are built from the cluster name, not the
+// provider basePath. Kept so App.vue's watcher type-checks.
+export function setBasePath(_ctxBasePath?: string | null) {
+  void _ctxBasePath
+}
+export function setToken(token?: string | null) {
+  bearerToken = token || null
+}
+export function setTenant(name?: string | null) {
+  clusterName = name || null
+}
+
+function clusterBase(): string {
+  if (!clusterName) {
+    throw <ErrorResponse>{ reason: 'TenantMissing', message: 'no workspace selected' }
+  }
+  return `/clusters/${clusterName}`
+}
+function apisBase(): string {
+  return clusterBase() + APIS_PREFIX
+}
+
+interface KCPMetadata {
+  name: string
+  uid?: string
+  creationTimestamp?: string
+}
+interface KCPCondition {
+  type: string
+  status: string
+  reason?: string
+  message?: string
+}
+interface KCPList<T> {
+  items: T[]
+}
+interface RawCR {
+  metadata: KCPMetadata
+  spec?: Record<string, unknown>
+  status?: { conditions?: KCPCondition[] } & Record<string, unknown>
+}
+
+async function kcpFetch<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (body) headers['Content-Type'] = 'application/json'
+  if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
+  const res = await fetch(path, {
+    method,
+    credentials: 'same-origin',
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  if (!res.ok) {
+    let reason = 'HTTPError'
+    let message = text || res.statusText
+    try {
+      const parsed = JSON.parse(text) as { reason?: string; message?: string }
+      if (parsed && (parsed.reason || parsed.message)) {
+        reason = parsed.reason || reason
+        message = parsed.message || message
+      }
+    } catch {
+      // non-JSON body — keep raw text
+    }
+    if (res.status === 404) reason = 'NotFound'
+    else if (res.status === 403 && /APIBinding|not\s+found/i.test(message)) reason = 'APIBindingMissing'
+    throw <ErrorResponse>{ reason, message }
+  }
+  return (text ? JSON.parse(text) : null) as T
+}
+
+function condTrue(cr: RawCR, type: string): boolean {
+  return (cr.status?.conditions ?? []).some(c => c.type === type && c.status === 'True')
+}
+function condMsg(cr: RawCR, type: string): string | undefined {
+  return (cr.status?.conditions ?? []).find(c => c.type === type)?.message
+}
+
+function connFromCR(cr: RawCR): Connection {
+  const spec = cr.spec ?? {}
+  const status = cr.status ?? {}
+  return {
+    name: cr.metadata.name,
+    provider: String(spec.provider ?? ''),
+    type: String(spec.type ?? ''),
+    owner: String(spec.owner ?? ''),
+    secretName: String((spec.secretRef as Record<string, unknown> | undefined)?.name ?? ''),
+    login: status.login ? String(status.login) : undefined,
+    scopes: Array.isArray(status.scopes) ? (status.scopes as string[]) : [],
+    validated: condTrue(cr, 'Validated'),
+    message: condMsg(cr, 'Validated') ?? condMsg(cr, 'Ready'),
+  }
+}
+
+function repoFromCR(cr: RawCR): Repository {
+  const spec = cr.spec ?? {}
+  const status = cr.status ?? {}
+  return {
+    name: cr.metadata.name,
+    connectionRef: String(spec.connectionRef ?? ''),
+    repo: String(spec.name ?? ''),
+    owner: spec.owner ? String(spec.owner) : undefined,
+    visibility: String(spec.visibility ?? 'private'),
+    description: spec.description ? String(spec.description) : undefined,
+    htmlURL: status.htmlURL ? String(status.htmlURL) : undefined,
+    sshURL: status.sshURL ? String(status.sshURL) : undefined,
+    cloneURL: status.cloneURL ? String(status.cloneURL) : undefined,
+    ready: condTrue(cr, 'Ready'),
+    message: condMsg(cr, 'Ready'),
+  }
+}
+
+function keyFromCR(cr: RawCR): DeployKey {
+  const spec = cr.spec ?? {}
+  const status = cr.status ?? {}
+  const secretRef = status.secretRef as Record<string, unknown> | undefined
+  return {
+    name: cr.metadata.name,
+    repositoryRef: String(spec.repositoryRef ?? ''),
+    title: spec.title ? String(spec.title) : undefined,
+    readOnly: Boolean(spec.readOnly),
+    generated: !spec.publicKey,
+    secretName: secretRef ? String(secretRef.name ?? '') : undefined,
+    keyID: status.keyID ? String(status.keyID) : undefined,
+    ready: condTrue(cr, 'Ready'),
+    message: condMsg(cr, 'Ready'),
+  }
+}
+
+function collabFromCR(cr: RawCR): Collaborator {
+  const spec = cr.spec ?? {}
+  return {
+    name: cr.metadata.name,
+    repositoryRef: String(spec.repositoryRef ?? ''),
+    username: String(spec.username ?? ''),
+    permission: String(spec.permission ?? 'pull'),
+    invitationPending: condTrue(cr, 'InvitationPending'),
+    ready: condTrue(cr, 'Ready'),
+    message: condMsg(cr, 'Ready'),
+  }
+}
+
+// dns1123 turns arbitrary text into a safe object name.
+function dns1123(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 253) || 'x'
+}
+
+export const api = {
+  // ── Connections ──────────────────────────────────────────────────────────
+  async listConnections(): Promise<Connection[]> {
+    const l = await kcpFetch<KCPList<RawCR>>('GET', apisBase() + '/connections')
+    return (l.items ?? []).map(connFromCR)
+  },
+
+  // connect creates the PAT Secret then the Connection that references it.
+  async connect(input: { name: string; owner: string; token: string; baseURL?: string }): Promise<Connection> {
+    const name = dns1123(input.name)
+    const secretName = name + '-token'
+    // 1) Secret holding the PAT.
+    await kcpFetch<unknown>(
+      'POST',
+      clusterBase() + `/api/v1/namespaces/${CRED_NAMESPACE}/secrets`,
+      {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: { name: secretName, namespace: CRED_NAMESPACE },
+        type: 'Opaque',
+        stringData: { [TOKEN_KEY]: input.token },
+      },
+    )
+    // 2) Connection referencing it.
+    const spec: Record<string, unknown> = {
+      provider: 'github',
+      type: 'pat',
+      owner: input.owner,
+      secretRef: { name: secretName, namespace: CRED_NAMESPACE, key: TOKEN_KEY },
+    }
+    if (input.baseURL) spec.baseURL = input.baseURL
+    const created = await kcpFetch<RawCR>('POST', apisBase() + '/connections', {
+      apiVersion: `${GROUP}/${VERSION}`,
+      kind: 'Connection',
+      metadata: { name },
+      spec,
+    })
+    return connFromCR(created)
+  },
+
+  async deleteConnection(name: string): Promise<void> {
+    await kcpFetch<unknown>('DELETE', apisBase() + '/connections/' + encodeURIComponent(name))
+  },
+
+  // ── Repositories ─────────────────────────────────────────────────────────
+  async listRepositories(): Promise<Repository[]> {
+    const l = await kcpFetch<KCPList<RawCR>>('GET', apisBase() + '/repositories')
+    return (l.items ?? []).map(repoFromCR)
+  },
+
+  async getRepository(name: string): Promise<Repository> {
+    const cr = await kcpFetch<RawCR>('GET', apisBase() + '/repositories/' + encodeURIComponent(name))
+    return repoFromCR(cr)
+  },
+
+  async createRepository(input: {
+    name: string
+    connectionRef: string
+    repo?: string
+    visibility?: string
+    description?: string
+    autoInit?: boolean
+  }): Promise<Repository> {
+    const name = dns1123(input.name)
+    const spec: Record<string, unknown> = {
+      connectionRef: input.connectionRef,
+      name: input.repo || input.name,
+    }
+    if (input.visibility) spec.visibility = input.visibility
+    if (input.description) spec.description = input.description
+    if (input.autoInit) spec.autoInit = true
+    const created = await kcpFetch<RawCR>('POST', apisBase() + '/repositories', {
+      apiVersion: `${GROUP}/${VERSION}`,
+      kind: 'Repository',
+      metadata: { name },
+      spec,
+    })
+    return repoFromCR(created)
+  },
+
+  async deleteRepository(name: string): Promise<void> {
+    await kcpFetch<unknown>('DELETE', apisBase() + '/repositories/' + encodeURIComponent(name))
+  },
+
+  // ── Deploy keys ──────────────────────────────────────────────────────────
+  async listDeployKeys(repositoryRef: string): Promise<DeployKey[]> {
+    const l = await kcpFetch<KCPList<RawCR>>('GET', apisBase() + '/deploykeys')
+    return (l.items ?? []).map(keyFromCR).filter(k => k.repositoryRef === repositoryRef)
+  },
+
+  async createDeployKey(input: {
+    repositoryRef: string
+    title?: string
+    publicKey?: string
+    readOnly?: boolean
+  }): Promise<DeployKey> {
+    const name = dns1123(input.repositoryRef + '-' + (input.title || 'key') + '-' + shortRand())
+    const spec: Record<string, unknown> = { repositoryRef: input.repositoryRef }
+    if (input.title) spec.title = input.title
+    if (input.publicKey) spec.publicKey = input.publicKey
+    if (input.readOnly) spec.readOnly = true
+    const created = await kcpFetch<RawCR>('POST', apisBase() + '/deploykeys', {
+      apiVersion: `${GROUP}/${VERSION}`,
+      kind: 'DeployKey',
+      metadata: { name },
+      spec,
+    })
+    return keyFromCR(created)
+  },
+
+  async deleteDeployKey(name: string): Promise<void> {
+    await kcpFetch<unknown>('DELETE', apisBase() + '/deploykeys/' + encodeURIComponent(name))
+  },
+
+  // ── Collaborators ────────────────────────────────────────────────────────
+  async listCollaborators(repositoryRef: string): Promise<Collaborator[]> {
+    const l = await kcpFetch<KCPList<RawCR>>('GET', apisBase() + '/collaborators')
+    return (l.items ?? []).map(collabFromCR).filter(c => c.repositoryRef === repositoryRef)
+  },
+
+  async createCollaborator(input: {
+    repositoryRef: string
+    username: string
+    permission?: string
+  }): Promise<Collaborator> {
+    const name = dns1123(input.repositoryRef + '-' + input.username)
+    const spec: Record<string, unknown> = {
+      repositoryRef: input.repositoryRef,
+      username: input.username,
+    }
+    if (input.permission) spec.permission = input.permission
+    const created = await kcpFetch<RawCR>('POST', apisBase() + '/collaborators', {
+      apiVersion: `${GROUP}/${VERSION}`,
+      kind: 'Collaborator',
+      metadata: { name },
+      spec,
+    })
+    return collabFromCR(created)
+  },
+
+  async deleteCollaborator(name: string): Promise<void> {
+    await kcpFetch<unknown>('DELETE', apisBase() + '/collaborators/' + encodeURIComponent(name))
+  },
+}
+
+function shortRand(): string {
+  // Browser crypto for a short suffix; avoids name collisions without Date/Math.random concerns.
+  const a = new Uint8Array(3)
+  crypto.getRandomValues(a)
+  return Array.from(a, b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -43,8 +43,175 @@ kedge-provider-code .code-muted {
   max-width: 60ch;
 }
 
-kedge-provider-code .code-todo {
-  margin-top: 1rem;
-  font-style: italic;
-  color: var(--color-text-secondary, #777);
+kedge-provider-code .code-muted.small {
+  font-size: 0.85em;
+}
+
+kedge-provider-code .code-empty {
+  color: var(--color-text-secondary, #999);
+  padding: 2rem 0;
+}
+
+kedge-provider-code .code-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+kedge-provider-code .code-head {
+  margin-bottom: 1rem;
+}
+
+kedge-provider-code .code-error {
+  color: var(--color-danger, #e5534b);
+}
+
+/* Buttons */
+kedge-provider-code .code-btn {
+  font: inherit;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  border: 1px solid var(--color-border, #2a2a2a);
+  background: var(--color-surface, #1b1b1b);
+  color: var(--color-text-primary, inherit);
+}
+kedge-provider-code .code-btn.primary {
+  background: var(--color-accent, #4f8cff);
+  border-color: var(--color-accent, #4f8cff);
+  color: #fff;
+}
+kedge-provider-code .code-btn.ghost {
+  background: transparent;
+  color: var(--color-text-secondary, #999);
+}
+kedge-provider-code .code-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+kedge-provider-code .code-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent, #4f8cff);
+  cursor: pointer;
+}
+
+/* Forms */
+kedge-provider-code .code-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-width: 32rem;
+  margin: 0.5rem 0 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 8px;
+}
+kedge-provider-code .code-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9em;
+  color: var(--color-text-secondary, #999);
+}
+kedge-provider-code .code-form input,
+kedge-provider-code .code-form select,
+kedge-provider-code .code-form textarea {
+  font: inherit;
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  background: var(--color-bg, #111);
+  color: var(--color-text-primary, inherit);
+}
+kedge-provider-code .code-form .code-check {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+}
+kedge-provider-code .code-form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Tables + lists */
+kedge-provider-code .code-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+kedge-provider-code .code-table th,
+kedge-provider-code .code-table td {
+  text-align: left;
+  padding: 0.45rem 0.6rem;
+  border-bottom: 1px solid var(--color-border, #2a2a2a);
+}
+kedge-provider-code .code-table th {
+  color: var(--color-text-secondary, #999);
+  font-weight: 600;
+}
+kedge-provider-code .code-right {
+  text-align: right;
+}
+
+kedge-provider-code .code-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+kedge-provider-code .code-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--color-border, #2a2a2a);
+}
+
+/* Two-column layout for the repo detail page */
+kedge-provider-code .code-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+@media (max-width: 720px) {
+  kedge-provider-code .code-cols {
+    grid-template-columns: 1fr;
+  }
+}
+kedge-provider-code .code-col h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+}
+
+/* Badges */
+kedge-provider-code .code-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.75em;
+  border: 1px solid var(--color-border, #2a2a2a);
+  color: var(--color-text-secondary, #999);
+}
+kedge-provider-code .code-badge.ok {
+  color: #3fb950;
+  border-color: #2ea04326;
+  background: #2ea04318;
+}
+kedge-provider-code .code-badge.warn {
+  color: #d29922;
+  border-color: #bb800926;
+  background: #bb800918;
+}
+kedge-provider-code .code-badge.muted {
+  color: var(--color-text-secondary, #999);
+}
+
+kedge-provider-code code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.85em;
 }

--- a/providers/code/portal/src/types.ts
+++ b/providers/code/portal/src/types.ts
@@ -9,3 +9,58 @@ export interface KedgeContext {
   basePath?: string
   subPath?: string
 }
+
+// ErrorResponse is the {reason, message} contract the views render against.
+// kcp Status errors are mapped into this shape in api.ts.
+export interface ErrorResponse {
+  reason: string
+  message: string
+}
+
+export interface Connection {
+  name: string
+  provider: string
+  type: string
+  owner: string
+  secretName: string
+  login?: string
+  scopes: string[]
+  validated: boolean
+  message?: string
+}
+
+export interface Repository {
+  name: string
+  connectionRef: string
+  repo: string
+  owner?: string
+  visibility: string
+  description?: string
+  htmlURL?: string
+  sshURL?: string
+  cloneURL?: string
+  ready: boolean
+  message?: string
+}
+
+export interface DeployKey {
+  name: string
+  repositoryRef: string
+  title?: string
+  readOnly: boolean
+  generated: boolean
+  secretName?: string
+  keyID?: string
+  ready: boolean
+  message?: string
+}
+
+export interface Collaborator {
+  name: string
+  repositoryRef: string
+  username: string
+  permission: string
+  invitationPending: boolean
+  ready: boolean
+  message?: string
+}

--- a/providers/code/portal/src/views/ConnectionsView.vue
+++ b/providers/code/portal/src/views/ConnectionsView.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { api } from '../api'
+import type { Connection, ErrorResponse } from '../types'
+
+const connections = ref<Connection[]>([])
+const error = ref<string | null>(null)
+const loading = ref(false)
+
+// connect form
+const showForm = ref(false)
+const name = ref('')
+const owner = ref('')
+const token = ref('')
+const baseURL = ref('')
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+
+let timer: number | undefined
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    connections.value = await api.listConnections()
+  } catch (e) {
+    const err = e as ErrorResponse
+    error.value = err.reason === 'TenantMissing' ? null : `${err.reason}: ${err.message}`
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submit() {
+  formError.value = null
+  if (!name.value || !owner.value || !token.value) {
+    formError.value = 'name, owner, and token are required'
+    return
+  }
+  submitting.value = true
+  try {
+    await api.connect({ name: name.value, owner: owner.value, token: token.value, baseURL: baseURL.value || undefined })
+    name.value = owner.value = token.value = baseURL.value = ''
+    showForm.value = false
+    await load()
+  } catch (e) {
+    const err = e as ErrorResponse
+    formError.value = `${err.reason}: ${err.message}`
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function remove(c: Connection) {
+  if (!confirm(`Delete connection "${c.name}"? Repositories using it will stop reconciling.`)) return
+  try {
+    await api.deleteConnection(c.name)
+    await load()
+  } catch (e) {
+    const err = e as ErrorResponse
+    error.value = `${err.reason}: ${err.message}`
+  }
+}
+
+onMounted(() => {
+  load()
+  timer = window.setInterval(load, 5000)
+})
+onUnmounted(() => window.clearInterval(timer))
+</script>
+
+<template>
+  <section class="code-panel">
+    <header class="code-row code-head">
+      <div>
+        <h2>Connections</h2>
+        <p class="code-muted">A connection binds your workspace to a git account via a token. Repositories are created under it.</p>
+      </div>
+      <button class="code-btn primary" @click="showForm = !showForm">{{ showForm ? 'Cancel' : 'Connect GitHub' }}</button>
+    </header>
+
+    <form v-if="showForm" class="code-form" @submit.prevent="submit">
+      <label>Name <input v-model="name" placeholder="my-github" autocomplete="off" /></label>
+      <label>Owner (org or user) <input v-model="owner" placeholder="acme" autocomplete="off" /></label>
+      <label>Personal access token <input v-model="token" type="password" placeholder="ghp_…" autocomplete="off" /></label>
+      <label>Base URL (GHES, optional) <input v-model="baseURL" placeholder="https://github.example.com/api/v3" autocomplete="off" /></label>
+      <div class="code-form-actions">
+        <button class="code-btn primary" type="submit" :disabled="submitting">{{ submitting ? 'Connecting…' : 'Create' }}</button>
+        <span v-if="formError" class="code-error">{{ formError }}</span>
+      </div>
+      <p class="code-muted small">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
+    </form>
+
+    <p v-if="error" class="code-error">{{ error }}</p>
+    <p v-else-if="loading && !connections.length" class="code-muted">Loading…</p>
+    <p v-else-if="!connections.length" class="code-muted">No connections yet.</p>
+
+    <table v-else class="code-table">
+      <thead>
+        <tr><th>Name</th><th>Owner</th><th>Login</th><th>Status</th><th></th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="c in connections" :key="c.name">
+          <td>{{ c.name }}</td>
+          <td>{{ c.owner }}</td>
+          <td>{{ c.login || '—' }}</td>
+          <td>
+            <span v-if="c.validated" class="code-badge ok">validated</span>
+            <span v-else class="code-badge warn" :title="c.message">pending</span>
+          </td>
+          <td class="code-right"><button class="code-btn ghost" @click="remove(c)">Delete</button></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>

--- a/providers/code/portal/src/views/RepoDetailView.vue
+++ b/providers/code/portal/src/views/RepoDetailView.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { api } from '../api'
+import type { Collaborator, DeployKey, ErrorResponse, Repository } from '../types'
+
+const props = defineProps<{ name: string }>()
+const emit = defineEmits<{ (e: 'back'): void }>()
+
+const repo = ref<Repository | null>(null)
+const keys = ref<DeployKey[]>([])
+const collabs = ref<Collaborator[]>([])
+const error = ref<string | null>(null)
+
+// deploy key form
+const keyTitle = ref('')
+const keyPublic = ref('')
+const keyReadOnly = ref(true)
+const keySubmitting = ref(false)
+const keyError = ref<string | null>(null)
+
+// collaborator form
+const collabUser = ref('')
+const collabPerm = ref('push')
+const collabSubmitting = ref(false)
+const collabError = ref<string | null>(null)
+
+let timer: number | undefined
+
+async function load() {
+  error.value = null
+  try {
+    const [r, k, c] = await Promise.all([
+      api.getRepository(props.name),
+      api.listDeployKeys(props.name),
+      api.listCollaborators(props.name),
+    ])
+    repo.value = r
+    keys.value = k
+    collabs.value = c
+  } catch (e) {
+    const err = e as ErrorResponse
+    if (err.reason !== 'TenantMissing') error.value = `${err.reason}: ${err.message}`
+  }
+}
+
+async function addKey() {
+  keyError.value = null
+  keySubmitting.value = true
+  try {
+    await api.createDeployKey({
+      repositoryRef: props.name,
+      title: keyTitle.value || undefined,
+      publicKey: keyPublic.value || undefined,
+      readOnly: keyReadOnly.value,
+    })
+    keyTitle.value = keyPublic.value = ''
+    await load()
+  } catch (e) {
+    const err = e as ErrorResponse
+    keyError.value = `${err.reason}: ${err.message}`
+  } finally {
+    keySubmitting.value = false
+  }
+}
+
+async function removeKey(k: DeployKey) {
+  if (!confirm(`Delete deploy key "${k.title || k.name}"?`)) return
+  try {
+    await api.deleteDeployKey(k.name)
+    await load()
+  } catch (e) {
+    error.value = (e as ErrorResponse).message
+  }
+}
+
+async function addCollab() {
+  collabError.value = null
+  if (!collabUser.value) {
+    collabError.value = 'username is required'
+    return
+  }
+  collabSubmitting.value = true
+  try {
+    await api.createCollaborator({ repositoryRef: props.name, username: collabUser.value, permission: collabPerm.value })
+    collabUser.value = ''
+    await load()
+  } catch (e) {
+    const err = e as ErrorResponse
+    collabError.value = `${err.reason}: ${err.message}`
+  } finally {
+    collabSubmitting.value = false
+  }
+}
+
+async function removeCollab(c: Collaborator) {
+  if (!confirm(`Remove collaborator "${c.username}"?`)) return
+  try {
+    await api.deleteCollaborator(c.name)
+    await load()
+  } catch (e) {
+    error.value = (e as ErrorResponse).message
+  }
+}
+
+onMounted(() => {
+  load()
+  timer = window.setInterval(load, 5000)
+})
+onUnmounted(() => window.clearInterval(timer))
+</script>
+
+<template>
+  <section class="code-panel">
+    <header class="code-row code-head">
+      <div>
+        <button class="code-link" @click="emit('back')">← Repositories</button>
+        <h2>{{ repo?.repo || name }}</h2>
+        <p class="code-muted">
+          <a v-if="repo?.htmlURL" :href="repo.htmlURL" target="_blank" rel="noopener">{{ repo.htmlURL }}</a>
+          <span v-else>not created yet</span>
+        </p>
+        <p v-if="repo?.sshURL" class="code-muted small">SSH: <code>{{ repo.sshURL }}</code></p>
+      </div>
+    </header>
+
+    <p v-if="error" class="code-error">{{ error }}</p>
+
+    <div class="code-cols">
+      <!-- Deploy keys -->
+      <div class="code-col">
+        <h3>Deploy keys</h3>
+        <form class="code-form" @submit.prevent="addKey">
+          <label>Title <input v-model="keyTitle" placeholder="ci-deploy" autocomplete="off" /></label>
+          <label>Public key (leave empty to generate)
+            <textarea v-model="keyPublic" rows="2" placeholder="ssh-ed25519 AAAA…" />
+          </label>
+          <label class="code-check"><input v-model="keyReadOnly" type="checkbox" /> read-only</label>
+          <div class="code-form-actions">
+            <button class="code-btn primary" type="submit" :disabled="keySubmitting">{{ keySubmitting ? 'Adding…' : 'Add deploy key' }}</button>
+            <span v-if="keyError" class="code-error">{{ keyError }}</span>
+          </div>
+          <p class="code-muted small">A generated key's private half is written to a Secret in your workspace.</p>
+        </form>
+        <p v-if="!keys.length" class="code-muted">No deploy keys.</p>
+        <ul v-else class="code-list">
+          <li v-for="k in keys" :key="k.name">
+            <span>
+              <strong>{{ k.title || k.name }}</strong>
+              <span class="code-badge" :class="k.readOnly ? 'muted' : 'warn'">{{ k.readOnly ? 'read-only' : 'read-write' }}</span>
+              <span v-if="k.generated && k.secretName" class="code-badge muted" :title="k.secretName">secret: {{ k.secretName }}</span>
+              <span v-if="k.ready" class="code-badge ok">ready</span>
+              <span v-else class="code-badge warn" :title="k.message">pending</span>
+            </span>
+            <button class="code-btn ghost" @click="removeKey(k)">Delete</button>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Collaborators -->
+      <div class="code-col">
+        <h3>Collaborators</h3>
+        <form class="code-form" @submit.prevent="addCollab">
+          <label>Username <input v-model="collabUser" placeholder="octocat" autocomplete="off" /></label>
+          <label>Permission
+            <select v-model="collabPerm">
+              <option value="pull">pull</option>
+              <option value="push">push</option>
+              <option value="admin">admin</option>
+            </select>
+          </label>
+          <div class="code-form-actions">
+            <button class="code-btn primary" type="submit" :disabled="collabSubmitting">{{ collabSubmitting ? 'Adding…' : 'Add collaborator' }}</button>
+            <span v-if="collabError" class="code-error">{{ collabError }}</span>
+          </div>
+        </form>
+        <p v-if="!collabs.length" class="code-muted">No collaborators.</p>
+        <ul v-else class="code-list">
+          <li v-for="c in collabs" :key="c.name">
+            <span>
+              <strong>{{ c.username }}</strong>
+              <span class="code-badge muted">{{ c.permission }}</span>
+              <span v-if="c.invitationPending" class="code-badge warn">invited</span>
+              <span v-else-if="c.ready" class="code-badge ok">active</span>
+            </span>
+            <button class="code-btn ghost" @click="removeCollab(c)">Remove</button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { api } from '../api'
+import type { Connection, ErrorResponse, Repository } from '../types'
+
+const emit = defineEmits<{ (e: 'open', name: string): void }>()
+
+const repos = ref<Repository[]>([])
+const connections = ref<Connection[]>([])
+const error = ref<string | null>(null)
+const loading = ref(false)
+
+const showForm = ref(false)
+const name = ref('')
+const repo = ref('')
+const connectionRef = ref('')
+const visibility = ref('private')
+const description = ref('')
+const autoInit = ref(true)
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+
+let timer: number | undefined
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const [r, c] = await Promise.all([api.listRepositories(), api.listConnections()])
+    repos.value = r
+    connections.value = c
+    if (!connectionRef.value && c.length) connectionRef.value = c[0].name
+  } catch (e) {
+    const err = e as ErrorResponse
+    error.value = err.reason === 'TenantMissing' ? null : `${err.reason}: ${err.message}`
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submit() {
+  formError.value = null
+  if (!name.value || !connectionRef.value) {
+    formError.value = 'name and connection are required'
+    return
+  }
+  submitting.value = true
+  try {
+    await api.createRepository({
+      name: name.value,
+      connectionRef: connectionRef.value,
+      repo: repo.value || undefined,
+      visibility: visibility.value,
+      description: description.value || undefined,
+      autoInit: autoInit.value,
+    })
+    name.value = repo.value = description.value = ''
+    showForm.value = false
+    await load()
+  } catch (e) {
+    const err = e as ErrorResponse
+    formError.value = `${err.reason}: ${err.message}`
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function remove(r: Repository) {
+  if (!confirm(`Delete repository "${r.repo}"? This removes it on the git host.`)) return
+  try {
+    await api.deleteRepository(r.name)
+    await load()
+  } catch (e) {
+    const err = e as ErrorResponse
+    error.value = `${err.reason}: ${err.message}`
+  }
+}
+
+onMounted(() => {
+  load()
+  timer = window.setInterval(load, 5000)
+})
+onUnmounted(() => window.clearInterval(timer))
+</script>
+
+<template>
+  <section class="code-panel">
+    <header class="code-row code-head">
+      <div>
+        <h2>Repositories</h2>
+        <p class="code-muted">Repositories the provider manages on the git host. Click one to manage deploy keys and collaborators.</p>
+      </div>
+      <button class="code-btn primary" :disabled="!connections.length" @click="showForm = !showForm">
+        {{ showForm ? 'Cancel' : 'New repository' }}
+      </button>
+    </header>
+
+    <p v-if="!connections.length" class="code-muted">Add a connection first, then create repositories under it.</p>
+
+    <form v-if="showForm" class="code-form" @submit.prevent="submit">
+      <label>Connection
+        <select v-model="connectionRef">
+          <option v-for="c in connections" :key="c.name" :value="c.name">{{ c.name }} ({{ c.owner }})</option>
+        </select>
+      </label>
+      <label>Object name <input v-model="name" placeholder="my-service" autocomplete="off" /></label>
+      <label>Repo name (defaults to object name) <input v-model="repo" placeholder="my-service" autocomplete="off" /></label>
+      <label>Visibility
+        <select v-model="visibility">
+          <option value="private">private</option>
+          <option value="public">public</option>
+          <option value="internal">internal</option>
+        </select>
+      </label>
+      <label>Description <input v-model="description" autocomplete="off" /></label>
+      <label class="code-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
+      <div class="code-form-actions">
+        <button class="code-btn primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create' }}</button>
+        <span v-if="formError" class="code-error">{{ formError }}</span>
+      </div>
+    </form>
+
+    <p v-if="error" class="code-error">{{ error }}</p>
+    <p v-else-if="loading && !repos.length" class="code-muted">Loading…</p>
+    <p v-else-if="!repos.length" class="code-muted">No repositories yet.</p>
+
+    <table v-else class="code-table">
+      <thead>
+        <tr><th>Name</th><th>Connection</th><th>Visibility</th><th>URL</th><th>Status</th><th></th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="r in repos" :key="r.name">
+          <td><button class="code-link" @click="emit('open', r.name)">{{ r.repo }}</button></td>
+          <td>{{ r.connectionRef }}</td>
+          <td>{{ r.visibility }}</td>
+          <td><a v-if="r.htmlURL" :href="r.htmlURL" target="_blank" rel="noopener">open ↗</a><span v-else>—</span></td>
+          <td>
+            <span v-if="r.ready" class="code-badge ok">ready</span>
+            <span v-else class="code-badge warn" :title="r.message">pending</span>
+          </td>
+          <td class="code-right"><button class="code-btn ghost" @click="remove(r)">Delete</button></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>


### PR DESCRIPTION
Final piece of the `code` provider (builds on #247/#248/#249): a working **portal** and **local-dev / Tilt** integration so it can be tested end-to-end.

## Portal (`providers/code/portal`)

- **`api.ts`** — kcp-native client talking to `/clusters/<tenant>/apis/code.kedge.faros.sh/...` for the four CRDs, plus `core/v1` Secret creation for the PAT. Identity comes from `kedgeContext` (token + tenant); kcp Status errors are mapped to the `{reason, message}` shape the views render.
- **Connections** — list + a *Connect GitHub* form that creates the token Secret and the Connection, showing validation status + the authenticated login/scopes.
- **Repositories** — list / create / delete; rows link into the detail page.
- **RepoDetail** — deploy keys (add with a generated **or** BYO key, delete) and collaborators (add with permission, remove), with invitation-pending status.
- **App.vue** routes on `kedgeContext.subPath` (`connections` | `repositories` | `repositories/<name>`). Styles namespaced under `kedge-provider-code`; light-DOM so the portal's CSS variables cascade in.

## Local dev

- **`make init-provider-code`** — the in-process dev hub doesn't mint a provider kubeconfig (no host cluster), so this writes a static-token dev kubeconfig pointed at `root:kedge:providers:code` and ensures the `APIExportEndpointSlice`. `run-provider-code` reads it via `CODE_KUBECONFIG` and falls back to portal/MCP-only when it's absent.
- **Tiltfile** — `code` / `code-register` / `code-init` / `code-unregister` resources (mirroring the other providers), plus the code portal added to the hub `mkdir` and the portal dev-server deps.

### How to test locally
```
tilt up
# then in the Tilt UI, trigger (▶):
#   code-register   → provisions root:kedge:providers:code
#   code-init       → writes the dev kubeconfig + endpoint slice
# the `code` resource restarts with the controller manager enabled.
```
The portal is served under `/ui/providers/code/`; connect a GitHub PAT, create a repo, add a deploy key / collaborator.

## Verification

- Portal: `vue-tsc` typecheck clean; `vite build` → `dist/main.js` (~93 kB). Provider binary builds with the new bundle embedded; `go vet` clean.
- Tiltfile parses (`tilt alpha tiltfile-result` → `Error: null`); `make init-provider-code` generates a valid kubeconfig.

## Notes

- No automated UI/e2e test here — it needs a live hub + a real GitHub PAT. The build/typecheck is green; a manual `tilt up` smoke test is the way to validate.
- With this, the `code` provider is feature-complete for v1 (GitHub). Later: GitLab backend; `github-app`/`oauth` credential types for per-user onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)