### PR TITLE
providers: publish code + infrastructure to standalone mirrors

### DIFF
--- a/.github/workflows/split-code.yaml
+++ b/.github/workflows/split-code.yaml
@@ -1,0 +1,132 @@
+name: Split code provider
+
+# Publishes providers/code from this monorepo to the standalone,
+# read-only mirror at faroshq/provider-code, preserving git history.
+#
+# Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
+# the same source always splits to the same commit sha1s, so pushes normally
+# fast-forward. Runs on every push to main (mirrors the branch) and on
+# per-provider release tags (see below). workflow_dispatch is provided for the
+# initial seed / manual re-sync. It also runs on PRs that touch the split
+# surface, but those only validate (install + split) — the deploy-key and push
+# steps are gated to non-PR events, so a PR never writes to the mirror.
+#
+# Releases are tagged per-provider in the monorepo as
+# `providers/code/vX.Y.Z`; the prefix is stripped on the way out, so the
+# mirror receives a plain `vX.Y.Z` tag (which then triggers its own image/chart
+# release workflows). A repo-wide `vX.Y.Z` tag does NOT release the mirror.
+#
+# Required secret: CODE_DEPLOY_KEY
+#   An SSH private key whose public half is added as a *write* deploy key on
+#   faroshq/provider-code. (A deploy key is scoped to one repo, so this is a
+#   distinct key from the other provider mirrors.)
+
+on:
+  push:
+    branches: [main]
+    tags: ['providers/code/v*']
+  pull_request:
+    branches: [main]
+    paths:
+      - 'providers/code/**'
+      - '.github/workflows/split-code.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize splits per ref so two runs never race on the same push to the
+# mirror. Do not cancel in-progress runs: a half-completed push is worse than
+# waiting.
+concurrency:
+  group: split-code-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PREFIX: providers/code
+  TARGET_REPO: git@github.com:faroshq/provider-code.git
+  TARGET_BRANCH: main
+  SPLITSH_VERSION: v1.0.1
+
+jobs:
+  split:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          # splitsh-lite needs the complete history to compute the split.
+          fetch-depth: 0
+
+      - name: Install splitsh-lite
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          # The v1.0.1 tarball stores the binary as ./splitsh-lite (leading
+          # ./), so GNU tar won't match a bare `splitsh-lite` member name.
+          curl -fsSL "https://github.com/splitsh/lite/releases/download/${SPLITSH_VERSION}/lite_linux_amd64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" ./splitsh-lite
+          chmod +x "$HOME/.local/bin/splitsh-lite"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Set up SSH deploy key
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          install -m 600 /dev/null ~/.ssh/id_split
+          echo "${{ secrets.CODE_DEPLOY_KEY }}" > ~/.ssh/id_split
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<'EOF'
+          Host github.com
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/id_split
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Compute split
+        run: |
+          set -euo pipefail
+
+          # Deterministic split of the provider subtree. The resulting commit
+          # objects are written into the local object store, so they can be
+          # pushed directly by sha. Runs on every event (incl. PRs) so it
+          # validates the install + split end-to-end without publishing.
+          #
+          # --origin takes a git REF, not a raw commit hash; HEAD is the
+          # checked-out commit (the pushed tip, or the PR merge commit) and
+          # resolves cleanly where a bare ${GITHUB_SHA} does not. Capture via a
+          # file so splitsh-lite's own output isn't swallowed by $(...) on error.
+          splitsh-lite --prefix="${PREFIX}" --origin=HEAD | tee /tmp/split-sha
+          SHA="$(tail -n1 /tmp/split-sha)"
+          [ -n "${SHA}" ] || { echo "split produced no sha"; exit 1; }
+          echo "Split sha: ${SHA}"
+          echo "SPLIT_SHA=${SHA}" >> "$GITHUB_ENV"
+
+      - name: Push to mirror
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          SHA="${SPLIT_SHA}"
+
+          git remote add mirror "${TARGET_REPO}"
+
+          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
+            # Per-provider tag: refs/tags/providers/code/vX.Y.Z. Strip the
+            # path prefix (everything up to the last '/') so the mirror gets a
+            # plain vX.Y.Z tag.
+            FULL_TAG="${GITHUB_REF#refs/tags/}"
+            TAG="${FULL_TAG##*/}"
+            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
+            # Tags are immutable; push without force so an accidental re-tag fails loudly.
+            git push mirror "${SHA}:refs/tags/${TAG}"
+          else
+            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+            # --force keeps the mirror a faithful reflection even if monorepo
+            # history is ever rewritten. The mirror is read-only, so there are
+            # no downstream commits to clobber.
+            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
+          fi

--- a/.github/workflows/split-infrastructure.yaml
+++ b/.github/workflows/split-infrastructure.yaml
@@ -1,0 +1,133 @@
+name: Split infrastructure provider
+
+# Publishes providers/infrastructure from this monorepo to the standalone,
+# read-only mirror at faroshq/provider-infrastructure, preserving git history.
+#
+# Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
+# the same source always splits to the same commit sha1s, so pushes normally
+# fast-forward. Runs on every push to main (mirrors the branch) and on
+# per-provider release tags (see below). workflow_dispatch is provided for the
+# initial seed / manual re-sync. It also runs on PRs that touch the split
+# surface, but those only validate (install + split) — the deploy-key and push
+# steps are gated to non-PR events, so a PR never writes to the mirror.
+#
+# Releases are tagged per-provider in the monorepo as
+# `providers/infrastructure/vX.Y.Z`; the prefix is stripped on the way out, so
+# the mirror receives a plain `vX.Y.Z` tag (which then triggers its own
+# image/chart release workflows). A repo-wide `vX.Y.Z` tag does NOT release the
+# mirror.
+#
+# Required secret: INFRA_DEPLOY_KEY
+#   An SSH private key whose public half is added as a *write* deploy key on
+#   faroshq/provider-infrastructure. (A deploy key is scoped to one repo, so
+#   this is a distinct key from the other provider mirrors.)
+
+on:
+  push:
+    branches: [main]
+    tags: ['providers/infrastructure/v*']
+  pull_request:
+    branches: [main]
+    paths:
+      - 'providers/infrastructure/**'
+      - '.github/workflows/split-infrastructure.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize splits per ref so two runs never race on the same push to the
+# mirror. Do not cancel in-progress runs: a half-completed push is worse than
+# waiting.
+concurrency:
+  group: split-infrastructure-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PREFIX: providers/infrastructure
+  TARGET_REPO: git@github.com:faroshq/provider-infrastructure.git
+  TARGET_BRANCH: main
+  SPLITSH_VERSION: v1.0.1
+
+jobs:
+  split:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          # splitsh-lite needs the complete history to compute the split.
+          fetch-depth: 0
+
+      - name: Install splitsh-lite
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          # The v1.0.1 tarball stores the binary as ./splitsh-lite (leading
+          # ./), so GNU tar won't match a bare `splitsh-lite` member name.
+          curl -fsSL "https://github.com/splitsh/lite/releases/download/${SPLITSH_VERSION}/lite_linux_amd64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" ./splitsh-lite
+          chmod +x "$HOME/.local/bin/splitsh-lite"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Set up SSH deploy key
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          install -m 600 /dev/null ~/.ssh/id_split
+          echo "${{ secrets.INFRA_DEPLOY_KEY }}" > ~/.ssh/id_split
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<'EOF'
+          Host github.com
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/id_split
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Compute split
+        run: |
+          set -euo pipefail
+
+          # Deterministic split of the provider subtree. The resulting commit
+          # objects are written into the local object store, so they can be
+          # pushed directly by sha. Runs on every event (incl. PRs) so it
+          # validates the install + split end-to-end without publishing.
+          #
+          # --origin takes a git REF, not a raw commit hash; HEAD is the
+          # checked-out commit (the pushed tip, or the PR merge commit) and
+          # resolves cleanly where a bare ${GITHUB_SHA} does not. Capture via a
+          # file so splitsh-lite's own output isn't swallowed by $(...) on error.
+          splitsh-lite --prefix="${PREFIX}" --origin=HEAD | tee /tmp/split-sha
+          SHA="$(tail -n1 /tmp/split-sha)"
+          [ -n "${SHA}" ] || { echo "split produced no sha"; exit 1; }
+          echo "Split sha: ${SHA}"
+          echo "SPLIT_SHA=${SHA}" >> "$GITHUB_ENV"
+
+      - name: Push to mirror
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          SHA="${SPLIT_SHA}"
+
+          git remote add mirror "${TARGET_REPO}"
+
+          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
+            # Per-provider tag: refs/tags/providers/infrastructure/vX.Y.Z. Strip
+            # the path prefix (everything up to the last '/') so the mirror gets
+            # a plain vX.Y.Z tag.
+            FULL_TAG="${GITHUB_REF#refs/tags/}"
+            TAG="${FULL_TAG##*/}"
+            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
+            # Tags are immutable; push without force so an accidental re-tag fails loudly.
+            git push mirror "${SHA}:refs/tags/${TAG}"
+          else
+            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+            # --force keeps the mirror a faithful reflection even if monorepo
+            # history is ever rewritten. The mirror is read-only, so there are
+            # no downstream commits to clobber.
+            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
+          fi

--- a/docs/provider-publishing.md
+++ b/docs/provider-publishing.md
@@ -17,12 +17,16 @@ fast-forward.
 
 ## What is published
 
-| Provider directory          | Mirror repository                | Workflow                                                  |
-| --------------------------- | -------------------------------- | --------------------------------------------------------- |
-| `providers/quickstart`      | `faroshq/provider-quickstart`    | [`.github/workflows/split-quickstart.yaml`](../.github/workflows/split-quickstart.yaml) |
+| Provider directory          | Mirror repository                  | Secret                  | Workflow                                                  |
+| --------------------------- | ---------------------------------- | ----------------------- | -------------------------------------------------------- |
+| `providers/quickstart`      | `faroshq/provider-quickstart`      | `QUICKSTART_DEPLOY_KEY` | [`split-quickstart.yaml`](../.github/workflows/split-quickstart.yaml) |
+| `providers/code`            | `faroshq/provider-code`            | `CODE_DEPLOY_KEY`       | [`split-code.yaml`](../.github/workflows/split-code.yaml) |
+| `providers/infrastructure`  | `faroshq/provider-infrastructure`  | `INFRA_DEPLOY_KEY`      | [`split-infrastructure.yaml`](../.github/workflows/split-infrastructure.yaml) |
 
-> Only `quickstart` is wired up so far. `code` and `infrastructure` follow the
-> same pattern — see [Adding another provider](#adding-another-provider).
+Each provider has its own workflow (identical except for the four `env:` values
+and the `secrets.*` reference) and its own deploy key — a GitHub deploy key is
+scoped to a single repo, so the keys **cannot** be shared across mirrors. See
+[Adding another provider](#adding-another-provider) for the generic pattern.
 
 ## When it runs
 
@@ -30,8 +34,15 @@ The split workflow triggers on:
 
 - **push to `main`** — mirrors the branch (force-pushed, so the mirror always
   reflects the monorepo even if history is rewritten).
-- **`v*` tags** — mirrors the tag (non-force; re-tagging fails loudly since
-  tags are immutable).
+- **per-provider release tags** — `providers/<name>/vX.Y.Z`. The path prefix is
+  stripped on the way out, so the mirror receives a plain `vX.Y.Z` tag (which
+  then triggers the mirror's own image/chart release workflows). Pushed
+  non-force, so re-tagging fails loudly since tags are immutable. A repo-wide
+  `vX.Y.Z` tag does **not** release any mirror.
+- **pull requests** touching the provider's subtree (or its workflow file) —
+  these only *validate* (install splitsh-lite + compute the split); the
+  deploy-key and push steps are gated to non-PR events, so a PR never writes to
+  a mirror.
 - **`workflow_dispatch`** — manual run, used for the initial seed or a manual
   re-sync.
 
@@ -41,27 +52,35 @@ mid-push.
 ## One-time setup per mirror
 
 These steps are **manual** and must be done once per provider mirror. They
-require admin on both the monorepo and the target repo.
+require admin on both the monorepo and the target repo. Substitute the
+provider's values from the [What is published](#what-is-published) table for
+`<name>` (e.g. `quickstart`), the mirror repo, and the secret name.
+
+> **Each mirror needs its own deploy key.** A GitHub deploy key (the public
+> half) can be registered on only one repository — adding a key that is already
+> a deploy key on another repo fails with *"Key is already in use."* So you
+> cannot reuse one key across `provider-quickstart`, `provider-code`, and
+> `provider-infrastructure`; generate a fresh key per mirror.
 
 ### 1. Create the target repository
 
-Create the mirror repo (e.g. `faroshq/provider-quickstart`). An empty repo is
+Create the mirror repo (e.g. `faroshq/provider-code`). An empty repo is
 fine — the first run creates the `main` branch.
 
 ### 2. Generate an SSH deploy key
 
 ```bash
-ssh-keygen -t ed25519 -C "kedge-split-quickstart" -f /tmp/quickstart_split -N ""
+ssh-keygen -t ed25519 -C "kedge-split-<name>" -f /tmp/<name>_split -N ""
 ```
 
-This produces a private key (`/tmp/quickstart_split`) and a public key
-(`/tmp/quickstart_split.pub`).
+This produces a private key (`/tmp/<name>_split`) and a public key
+(`/tmp/<name>_split.pub`).
 
 ### 3. Add the public key as a write deploy key on the mirror
 
-In **`faroshq/provider-quickstart`** → **Settings → Deploy keys → Add deploy key**:
+In **the mirror repo** → **Settings → Deploy keys → Add deploy key**:
 
-- Paste the contents of `/tmp/quickstart_split.pub`.
+- Paste the contents of `/tmp/<name>_split.pub`.
 - **Check "Allow write access".**
 
 A deploy key is scoped to that single repo, which is why we use it instead of a
@@ -71,13 +90,13 @@ broad personal access token.
 
 In **`faroshq/kedge`** → **Settings → Secrets and variables → Actions → New repository secret**:
 
-- Name: `QUICKSTART_DEPLOY_KEY`
-- Value: the full contents of `/tmp/quickstart_split` (the private key,
+- Name: the provider's secret from the table (e.g. `CODE_DEPLOY_KEY`).
+- Value: the full contents of `/tmp/<name>_split` (the private key,
   including the `-----BEGIN/END-----` lines).
 
 ### 5. Seed the mirror
 
-Run the workflow once manually: **Actions → Split quickstart provider → Run
+Run the workflow once manually: **Actions → Split \<name> provider → Run
 workflow**. After the first successful run the mirror tracks the monorepo
 automatically.
 
@@ -86,44 +105,60 @@ automatically.
 Delete the local key copies once they are stored in GitHub:
 
 ```bash
-rm -f /tmp/quickstart_split /tmp/quickstart_split.pub
+rm -f /tmp/<name>_split /tmp/<name>_split.pub
 ```
 
 ## How the split works (internals)
 
-The workflow ([`split-quickstart.yaml`](../.github/workflows/split-quickstart.yaml)):
+Each split workflow (e.g. [`split-code.yaml`](../.github/workflows/split-code.yaml)):
 
 1. Checks out the monorepo with **full history** (`fetch-depth: 0`) — required
    for splitsh-lite to compute the subtree.
 2. Downloads the pinned **splitsh-lite `v1.0.1`** prebuilt Linux binary
    (statically bundles libgit2; `v2.0.0` ships no Linux binary and needs cgo,
-   so we pin `v1.0.1`).
-3. Writes `QUICKSTART_DEPLOY_KEY` to `~/.ssh` and configures `github.com` to
-   use it.
-4. Runs `splitsh-lite --prefix=providers/quickstart --origin=$GITHUB_SHA`,
-   which writes the split commits into the local object store and prints the
-   tip sha.
-5. Pushes that sha to the mirror — to `refs/heads/main` for branch pushes, or
-   `refs/tags/<tag>` for tag pushes.
+   so we pin `v1.0.1`). The `v1.0.1` tarball stores the binary as
+   `./splitsh-lite` (leading `./`), so the extraction names it explicitly.
+3. On non-PR events, writes the provider's deploy-key secret to `~/.ssh` and
+   configures `github.com` to use it. (On PRs this step is skipped.)
+4. Runs `splitsh-lite --prefix=providers/<name> --origin=HEAD`, which writes the
+   split commits into the local object store and prints the tip sha. This runs
+   on **every** event (PRs included) so it validates the install + split
+   end-to-end without publishing. `--origin` takes a git ref, and `HEAD`
+   resolves cleanly for both branch pushes and PR merge commits.
+5. On non-PR events, pushes that sha to the mirror — to `refs/heads/main` for
+   branch pushes (force), or `refs/tags/vX.Y.Z` for tag pushes (non-force,
+   prefix stripped from `providers/<name>/vX.Y.Z`).
 
 ## Adding another provider
 
-To publish `code` or `infrastructure`, copy the quickstart workflow and change
-three things, then repeat the [one-time setup](#one-time-setup-per-mirror) with
-a new key and secret name:
+All three current providers (`quickstart`, `code`, `infrastructure`) are wired
+up. To publish a new one, copy any existing split workflow (they are identical
+apart from four `env:` values, the trigger paths/tags, the concurrency group,
+and the `secrets.*` reference) and change:
 
 ```yaml
+name: Split <name> provider
+on:
+  push:
+    tags: ['providers/<name>/v*']
+  pull_request:
+    paths:
+      - 'providers/<name>/**'
+      - '.github/workflows/split-<name>.yaml'
+concurrency:
+  group: split-<name>-${{ github.ref }}
 env:
-  PREFIX: providers/code                          # the subtree to split
-  TARGET_REPO: git@github.com:faroshq/provider-code.git
+  PREFIX: providers/<name>                         # the subtree to split
+  TARGET_REPO: git@github.com:faroshq/provider-<name>.git
   TARGET_BRANCH: main
   SPLITSH_VERSION: v1.0.1
-# ...and reference a per-mirror secret, e.g. secrets.CODE_DEPLOY_KEY
+# ...and reference a per-mirror secret, e.g. secrets.<NAME>_DEPLOY_KEY
 ```
 
-Use a distinct deploy key + secret per mirror so a leaked key only affects one
-repo. (These can later be collapsed into a single matrix workflow if the list
-grows.)
+Then repeat the [one-time setup](#one-time-setup-per-mirror) with a fresh key
+and secret name. Use a distinct deploy key + secret per mirror so a leaked key
+only affects one repo. (These can later be collapsed into a single matrix
+workflow if the list grows.)
 
 ## Go module paths
 
@@ -132,12 +167,15 @@ path must match its mirror URL for the mirror to be `go get`-able at its own
 path. Each published provider's `go.mod` is therefore declared with the mirror
 path rather than a monorepo-nested path:
 
-| Provider               | `module` declaration in `go.mod`              |
-| ---------------------- | --------------------------------------------- |
-| `providers/quickstart` | `github.com/faroshq/provider-quickstart`      |
+| Provider                   | `module` declaration in `go.mod`              |
+| -------------------------- | --------------------------------------------- |
+| `providers/quickstart`     | `github.com/faroshq/provider-quickstart`      |
+| `providers/code`           | `github.com/faroshq/provider-code`            |
+| `providers/infrastructure` | `github.com/faroshq/provider-infrastructure`  |
 
 This is transparent to the monorepo because `go.work` references providers by
-directory, not by module path. When wiring up a new provider mirror, set its
-`go.mod` module to the mirror URL (e.g. `github.com/faroshq/provider-code`)
-before the first split, and fix up any in-repo imports of that module
-accordingly.
+directory, not by module path, and no other monorepo module imports these
+provider modules. When wiring up a new provider mirror, set its `go.mod` module
+to the mirror URL (e.g. `github.com/faroshq/provider-code`) before the first
+split, and fix up the provider's own in-repo imports of that module path
+accordingly (`code` and `infrastructure` each had ~17 self-imports to rewrite).

--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -1,5 +1,16 @@
 # code provider
 
+> [!IMPORTANT]
+> **Read-only mirror — do not push or open PRs here.**
+> The standalone [`faroshq/provider-code`](https://github.com/faroshq/provider-code)
+> repository is **automatically synced** from the kedge monorepo
+> [`faroshq/kedge`](https://github.com/faroshq/kedge) (path `providers/code/`)
+> via [splitsh-lite](https://github.com/splitsh/lite). Every sync force-updates
+> the mirror, so any direct change here is overwritten. File issues and PRs
+> against [`faroshq/kedge`](https://github.com/faroshq/kedge) instead.
+> See [docs/provider-publishing.md](../../docs/provider-publishing.md) for how
+> the mirror is published.
+
 A kedge provider that manages source-code repositories and their access —
 deploy keys, collaborators, and (read-only) published packages — across git
 hosting providers (**GitHub** today) on behalf of kedge tenants. A tenant adds a

--- a/providers/code/backend/github/backend.go
+++ b/providers/code/backend/github/backend.go
@@ -30,8 +30,8 @@ import (
 	gogithub "github.com/google/go-github/v66/github"
 	"golang.org/x/oauth2"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
 )
 
 // Backend is the GitHub implementation of backend.GitBackend.

--- a/providers/code/backend/interface.go
+++ b/providers/code/backend/interface.go
@@ -30,7 +30,7 @@ import (
 	"sort"
 	"sync"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
 )
 
 // Credential is the resolved secret material a GitBackend authenticates with.

--- a/providers/code/backend/stub/stub.go
+++ b/providers/code/backend/stub/stub.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"fmt"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
 )
 
 // Backend is the canned-success stub. The Seen* fields let tests assert which

--- a/providers/code/controller/collaborator/controller.go
+++ b/providers/code/controller/collaborator/controller.go
@@ -28,9 +28,9 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/controller/shared"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/controller/shared"
 )
 
 // Reconciler manages Collaborator CRs.

--- a/providers/code/controller/connection/controller.go
+++ b/providers/code/controller/connection/controller.go
@@ -28,9 +28,9 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/controller/shared"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/controller/shared"
 )
 
 // Reconciler validates Connection credentials against the git host.

--- a/providers/code/controller/deploykey/controller.go
+++ b/providers/code/controller/deploykey/controller.go
@@ -33,10 +33,10 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/controller/shared"
-	"github.com/faroshq/faros-kedge/providers/code/tenant"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/controller/shared"
+	"github.com/faroshq/provider-code/tenant"
 )
 
 // secretDataKeyPrivate / secretDataKeyPublic are the Secret data keys the

--- a/providers/code/controller/packages/controller.go
+++ b/providers/code/controller/packages/controller.go
@@ -40,9 +40,9 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/controller/shared"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/controller/shared"
 )
 
 // defaultCrawlInterval is how often each Repository is re-crawled for packages.

--- a/providers/code/controller/packages/controller_test.go
+++ b/providers/code/controller/packages/controller_test.go
@@ -20,9 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	codescheme "github.com/faroshq/faros-kedge/providers/code/scheme"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	codescheme "github.com/faroshq/provider-code/scheme"
 )
 
 func testRepo() *codev1alpha1.Repository {

--- a/providers/code/controller/repository/controller.go
+++ b/providers/code/controller/repository/controller.go
@@ -27,9 +27,9 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/controller/shared"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/controller/shared"
 )
 
 // Reconciler ensures Repository CRs against the git host.

--- a/providers/code/controller/shared/shared.go
+++ b/providers/code/controller/shared/shared.go
@@ -26,9 +26,9 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/tenant"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/tenant"
 )
 
 // ClusterClient resolves the controller-runtime client scoped to the tenant

--- a/providers/code/controller_manager.go
+++ b/providers/code/controller_manager.go
@@ -39,14 +39,14 @@ import (
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	"github.com/faroshq/faros-kedge/providers/code/controller/collaborator"
-	"github.com/faroshq/faros-kedge/providers/code/controller/connection"
-	"github.com/faroshq/faros-kedge/providers/code/controller/deploykey"
-	"github.com/faroshq/faros-kedge/providers/code/controller/packages"
-	"github.com/faroshq/faros-kedge/providers/code/controller/repository"
-	"github.com/faroshq/faros-kedge/providers/code/install"
-	codescheme "github.com/faroshq/faros-kedge/providers/code/scheme"
+	"github.com/faroshq/provider-code/backend"
+	"github.com/faroshq/provider-code/controller/collaborator"
+	"github.com/faroshq/provider-code/controller/connection"
+	"github.com/faroshq/provider-code/controller/deploykey"
+	"github.com/faroshq/provider-code/controller/packages"
+	"github.com/faroshq/provider-code/controller/repository"
+	"github.com/faroshq/provider-code/install"
+	codescheme "github.com/faroshq/provider-code/scheme"
 )
 
 // endpointSliceName is the APIExportEndpointSlice the multicluster provider

--- a/providers/code/go.mod
+++ b/providers/code/go.mod
@@ -1,4 +1,4 @@
-module github.com/faroshq/faros-kedge/providers/code
+module github.com/faroshq/provider-code
 
 go 1.26.3
 

--- a/providers/code/init_cmd.go
+++ b/providers/code/init_cmd.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/faroshq/faros-kedge/providers/code/install"
+	"github.com/faroshq/provider-code/install"
 )
 
 // runInitCmd is the one-shot bootstrap. The hub provisioner already

--- a/providers/code/main.go
+++ b/providers/code/main.go
@@ -33,12 +33,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/faroshq/faros-kedge/providers/code/backend"
-	githubbackend "github.com/faroshq/faros-kedge/providers/code/backend/github"
-	"github.com/faroshq/faros-kedge/providers/code/mcpserver"
-	"github.com/faroshq/faros-kedge/providers/code/oauthgithub"
-	"github.com/faroshq/faros-kedge/providers/code/server"
-	"github.com/faroshq/faros-kedge/providers/code/tenant"
+	"github.com/faroshq/provider-code/backend"
+	githubbackend "github.com/faroshq/provider-code/backend/github"
+	"github.com/faroshq/provider-code/mcpserver"
+	"github.com/faroshq/provider-code/oauthgithub"
+	"github.com/faroshq/provider-code/server"
+	"github.com/faroshq/provider-code/tenant"
 )
 
 // Subcommands:

--- a/providers/code/mcpserver/server.go
+++ b/providers/code/mcpserver/server.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/faroshq/faros-kedge/providers/code/tenant"
+	"github.com/faroshq/provider-code/tenant"
 )
 
 // Deps is what the MCP transport needs: the per-tenant caller-token client

--- a/providers/code/mcpserver/tools.go
+++ b/providers/code/mcpserver/tools.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
 )
 
 var (

--- a/providers/code/mcpserver/tools_write.go
+++ b/providers/code/mcpserver/tools_write.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
 )
 
 var (

--- a/providers/code/scheme/scheme.go
+++ b/providers/code/scheme/scheme.go
@@ -23,7 +23,7 @@ import (
 	apiskcpv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	corev1alpha1 "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 
-	codev1alpha1 "github.com/faroshq/faros-kedge/providers/code/apis/v1alpha1"
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
 )
 
 // NewScheme returns a fully-populated scheme. Panics on registration error

--- a/providers/infrastructure/README.md
+++ b/providers/infrastructure/README.md
@@ -1,5 +1,16 @@
 # infrastructure provider
 
+> [!IMPORTANT]
+> **Read-only mirror — do not push or open PRs here.**
+> The standalone [`faroshq/provider-infrastructure`](https://github.com/faroshq/provider-infrastructure)
+> repository is **automatically synced** from the kedge monorepo
+> [`faroshq/kedge`](https://github.com/faroshq/kedge) (path `providers/infrastructure/`)
+> via [splitsh-lite](https://github.com/splitsh/lite). Every sync force-updates
+> the mirror, so any direct change here is overwritten. File issues and PRs
+> against [`faroshq/kedge`](https://github.com/faroshq/kedge) instead.
+> See [docs/provider-publishing.md](../../docs/provider-publishing.md) for how
+> the mirror is published.
+
 A kedge provider that brokers application templates from a central
 [kro](https://github.com/faroshq/kro-multicluster) (Kube Resource
 Orchestrator) cluster into kedge tenant workspaces. A tenant picks a

--- a/providers/infrastructure/backend/interface.go
+++ b/providers/infrastructure/backend/interface.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/client-go/rest"
 
-	infrastructurev1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrastructurev1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 // Backend is the seam between the platform layer and any concrete

--- a/providers/infrastructure/backend/kro/backend.go
+++ b/providers/infrastructure/backend/kro/backend.go
@@ -37,8 +37,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+	"github.com/faroshq/provider-infrastructure/backend"
 )
 
 // Name is the backend identifier operators put in Template.spec.backend.

--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 func TestOpenAPIToSimpleSchema(t *testing.T) {

--- a/providers/infrastructure/backend/kro/rgd.go
+++ b/providers/infrastructure/backend/kro/rgd.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 const (

--- a/providers/infrastructure/backend/stub/stub.go
+++ b/providers/infrastructure/backend/stub/stub.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	infrastructurev1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
+	infrastructurev1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+	"github.com/faroshq/provider-infrastructure/backend"
 )
 
 // Name registered with backend.Registry. Operators put this string

--- a/providers/infrastructure/controller/template/apiexport.go
+++ b/providers/infrastructure/controller/template/apiexport.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 // APIExportName is the well-known name of the provider's APIExport,

--- a/providers/infrastructure/controller/template/controller.go
+++ b/providers/infrastructure/controller/template/controller.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+	"github.com/faroshq/provider-infrastructure/backend"
 )
 
 // crdGVR is what the Reconciler's dynamic client targets when

--- a/providers/infrastructure/controller/template/controller_test.go
+++ b/providers/infrastructure/controller/template/controller_test.go
@@ -50,9 +50,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend/stub"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+	"github.com/faroshq/provider-infrastructure/backend"
+	"github.com/faroshq/provider-infrastructure/backend/stub"
 )
 
 // newTestReconciler wires up the two fakes + a backend registry

--- a/providers/infrastructure/controller_manager.go
+++ b/providers/infrastructure/controller_manager.go
@@ -34,11 +34,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend"
-	krobackend "github.com/faroshq/faros-kedge/providers/infrastructure/backend/kro"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/backend/stub"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/controller/template"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/install"
+	"github.com/faroshq/provider-infrastructure/backend"
+	krobackend "github.com/faroshq/provider-infrastructure/backend/kro"
+	"github.com/faroshq/provider-infrastructure/backend/stub"
+	"github.com/faroshq/provider-infrastructure/controller/template"
+	"github.com/faroshq/provider-infrastructure/install"
 )
 
 // startControllerManager builds a controller-runtime manager pointed

--- a/providers/infrastructure/go.mod
+++ b/providers/infrastructure/go.mod
@@ -1,4 +1,4 @@
-module github.com/faroshq/faros-kedge/providers/infrastructure
+module github.com/faroshq/provider-infrastructure
 
 go 1.26.0
 

--- a/providers/infrastructure/init_cmd.go
+++ b/providers/infrastructure/init_cmd.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/faroshq/faros-kedge/providers/infrastructure/install"
+	"github.com/faroshq/provider-infrastructure/install"
 )
 
 // runInitCmd drives the bootstrap chain. Reads admin credentials from

--- a/providers/infrastructure/install/apiexport.go
+++ b/providers/infrastructure/install/apiexport.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 // APIExportName must match the provider's CatalogEntry.spec.apiExport.name.

--- a/providers/infrastructure/install/cachedresource.go
+++ b/providers/infrastructure/install/cachedresource.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 // cachedResourceGVR is what we Get/Create against. CachedResource is

--- a/providers/infrastructure/install/seedtemplates.go
+++ b/providers/infrastructure/install/seedtemplates.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	infrav1alpha1 "github.com/faroshq/faros-kedge/providers/infrastructure/apis/v1alpha1"
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 //go:embed templates/*.yaml

--- a/providers/infrastructure/main.go
+++ b/providers/infrastructure/main.go
@@ -35,9 +35,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/faroshq/faros-kedge/providers/infrastructure/mcpserver"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/server"
-	"github.com/faroshq/faros-kedge/providers/infrastructure/tenant"
+	"github.com/faroshq/provider-infrastructure/mcpserver"
+	"github.com/faroshq/provider-infrastructure/server"
+	"github.com/faroshq/provider-infrastructure/tenant"
 )
 
 // Subcommands:

--- a/providers/infrastructure/mcpserver/catalog.go
+++ b/providers/infrastructure/mcpserver/catalog.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/faroshq/faros-kedge/providers/infrastructure/kro"
+	"github.com/faroshq/provider-infrastructure/kro"
 )
 
 // templateGroup is the fixed group every Template + per-template instance

--- a/providers/infrastructure/mcpserver/server.go
+++ b/providers/infrastructure/mcpserver/server.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/faroshq/faros-kedge/providers/infrastructure/tenant"
+	"github.com/faroshq/provider-infrastructure/tenant"
 )
 
 // Deps is what the MCP transport needs. Templates + instances are CRD-based

--- a/providers/infrastructure/mcpserver/tools.go
+++ b/providers/infrastructure/mcpserver/tools.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/faroshq/faros-kedge/providers/infrastructure/kro"
+	"github.com/faroshq/provider-infrastructure/kro"
 )
 
 // tenantClient resolves a tenant-scoped kcp dynamic client that acts AS THE


### PR DESCRIPTION
Wires `providers/code` and `providers/infrastructure` into the same history-preserving split-publish pattern already used for `providers/quickstart` (#262) — splitsh-lite → read-only standalone mirror — so external consumers can depend on and browse each provider on its own.

## What's here

**New split workflows** (copied verbatim from `split-quickstart.yaml` apart from the prefix, target repo, per-provider tag/path triggers, concurrency group, and deploy-key secret):
- `.github/workflows/split-code.yaml` → `faroshq/provider-code` (secret `CODE_DEPLOY_KEY`)
- `.github/workflows/split-infrastructure.yaml` → `faroshq/provider-infrastructure` (secret `INFRA_DEPLOY_KEY`)

They validate-only on PRs (install splitsh-lite + compute the split, no mirror write) and push only on non-PR events.

**Module renames** so each mirror is `go get`-able at its own path:
- `github.com/faroshq/faros-kedge/providers/code` → `github.com/faroshq/provider-code`
- `github.com/faroshq/faros-kedge/providers/infrastructure` → `github.com/faroshq/provider-infrastructure`

plus each provider's ~17 in-repo self-imports. Isolated: no other monorepo module imports these, and `go.work` references them by directory. Both modules build clean.

**Docs/READMEs:**
- Read-only mirror banner on each provider README.
- `docs/provider-publishing.md`: published table + secret names, corrected trigger/internals sections to match the current workflow, generic per-mirror setup steps, module-path table.

## Required GitHub setup before this can sync (per mirror)

A GitHub deploy key is scoped to a single repo and **cannot** be reused across mirrors, so each needs its own:

1. Create `faroshq/provider-code` and `faroshq/provider-infrastructure`.
2. Generate an ed25519 key per mirror; add the **public** half as a **write** deploy key on the mirror repo.
3. Add the **private** half as a monorepo Actions secret: `CODE_DEPLOY_KEY`, `INFRA_DEPLOY_KEY`.
4. After merge, seed each via **Actions → Run workflow** (the manual-dispatch button only appears once the workflow is on `main`).

Until the repos + secrets exist, the push step will fail; the validate step runs regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)