### PR TITLE
providers/code: wire into Tiltfile.cluster + portable init kubeconfig — PR E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -720,12 +720,15 @@ uninstall-provider-code: ## Delete the code CatalogEntry
 
 CODE_WORKSPACE_PATH ?= root:kedge:providers:code
 ## Dev bootstrap for the code provider. The hub mints a real provider
-## kubeconfig only when it runs with a host cluster (--kubeconfig); the
-## in-process dev hub does not, so we synthesize a static-token kubeconfig
-## pointed at the provider workspace and ensure the APIExportEndpointSlice the
+## kubeconfig only when it runs with a host cluster (--kubeconfig); the dev hubs
+## (embedded + Tiltfile.cluster) do not, so we derive a runtime kubeconfig from
+## the admin kubeconfig — reusing its working credential (a static token in
+## embedded mode, a client cert in cluster mode) and retargeting only the server
+## URL to the provider workspace — and ensure the APIExportEndpointSlice the
 ## controller manager needs. run-provider-code reads it via CODE_KUBECONFIG.
 ## Order: install-provider-code (creates the workspace) → init-provider-code →
-## run-provider-code. Re-runnable.
+## run-provider-code. Re-runnable. The Tiltfile.cluster flow reuses this target
+## verbatim, overriding KROMC_KCP_KUBECONFIG / KROMC_KCP_SERVER.
 init-provider-code: build-code-provider ## Write the dev kubeconfig + ensure the code APIExportEndpointSlice
 	@test -f $(KROMC_KCP_KUBECONFIG) || { \
 		echo "kubeconfig not found at $(KROMC_KCP_KUBECONFIG)"; \
@@ -733,9 +736,12 @@ init-provider-code: build-code-provider ## Write the dev kubeconfig + ensure the
 		exit 1; \
 	}
 	@mkdir -p $(KCP_DATA_DIR)
-	@echo "Writing dev kubeconfig $(CODE_RUNTIME_KUBECONFIG) (workspace $(CODE_WORKSPACE_PATH))"
-	@printf 'apiVersion: v1\nkind: Config\ncurrent-context: code\nclusters:\n- name: code\n  cluster:\n    server: %s/clusters/%s\n    insecure-skip-tls-verify: true\ncontexts:\n- name: code\n  context:\n    cluster: code\n    user: code\nusers:\n- name: code\n  user:\n    token: %s\n' \
-		"$(KROMC_KCP_SERVER)" "$(CODE_WORKSPACE_PATH)" "$(KROMC_TOKEN)" > $(CODE_RUNTIME_KUBECONFIG)
+	@echo "Writing dev kubeconfig $(CODE_RUNTIME_KUBECONFIG) (workspace $(CODE_WORKSPACE_PATH), server $(KROMC_KCP_SERVER))"
+	@kubectl --kubeconfig=$(KROMC_KCP_KUBECONFIG) config view --minify --flatten > $(CODE_RUNTIME_KUBECONFIG)
+	@CL=$$(kubectl --kubeconfig=$(CODE_RUNTIME_KUBECONFIG) config view -o jsonpath='{.clusters[0].name}'); \
+		kubectl --kubeconfig=$(CODE_RUNTIME_KUBECONFIG) config set-cluster "$$CL" \
+			--server=$(KROMC_KCP_SERVER)/clusters/$(CODE_WORKSPACE_PATH) \
+			--insecure-skip-tls-verify=true >/dev/null
 	CODE_KUBECONFIG=$(CODE_RUNTIME_KUBECONFIG) \
 	CODE_WORKSPACE_PATH=$(CODE_WORKSPACE_PATH) \
 		$(BINDIR)/code-provider init

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -178,6 +178,7 @@ local_resource(
         'providers/mcp/portal/src',
         'providers/kubernetesedges/portal/src',
         'providers/serveredges/portal/src',
+        'providers/code/portal/src',
     ],
     labels=['hub'],
 )
@@ -398,6 +399,7 @@ def rewrite_manifest_cmd(src):
 
 QUICKSTART_REWRITE_CMD, QUICKSTART_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/quickstart/manifest.yaml')
 INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/infrastructure/manifest.yaml')
+CODE_REWRITE_CMD, CODE_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/code/manifest.yaml')
 
 # --- providers-quickstart ---
 local_resource(
@@ -562,6 +564,83 @@ local_resource(
     auto_init=False,
     resource_deps=['kedge-hub'],
     labels=['providers-kro'],
+)
+
+# --- providers-code (git repository management) ---
+# Host binary on :8083, same shape as quickstart/infrastructure. register/init/
+# unregister override KROMC_KCP_KUBECONFIG / KROMC_KCP_SERVER to the in-cluster
+# kcp front-proxy (the embedded-kcp defaults are localhost). init-provider-code
+# derives the runtime kubeconfig from that admin kubeconfig, so it reuses the
+# front-proxy credential in cluster mode without a separate token.
+local_resource(
+    'code',
+    cmd='make build-code-provider',
+    serve_cmd='make run-provider-code',
+    deps=[
+        'providers/code/main.go',
+        'providers/code/heartbeat.go',
+        'providers/code/assets.go',
+        'providers/code/controller_manager.go',
+        'providers/code/init_cmd.go',
+        'providers/code/server',
+        'providers/code/tenant',
+        'providers/code/mcpserver',
+        'providers/code/controller',
+        'providers/code/backend',
+        'providers/code/install',
+        'providers/code/scheme',
+        'providers/code/portal/src',
+        'providers/code/portal/package.json',
+        'providers/code/go.mod',
+        'providers/code/go.sum',
+        '.kcp/code-runtime.kubeconfig',
+    ],
+    resource_deps=['kedge-hub'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=8083, path='/healthz'),
+    ),
+    labels=['providers-code'],
+)
+
+local_resource(
+    'code-register',
+    cmd=('{rewrite} && KROMC_KCP_KUBECONFIG={kc} KROMC_KCP_SERVER={sv} ' +
+         'CODE_MANIFEST={mf} make install-provider-code').format(
+             rewrite=CODE_REWRITE_CMD, kc=KCP_ADMIN_KUBECONFIG,
+             sv=KCP_ADMIN_SERVER, mf=CODE_MANIFEST_REWRITTEN),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kedge-hub'],
+    labels=['providers-code'],
+)
+
+# Writes the runtime kubeconfig (derived from the front-proxy admin kubeconfig)
+# and ensures the APIExportEndpointSlice. Order:
+#   code-register → creates root:kedge:providers:code
+#   code-init     → writes kubeconfig + endpoint slice
+#   code (serve)  → restarts when the kubeconfig dep appears
+local_resource(
+    'code-init',
+    cmd=('KROMC_KCP_KUBECONFIG={kc} KROMC_KCP_SERVER={sv} ' +
+         'make init-provider-code').format(
+             kc=KCP_ADMIN_KUBECONFIG, sv=KCP_ADMIN_SERVER),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kedge-hub', 'code-register'],
+    labels=['providers-code'],
+)
+
+local_resource(
+    'code-unregister',
+    cmd=('{rewrite} && KROMC_KCP_KUBECONFIG={kc} KROMC_KCP_SERVER={sv} ' +
+         'CODE_MANIFEST={mf} make uninstall-provider-code').format(
+             rewrite=CODE_REWRITE_CMD, kc=KCP_ADMIN_KUBECONFIG,
+             sv=KCP_ADMIN_SERVER, mf=CODE_MANIFEST_REWRITTEN),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kedge-hub'],
+    labels=['providers-code'],
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The code provider was wired into the embedded-kcp `Tiltfile` in #250 but **not** into `Tiltfile.cluster` (the multi-shard kcp + in-cluster-hub variant). This adds it there.

## What

- **`Tiltfile.cluster`** — a `providers-code` group (`code` / `code-register` / `code-init` / `code-unregister`) mirroring the infrastructure block:
  - `code` runs the host binary on `:8083` (`resource_deps=['kedge-hub']`).
  - register/unregister rewrite the CatalogEntry's `localhost` URLs → `host.docker.internal` (so the in-cluster hub can reach the host-run provider) and target the in-cluster kcp front-proxy via `KCP_ADMIN_KUBECONFIG` / `KCP_ADMIN_SERVER`.
  - the code portal is added to `portal-build` deps.
- **`Makefile` `init-provider-code`** — now **derives** the runtime kubeconfig from the admin kubeconfig (`kubectl config view --minify --flatten`, then retarget the server to the provider workspace) instead of hand-rolling a static-token one. This reuses whatever credential the admin kubeconfig carries — a static token in embedded mode, a client cert in cluster mode — so the single target works for **both** Tiltfiles. The cluster resources just override `KROMC_KCP_KUBECONFIG` / `KROMC_KCP_SERVER`.

## Verification

- `tilt alpha tiltfile-result -f Tiltfile.cluster` parses cleanly (exit 0; `code-register`/`code-init`/`code-unregister` present under `providers-code`, no errors).
- `make -n init-provider-code` emits the expected derive-from-admin commands.

## Notes

- The embedded-kcp flow (`./Tiltfile`, from #250) is unchanged except that `init-provider-code` now derives from `.kcp/admin.kubeconfig` rather than emitting a static-token file — same result, more robust.
- Same caveat as before: not yet run end-to-end against a live cluster + real GitHub PAT. Parse/dry-run are green; a `tilt up -f Tiltfile.cluster` smoke test is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)