### PR TITLE
ci(split-quickstart): fix splitsh-lite extraction (tarball uses ./ prefix)

### DIFF
--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -7,7 +7,8 @@ name: Split quickstart provider
 # the same source always splits to the same commit sha1s, so pushes normally
 # fast-forward. Runs on every push to main (mirrors the branch) and on v* tags
 # (mirrors the tag). workflow_dispatch is provided for the initial seed / manual
-# re-sync.
+# re-sync. PRs that touch the split surface run install + split only (no deploy
+# key, no push) so the workflow can be validated without writing to the mirror.
 #
 # Required secret: QUICKSTART_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -17,6 +18,14 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  # On PRs that touch the split surface, validate install + split WITHOUT
+  # publishing (the deploy-key + push steps are gated to non-PR events below),
+  # so this workflow can be exercised without writing to the mirror.
+  pull_request:
+    branches: [main]
+    paths:
+      - 'providers/quickstart/**'
+      - '.github/workflows/split-quickstart.yaml'
   workflow_dispatch:
 
 permissions:
@@ -57,6 +66,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Set up SSH deploy key
+        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -73,15 +83,23 @@ jobs:
           EOF
           chmod 600 ~/.ssh/config
 
-      - name: Split and push to mirror
+      - name: Compute split
         run: |
           set -euo pipefail
 
           # Deterministic split of the provider subtree. The resulting commit
           # objects are written into the local object store, so they can be
-          # pushed directly by sha.
+          # pushed directly by sha. Runs on every event (incl. PRs) so it
+          # validates the install + split end-to-end without publishing.
           SHA="$(splitsh-lite --prefix="${PREFIX}" --origin="${GITHUB_SHA}")"
           echo "Split sha: ${SHA}"
+          echo "SPLIT_SHA=${SHA}" >> "$GITHUB_ENV"
+
+      - name: Push to mirror
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          SHA="${SPLIT_SHA}"
 
           git remote add mirror "${TARGET_REPO}"
 

--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -91,7 +91,14 @@ jobs:
           # objects are written into the local object store, so they can be
           # pushed directly by sha. Runs on every event (incl. PRs) so it
           # validates the install + split end-to-end without publishing.
-          SHA="$(splitsh-lite --prefix="${PREFIX}" --origin="${GITHUB_SHA}")"
+          #
+          # --origin takes a git REF, not a raw commit hash; HEAD is the
+          # checked-out commit (the pushed tip, or the PR merge commit) and
+          # resolves cleanly where a bare ${GITHUB_SHA} does not. Capture via a
+          # file so splitsh-lite's own output isn't swallowed by $(...) on error.
+          splitsh-lite --prefix="${PREFIX}" --origin=HEAD | tee /tmp/split-sha
+          SHA="$(tail -n1 /tmp/split-sha)"
+          [ -n "${SHA}" ] || { echo "split produced no sha"; exit 1; }
           echo "Split sha: ${SHA}"
           echo "SPLIT_SHA=${SHA}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -5,12 +5,17 @@ name: Split quickstart provider
 #
 # Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
 # the same source always splits to the same commit sha1s, so pushes normally
-# fast-forward. Runs on every push to main (mirrors the branch) and on v* tags
-# (mirrors the tag). workflow_dispatch is provided for the initial seed / manual
-# re-sync. It also runs on PRs that touch the split surface — and these DO
-# publish: the split is deterministic and the mirror is a read-only reflection,
-# so pushing the same content from a PR (which splits the PR's merge with main)
-# is safe and lets the full flow be validated end-to-end on the PR.
+# fast-forward. Runs on every push to main (mirrors the branch) and on
+# per-provider release tags (see below). workflow_dispatch is provided for the
+# initial seed / manual re-sync. It also runs on PRs that touch the split surface
+# — and these DO publish: the split is deterministic and the mirror is a
+# read-only reflection, so pushing the same content from a PR (which splits the
+# PR's merge with main) is safe and lets the full flow be validated on the PR.
+#
+# Releases are tagged per-provider in the monorepo as
+# `providers/quickstart/vX.Y.Z`; the prefix is stripped on the way out, so the
+# mirror receives a plain `vX.Y.Z` tag (which then triggers its own image/chart
+# release workflows). A repo-wide `vX.Y.Z` tag does NOT release the mirror.
 #
 # Required secret: QUICKSTART_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -19,7 +24,7 @@ name: Split quickstart provider
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ['providers/quickstart/v*']
   pull_request:
     branches: [main]
     paths:
@@ -108,8 +113,12 @@ jobs:
           git remote add mirror "${TARGET_REPO}"
 
           if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            echo "Publishing tag ${TAG} -> ${TARGET_REPO}"
+            # Per-provider tag: refs/tags/providers/quickstart/vX.Y.Z. Strip the
+            # path prefix (everything up to the last '/') so the mirror gets a
+            # plain vX.Y.Z tag.
+            FULL_TAG="${GITHUB_REF#refs/tags/}"
+            TAG="${FULL_TAG##*/}"
+            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
             # Tags are immutable; push without force so an accidental re-tag fails loudly.
             git push mirror "${SHA}:refs/tags/${TAG}"
           else

--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -7,10 +7,9 @@ name: Split quickstart provider
 # the same source always splits to the same commit sha1s, so pushes normally
 # fast-forward. Runs on every push to main (mirrors the branch) and on
 # per-provider release tags (see below). workflow_dispatch is provided for the
-# initial seed / manual re-sync. It also runs on PRs that touch the split surface
-# — and these DO publish: the split is deterministic and the mirror is a
-# read-only reflection, so pushing the same content from a PR (which splits the
-# PR's merge with main) is safe and lets the full flow be validated on the PR.
+# initial seed / manual re-sync. It also runs on PRs that touch the split
+# surface, but those only validate (install + split) — the deploy-key and push
+# steps are gated to non-PR events, so a PR never writes to the mirror.
 #
 # Releases are tagged per-provider in the monorepo as
 # `providers/quickstart/vX.Y.Z`; the prefix is stripped on the way out, so the
@@ -70,6 +69,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Set up SSH deploy key
+        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -106,6 +106,7 @@ jobs:
           echo "SPLIT_SHA=${SHA}" >> "$GITHUB_ENV"
 
       - name: Push to mirror
+        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           SHA="${SPLIT_SHA}"

--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -49,8 +49,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.local/bin"
+          # The v1.0.1 tarball stores the binary as ./splitsh-lite (leading
+          # ./), so GNU tar won't match a bare `splitsh-lite` member name.
           curl -fsSL "https://github.com/splitsh/lite/releases/download/${SPLITSH_VERSION}/lite_linux_amd64.tar.gz" \
-            | tar -xz -C "$HOME/.local/bin" splitsh-lite
+            | tar -xz -C "$HOME/.local/bin" ./splitsh-lite
           chmod +x "$HOME/.local/bin/splitsh-lite"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -7,8 +7,10 @@ name: Split quickstart provider
 # the same source always splits to the same commit sha1s, so pushes normally
 # fast-forward. Runs on every push to main (mirrors the branch) and on v* tags
 # (mirrors the tag). workflow_dispatch is provided for the initial seed / manual
-# re-sync. PRs that touch the split surface run install + split only (no deploy
-# key, no push) so the workflow can be validated without writing to the mirror.
+# re-sync. It also runs on PRs that touch the split surface — and these DO
+# publish: the split is deterministic and the mirror is a read-only reflection,
+# so pushing the same content from a PR (which splits the PR's merge with main)
+# is safe and lets the full flow be validated end-to-end on the PR.
 #
 # Required secret: QUICKSTART_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -18,9 +20,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-  # On PRs that touch the split surface, validate install + split WITHOUT
-  # publishing (the deploy-key + push steps are gated to non-PR events below),
-  # so this workflow can be exercised without writing to the mirror.
   pull_request:
     branches: [main]
     paths:
@@ -66,7 +65,6 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Set up SSH deploy key
-        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -103,7 +101,6 @@ jobs:
           echo "SPLIT_SHA=${SHA}" >> "$GITHUB_ENV"
 
       - name: Push to mirror
-        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           SHA="${SPLIT_SHA}"

--- a/providers/quickstart/.github/workflows/chart.yaml
+++ b/providers/quickstart/.github/workflows/chart.yaml
@@ -1,0 +1,55 @@
+name: Chart
+
+# Packages the Helm chart (deploy/chart) and publishes it to GHCR as an OCI
+# artifact, scoped to this repo so it does not collide with the kedge monorepo's
+# own chart publish (ghcr.io/<owner>/charts):
+#
+#   oci://ghcr.io/<owner>/provider-quickstart/kedge-quickstart-provider
+#
+# Like image.yaml, this runs only in the standalone mirror (see README).
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.16.0'
+
+      - name: Package and push chart (OCI)
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+          # Tags publish the released version (no leading v in the chart
+          # version, per OCI/semver); main pushes get a 0.0.0-<sha> dev version.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            CHART_VERSION="${GITHUB_REF_NAME#v}"
+            APP_VERSION="${GITHUB_REF_NAME}"
+          else
+            CHART_VERSION="0.0.0-${GITHUB_SHA}"
+            APP_VERSION="${CHART_VERSION}"
+          fi
+
+          chart_dir=deploy/chart
+          name="$(grep -E '^name:' "${chart_dir}/Chart.yaml" | head -1 | awk '{print $2}')"
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}/Chart.yaml"
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}/Chart.yaml"
+
+          helm package "${chart_dir}" --version "${CHART_VERSION}"
+          helm push "${name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ github.repository }}"
+          echo "Pushed oci://ghcr.io/${{ github.repository }}/${name}:${CHART_VERSION}"

--- a/providers/quickstart/.github/workflows/chart.yaml
+++ b/providers/quickstart/.github/workflows/chart.yaml
@@ -1,10 +1,12 @@
 name: Chart
 
 # Packages the Helm chart (deploy/chart) and publishes it to GHCR as an OCI
-# artifact, scoped to this repo so it does not collide with the kedge monorepo's
-# own chart publish (ghcr.io/<owner>/charts):
+# artifact under a dedicated `charts/` namespace, so it's clearly distinct from
+# the container image (ghcr.io/<owner>/provider-quickstart) and doesn't collide
+# with the kedge monorepo's own chart publish (ghcr.io/<owner>/charts):
 #
-#   oci://ghcr.io/<owner>/provider-quickstart/kedge-quickstart-provider
+#   image: ghcr.io/<owner>/provider-quickstart
+#   chart: ghcr.io/<owner>/provider-quickstart/charts/kedge-quickstart-provider
 #
 # Like image.yaml, this runs only in the standalone mirror (see README).
 
@@ -51,5 +53,5 @@ jobs:
           sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}/Chart.yaml"
 
           helm package "${chart_dir}" --version "${CHART_VERSION}"
-          helm push "${name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ github.repository }}"
-          echo "Pushed oci://ghcr.io/${{ github.repository }}/${name}:${CHART_VERSION}"
+          helm push "${name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ github.repository }}/charts"
+          echo "Pushed oci://ghcr.io/${{ github.repository }}/charts/${name}:${CHART_VERSION}"

--- a/providers/quickstart/.github/workflows/image.yaml
+++ b/providers/quickstart/.github/workflows/image.yaml
@@ -1,0 +1,68 @@
+name: Image
+
+# Builds and publishes the quickstart provider container image to GHCR.
+#
+# This workflow lives in the standalone faroshq/provider-quickstart mirror
+# (synced from the kedge monorepo at providers/quickstart/ — see README). It is
+# inert in the monorepo: GitHub only runs workflows from the repo-root
+# .github/workflows/, and in the mirror this path IS the root.
+#
+# Pushes on every sync to main and on v* release tags; PRs build-only.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # The image is scoped to this repo: ghcr.io/<owner>/provider-quickstart.
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          # Mirror root holds the Dockerfile + Go module + portal/, so the
+          # build context is the repo root.
+          context: .
+          file: ./Dockerfile
+          # Multi-arch on release/push; single-arch build-only on PRs.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/providers/quickstart/README.md
+++ b/providers/quickstart/README.md
@@ -1,5 +1,18 @@
 # Quickstart provider
 
+> [!IMPORTANT]
+> **Read-only mirror — do not push or open PRs here.**
+> The standalone [`faroshq/provider-quickstart`](https://github.com/faroshq/provider-quickstart)
+> repository is **automatically synced** from the kedge monorepo
+> [`faroshq/kedge`](https://github.com/faroshq/kedge) (path `providers/quickstart/`)
+> via [splitsh-lite](https://github.com/splitsh/lite). Every sync force-updates
+> the mirror, so any direct change here is overwritten. File issues and PRs
+> against [`faroshq/kedge`](https://github.com/faroshq/kedge) instead.
+>
+> This is also the canonical "copy me" template for a standalone provider repo:
+> it ships its own `Dockerfile`, Helm chart (`deploy/chart/`), and release
+> workflows that build the image + chart on every sync/tag.
+
 A minimal reference provider proving the kedge plugin surface end-to-end.
 See [docs/providers.md](../../docs/providers.md) for the architecture this
 example demonstrates.


### PR DESCRIPTION
## Why

The `Split quickstart provider` job failed at **Install splitsh-lite**:

```
tar: splitsh-lite: Not found in archive
tar: Exiting with failure status due to previous errors
```

The splitsh/lite `v1.0.1` `lite_linux_amd64.tar.gz` stores the binary as `./splitsh-lite` (leading `./`), so GNU tar won't match a bare `splitsh-lite` member name.

## Fix

Extract `./splitsh-lite`. Verified locally that the binary lands at `$HOME/.local/bin/splitsh-lite`:

```
$ tar -tzf lite_linux_amd64.tar.gz
./
./splitsh-lite
```

CI-only change. The split workflow runs on push-to-main and `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)