### PR TITLE
providers/code: fix unreadable portal form inputs

### DIFF
--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -14,7 +14,7 @@ kedge-provider-code {
 kedge-provider-code .code-tabs {
   display: flex;
   gap: 0.5rem;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  border-bottom: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.3));
   margin-bottom: 1rem;
 }
 
@@ -72,7 +72,7 @@ kedge-provider-code .code-btn {
   border-radius: 6px;
   padding: 0.4rem 0.75rem;
   cursor: pointer;
-  border: 1px solid var(--color-border, #2a2a2a);
+  border: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.3));
   background: var(--color-surface, #1b1b1b);
   color: var(--color-text-primary, inherit);
 }
@@ -106,7 +106,7 @@ kedge-provider-code .code-form {
   max-width: 32rem;
   margin: 0.5rem 0 1.25rem;
   padding: 1rem;
-  border: 1px solid var(--color-border, #2a2a2a);
+  border: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.3));
   border-radius: 8px;
 }
 kedge-provider-code .code-form label {
@@ -122,9 +122,13 @@ kedge-provider-code .code-form textarea {
   font: inherit;
   padding: 0.4rem 0.5rem;
   border-radius: 6px;
-  border: 1px solid var(--color-border, #2a2a2a);
-  background: var(--color-bg, #111);
-  color: var(--color-text-primary, inherit);
+  border: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.4));
+  background: var(--color-surface-raised, #ffffff);
+  color: var(--color-text-primary, #0f172a);
+}
+kedge-provider-code .code-form input::placeholder,
+kedge-provider-code .code-form textarea::placeholder {
+  color: var(--color-text-secondary, #8a8a8a);
 }
 kedge-provider-code .code-form .code-check {
   flex-direction: row;
@@ -147,7 +151,7 @@ kedge-provider-code .code-table th,
 kedge-provider-code .code-table td {
   text-align: left;
   padding: 0.45rem 0.6rem;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  border-bottom: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.3));
 }
 kedge-provider-code .code-table th {
   color: var(--color-text-secondary, #999);
@@ -168,7 +172,7 @@ kedge-provider-code .code-list li {
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.45rem 0;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  border-bottom: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.3));
 }
 
 /* Two-column layout for the repo detail page */
@@ -194,7 +198,7 @@ kedge-provider-code .code-badge {
   padding: 0.05rem 0.4rem;
   border-radius: 999px;
   font-size: 0.75em;
-  border: 1px solid var(--color-border, #2a2a2a);
+  border: 1px solid var(--color-border-default, rgba(128, 128, 128, 0.3));
   color: var(--color-text-secondary, #999);
 }
 kedge-provider-code .code-badge.ok {


### PR DESCRIPTION
The code provider portal's form text fields rendered **black-on-near-black** (unreadable).

**Cause:** the inputs used `background: var(--color-bg, #111)`, but the portal defines no `--color-bg` token → fell back to `#111`. In the **light** theme the (correct) `--color-text-primary: #0f172a` text then sat dark-on-dark. Inputs also used `--color-border` instead of the real `--color-border-default`.

**Fix:** use the portal's actual design tokens — `--color-surface-raised` for input backgrounds (`#ffffff` light / `#0d0d14` dark), `--color-text-primary` for text, `--color-border-default` for borders throughout — plus a readable placeholder color. Correct contrast in both themes.

Trivial CSS-only change in `providers/code/portal/src/style.css`; portal builds clean (`vite build` → 93 kB).