### PR TITLE
providers: drop kcpFetch — code + infrastructure portals fully on the GraphQL gateway

### DIFF
--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { STORAGE_KEYS } from '@/lib/constants'
+import { graphqlMutate } from '@/composables/useGraphQL'
 
 // ProviderDTO is the wire shape returned by the hub's GET /api/providers.
 // Keep it aligned with pkg/hub/providers/api.go:providerDTO.
@@ -303,21 +304,18 @@ export const useProvidersStore = defineStore('providers', () => {
   }
 
   async function disable(p: ProviderDTO): Promise<void> {
-    const cluster = currentTenantWorkspace()
-    if (!cluster) throw new Error('no tenant workspace in session')
     const bindingName = bindingNamesByProvider.value[p.name]
     if (!bindingName) return
-    const res = await fetch(
-      `/clusters/${cluster}/apis/apis.kcp.io/v1alpha2/apibindings/${bindingName}`,
-      {
-        method: 'DELETE',
-        headers: authHeaders(),
-        credentials: 'same-origin',
-      },
-    )
-    if (!res.ok && res.status !== 404) {
-      const detail = await res.text().catch(() => '')
-      throw new Error(`disable ${p.name} failed: ${res.status} ${res.statusText} ${detail}`)
+    // Disable = remove the tenant's APIBinding, via the GraphQL gateway (like
+    // every other kcp call). Idempotent: an already-gone binding is fine.
+    try {
+      await graphqlMutate(
+        'mutation($n: String!) { apis_kcp_io { v1alpha2 { deleteAPIBinding(name: $n) } } }',
+        { n: bindingName },
+      )
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      if (!/not\s*found/i.test(msg)) throw new Error(`disable ${p.name} failed: ${msg}`)
     }
     const next = { ...bindingNamesByProvider.value }
     delete next[p.name]
@@ -384,17 +382,4 @@ function authHeaders(): Record<string, string> {
     /* ignore */
   }
   return h
-}
-
-// currentTenantWorkspace reads auth state directly from localStorage to
-// avoid an import cycle with @/stores/auth.
-function currentTenantWorkspace(): string | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEYS.auth)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as { clusterName?: string }
-    return parsed.clusterName ?? null
-  } catch {
-    return null
-  }
 }

--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -52,12 +52,13 @@ this provider pod
    └  MCP (AS THE CALLER, caller's own bearer token)
 ```
 
-Reads do **not** go through this pod's HTTP surface: the portal reads every CR —
+CRUD does **not** go through this pod's HTTP surface: the portal drives every CR —
 Connections, Repositories, DeployKeys, Collaborators, and the crawled Packages —
-through the hub's GraphQL gateway at `/graphql/<workspace>` (`code_kedge_faros_sh
-{ v1alpha1 { … } }`). Writes still use the kcp REST proxy with the user's token
-(create/patch/delete + the credential Secret). The pod's HTTP surface is only for
-the MCP tools and the GitHub OAuth callback.
+through the hub's GraphQL gateway at `/graphql/<workspace>`. Reads are
+`code_kedge_faros_sh { v1alpha1 { … } }` queries; writes are create/update/delete
+mutations (plus `applyYaml` for create-or-update, which also writes the credential
+Secret). The pod's HTTP surface is only for the MCP tools and the GitHub OAuth
+callback.
 
 ## Run locally
 

--- a/providers/code/portal/src/api.ts
+++ b/providers/code/portal/src/api.ts
@@ -1,12 +1,11 @@
-// kcp-native client for the code provider's portal.
+// GraphQL client for the code provider's portal.
 //
-// Talks to kcp directly through the hub's kcp REST proxy:
-//   /clusters/<tenant>/apis/code.kedge.faros.sh/v1alpha1/<resource>   (our CRDs)
-//   /clusters/<tenant>/api/v1/namespaces/default/secrets              (PAT secret)
-//
-// The shell pushes kedgeContext.tenant (kcp cluster name) and
-// kedgeContext.token (bearer). All four code CRDs are cluster-scoped, so their
-// CRs live at <cluster>/apis/<g>/<v>/<plural>/<name> with no namespace segment.
+// Every read and write goes through the hub's embedded GraphQL gateway at
+// /graphql/<cluster> — reads as `code_kedge_faros_sh { v1alpha1 { … } }`
+// queries, writes as create/update/delete mutations (and applyYaml for
+// create-or-update). The shell pushes kedgeContext.tenant (kcp cluster name,
+// used as the /graphql path segment) and kedgeContext.token (bearer). The one
+// non-gateway call is oauthConfig, which probes the provider backend directly.
 
 import type {
   Collaborator,
@@ -20,7 +19,6 @@ import type {
 
 const GROUP = 'code.kedge.faros.sh'
 const VERSION = 'v1alpha1'
-const APIS_PREFIX = `/apis/${GROUP}/${VERSION}`
 const CRED_NAMESPACE = 'default'
 const TOKEN_KEY = 'token'
 
@@ -39,16 +37,6 @@ export function setTenant(name?: string | null) {
   clusterName = name || null
 }
 
-function clusterBase(): string {
-  if (!clusterName) {
-    throw <ErrorResponse>{ reason: 'TenantMissing', message: 'no workspace selected' }
-  }
-  return `/clusters/${clusterName}`
-}
-function apisBase(): string {
-  return clusterBase() + APIS_PREFIX
-}
-
 interface KCPMetadata {
   name: string
   uid?: string
@@ -65,36 +53,6 @@ interface RawCR {
   metadata: KCPMetadata
   spec?: Record<string, unknown>
   status?: { conditions?: KCPCondition[] } & Record<string, unknown>
-}
-
-async function kcpFetch<T>(method: string, path: string, body?: unknown, contentType?: string): Promise<T> {
-  const headers: Record<string, string> = { Accept: 'application/json' }
-  if (body) headers['Content-Type'] = contentType || 'application/json'
-  if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
-  const res = await fetch(path, {
-    method,
-    credentials: 'same-origin',
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  })
-  const text = await res.text()
-  if (!res.ok) {
-    let reason = 'HTTPError'
-    let message = text || res.statusText
-    try {
-      const parsed = JSON.parse(text) as { reason?: string; message?: string }
-      if (parsed && (parsed.reason || parsed.message)) {
-        reason = parsed.reason || reason
-        message = parsed.message || message
-      }
-    } catch {
-      // non-JSON body — keep raw text
-    }
-    if (res.status === 404) reason = 'NotFound'
-    else if (res.status === 403 && /APIBinding|not\s+found/i.test(message)) reason = 'APIBindingMissing'
-    throw <ErrorResponse>{ reason, message }
-  }
-  return (text ? JSON.parse(text) : null) as T
 }
 
 // graphqlQuery runs a query against the hub's embedded GraphQL gateway at
@@ -219,41 +177,37 @@ function dns1123(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 253) || 'x'
 }
 
-// createOrGet POSTs body to a collection and, if the object already exists,
-// fetches the existing one instead — so connecting is idempotent.
-async function createOrGet(collectionPath: string, name: string, body: unknown): Promise<RawCR> {
-  try {
-    return await kcpFetch<RawCR>('POST', collectionPath, body)
-  } catch (e) {
-    if ((e as ErrorResponse).reason === 'AlreadyExists') {
-      return await kcpFetch<RawCR>('GET', collectionPath + '/' + encodeURIComponent(name))
-    }
-    throw e
-  }
+// ── GraphQL write helpers ──────────────────────────────────────────────────
+// All writes go through the gateway's mutation API (no kcp REST proxy). applyCR
+// wraps applyYaml, whose server-side create-or-update semantics make writes
+// idempotent and handle the "adopt an existing object" case (e.g. a leftover
+// credential Secret) without client-side resourceVersion juggling.
+async function applyCR(manifest: Record<string, unknown>): Promise<RawCR> {
+  const data = await graphqlQuery<{ applyYaml?: unknown }>(
+    'mutation($y: String!) { applyYaml(yaml: $y) }',
+    { y: JSON.stringify(manifest) },
+  )
+  // applyYaml returns the applied object as a JSON string (JSONString scalar);
+  // tolerate an already-parsed object too.
+  const raw = data.applyYaml
+  return (typeof raw === 'string' ? JSON.parse(raw || '{}') : raw ?? {}) as RawCR
 }
 
-// upsertSecret writes the token Secret, adopting and overwriting a leftover one
-// from a prior connection rather than failing on AlreadyExists. owner is an
-// ownerReference to the Connection so kcp GC removes the Secret with it.
-async function upsertSecret(secretName: string, token: string, owner: Record<string, unknown>): Promise<void> {
-  const collection = clusterBase() + `/api/v1/namespaces/${CRED_NAMESPACE}/secrets`
-  const body: Record<string, unknown> = {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: { name: secretName, namespace: CRED_NAMESPACE, ownerReferences: [owner] },
-    type: 'Opaque',
-    stringData: { [TOKEN_KEY]: token },
-  }
-  try {
-    await kcpFetch<unknown>('POST', collection, body)
-  } catch (e) {
-    if ((e as ErrorResponse).reason !== 'AlreadyExists') throw e
-    // Adopt the existing Secret: carry its resourceVersion into the replace so
-    // the update is accepted, and overwrite the token + ownerReferences.
-    const existing = await kcpFetch<RawCR>('GET', collection + '/' + encodeURIComponent(secretName))
-    ;(body.metadata as Record<string, unknown>).resourceVersion = existing.metadata.resourceVersion
-    await kcpFetch<unknown>('PUT', collection + '/' + encodeURIComponent(secretName), body)
-  }
+// deleteCR deletes a code-group resource by name via the delete<Kind> mutation.
+async function deleteCR(kind: string, name: string): Promise<void> {
+  await graphqlQuery(
+    `mutation($n: String!) { code_kedge_faros_sh { v1alpha1 { delete${kind}(name: $n) } } }`,
+    { n: name },
+  )
+}
+
+// deleteSecret removes a credential Secret (core/v1, namespaced) by name. Best-
+// effort: a missing Secret is not an error for the caller.
+async function deleteSecret(name: string): Promise<void> {
+  await graphqlQuery(
+    'mutation($n: String!, $ns: String!) { v1 { deleteSecret(name: $n, namespace: $ns) } }',
+    { n: name, ns: CRED_NAMESPACE },
+  )
 }
 
 // ── GraphQL read helpers ───────────────────────────────────────────────────
@@ -317,18 +271,24 @@ export const api = {
       secretRef: { name: secretName, namespace: CRED_NAMESPACE, key: TOKEN_KEY },
     }
     if (input.baseURL) spec.baseURL = input.baseURL
-    const conn = await createOrGet(apisBase() + '/connections', name, {
+    const conn = await applyCR({
       apiVersion: `${GROUP}/${VERSION}`,
       kind: 'Connection',
       metadata: { name },
       spec,
     })
-    // 2) Secret holding the token, owned by the Connection.
-    await upsertSecret(secretName, input.token, {
-      apiVersion: `${GROUP}/${VERSION}`,
-      kind: 'Connection',
-      name,
-      uid: conn.metadata.uid,
+    // 2) Secret holding the token, owned by the Connection so kcp GC removes it
+    // with the Connection. applyCR's create-or-update adopts a leftover Secret.
+    await applyCR({
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: secretName,
+        namespace: CRED_NAMESPACE,
+        ownerReferences: [{ apiVersion: `${GROUP}/${VERSION}`, kind: 'Connection', name, uid: conn.metadata.uid }],
+      },
+      type: 'Opaque',
+      stringData: { [TOKEN_KEY]: input.token },
     })
     return connFromCR(conn)
   },
@@ -339,17 +299,18 @@ export const api = {
     // immediate and guarantees the name is free for the next connection.
     let secretName = name + '-token'
     try {
-      const conn = await kcpFetch<RawCR>('GET', apisBase() + '/connections/' + encodeURIComponent(name))
+      const conn = await gqlGet('Connection', name, F_CONNECTION)
       const ref = conn.spec?.secretRef as Record<string, unknown> | undefined
       if (ref?.name) secretName = String(ref.name)
     } catch {
       // connection already gone — fall back to the naming convention
     }
-    await kcpFetch<unknown>('DELETE', apisBase() + '/connections/' + encodeURIComponent(name))
+    await deleteCR('Connection', name)
     try {
-      await kcpFetch<unknown>('DELETE', clusterBase() + `/api/v1/namespaces/${CRED_NAMESPACE}/secrets/` + encodeURIComponent(secretName))
+      await deleteSecret(secretName)
     } catch (e) {
-      if ((e as ErrorResponse).reason !== 'NotFound') throw e
+      // best-effort: a since-deleted Secret (GC raced us) is fine
+      if (!/not\s*found/i.test((e as ErrorResponse).message ?? '')) throw e
     }
   },
 
@@ -393,7 +354,7 @@ export const api = {
     if (input.visibility) spec.visibility = input.visibility
     if (input.description) spec.description = input.description
     if (input.autoInit) spec.autoInit = true
-    const created = await kcpFetch<RawCR>('POST', apisBase() + '/repositories', {
+    const created = await applyCR({
       apiVersion: `${GROUP}/${VERSION}`,
       kind: 'Repository',
       metadata: { name },
@@ -403,19 +364,24 @@ export const api = {
   },
 
   async deleteRepository(name: string): Promise<void> {
-    await kcpFetch<unknown>('DELETE', apisBase() + '/repositories/' + encodeURIComponent(name))
+    await deleteCR('Repository', name)
   },
 
   // updateRepositoryConnection repoints an existing Repository at a different
-  // Connection via a merge-patch on spec.connectionRef. The controller re-resolves
-  // the new credential/owner on the next reconcile.
+  // Connection. The update<Kind> mutation is a server-side merge-patch, so only
+  // spec.connectionRef changes; the controller re-resolves the new credential/
+  // owner on the next reconcile.
   async updateRepositoryConnection(name: string, connectionRef: string): Promise<Repository> {
-    const updated = await kcpFetch<RawCR>(
-      'PATCH',
-      apisBase() + '/repositories/' + encodeURIComponent(name),
-      { spec: { connectionRef } },
-      'application/merge-patch+json',
+    const data = await graphqlQuery<{ code_kedge_faros_sh?: { v1alpha1?: { updateRepository?: RawCR } } }>(
+      `mutation($n: String!, $ref: String!) {
+        code_kedge_faros_sh { v1alpha1 {
+          updateRepository(name: $n, object: { spec: { connectionRef: $ref } }) { ${F_REPOSITORY} }
+        } }
+      }`,
+      { n: name, ref: connectionRef },
     )
+    const updated = data.code_kedge_faros_sh?.v1alpha1?.updateRepository
+    if (!updated) throw <ErrorResponse>{ reason: 'ServerError', message: 'updateRepository returned no object' }
     return repoFromCR(updated)
   },
 
@@ -435,7 +401,7 @@ export const api = {
     if (input.title) spec.title = input.title
     if (input.publicKey) spec.publicKey = input.publicKey
     if (input.readOnly) spec.readOnly = true
-    const created = await kcpFetch<RawCR>('POST', apisBase() + '/deploykeys', {
+    const created = await applyCR({
       apiVersion: `${GROUP}/${VERSION}`,
       kind: 'DeployKey',
       metadata: { name },
@@ -445,7 +411,7 @@ export const api = {
   },
 
   async deleteDeployKey(name: string): Promise<void> {
-    await kcpFetch<unknown>('DELETE', apisBase() + '/deploykeys/' + encodeURIComponent(name))
+    await deleteCR('DeployKey', name)
   },
 
   // ── Collaborators ────────────────────────────────────────────────────────
@@ -464,7 +430,7 @@ export const api = {
       username: input.username,
     }
     if (input.permission) spec.permission = input.permission
-    const created = await kcpFetch<RawCR>('POST', apisBase() + '/collaborators', {
+    const created = await applyCR({
       apiVersion: `${GROUP}/${VERSION}`,
       kind: 'Collaborator',
       metadata: { name },
@@ -474,7 +440,7 @@ export const api = {
   },
 
   async deleteCollaborator(name: string): Promise<void> {
-    await kcpFetch<unknown>('DELETE', apisBase() + '/collaborators/' + encodeURIComponent(name))
+    await deleteCR('Collaborator', name)
   },
 
   // ── Packages (read-only) ─────────────────────────────────────────────────

--- a/providers/infrastructure/portal/package-lock.json
+++ b/providers/infrastructure/portal/package-lock.json
@@ -8,6 +8,8 @@
       "name": "kedge-provider-infrastructure-portal",
       "version": "0.1.0",
       "dependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "js-yaml": "^4.2.0",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -868,6 +870,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -1054,6 +1062,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1185,6 +1199,28 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/magic-string": {

--- a/providers/infrastructure/portal/package.json
+++ b/providers/infrastructure/portal/package.json
@@ -10,6 +10,8 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.2.0",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/providers/infrastructure/portal/src/App.vue
+++ b/providers/infrastructure/portal/src/App.vue
@@ -53,8 +53,8 @@ const tenantPath = computed(() => props.ctx?.tenant ?? null)
 // re-pushes context (e.g. token rotation, workspace switch).
 watch(() => props.ctx?.basePath, (v) => setBasePath(v), { immediate: true })
 watch(() => props.ctx?.token, (v) => setToken(v), { immediate: true })
-// ctx.tenant is the kcp cluster name auth.clusterName, which forms
-// the /clusters/<x>/apis/... prefix every kcp REST call below uses.
+// ctx.tenant is the kcp cluster name auth.clusterName, used as the
+// /graphql/<cluster> path segment for every gateway call in api.ts.
 watch(() => props.ctx?.tenant, (v) => setTenant(v), { immediate: true })
 
 // navigate dispatches a kedge-navigate CustomEvent (bubbles) so the
@@ -107,8 +107,8 @@ function provisioned(name: string) {
 <template>
   <div ref="rootRef" class="app">
     <!--
-      Every routed page calls into api.ts on mount, which builds a
-      /clusters/<tenant>/apis/... URL. Without a tenant the call
+      Every routed page calls into api.ts on mount, which queries the
+      /graphql/<tenant> gateway. Without a tenant the call
       throws "no workspace selected" — accurate, but ugly. Gate page
       render on a non-empty tenantPath so the page only mounts when
       api.ts is ready. The host pushes ctx.tenant immediately after

--- a/providers/infrastructure/portal/src/DashboardTile.vue
+++ b/providers/infrastructure/portal/src/DashboardTile.vue
@@ -122,7 +122,7 @@ const AlertCircle = (props: { class?: string }) =>
 interface KedgeContext {
   token?: string | null
   // tenant is the kcp cluster name (auth.clusterName in the shell).
-  // Used as the /clusters/<x>/ prefix on every kcp REST call.
+  // Used as the /graphql/<cluster> path segment for gateway calls.
   tenant?: string | null
   basePath?: string
 }
@@ -159,7 +159,7 @@ const recent = computed(() =>
     .slice(0, 4),
 )
 
-// Refresh delegates to the shared kcp client in api.ts. The shell
+// Refresh delegates to the shared GraphQL client in api.ts. The shell
 // pushes the same token + tenant (auth.clusterName) to every mounted
 // element, so even when the tile and the full provider page are open
 // at the same time both end up with the same module state.
@@ -167,7 +167,7 @@ async function refresh() {
   const ctx = props.context
   if (!ctx?.tenant) {
     // No workspace selected yet — render the empty state rather than
-    // hitting kcp without a /clusters/ prefix.
+    // querying the gateway without a cluster.
     instances.value = []
     error.value = null
     loading.value = false

--- a/providers/infrastructure/portal/src/api.ts
+++ b/providers/infrastructure/portal/src/api.ts
@@ -211,8 +211,13 @@ async function refreshIndex(): Promise<InfraIndex> {
     else if (f.typeName === 'String') continue // <Kind>Yaml fields
     else resourceTypeByKind.set(f.name, f.typeName) // single field: name === Kind
   }
+  // Only map kinds that are actual Template instances — the schema also exposes
+  // Template (and other) resources whose status has no phase/message, and which
+  // must not be swept into the instance list.
+  const instanceKinds = new Set(templates.map(t => t.kind).filter(Boolean))
   const listFieldByKind = new Map<string, string>()
   for (const [kind, resourceType] of resourceTypeByKind) {
+    if (!instanceKinds.has(kind)) continue
     const lf = listByResourceType.get(resourceType)
     if (lf) listFieldByKind.set(kind, lf)
   }

--- a/providers/infrastructure/portal/src/api.ts
+++ b/providers/infrastructure/portal/src/api.ts
@@ -1,48 +1,36 @@
-// kcp-native client for the infrastructure provider's portal.
+// GraphQL client for the infrastructure provider's portal.
 //
-// Talks to kcp directly through the hub's kcp REST proxy at
-// /clusters/<tenant>/apis/infrastructure.kedge.faros.sh/v1alpha1/...
-// — no more provider-side REST broker. The shell pushes:
+// Every read and write goes through the hub's embedded GraphQL gateway at
+// /graphql/<cluster> — the same workspace-scoped, caller-authenticated path the
+// rest of the platform uses. The shell pushes kedgeContext.tenant (kcp cluster
+// name, used as the /graphql path segment) and kedgeContext.token (bearer).
 //
-//   kedgeContext.tenant  → kcp cluster name (auth.clusterName)
-//   kedgeContext.token   → bearer for the kcp APIServer
-//   kedgeContext.basePath → /ui/providers/infrastructure (kept only
-//                           for legacy fallback callers that haven't
-//                           been migrated; not used for kcp paths)
-//
-// The hub forwards anything under /clusters/<x>/{apis,api}/... to kcp
-// after attaching the OIDC identity (see pkg/hub/server.go's kcpProxy
-// mount point). The browser is authenticated with the same bearer
-// that the kcp proxy validates.
+// Templates and per-template instance CRDs live in the infrastructure group, so
+// they surface under the GraphQL field `infrastructure_kedge_faros_sh`. Instance
+// kinds are declared per Template, so their list field (`<Plural>`) is discovered
+// by introspection; reads of an instance's arbitrary spec use the gateway's raw
+// `<Kind>Yaml` escape hatch (parsed with js-yaml), and writes use `applyYaml` /
+// `delete<Kind>` mutations — no field schema needs to be known ahead of time.
 
+import { load as yamlLoad } from 'js-yaml'
 import type { ErrorResponse, Instance, JSONSchema, Template } from './types'
 
 const GROUP = 'infrastructure.kedge.faros.sh'
 const VERSION = 'v1alpha1'
-const APIS_PREFIX = `/apis/${GROUP}/${VERSION}`
-const TEMPLATES_RESOURCE = 'templates'
-// Per-template CRDs (Redis, Postgres, …) are cluster-scoped — see
-// controller/template/controller.go where Scope is ClusterScoped.
-// That means instance CRs live at <cluster>/apis/<g>/<v>/<plural>/<name>
-// without a namespace segment.
+// GraphQL field for the group (dots → underscores, per the gateway's sanitizer).
+const GROUP_FIELD = 'infrastructure_kedge_faros_sh'
 
 let bearerToken: string | null = null
 let clusterName: string | null = null
-// setBasePath is kept as a no-op so App.vue's existing watcher still
-// type-checks; the kcp path is constructed from clusterName, not the
-// provider-name basePath, so the value is intentionally discarded.
+
+// setBasePath is a no-op: the gateway path is built from the cluster name, not
+// the provider basePath. Kept so App.vue's watcher type-checks.
 export function setBasePath(_ctxBasePath?: string | null) {
   void _ctxBasePath
 }
-
 export function setToken(token?: string | null) {
   bearerToken = token || null
 }
-
-// setTenant accepts the kcp cluster name (kedgeContext.tenant from
-// the shell, equal to auth.clusterName). Without it every call below
-// throws an ErrorResponse with reason TenantMissing so views render
-// their "no workspace selected" state instead of crashing.
 export function setTenant(name?: string | null) {
   const next = name || null
   if (next !== clusterName) {
@@ -52,116 +40,103 @@ export function setTenant(name?: string | null) {
   clusterName = next
 }
 
-function clusterBase(): string {
+// ── GraphQL transport ───────────────────────────────────────────────────────
+// graphqlQuery POSTs a query/mutation to /graphql/<cluster> and returns data,
+// mapping gateway errors onto the {reason,message} contract the views branch on.
+async function graphqlQuery<T>(query: string, variables: Record<string, unknown> = {}): Promise<T> {
   if (!clusterName) {
     throw <ErrorResponse>{ reason: 'TenantMissing', message: 'no workspace selected' }
   }
-  return `/clusters/${clusterName}${APIS_PREFIX}`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json' }
+  if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
+  const res = await fetch('/graphql/' + clusterName, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers,
+    body: JSON.stringify({ query, variables }),
+  })
+  const text = await res.text()
+  if (!res.ok) {
+    throw <ErrorResponse>{ reason: res.status === 404 ? 'NotFound' : 'HTTPError', message: text || res.statusText }
+  }
+  const body = (text ? JSON.parse(text) : {}) as { data?: T; errors?: { message: string }[] }
+  if (body.errors && body.errors.length) {
+    const message = body.errors.map(e => e.message).join('; ')
+    let reason = 'GraphQLError'
+    if (/not\s*found|notfound/i.test(message)) reason = 'NotFound'
+    else if (/apibinding|no matches for kind|forbidden/i.test(message)) reason = 'APIBindingMissing'
+    throw <ErrorResponse>{ reason, message }
+  }
+  return (body.data ?? {}) as T
 }
 
-interface KCPMetadata {
-  name: string
-  namespace?: string
-  uid?: string
-  resourceVersion?: string
-  creationTimestamp?: string
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+// applyCR applies a manifest (create-or-update) via the gateway's applyYaml and
+// returns the resulting object (applyYaml serialises it as a JSON string).
+async function applyCR(manifest: Record<string, unknown>): Promise<RawObject> {
+  const data = await graphqlQuery<{ applyYaml?: unknown }>(
+    'mutation($y: String!) { applyYaml(yaml: $y) }',
+    { y: JSON.stringify(manifest) },
+  )
+  const raw = data.applyYaml
+  return (typeof raw === 'string' ? JSON.parse(raw || '{}') : raw ?? {}) as RawObject
 }
-interface KCPList<T> {
-  items: T[]
-}
-interface KCPTemplate {
-  metadata: KCPMetadata
-  spec: {
-    displayName?: string
-    description?: string
-    category?: string
-    cloud?: string
-    version?: string
-    iconURL?: string
-    backend?: string
-    instanceCRD: { group: string; version: string; resource: string; kind: string }
-    schema?: unknown // RawExtension — already a JSON object after .json() parse
-    sampleValues?: Record<string, unknown>
-  }
-}
-interface KCPInstance {
+
+// Infra<V> shapes a gateway response nested under the infra group/version. The
+// literal keys match GROUP_FIELD / VERSION, which are literal-typed consts, so
+// `data[GROUP_FIELD]?.[VERSION]` indexes cleanly.
+type Infra<V> = { infrastructure_kedge_faros_sh?: { v1alpha1?: V } }
+
+interface RawObject {
   apiVersion?: string
   kind?: string
-  metadata: KCPMetadata
+  metadata?: {
+    name?: string
+    namespace?: string
+    creationTimestamp?: string
+    labels?: Record<string, string>
+  }
   spec?: Record<string, unknown>
   status?: {
     phase?: string
     message?: string
-    conditions?: Array<{
-      type: string
-      status: string
-      reason?: string
-      message?: string
-      lastTransitionTime?: string
-    }>
+    conditions?: Array<{ type: string; status: string; reason?: string; message?: string; lastTransitionTime?: string }>
   }
 }
 
-async function kcpFetch<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const headers: Record<string, string> = { Accept: 'application/json' }
-  if (body) headers['Content-Type'] = 'application/json'
-  if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
-  const res = await fetch(path, {
-    method,
-    credentials: 'same-origin',
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  })
-  const text = await res.text()
-  // kcp returns Status objects on error; map them into the
-  // {reason, message} contract the views are already coded against.
-  if (!res.ok) {
-    let reason = 'HTTPError'
-    let message = text || res.statusText
+// ── Mappers ─────────────────────────────────────────────────────────────────
+function templateFromGQL(name: string, spec: Record<string, unknown>): Template {
+  const instanceCRD = (spec.instanceCRD ?? {}) as { kind?: string }
+  // spec.schema is a preserve-unknown-fields field → the gateway returns it as a
+  // JSON string (JSONString scalar); parse it back into the JSONSchema object.
+  let inputsSchema: JSONSchema = { type: 'object', properties: {} }
+  if (typeof spec.schema === 'string' && spec.schema) {
     try {
-      const parsed = JSON.parse(text) as { reason?: string; message?: string; status?: string; code?: number }
-      if (parsed && (parsed.reason || parsed.message)) {
-        reason = parsed.reason || reason
-        message = parsed.message || message
-      }
+      inputsSchema = JSON.parse(spec.schema) as JSONSchema
     } catch {
-      // non-JSON body — keep raw text as the message
+      // leave the empty default
     }
-    if (res.status === 404 && /^templates?\b/.test(path.split(APIS_PREFIX)[1] ?? '')) {
-      reason = 'TemplateNotFound'
-    } else if (res.status === 404) {
-      reason = 'InstanceNotFound'
-    } else if (res.status === 403 && /not\s+found.*APIBinding|no APIBinding/i.test(message)) {
-      reason = 'APIBindingMissing'
-    }
-    throw <ErrorResponse>{ reason, message }
+  } else if (spec.schema && typeof spec.schema === 'object') {
+    inputsSchema = spec.schema as JSONSchema
   }
-  return (text ? JSON.parse(text) : null) as T
-}
-
-function templateFromKCP(t: KCPTemplate): Template {
   return {
-    name: t.metadata.name,
-    displayName: t.spec.displayName || t.metadata.name,
-    description: t.spec.description ?? '',
-    category: t.spec.category,
-    cloud: t.spec.cloud,
-    version: t.spec.version,
-    iconURL: t.spec.iconURL,
-    kind: t.spec.instanceCRD.kind,
-    inputsSchema: (t.spec.schema as JSONSchema) ?? { type: 'object', properties: {} },
-    sampleValues: t.spec.sampleValues,
+    name,
+    displayName: (spec.displayName as string) || name,
+    description: (spec.description as string) ?? '',
+    category: spec.category as string | undefined,
+    cloud: spec.cloud as string | undefined,
+    version: spec.version as string | undefined,
+    iconURL: spec.iconURL as string | undefined,
+    kind: instanceCRD.kind ?? '',
+    inputsSchema,
+    sampleValues: spec.sampleValues as Record<string, unknown> | undefined,
   }
 }
 
-// instanceFromKCP collapses a per-template CR into the Instance shape
-// the views read. The "template" field is the originating Template's
-// name (carried via the kedge.faros.sh/template label set by the
-// platform's CR-creation path; falls back to the CR's kind).
-function instanceFromKCP(c: KCPInstance, templateByKind: Map<string, string>): Instance {
-  const labels = c.metadata.labels ?? {}
+// instanceFromObj collapses a per-template CR (any object with metadata/spec/
+// status) into the Instance shape the views read. The originating Template is
+// taken from the kedge.faros.sh/template label, falling back to the kind.
+function instanceFromObj(c: RawObject, templateByKind: Map<string, string>): Instance {
+  const labels = c.metadata?.labels ?? {}
   const tmpl = labels['kedge.faros.sh/template'] || (c.kind ? templateByKind.get(c.kind) ?? c.kind : '')
   const conditions = (c.status?.conditions ?? []).map(cond => ({
     type: cond.type,
@@ -171,69 +146,94 @@ function instanceFromKCP(c: KCPInstance, templateByKind: Map<string, string>): I
     time: cond.lastTransitionTime,
   }))
   return {
-    name: c.metadata.name,
-    namespace: c.metadata.namespace ?? '',
+    name: c.metadata?.name ?? '',
+    namespace: c.metadata?.namespace ?? '',
     template: tmpl,
-    phase: c.status?.phase || (conditions.find(c => c.type === 'Ready')?.status === 'True' ? 'Ready' : 'Pending'),
+    phase: c.status?.phase || (conditions.find(x => x.type === 'Ready')?.status === 'True' ? 'Ready' : 'Pending'),
     message: c.status?.message,
     conditions,
     values: c.spec,
-    createdAt: c.metadata.creationTimestamp ?? '',
+    createdAt: c.metadata?.creationTimestamp ?? '',
   }
 }
 
-// Listing per-template CRs requires knowing each Template's plural.
-// templateIndex memoizes the list and is bypassed when the caller
-// asks for a fresh fetch. Templates change rarely; a 10s TTL is
-// plenty for the auto-refresh InstanceListPage does.
-interface TemplateIndex {
+// ── Template + instance-field index ─────────────────────────────────────────
+// Listing instances needs each kind's GraphQL list field (`<Plural>` =
+// Pluralize(Kind), not derivable client-side), so we discover it by introspection
+// once and cache it alongside the Templates (10s TTL — both change rarely).
+interface InfraIndex {
   fetchedAt: number
   templates: Template[]
-  // Plural ('redis') ↔ Kind ('Redis') maps — both directions because
-  // instance CRs only carry the Kind in their apiVersion+kind, but
-  // list URLs need the plural.
-  pluralByName: Map<string, string>
-  kindByPlural: Map<string, string>
   templateByKind: Map<string, string>
+  // kind → GraphQL list field name (only kinds whose CRD is actually established
+  // in the workspace, so a Template with no bound CRD is naturally skipped).
+  listFieldByKind: Map<string, string>
 }
-let cachedIndex: TemplateIndex | null = null
+let cachedIndex: InfraIndex | null = null
 const INDEX_TTL_MS = 10_000
 
-async function refreshIndex(): Promise<TemplateIndex> {
-  const list = await kcpFetch<KCPList<KCPTemplate>>('GET', clusterBase() + '/' + TEMPLATES_RESOURCE)
-  const templates = (list.items ?? []).map(templateFromKCP)
-  const pluralByName = new Map<string, string>()
-  const kindByPlural = new Map<string, string>()
+// introspectVersionFields walks Query → infrastructure_kedge_faros_sh → v1alpha1
+// in a single introspection query and returns its fields with (unwrapped) type
+// names, so we can map each instance kind to its list field.
+async function introspectVersionFields(): Promise<Array<{ name: string; typeName: string }>> {
+  const q = `{ __type(name: "Query") { fields { name type { fields { name type { name fields { name type { name kind ofType { name kind } } } } } } } } }`
+  const data = await graphqlQuery<{
+    __type?: { fields?: Array<{ name: string; type?: { fields?: Array<{ name: string; type?: { fields?: Array<{ name: string; type?: { name?: string; ofType?: { name?: string } } }> } }> } }> }
+  }>(q)
+  const group = (data.__type?.fields ?? []).find(f => f.name === GROUP_FIELD)
+  const version = (group?.type?.fields ?? []).find(f => f.name === VERSION)
+  return (version?.type?.fields ?? []).map(f => ({
+    name: f.name,
+    typeName: f.type?.ofType?.name ?? f.type?.name ?? '',
+  }))
+}
+
+async function refreshIndex(): Promise<InfraIndex> {
+  const [tmplData, versionFields] = await Promise.all([
+    graphqlQuery<Infra<{ Templates?: { items?: Array<{ metadata: { name: string }; spec: Record<string, unknown> }> } }>>(
+      `{ ${GROUP_FIELD} { ${VERSION} { Templates { items { metadata { name } spec { displayName description category version iconURL backend instanceCRD { group version resource kind } schema } } } } } }`,
+    ),
+    introspectVersionFields(),
+  ])
+
+  const items = tmplData[GROUP_FIELD]?.[VERSION]?.Templates?.items ?? []
+  const templates = items.map(t => templateFromGQL(t.metadata.name, t.spec ?? {}))
   const templateByKind = new Map<string, string>()
-  for (const t of list.items ?? []) {
-    pluralByName.set(t.metadata.name, t.spec.instanceCRD.resource)
-    kindByPlural.set(t.spec.instanceCRD.resource, t.spec.instanceCRD.kind)
-    templateByKind.set(t.spec.instanceCRD.kind, t.metadata.name)
+  for (const t of templates) if (t.kind) templateByKind.set(t.kind, t.name)
+
+  // Map kind → list field via the resource-type relationship: the list field's
+  // type is `<resourceType>List`, the single field's type is `<resourceType>`.
+  const listByResourceType = new Map<string, string>()
+  const resourceTypeByKind = new Map<string, string>()
+  for (const f of versionFields) {
+    if (!f.typeName) continue
+    if (f.typeName.endsWith('List')) listByResourceType.set(f.typeName.slice(0, -'List'.length), f.name)
+    else if (f.typeName === 'String') continue // <Kind>Yaml fields
+    else resourceTypeByKind.set(f.name, f.typeName) // single field: name === Kind
   }
-  cachedIndex = { fetchedAt: Date.now(), templates, pluralByName, kindByPlural, templateByKind }
+  const listFieldByKind = new Map<string, string>()
+  for (const [kind, resourceType] of resourceTypeByKind) {
+    const lf = listByResourceType.get(resourceType)
+    if (lf) listFieldByKind.set(kind, lf)
+  }
+
+  cachedIndex = { fetchedAt: Date.now(), templates, templateByKind, listFieldByKind }
   return cachedIndex
 }
 
-async function getIndex(force = false): Promise<TemplateIndex> {
-  if (!force && cachedIndex && Date.now() - cachedIndex.fetchedAt < INDEX_TTL_MS) {
-    return cachedIndex
-  }
+async function getIndex(force = false): Promise<InfraIndex> {
+  if (!force && cachedIndex && Date.now() - cachedIndex.fetchedAt < INDEX_TTL_MS) return cachedIndex
   return refreshIndex()
 }
 
-// Build the Resource Graph (the wire body) for a per-template CR.
-// The instance kind/apiVersion come from the Template's spec.instanceCRD;
+// Build the wire manifest for a per-template instance CR. The kind/apiVersion
+// come from the Template's instanceCRD (all instances live in the infra group);
 // the input `values` go under .spec verbatim.
-function buildInstanceBody(tmpl: { kind: string; apiVersion: string }, name: string, values: Record<string, unknown>) {
+function buildInstanceManifest(kind: string, name: string, templateName: string, values: Record<string, unknown>) {
   return {
-    apiVersion: tmpl.apiVersion,
-    kind: tmpl.kind,
-    metadata: {
-      name,
-      labels: {
-        'kedge.faros.sh/template': name && tmpl.kind ? tmpl.kind : '',
-      },
-    },
+    apiVersion: GROUP + '/' + VERSION,
+    kind,
+    metadata: { name, labels: { 'kedge.faros.sh/template': templateName } },
     spec: values,
   }
 }
@@ -248,11 +248,13 @@ export const api = {
   },
 
   async getTemplate(name: string): Promise<{ template: Template }> {
-    const t = await kcpFetch<KCPTemplate>(
-      'GET',
-      clusterBase() + '/' + TEMPLATES_RESOURCE + '/' + encodeURIComponent(name),
+    const data = await graphqlQuery<Infra<{ Template?: { metadata: { name: string }; spec: Record<string, unknown> } }>>(
+      `query($n: String!) { ${GROUP_FIELD} { ${VERSION} { Template(name: $n) { metadata { name } spec { displayName description category version iconURL backend instanceCRD { group version resource kind } schema } } } } }`,
+      { n: name },
     )
-    return { template: templateFromKCP(t) }
+    const t = data[GROUP_FIELD]?.[VERSION]?.Template
+    if (!t) throw <ErrorResponse>{ reason: 'TemplateNotFound', message: 'template ' + name + ' not found' }
+    return { template: templateFromGQL(t.metadata.name, t.spec ?? {}) }
   },
 
   async createInstance(body: {
@@ -262,88 +264,75 @@ export const api = {
     values: Record<string, unknown>
   }): Promise<Instance> {
     const idx = await getIndex()
-    const tmplListItem = idx.templates.find(t => t.name === body.templateName)
-    const plural = idx.pluralByName.get(body.templateName)
-    if (!tmplListItem || !plural) {
+    const tmpl = idx.templates.find(t => t.name === body.templateName)
+    if (!tmpl || !tmpl.kind) {
       throw <ErrorResponse>{ reason: 'TemplateNotFound', message: 'template ' + body.templateName + ' not found' }
     }
-    const apiVersion = GROUP + '/' + VERSION
-    const cr = buildInstanceBody({ apiVersion, kind: tmplListItem.kind }, body.name, body.values)
-    // Tag with the originating template name so listInstances can
-    // attribute the CR back without a second lookup.
-    cr.metadata.labels['kedge.faros.sh/template'] = body.templateName
-    const created = await kcpFetch<KCPInstance>(
-      'POST',
-      clusterBase() + '/' + plural,
-      cr,
-    )
-    return instanceFromKCP(created, idx.templateByKind)
+    const manifest = buildInstanceManifest(tmpl.kind, body.name, body.templateName, body.values)
+    const created = await applyCR(manifest)
+    return instanceFromObj(created, idx.templateByKind)
   },
 
   async listInstances(): Promise<{ items: Instance[] }> {
     const idx = await getIndex()
-    if (idx.templates.length === 0) return { items: [] }
-    // One LIST per template. Parallel — kcp serves these from the
-    // same workspace so concurrency is cheap. We tolerate per-kind
-    // 404s (CRD not yet established) by treating them as empty.
+    const kinds = [...idx.listFieldByKind.keys()]
+    if (kinds.length === 0) return { items: [] }
+    // One LIST per established kind, in parallel. metadata + status only — the
+    // list view never needs the (arbitrary) spec, so we don't select it.
+    const SEL = 'items { metadata { name namespace creationTimestamp labels } status { phase message conditions { type status reason message lastTransitionTime } } }'
     const lists = await Promise.all(
-      idx.templates.map(async t => {
-        const plural = idx.pluralByName.get(t.name)
-        if (!plural) return [] as KCPInstance[]
+      kinds.map(async kind => {
+        const field = idx.listFieldByKind.get(kind)!
         try {
-          const r = await kcpFetch<KCPList<KCPInstance>>('GET', clusterBase() + '/' + plural)
-          return r.items ?? []
+          const data = await graphqlQuery<Infra<Record<string, { items?: RawObject[] }>>>(
+            `{ ${GROUP_FIELD} { ${VERSION} { ${field} { ${SEL} } } } }`,
+          )
+          return data[GROUP_FIELD]?.[VERSION]?.[field]?.items ?? []
         } catch (e) {
-          const err = e as ErrorResponse
-          if (err.reason === 'InstanceNotFound' || err.reason === 'TemplateNotFound') return []
+          if ((e as ErrorResponse).reason === 'NotFound') return []
           throw e
         }
       }),
     )
-    const items = lists.flat().map(c => instanceFromKCP(c, idx.templateByKind))
+    const items = lists.flat().map(c => instanceFromObj(c, idx.templateByKind))
     return { items }
   },
 
   async getInstance(name: string): Promise<Instance> {
-    // The REST API didn't carry the template name on the URL, so the
-    // only way to resolve a CR by bare name is to probe each Template's
-    // plural. listInstances is too coarse; do parallel GETs and pick
-    // the first 2xx.
+    // The CR's kind isn't on the URL, so probe each established kind's raw
+    // <Kind>Yaml in parallel and take the first hit. Yaml gives the full object
+    // (incl. the arbitrary spec) without needing its schema.
     const idx = await getIndex()
-    const probes = idx.templates.map(async t => {
-      const plural = idx.pluralByName.get(t.name)
-      if (!plural) return null
+    const kinds = [...idx.listFieldByKind.keys()]
+    const probes = kinds.map(async kind => {
       try {
-        return await kcpFetch<KCPInstance>(
-          'GET',
-          clusterBase() + '/' + plural + '/' + encodeURIComponent(name),
+        const data = await graphqlQuery<Infra<Record<string, string>>>(
+          `query($n: String!) { ${GROUP_FIELD} { ${VERSION} { ${kind}Yaml(name: $n) } } }`,
+          { n: name },
         )
+        const text = data[GROUP_FIELD]?.[VERSION]?.[kind + 'Yaml']
+        return text ? (yamlLoad(text) as RawObject) : null
       } catch (e) {
-        const err = e as ErrorResponse
-        if (err.reason === 'InstanceNotFound') return null
+        if ((e as ErrorResponse).reason === 'NotFound') return null
         throw e
       }
     })
     const found = (await Promise.all(probes)).find(Boolean)
-    if (!found) {
-      throw <ErrorResponse>{ reason: 'InstanceNotFound', message: 'instance ' + name + ' not found' }
-    }
-    return instanceFromKCP(found, idx.templateByKind)
+    if (!found) throw <ErrorResponse>{ reason: 'InstanceNotFound', message: 'instance ' + name + ' not found' }
+    return instanceFromObj(found, idx.templateByKind)
   },
 
   async deleteInstance(name: string): Promise<void> {
     const idx = await getIndex()
-    // Resolve which template the CR belongs to: cheap path is a label
-    // lookup via getInstance, since that's a small batch of parallel
-    // probes the browser is fine to pay for.
+    // Resolve which kind the CR is, then delete<Kind>.
     const inst = await this.getInstance(name)
-    const plural = idx.pluralByName.get(inst.template)
-    if (!plural) {
-      throw <ErrorResponse>{ reason: 'InstanceNotFound', message: 'cannot resolve plural for ' + name }
+    const kind = idx.templates.find(t => t.name === inst.template)?.kind
+    if (!kind) {
+      throw <ErrorResponse>{ reason: 'InstanceNotFound', message: 'cannot resolve kind for ' + name }
     }
-    await kcpFetch<unknown>(
-      'DELETE',
-      clusterBase() + '/' + plural + '/' + encodeURIComponent(name),
+    await graphqlQuery(
+      `mutation($n: String!) { ${GROUP_FIELD} { ${VERSION} { delete${kind}(name: $n) } } }`,
+      { n: name },
     )
   },
 }


### PR DESCRIPTION
Removes `kcpFetch` from **both** provider portals; all reads and writes now go through the hub's embedded GraphQL gateway (`/graphql/<cluster>`). Repo-wide `kcpFetch` count is now **0**. Completes the migration started in #258/#259.

## Code provider (`providers/code/portal`)
Reads were already on GraphQL; this converts the writes:
- create/upsert (Connection + token Secret, Repository, DeployKey, Collaborator) → `applyYaml` (server-side create-or-update; idempotent, adopts a leftover Secret).
- connection repoint → `update<Kind>` merge-patch.
- deletes → `delete<Kind>` / `deleteSecret`.
- `kcpFetch`/`apisBase`/`clusterBase` removed; only `oauthConfig` (provider-backend probe) is non-gateway.

## Infrastructure provider (`providers/infrastructure/portal`)
Instances are per-Template CRDs with arbitrary GVKs/schemas, so this needed more:
- **Templates** → typed query; `spec.schema` (preserve-unknown-fields) returns as a JSONString, parsed client-side.
- **Instance list field** (`<Plural>` = `Pluralize(Kind)`, not derivable in JS) → discovered via one cached introspection, scoped to kinds declared by a Template's `instanceCRD.kind` (so `Template` itself and other resources aren't swept in).
- **List** → metadata + status only (the list view never needs the arbitrary spec).
- **getInstance** → the gateway's raw `<Kind>Yaml` escape hatch, parsed with `js-yaml` (new dep) — full object incl. arbitrary spec without knowing its schema.
- **create** → `applyYaml`; **delete** → `delete<Kind>`.

## Testing
- Both portals: `vue-tsc` + `vite build` clean.
- Live-validated every path against the Tilt gateway non-destructively: reads return real data; `applyYaml` round-trips (incl. `metadata.uid`); `update<Kind>`/`delete<Kind>`/`deleteSecret`/`deleteRedisCache` via `dryRun`; Template `schema` and `<Kind>Yaml` parse; instance lists scoped correctly (`RedisCaches`/`SimpleWebApps`, not `Templates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)