### PR TITLE
providers/code: specific Repository ConnectionNotReady reason + form guard

### DIFF
--- a/providers/code/controller/repository/controller.go
+++ b/providers/code/controller/repository/controller.go
@@ -64,7 +64,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	b, conn, cred, ready := r.resolve(ctx, c, &repo)
+	b, conn, cred, notReady := r.resolve(ctx, c, &repo)
+	ready := notReady == ""
 
 	// Deletion path.
 	if !repo.DeletionTimestamp.IsZero() {
@@ -92,9 +93,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	}
 
 	if !ready {
-		// resolve() already recorded the reason on status via fail-less path;
-		// surface a generic not-ready and requeue when the Connection appears.
-		return r.fail(ctx, c, &repo, "ConnectionNotReady", "referenced connection or credential is not available yet")
+		// notReady names exactly which piece is missing (wrong connectionRef,
+		// unknown provider, or unreadable credential) so the status is actionable.
+		return r.fail(ctx, c, &repo, "ConnectionNotReady", notReady)
 	}
 
 	res, err := b.EnsureRepository(ctx, conn, cred, &repo)
@@ -115,23 +116,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-// resolve loads the backend, Connection, and credential for repo. ready is
-// false (with no error) when any piece is missing — the caller decides whether
-// that's fatal (create) or tolerable (delete).
-func (r *Reconciler) resolve(ctx context.Context, c client.Client, repo *codev1alpha1.Repository) (backend.GitBackend, *codev1alpha1.Connection, backend.Credential, bool) {
+// resolve loads the backend, Connection, and credential for repo. The returned
+// string is empty on success, otherwise a specific human-readable reason naming
+// the missing piece (used for the NotReady status; the caller decides whether
+// that's fatal for create or tolerable for delete).
+func (r *Reconciler) resolve(ctx context.Context, c client.Client, repo *codev1alpha1.Repository) (backend.GitBackend, *codev1alpha1.Connection, backend.Credential, string) {
 	conn, err := shared.ResolveConnection(ctx, c, repo.Spec.ConnectionRef)
 	if err != nil {
-		return nil, nil, backend.Credential{}, false
+		return nil, nil, backend.Credential{}, err.Error()
 	}
 	b, ok := r.Backends.Get(string(conn.Spec.Provider))
 	if !ok {
-		return nil, conn, backend.Credential{}, false
+		return nil, conn, backend.Credential{}, fmt.Sprintf("no backend registered for provider %q (connection %q)", conn.Spec.Provider, conn.Name)
 	}
 	cred, err := shared.ResolveCredential(ctx, c, conn)
 	if err != nil {
-		return b, conn, backend.Credential{}, false
+		return b, conn, backend.Credential{}, fmt.Sprintf("credential for connection %q unavailable: %v", conn.Name, err)
 	}
-	return b, conn, cred, true
+	return b, conn, cred, ""
 }
 
 func (r *Reconciler) fail(ctx context.Context, c client.Client, repo *codev1alpha1.Repository, reason, msg string) (ctrl.Result, error) {

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -29,7 +29,12 @@ async function load() {
     const [r, c] = await Promise.all([api.listRepositories(), api.listConnections()])
     repos.value = r
     connections.value = c
-    if (!connectionRef.value && c.length) connectionRef.value = c[0].name
+    // Default to (and recover to) a connection that actually exists — otherwise
+    // a stale ref (e.g. a since-deleted connection) silently sticks and the
+    // Repository fails to reconcile with "connection not found".
+    if (c.length && !c.some(x => x.name === connectionRef.value)) {
+      connectionRef.value = c[0].name
+    }
   } catch (e) {
     const err = e as ErrorResponse
     error.value = err.reason === 'TenantMissing' ? null : `${err.reason}: ${err.message}`


### PR DESCRIPTION
A `Repository` whose `connectionRef` points at a non-existent connection (e.g. one that was deleted, or a stale form selection) failed with the opaque:

```
ConnectionNotReady: referenced connection or credential is not available yet
```

…which gave no hint that the *reference* was simply wrong (vs a real credential problem). Hit this debugging a repo that referenced `mjudeikis` when the connection was actually named `github-mjudeikis`.

## Fixes
- **repository controller** — `resolve()` returns the **specific reason**: the connection-not-found error (`connection "x" not found`), an unknown-provider message, or the credential error — surfaced on the `Ready=False` condition. The three failure modes are no longer collapsed into one string.
- **RepositoriesView** — the connection `<select>` now defaults to (and recovers to) a connection that actually exists, instead of only setting a default when empty. Prevents a stale `connectionRef` (from a since-deleted connection) silently sticking and producing an unreconcilable Repository.

`go build`/`vet`, `vue-tsc`, `vite build` clean.