### PR TITLE
providers/code: restyle portal to match the rest of the portal

### DIFF
--- a/providers/code/portal/src/App.vue
+++ b/providers/code/portal/src/App.vue
@@ -42,13 +42,13 @@ function navigate(sub: string) {
 </script>
 
 <template>
-  <div class="code-shell">
-    <nav class="code-tabs">
+  <div class="app">
+    <nav class="tabs">
       <button :class="{ active: route.page === 'connections' }" @click="navigate('connections')">Connections</button>
       <button :class="{ active: route.page === 'repositories' }" @click="navigate('repositories')">Repositories</button>
     </nav>
 
-    <p v-if="!hasTenant" class="code-empty">Select a workspace to manage code.</p>
+    <p v-if="!hasTenant" class="empty">Select a workspace to manage code.</p>
 
     <template v-else>
       <ConnectionsView v-if="route.page === 'connections'" />

--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -1,8 +1,10 @@
 /*
- * code provider element styles. Imported as a string by main.ts and injected
- * as one <style> tag in the host document. The element renders in LIGHT DOM so
- * the portal's CSS custom properties cascade in; every selector is namespaced
- * under kedge-provider-code so these styles cannot leak into the portal.
+ * code provider element styles. Imported as a string by main.ts and injected as
+ * one <style> tag in the host document. The element renders in LIGHT DOM so the
+ * portal's CSS custom properties (--color-*) cascade in; every selector is
+ * namespaced under kedge-provider-code so these styles cannot leak into the
+ * portal. Structure + tokens mirror the infrastructure provider so the two look
+ * like one product.
  */
 
 kedge-provider-code {
@@ -11,207 +13,350 @@ kedge-provider-code {
   color: var(--color-text-primary, inherit);
 }
 
-kedge-provider-code .code-tabs {
+kedge-provider-code .app {
+  padding: 8px 0;
   display: flex;
-  gap: 0.5rem;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
-  margin-bottom: 1rem;
+  flex-direction: column;
+  gap: 16px;
 }
 
-kedge-provider-code .code-tabs button {
+/* Tabs (segmented sub-nav) */
+kedge-provider-code .tabs {
+  display: flex;
+  gap: 4px;
+}
+kedge-provider-code .tabs button {
   background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  padding: 0.5rem 0.75rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 5px 12px;
   cursor: pointer;
-  color: var(--color-text-secondary, #999);
+  color: var(--color-text-secondary, #7e7e96);
   font: inherit;
+  font-size: 12px;
+  font-weight: 500;
 }
-
-kedge-provider-code .code-tabs button.active {
+kedge-provider-code .tabs button:hover {
   color: var(--color-text-primary, inherit);
-  border-bottom-color: var(--color-accent, #4f8cff);
+  background: var(--color-surface-hover, rgba(255, 255, 255, 0.04));
+}
+kedge-provider-code .tabs button.active {
+  color: var(--color-accent, #7c5bf5);
+  background: var(--color-accent-subtle, rgba(124, 91, 245, 0.1));
+  border-color: var(--color-accent, #7c5bf5);
 }
 
-kedge-provider-code .code-panel h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.25rem;
+/* Page scaffold */
+kedge-provider-code .page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
-
-kedge-provider-code .code-muted {
-  color: var(--color-text-secondary, #999);
-  max-width: 60ch;
-}
-
-kedge-provider-code .code-muted.small {
-  font-size: 0.85em;
-}
-
-kedge-provider-code .code-empty {
-  color: var(--color-text-secondary, #999);
-  padding: 2rem 0;
-}
-
-kedge-provider-code .code-row {
+kedge-provider-code .page-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 16px;
 }
-kedge-provider-code .code-head {
-  margin-bottom: 1rem;
-}
-
-kedge-provider-code .code-error {
-  color: var(--color-danger, #e5534b);
-}
-
-/* Buttons */
-kedge-provider-code .code-btn {
-  font: inherit;
-  border-radius: 6px;
-  padding: 0.4rem 0.75rem;
-  cursor: pointer;
-  border: 1px solid var(--color-border, #2a2a2a);
-  background: var(--color-surface, #1b1b1b);
-  color: var(--color-text-primary, inherit);
-}
-kedge-provider-code .code-btn.primary {
-  background: var(--color-accent, #4f8cff);
-  border-color: var(--color-accent, #4f8cff);
-  color: #fff;
-}
-kedge-provider-code .code-btn.ghost {
-  background: transparent;
-  color: var(--color-text-secondary, #999);
-}
-kedge-provider-code .code-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-kedge-provider-code .code-link {
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  color: var(--color-accent, #4f8cff);
-  cursor: pointer;
-}
-
-/* Forms */
-kedge-provider-code .code-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  max-width: 32rem;
-  margin: 0.5rem 0 1.25rem;
-  padding: 1rem;
-  border: 1px solid var(--color-border, #2a2a2a);
-  border-radius: 8px;
-}
-kedge-provider-code .code-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.9em;
-  color: var(--color-text-secondary, #999);
-}
-kedge-provider-code .code-form input,
-kedge-provider-code .code-form select,
-kedge-provider-code .code-form textarea {
-  font: inherit;
-  padding: 0.4rem 0.5rem;
-  border-radius: 6px;
-  border: 1px solid var(--color-border, #2a2a2a);
-  background: var(--color-bg, #111);
-  color: var(--color-text-primary, inherit);
-}
-kedge-provider-code .code-form .code-check {
-  flex-direction: row;
-  align-items: center;
-  gap: 0.4rem;
-}
-kedge-provider-code .code-form-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-/* Tables + lists */
-kedge-provider-code .code-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.92em;
-}
-kedge-provider-code .code-table th,
-kedge-provider-code .code-table td {
-  text-align: left;
-  padding: 0.45rem 0.6rem;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
-}
-kedge-provider-code .code-table th {
-  color: var(--color-text-secondary, #999);
+kedge-provider-code .page-title {
+  margin: 0 0 4px;
+  font-size: 15px;
   font-weight: 600;
 }
-kedge-provider-code .code-right {
-  text-align: right;
+kedge-provider-code .page-meta {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-secondary, #7e7e96);
+  max-width: 70ch;
+  line-height: 1.5;
 }
 
-kedge-provider-code .code-list {
-  list-style: none;
-  margin: 0.5rem 0 0;
-  padding: 0;
+/* Panels (cards) */
+kedge-provider-code .panel {
+  background: var(--color-surface-raised, #0d0d14);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.04));
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
-kedge-provider-code .code-list li {
+kedge-provider-code .panel-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary, currentColor);
+}
+kedge-provider-code .panel-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.45rem 0;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  gap: 8px;
 }
 
-/* Two-column layout for the repo detail page */
-kedge-provider-code .code-cols {
+/* Two-column grid for the detail page */
+kedge-provider-code .grid-2 {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  gap: 12px;
+  grid-template-columns: 1fr;
 }
-@media (max-width: 720px) {
-  kedge-provider-code .code-cols {
-    grid-template-columns: 1fr;
+@media (min-width: 860px) {
+  kedge-provider-code .grid-2 {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
   }
 }
-kedge-provider-code .code-col h3 {
-  margin: 0 0 0.5rem;
-  font-size: 1.05rem;
+
+/* Definition list for key/value rows on the detail page */
+kedge-provider-code .props {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 16px;
+  margin: 0;
+  font-size: 12px;
+}
+kedge-provider-code .props dt {
+  color: var(--color-text-muted, #44445a);
+}
+kedge-provider-code .props dd {
+  margin: 0;
+  color: var(--color-text-secondary, #7e7e96);
+  word-break: break-all;
 }
 
-/* Badges */
-kedge-provider-code .code-badge {
-  display: inline-block;
-  margin-left: 0.4rem;
-  padding: 0.05rem 0.4rem;
+/* Tables */
+kedge-provider-code .table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+kedge-provider-code .table th,
+kedge-provider-code .table td {
+  text-align: left;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.04));
+}
+kedge-provider-code .table tbody tr:last-child td {
+  border-bottom: none;
+}
+kedge-provider-code .table tbody tr {
+  transition: background-color 0.1s ease;
+}
+kedge-provider-code .table tbody tr:hover {
+  background: var(--color-accent-subtle, rgba(124, 91, 245, 0.05));
+}
+kedge-provider-code .table th {
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #44445a);
+}
+kedge-provider-code .table td.right,
+kedge-provider-code .table th.right {
+  text-align: right;
+}
+
+/* Buttons */
+kedge-provider-code button.primary {
+  background: var(--color-accent, #7c5bf5);
+  color: #fff;
+  border: 1px solid var(--color-accent, #7c5bf5);
+  border-radius: 8px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+kedge-provider-code button.primary:hover {
+  background: var(--color-accent-hover, #9b85f7);
+}
+kedge-provider-code button.primary:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+kedge-provider-code button.secondary {
+  background: var(--color-surface-overlay, #14141f);
+  color: var(--color-text-primary, inherit);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+kedge-provider-code button.secondary:hover {
+  background: var(--color-surface-hover, #1a1a28);
+}
+kedge-provider-code button.danger {
+  background: transparent;
+  color: var(--color-danger, #f87171);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  padding: 5px 12px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.12s ease;
+}
+kedge-provider-code button.danger:hover {
+  border-color: var(--color-danger, #f87171);
+  background: var(--color-danger-subtle, rgba(248, 113, 113, 0.1));
+}
+kedge-provider-code button.link {
+  background: transparent;
+  border: none;
+  color: var(--color-accent, #7c5bf5);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+kedge-provider-code button.link:hover {
+  color: var(--color-accent-hover, #9b85f7);
+}
+kedge-provider-code button.link.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-text-muted, #44445a);
+  margin-bottom: 4px;
+}
+kedge-provider-code button.link.back:hover {
+  color: var(--color-accent, #7c5bf5);
+}
+
+kedge-provider-code .actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Forms */
+kedge-provider-code .form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 36rem;
+}
+kedge-provider-code .field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+kedge-provider-code .field-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-secondary, currentColor);
+}
+kedge-provider-code .field input,
+kedge-provider-code .field select,
+kedge-provider-code .field textarea,
+kedge-provider-code .inline-form input,
+kedge-provider-code .inline-form select {
+  background: var(--color-surface-overlay, #14141f);
+  color: var(--color-text-primary, inherit);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.08));
+  border-radius: 6px;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 12px;
+  width: 100%;
+  box-sizing: border-box;
+}
+kedge-provider-code .field input::placeholder,
+kedge-provider-code .field textarea::placeholder {
+  color: var(--color-text-muted, #44445a);
+}
+kedge-provider-code .field input:focus,
+kedge-provider-code .field select:focus,
+kedge-provider-code .field textarea:focus {
+  outline: none;
+  border-color: var(--color-accent, #7c5bf5);
+}
+kedge-provider-code .field-check {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--color-text-secondary, #7e7e96);
+}
+kedge-provider-code .field-check input {
+  width: auto;
+}
+
+/* Status badges (pills) */
+kedge-provider-code .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 9px;
   border-radius: 999px;
-  font-size: 0.75em;
-  border: 1px solid var(--color-border, #2a2a2a);
-  color: var(--color-text-secondary, #999);
+  border: 1px solid var(--color-border-default, transparent);
+  background: var(--color-surface-overlay, transparent);
+  color: var(--color-text-muted, inherit);
+  white-space: nowrap;
 }
-kedge-provider-code .code-badge.ok {
-  color: #3fb950;
-  border-color: #2ea04326;
-  background: #2ea04318;
+kedge-provider-code .badge::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: currentColor;
 }
-kedge-provider-code .code-badge.warn {
-  color: #d29922;
-  border-color: #bb800926;
-  background: #bb800918;
+kedge-provider-code .badge.ok {
+  border-color: var(--color-success-subtle, rgba(52, 211, 153, 0.3));
+  background: var(--color-success-subtle, rgba(52, 211, 153, 0.1));
+  color: var(--color-success, #34d399);
 }
-kedge-provider-code .code-badge.muted {
-  color: var(--color-text-secondary, #999);
+kedge-provider-code .badge.warn {
+  border-color: var(--color-warning-subtle, rgba(251, 191, 36, 0.3));
+  background: var(--color-warning-subtle, rgba(251, 191, 36, 0.1));
+  color: var(--color-warning, #fbbf24);
+}
+kedge-provider-code .badge.fail {
+  border-color: var(--color-danger-subtle, rgba(248, 113, 113, 0.3));
+  background: var(--color-danger-subtle, rgba(248, 113, 113, 0.1));
+  color: var(--color-danger, #f87171);
+}
+kedge-provider-code .badge.muted::before {
+  display: none;
 }
 
+/* Misc text */
+kedge-provider-code .muted {
+  color: var(--color-text-muted, #44445a);
+  font-size: 12px;
+}
+kedge-provider-code .error {
+  color: var(--color-danger, #f87171);
+  font-size: 12px;
+}
+kedge-provider-code .empty {
+  color: var(--color-text-secondary, #7e7e96);
+  font-size: 12px;
+  padding: 8px 0;
+}
+kedge-provider-code a {
+  color: var(--color-accent, #7c5bf5);
+  text-decoration: none;
+}
+kedge-provider-code a:hover {
+  text-decoration: underline;
+}
 kedge-provider-code code {
-  font-family: ui-monospace, monospace;
-  font-size: 0.85em;
+  background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04));
+  color: var(--color-text-secondary, currentColor);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11px;
 }

--- a/providers/code/portal/src/views/ConnectionsView.vue
+++ b/providers/code/portal/src/views/ConnectionsView.vue
@@ -70,47 +70,52 @@ onUnmounted(() => window.clearInterval(timer))
 </script>
 
 <template>
-  <section class="code-panel">
-    <header class="code-row code-head">
+  <section class="page">
+    <header class="page-head">
       <div>
-        <h2>Connections</h2>
-        <p class="code-muted">A connection binds your workspace to a git account via a token. Repositories are created under it.</p>
+        <h2 class="page-title">Connections</h2>
+        <p class="page-meta">A connection binds your workspace to a git account via a token. Repositories are created under it.</p>
       </div>
-      <button class="code-btn primary" @click="showForm = !showForm">{{ showForm ? 'Cancel' : 'Connect GitHub' }}</button>
+      <button class="primary" @click="showForm = !showForm">{{ showForm ? 'Cancel' : 'Connect GitHub' }}</button>
     </header>
 
-    <form v-if="showForm" class="code-form" @submit.prevent="submit">
-      <label>Name <input v-model="name" placeholder="my-github" autocomplete="off" /></label>
-      <label>Owner (org or user) <input v-model="owner" placeholder="acme" autocomplete="off" /></label>
-      <label>Personal access token <input v-model="token" type="password" placeholder="ghp_…" autocomplete="off" /></label>
-      <label>Base URL (GHES, optional) <input v-model="baseURL" placeholder="https://github.example.com/api/v3" autocomplete="off" /></label>
-      <div class="code-form-actions">
-        <button class="code-btn primary" type="submit" :disabled="submitting">{{ submitting ? 'Connecting…' : 'Create' }}</button>
-        <span v-if="formError" class="code-error">{{ formError }}</span>
-      </div>
-      <p class="code-muted small">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
-    </form>
+    <div v-if="showForm" class="panel">
+      <h3 class="panel-title">Connect GitHub</h3>
+      <form class="form" @submit.prevent="submit">
+        <div class="field"><span class="field-label">Name</span><input v-model="name" placeholder="my-github" autocomplete="off" /></div>
+        <div class="field"><span class="field-label">Owner (org or user)</span><input v-model="owner" placeholder="acme" autocomplete="off" /></div>
+        <div class="field"><span class="field-label">Personal access token</span><input v-model="token" type="password" placeholder="ghp_…" autocomplete="off" /></div>
+        <div class="field"><span class="field-label">Base URL (GHES, optional)</span><input v-model="baseURL" placeholder="https://github.example.com/api/v3" autocomplete="off" /></div>
+        <div class="actions">
+          <button class="primary" type="submit" :disabled="submitting">{{ submitting ? 'Connecting…' : 'Create' }}</button>
+          <span v-if="formError" class="error">{{ formError }}</span>
+        </div>
+        <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
+      </form>
+    </div>
 
-    <p v-if="error" class="code-error">{{ error }}</p>
-    <p v-else-if="loading && !connections.length" class="code-muted">Loading…</p>
-    <p v-else-if="!connections.length" class="code-muted">No connections yet.</p>
+    <p v-if="error" class="error">{{ error }}</p>
+    <p v-else-if="loading && !connections.length" class="muted">Loading…</p>
+    <p v-else-if="!connections.length" class="empty">No connections yet.</p>
 
-    <table v-else class="code-table">
-      <thead>
-        <tr><th>Name</th><th>Owner</th><th>Login</th><th>Status</th><th></th></tr>
-      </thead>
-      <tbody>
-        <tr v-for="c in connections" :key="c.name">
-          <td>{{ c.name }}</td>
-          <td>{{ c.owner }}</td>
-          <td>{{ c.login || '—' }}</td>
-          <td>
-            <span v-if="c.validated" class="code-badge ok">validated</span>
-            <span v-else class="code-badge warn" :title="c.message">pending</span>
-          </td>
-          <td class="code-right"><button class="code-btn ghost" @click="remove(c)">Delete</button></td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else class="panel">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Owner</th><th>Login</th><th>Status</th><th class="right"></th></tr>
+        </thead>
+        <tbody>
+          <tr v-for="c in connections" :key="c.name">
+            <td>{{ c.name }}</td>
+            <td>{{ c.owner }}</td>
+            <td>{{ c.login || '—' }}</td>
+            <td>
+              <span v-if="c.validated" class="badge ok">validated</span>
+              <span v-else class="badge warn" :title="c.message">pending</span>
+            </td>
+            <td class="right"><button class="danger" @click="remove(c)">Delete</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 </template>

--- a/providers/code/portal/src/views/RepoDetailView.vue
+++ b/providers/code/portal/src/views/RepoDetailView.vue
@@ -110,81 +110,107 @@ onUnmounted(() => window.clearInterval(timer))
 </script>
 
 <template>
-  <section class="code-panel">
-    <header class="code-row code-head">
+  <section class="page">
+    <button class="link back" @click="emit('back')">← Repositories</button>
+
+    <header class="page-head">
       <div>
-        <button class="code-link" @click="emit('back')">← Repositories</button>
-        <h2>{{ repo?.repo || name }}</h2>
-        <p class="code-muted">
+        <h2 class="page-title">{{ repo?.repo || name }}</h2>
+        <p class="page-meta">
           <a v-if="repo?.htmlURL" :href="repo.htmlURL" target="_blank" rel="noopener">{{ repo.htmlURL }}</a>
-          <span v-else>not created yet</span>
+          <span v-else class="muted">not created yet</span>
         </p>
-        <p v-if="repo?.sshURL" class="code-muted small">SSH: <code>{{ repo.sshURL }}</code></p>
       </div>
+      <span v-if="repo" :class="['badge', repo.ready ? 'ok' : 'warn']" :title="repo.message">{{ repo.ready ? 'ready' : 'pending' }}</span>
     </header>
 
-    <p v-if="error" class="code-error">{{ error }}</p>
+    <p v-if="error" class="error">{{ error }}</p>
 
-    <div class="code-cols">
+    <!-- Overview -->
+    <div v-if="repo" class="panel">
+      <h3 class="panel-title">Overview</h3>
+      <dl class="props">
+        <dt>Connection</dt><dd>{{ repo.connectionRef }}</dd>
+        <dt>Visibility</dt><dd>{{ repo.visibility }}</dd>
+        <dt v-if="repo.cloneURL">Clone URL</dt><dd v-if="repo.cloneURL"><code>{{ repo.cloneURL }}</code></dd>
+        <dt v-if="repo.sshURL">SSH URL</dt><dd v-if="repo.sshURL"><code>{{ repo.sshURL }}</code></dd>
+      </dl>
+    </div>
+
+    <div class="grid-2">
       <!-- Deploy keys -->
-      <div class="code-col">
-        <h3>Deploy keys</h3>
-        <form class="code-form" @submit.prevent="addKey">
-          <label>Title <input v-model="keyTitle" placeholder="ci-deploy" autocomplete="off" /></label>
-          <label>Public key (leave empty to generate)
+      <div class="panel">
+        <div class="panel-head">
+          <h3 class="panel-title">Deploy keys</h3>
+          <span class="muted">{{ keys.length }}</span>
+        </div>
+        <form class="form" @submit.prevent="addKey">
+          <div class="field"><span class="field-label">Title</span><input v-model="keyTitle" placeholder="ci-deploy" autocomplete="off" /></div>
+          <div class="field">
+            <span class="field-label">Public key (leave empty to generate)</span>
             <textarea v-model="keyPublic" rows="2" placeholder="ssh-ed25519 AAAA…" />
-          </label>
-          <label class="code-check"><input v-model="keyReadOnly" type="checkbox" /> read-only</label>
-          <div class="code-form-actions">
-            <button class="code-btn primary" type="submit" :disabled="keySubmitting">{{ keySubmitting ? 'Adding…' : 'Add deploy key' }}</button>
-            <span v-if="keyError" class="code-error">{{ keyError }}</span>
           </div>
-          <p class="code-muted small">A generated key's private half is written to a Secret in your workspace.</p>
+          <label class="field field-check"><input v-model="keyReadOnly" type="checkbox" /> read-only</label>
+          <div class="actions">
+            <button class="primary" type="submit" :disabled="keySubmitting">{{ keySubmitting ? 'Adding…' : 'Add deploy key' }}</button>
+            <span v-if="keyError" class="error">{{ keyError }}</span>
+          </div>
+          <p class="muted">A generated key's private half is written to a Secret in your workspace.</p>
         </form>
-        <p v-if="!keys.length" class="code-muted">No deploy keys.</p>
-        <ul v-else class="code-list">
-          <li v-for="k in keys" :key="k.name">
-            <span>
-              <strong>{{ k.title || k.name }}</strong>
-              <span class="code-badge" :class="k.readOnly ? 'muted' : 'warn'">{{ k.readOnly ? 'read-only' : 'read-write' }}</span>
-              <span v-if="k.generated && k.secretName" class="code-badge muted" :title="k.secretName">secret: {{ k.secretName }}</span>
-              <span v-if="k.ready" class="code-badge ok">ready</span>
-              <span v-else class="code-badge warn" :title="k.message">pending</span>
-            </span>
-            <button class="code-btn ghost" @click="removeKey(k)">Delete</button>
-          </li>
-        </ul>
+        <p v-if="!keys.length" class="empty">No deploy keys.</p>
+        <table v-else class="table">
+          <tbody>
+            <tr v-for="k in keys" :key="k.name">
+              <td>
+                <strong>{{ k.title || k.name }}</strong>
+                <div v-if="k.generated && k.secretName" class="muted">secret: <code>{{ k.secretName }}</code></div>
+              </td>
+              <td><span class="badge muted">{{ k.readOnly ? 'read-only' : 'read-write' }}</span></td>
+              <td>
+                <span v-if="k.ready" class="badge ok">ready</span>
+                <span v-else class="badge warn" :title="k.message">pending</span>
+              </td>
+              <td class="right"><button class="danger" @click="removeKey(k)">Delete</button></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
 
       <!-- Collaborators -->
-      <div class="code-col">
-        <h3>Collaborators</h3>
-        <form class="code-form" @submit.prevent="addCollab">
-          <label>Username <input v-model="collabUser" placeholder="octocat" autocomplete="off" /></label>
-          <label>Permission
+      <div class="panel">
+        <div class="panel-head">
+          <h3 class="panel-title">Collaborators</h3>
+          <span class="muted">{{ collabs.length }}</span>
+        </div>
+        <form class="form" @submit.prevent="addCollab">
+          <div class="field"><span class="field-label">Username</span><input v-model="collabUser" placeholder="octocat" autocomplete="off" /></div>
+          <div class="field">
+            <span class="field-label">Permission</span>
             <select v-model="collabPerm">
               <option value="pull">pull</option>
               <option value="push">push</option>
               <option value="admin">admin</option>
             </select>
-          </label>
-          <div class="code-form-actions">
-            <button class="code-btn primary" type="submit" :disabled="collabSubmitting">{{ collabSubmitting ? 'Adding…' : 'Add collaborator' }}</button>
-            <span v-if="collabError" class="code-error">{{ collabError }}</span>
+          </div>
+          <div class="actions">
+            <button class="primary" type="submit" :disabled="collabSubmitting">{{ collabSubmitting ? 'Adding…' : 'Add collaborator' }}</button>
+            <span v-if="collabError" class="error">{{ collabError }}</span>
           </div>
         </form>
-        <p v-if="!collabs.length" class="code-muted">No collaborators.</p>
-        <ul v-else class="code-list">
-          <li v-for="c in collabs" :key="c.name">
-            <span>
-              <strong>{{ c.username }}</strong>
-              <span class="code-badge muted">{{ c.permission }}</span>
-              <span v-if="c.invitationPending" class="code-badge warn">invited</span>
-              <span v-else-if="c.ready" class="code-badge ok">active</span>
-            </span>
-            <button class="code-btn ghost" @click="removeCollab(c)">Remove</button>
-          </li>
-        </ul>
+        <p v-if="!collabs.length" class="empty">No collaborators.</p>
+        <table v-else class="table">
+          <tbody>
+            <tr v-for="c in collabs" :key="c.name">
+              <td><strong>{{ c.username }}</strong></td>
+              <td><span class="badge muted">{{ c.permission }}</span></td>
+              <td>
+                <span v-if="c.invitationPending" class="badge warn">invited</span>
+                <span v-else-if="c.ready" class="badge ok">active</span>
+              </td>
+              <td class="right"><button class="danger" @click="removeCollab(c)">Remove</button></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </section>

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -84,63 +84,70 @@ onUnmounted(() => window.clearInterval(timer))
 </script>
 
 <template>
-  <section class="code-panel">
-    <header class="code-row code-head">
+  <section class="page">
+    <header class="page-head">
       <div>
-        <h2>Repositories</h2>
-        <p class="code-muted">Repositories the provider manages on the git host. Click one to manage deploy keys and collaborators.</p>
+        <h2 class="page-title">Repositories</h2>
+        <p class="page-meta">Repositories the provider manages on the git host. Click one to manage deploy keys and collaborators.</p>
       </div>
-      <button class="code-btn primary" :disabled="!connections.length" @click="showForm = !showForm">
+      <button class="primary" :disabled="!connections.length" @click="showForm = !showForm">
         {{ showForm ? 'Cancel' : 'New repository' }}
       </button>
     </header>
 
-    <p v-if="!connections.length" class="code-muted">Add a connection first, then create repositories under it.</p>
+    <p v-if="!connections.length" class="empty">Add a connection first, then create repositories under it.</p>
 
-    <form v-if="showForm" class="code-form" @submit.prevent="submit">
-      <label>Connection
-        <select v-model="connectionRef">
-          <option v-for="c in connections" :key="c.name" :value="c.name">{{ c.name }} ({{ c.owner }})</option>
-        </select>
-      </label>
-      <label>Object name <input v-model="name" placeholder="my-service" autocomplete="off" /></label>
-      <label>Repo name (defaults to object name) <input v-model="repo" placeholder="my-service" autocomplete="off" /></label>
-      <label>Visibility
-        <select v-model="visibility">
-          <option value="private">private</option>
-          <option value="public">public</option>
-          <option value="internal">internal</option>
-        </select>
-      </label>
-      <label>Description <input v-model="description" autocomplete="off" /></label>
-      <label class="code-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
-      <div class="code-form-actions">
-        <button class="code-btn primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create' }}</button>
-        <span v-if="formError" class="code-error">{{ formError }}</span>
-      </div>
-    </form>
+    <div v-if="showForm" class="panel">
+      <h3 class="panel-title">New repository</h3>
+      <form class="form" @submit.prevent="submit">
+        <div class="field">
+          <span class="field-label">Connection</span>
+          <select v-model="connectionRef">
+            <option v-for="c in connections" :key="c.name" :value="c.name">{{ c.name }} ({{ c.owner }})</option>
+          </select>
+        </div>
+        <div class="field"><span class="field-label">Object name</span><input v-model="name" placeholder="my-service" autocomplete="off" /></div>
+        <div class="field"><span class="field-label">Repo name (defaults to object name)</span><input v-model="repo" placeholder="my-service" autocomplete="off" /></div>
+        <div class="field">
+          <span class="field-label">Visibility</span>
+          <select v-model="visibility">
+            <option value="private">private</option>
+            <option value="public">public</option>
+            <option value="internal">internal</option>
+          </select>
+        </div>
+        <div class="field"><span class="field-label">Description</span><input v-model="description" autocomplete="off" /></div>
+        <label class="field field-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
+        <div class="actions">
+          <button class="primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create' }}</button>
+          <span v-if="formError" class="error">{{ formError }}</span>
+        </div>
+      </form>
+    </div>
 
-    <p v-if="error" class="code-error">{{ error }}</p>
-    <p v-else-if="loading && !repos.length" class="code-muted">Loading…</p>
-    <p v-else-if="!repos.length" class="code-muted">No repositories yet.</p>
+    <p v-if="error" class="error">{{ error }}</p>
+    <p v-else-if="loading && !repos.length" class="muted">Loading…</p>
+    <p v-else-if="!repos.length" class="empty">No repositories yet.</p>
 
-    <table v-else class="code-table">
-      <thead>
-        <tr><th>Name</th><th>Connection</th><th>Visibility</th><th>URL</th><th>Status</th><th></th></tr>
-      </thead>
-      <tbody>
-        <tr v-for="r in repos" :key="r.name">
-          <td><button class="code-link" @click="emit('open', r.name)">{{ r.repo }}</button></td>
-          <td>{{ r.connectionRef }}</td>
-          <td>{{ r.visibility }}</td>
-          <td><a v-if="r.htmlURL" :href="r.htmlURL" target="_blank" rel="noopener">open ↗</a><span v-else>—</span></td>
-          <td>
-            <span v-if="r.ready" class="code-badge ok">ready</span>
-            <span v-else class="code-badge warn" :title="r.message">pending</span>
-          </td>
-          <td class="code-right"><button class="code-btn ghost" @click="remove(r)">Delete</button></td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else class="panel">
+      <table class="table">
+        <thead>
+          <tr><th>Name</th><th>Connection</th><th>Visibility</th><th>URL</th><th>Status</th><th class="right"></th></tr>
+        </thead>
+        <tbody>
+          <tr v-for="r in repos" :key="r.name">
+            <td><button class="link" @click="emit('open', r.name)">{{ r.repo }}</button></td>
+            <td>{{ r.connectionRef }}</td>
+            <td>{{ r.visibility }}</td>
+            <td><a v-if="r.htmlURL" :href="r.htmlURL" target="_blank" rel="noopener">open ↗</a><span v-else class="muted">—</span></td>
+            <td>
+              <span v-if="r.ready" class="badge ok">ready</span>
+              <span v-else class="badge warn" :title="r.message">pending</span>
+            </td>
+            <td class="right"><button class="danger" @click="remove(r)">Delete</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 </template>


### PR DESCRIPTION
The code portal's tables, cards, and detail page looked nothing like the other providers (hand-rolled CSS, off-theme). This restyles it to share the portal's design language.

## What

`style.css` is rewritten to mirror the **infrastructure provider**'s conventions, using the portal's shared `--color-*` tokens (inherited via the light-DOM cascade — no redefinition):

- **Page scaffold:** `.page` / `.page-head` / `.page-title` / `.page-meta`
- **Cards:** `.panel` / `.panel-title`
- **Tables:** `.table` — uppercase muted headers, subtle row borders, accent-tinted row hover
- **Status pills:** `.badge.ok` / `.warn` / `.fail` (with a status dot), matching the portal's StatusBadge look
- **Buttons:** `.primary` / `.secondary` / `.danger` / `.link`; **forms:** `.field` / `.field-label` with focus rings
- **Detail page (the "no details page" complaint):** RepoDetail is now a real detail page — back link, title + status badge, an **Overview** panel (connection, visibility, clone/SSH URLs), and a two-column grid of **Deploy keys** + **Collaborators** panels with inline add-forms and tables.
- Repositories/Connections lists now sit inside panels with the shared table style.

## Supersedes #252

This rewrites the whole stylesheet with the correct tokens, so it includes (and replaces) the input-contrast fix in #252 — **#252 can be closed** once this merges.

## Verification
- `vue-tsc --noEmit` clean; `vite build` → `dist/main.js` (~99 kB). No stale `.code-*` classes remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)