### PR TITLE
providers/quickstart: publish to standalone mirror via splitsh-lite

### DIFF
--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -1,0 +1,97 @@
+name: Split quickstart provider
+
+# Publishes providers/quickstart from this monorepo to the standalone,
+# read-only mirror at faroshq/provider-quickstart, preserving git history.
+#
+# Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
+# the same source always splits to the same commit sha1s, so pushes normally
+# fast-forward. Runs on every push to main (mirrors the branch) and on v* tags
+# (mirrors the tag). workflow_dispatch is provided for the initial seed / manual
+# re-sync.
+#
+# Required secret: QUICKSTART_DEPLOY_KEY
+#   An SSH private key whose public half is added as a *write* deploy key on
+#   faroshq/provider-quickstart.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize splits per ref so two runs never race on the same push to the
+# mirror. Do not cancel in-progress runs: a half-completed push is worse than
+# waiting.
+concurrency:
+  group: split-quickstart-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PREFIX: providers/quickstart
+  TARGET_REPO: git@github.com:faroshq/provider-quickstart.git
+  TARGET_BRANCH: main
+  SPLITSH_VERSION: v1.0.1
+
+jobs:
+  split:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          # splitsh-lite needs the complete history to compute the split.
+          fetch-depth: 0
+
+      - name: Install splitsh-lite
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/splitsh/lite/releases/download/${SPLITSH_VERSION}/lite_linux_amd64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" splitsh-lite
+          chmod +x "$HOME/.local/bin/splitsh-lite"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Set up SSH deploy key
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          install -m 600 /dev/null ~/.ssh/id_split
+          echo "${{ secrets.QUICKSTART_DEPLOY_KEY }}" > ~/.ssh/id_split
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<'EOF'
+          Host github.com
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/id_split
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Split and push to mirror
+        run: |
+          set -euo pipefail
+
+          # Deterministic split of the provider subtree. The resulting commit
+          # objects are written into the local object store, so they can be
+          # pushed directly by sha.
+          SHA="$(splitsh-lite --prefix="${PREFIX}" --origin="${GITHUB_SHA}")"
+          echo "Split sha: ${SHA}"
+
+          git remote add mirror "${TARGET_REPO}"
+
+          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            echo "Publishing tag ${TAG} -> ${TARGET_REPO}"
+            # Tags are immutable; push without force so an accidental re-tag fails loudly.
+            git push mirror "${SHA}:refs/tags/${TAG}"
+          else
+            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+            # --force keeps the mirror a faithful reflection even if monorepo
+            # history is ever rewritten. The mirror is read-only, so there are
+            # no downstream commits to clobber.
+            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
+          fi

--- a/docs/provider-publishing.md
+++ b/docs/provider-publishing.md
@@ -1,0 +1,143 @@
+# Publishing providers to standalone mirrors
+
+**Last updated:** 2026-06-11
+
+kedge is a monorepo, but each provider under `providers/` is also published to
+its own standalone, **read-only** GitHub repository. This lets external
+consumers depend on (and browse) a single provider without cloning the whole
+monorepo — the same pattern Kubernetes uses with its
+[`publishing-bot`](https://github.com/kubernetes/publishing-bot) and Symfony/Laravel
+use for their components.
+
+Publishing is done with [splitsh-lite](https://github.com/splitsh/lite), which
+produces a real, **history-preserving** subtree split (not a squashed
+snapshot). splitsh-lite is deterministic: the same source always splits to the
+same commit sha1s, so the mirror is append-only and pushes normally
+fast-forward.
+
+## What is published
+
+| Provider directory          | Mirror repository                | Workflow                                                  |
+| --------------------------- | -------------------------------- | --------------------------------------------------------- |
+| `providers/quickstart`      | `faroshq/provider-quickstart`    | [`.github/workflows/split-quickstart.yaml`](../.github/workflows/split-quickstart.yaml) |
+
+> Only `quickstart` is wired up so far. `code` and `infrastructure` follow the
+> same pattern — see [Adding another provider](#adding-another-provider).
+
+## When it runs
+
+The split workflow triggers on:
+
+- **push to `main`** — mirrors the branch (force-pushed, so the mirror always
+  reflects the monorepo even if history is rewritten).
+- **`v*` tags** — mirrors the tag (non-force; re-tagging fails loudly since
+  tags are immutable).
+- **`workflow_dispatch`** — manual run, used for the initial seed or a manual
+  re-sync.
+
+Runs are serialized per ref (`concurrency` group) and never cancelled
+mid-push.
+
+## One-time setup per mirror
+
+These steps are **manual** and must be done once per provider mirror. They
+require admin on both the monorepo and the target repo.
+
+### 1. Create the target repository
+
+Create the mirror repo (e.g. `faroshq/provider-quickstart`). An empty repo is
+fine — the first run creates the `main` branch.
+
+### 2. Generate an SSH deploy key
+
+```bash
+ssh-keygen -t ed25519 -C "kedge-split-quickstart" -f /tmp/quickstart_split -N ""
+```
+
+This produces a private key (`/tmp/quickstart_split`) and a public key
+(`/tmp/quickstart_split.pub`).
+
+### 3. Add the public key as a write deploy key on the mirror
+
+In **`faroshq/provider-quickstart`** → **Settings → Deploy keys → Add deploy key**:
+
+- Paste the contents of `/tmp/quickstart_split.pub`.
+- **Check "Allow write access".**
+
+A deploy key is scoped to that single repo, which is why we use it instead of a
+broad personal access token.
+
+### 4. Add the private key as a secret on the monorepo
+
+In **`faroshq/kedge`** → **Settings → Secrets and variables → Actions → New repository secret**:
+
+- Name: `QUICKSTART_DEPLOY_KEY`
+- Value: the full contents of `/tmp/quickstart_split` (the private key,
+  including the `-----BEGIN/END-----` lines).
+
+### 5. Seed the mirror
+
+Run the workflow once manually: **Actions → Split quickstart provider → Run
+workflow**. After the first successful run the mirror tracks the monorepo
+automatically.
+
+### 6. Clean up
+
+Delete the local key copies once they are stored in GitHub:
+
+```bash
+rm -f /tmp/quickstart_split /tmp/quickstart_split.pub
+```
+
+## How the split works (internals)
+
+The workflow ([`split-quickstart.yaml`](../.github/workflows/split-quickstart.yaml)):
+
+1. Checks out the monorepo with **full history** (`fetch-depth: 0`) — required
+   for splitsh-lite to compute the subtree.
+2. Downloads the pinned **splitsh-lite `v1.0.1`** prebuilt Linux binary
+   (statically bundles libgit2; `v2.0.0` ships no Linux binary and needs cgo,
+   so we pin `v1.0.1`).
+3. Writes `QUICKSTART_DEPLOY_KEY` to `~/.ssh` and configures `github.com` to
+   use it.
+4. Runs `splitsh-lite --prefix=providers/quickstart --origin=$GITHUB_SHA`,
+   which writes the split commits into the local object store and prints the
+   tip sha.
+5. Pushes that sha to the mirror — to `refs/heads/main` for branch pushes, or
+   `refs/tags/<tag>` for tag pushes.
+
+## Adding another provider
+
+To publish `code` or `infrastructure`, copy the quickstart workflow and change
+three things, then repeat the [one-time setup](#one-time-setup-per-mirror) with
+a new key and secret name:
+
+```yaml
+env:
+  PREFIX: providers/code                          # the subtree to split
+  TARGET_REPO: git@github.com:faroshq/provider-code.git
+  TARGET_BRANCH: main
+  SPLITSH_VERSION: v1.0.1
+# ...and reference a per-mirror secret, e.g. secrets.CODE_DEPLOY_KEY
+```
+
+Use a distinct deploy key + secret per mirror so a leaked key only affects one
+repo. (These can later be collapsed into a single matrix workflow if the list
+grows.)
+
+## Go module paths
+
+A split mirror keeps the monorepo's `go.mod` verbatim, so a provider's module
+path must match its mirror URL for the mirror to be `go get`-able at its own
+path. Each published provider's `go.mod` is therefore declared with the mirror
+path rather than a monorepo-nested path:
+
+| Provider               | `module` declaration in `go.mod`              |
+| ---------------------- | --------------------------------------------- |
+| `providers/quickstart` | `github.com/faroshq/provider-quickstart`      |
+
+This is transparent to the monorepo because `go.work` references providers by
+directory, not by module path. When wiring up a new provider mirror, set its
+`go.mod` module to the mirror URL (e.g. `github.com/faroshq/provider-code`)
+before the first split, and fix up any in-repo imports of that module
+accordingly.

--- a/providers/quickstart/go.mod
+++ b/providers/quickstart/go.mod
@@ -1,3 +1,3 @@
-module github.com/faroshq/faros-kedge/providers/quickstart
+module github.com/faroshq/provider-quickstart
 
 go 1.24


### PR DESCRIPTION
## What

Publishes `providers/quickstart` from this monorepo to the read-only standalone mirror **`faroshq/provider-quickstart`**, preserving git history — the same pattern Kubernetes (`publishing-bot`) and Symfony/Laravel use.

## Changes

- **`.github/workflows/split-quickstart.yaml`** — splits `providers/quickstart` out with [`splitsh-lite`](https://github.com/splitsh/lite) (deterministic, history-preserving — not a squashed snapshot). Triggers on push to `main`, `v*` tags, and `workflow_dispatch`. Authenticates with a per-mirror **SSH deploy key** (`secrets.QUICKSTART_DEPLOY_KEY`). Pinned to splitsh-lite `v1.0.1` (prebuilt Linux binary; `v2.0.0` ships no Linux binary).
- **`providers/quickstart/go.mod`** — module renamed to `github.com/faroshq/provider-quickstart` so the mirror is `go get`-able at its own path. Isolated: no in-repo importers, `go.work` references it by directory.
- **`docs/provider-publishing.md`** — the publishing pattern, one-time setup per mirror (target repo → deploy key → secret → seed → cleanup), internals, how to add `code`/`infrastructure` next, and the module-path table.

## Trigger note

`workflow_dispatch` and the push/tag triggers only become active **once this workflow file is on `main`**. After merge, run **Actions → Split quickstart provider → Run workflow** once to seed the mirror.

## Validated

- Local dry-run (`git subtree split --prefix=providers/quickstart`, equivalent sha1s) produces a clean root with the provider files at top level.
- `go build ./...` passes after the module rename.

## Follow-ups (not in this PR)

- A checked-in `~9 MB` `providers/quickstart/quickstart` binary will be mirrored; consider `.gitignore` + `git rm`.
- `code` and `infrastructure` mirrors follow the same template (new module paths + per-mirror deploy keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)