### PR TITLE
hub: Enable-time edges-proxy grant for providers (spec.edgeProxyAccess)

### DIFF
--- a/apis/providers/v1alpha1/types_catalogentry.go
+++ b/apis/providers/v1alpha1/types_catalogentry.go
@@ -115,6 +115,17 @@ type CatalogEntrySpec struct {
 	// the hub (Phase 1B will wire it up).
 	// +optional
 	APIExport *ProviderAPIExport `json:"apiExport,omitempty"`
+
+	// EdgeProxyAccess requests that, when a tenant enables this provider,
+	// the hub grants the provider's ServiceAccount the "proxy" verb on
+	// edges.kedge.faros.sh in the tenant's workspace. This lets the
+	// provider open background connections to the tenant's edge clusters
+	// through the hub's edges-proxy (e.g. the kuery provider's informer
+	// sync). The grant is materialized as a ClusterRole/ClusterRoleBinding
+	// in the tenant workspace on Enable and removed on Disable; like
+	// permission claims, it is surfaced in the portal's Enable dialog.
+	// +optional
+	EdgeProxyAccess bool `json:"edgeProxyAccess,omitempty"`
 }
 
 // ProviderUI declares a provider's micro-frontend target. Exactly one of

--- a/config/crds/providers.kedge.faros.sh_catalogentries.yaml
+++ b/config/crds/providers.kedge.faros.sh_catalogentries.yaml
@@ -175,6 +175,17 @@ spec:
                   catalog.
                 maxLength: 128
                 type: string
+              edgeProxyAccess:
+                description: |-
+                  EdgeProxyAccess requests that, when a tenant enables this provider,
+                  the hub grants the provider's ServiceAccount the "proxy" verb on
+                  edges.kedge.faros.sh in the tenant's workspace. This lets the
+                  provider open background connections to the tenant's edge clusters
+                  through the hub's edges-proxy (e.g. the kuery provider's informer
+                  sync). The grant is materialized as a ClusterRole/ClusterRoleBinding
+                  in the tenant workspace on Enable and removed on Disable; like
+                  permission claims, it is surfaced in the portal's Enable dialog.
+                type: boolean
               iconURL:
                 description: |-
                   IconURL is a portal-relative path to an icon for the catalog card.

--- a/config/kcp/apiexport-providers.kedge.faros.sh.yaml
+++ b/config/kcp/apiexport-providers.kedge.faros.sh.yaml
@@ -6,7 +6,7 @@ spec:
   resources:
   - group: providers.kedge.faros.sh
     name: catalogentries
-    schema: v260603-2b37ceb.catalogentries.providers.kedge.faros.sh
+    schema: v260612-5da57dc.catalogentries.providers.kedge.faros.sh
     storage:
       crd: {}
 status: {}

--- a/config/kcp/apiresourceschema-catalogentries.providers.kedge.faros.sh.yaml
+++ b/config/kcp/apiresourceschema-catalogentries.providers.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260603-2b37ceb.catalogentries.providers.kedge.faros.sh
+  name: v260612-5da57dc.catalogentries.providers.kedge.faros.sh
 spec:
   group: providers.kedge.faros.sh
   names:
@@ -171,6 +171,17 @@ spec:
                 catalog.
               maxLength: 128
               type: string
+            edgeProxyAccess:
+              description: |-
+                EdgeProxyAccess requests that, when a tenant enables this provider,
+                the hub grants the provider's ServiceAccount the "proxy" verb on
+                edges.kedge.faros.sh in the tenant's workspace. This lets the
+                provider open background connections to the tenant's edge clusters
+                through the hub's edges-proxy (e.g. the kuery provider's informer
+                sync). The grant is materialized as a ClusterRole/ClusterRoleBinding
+                in the tenant workspace on Enable and removed on Disable; like
+                permission claims, it is surfaced in the portal's Enable dialog.
+              type: boolean
             iconURL:
               description: |-
                 IconURL is a portal-relative path to an icon for the catalog card.

--- a/docs/kuery-provider-architecture.md
+++ b/docs/kuery-provider-architecture.md
@@ -181,11 +181,16 @@ cluster). Extend authorize() the same way:
 
 1. If the token parses as an SA token, TokenReview in the SA's **home cluster** (kcp
    verifies the signature there, so the home cluster is verified, not just claimed).
-2. SAR in the tenant workspace with a **cluster-qualified synthetic identity**, e.g.
-   `system:kedge:provider-sa:{homeCluster}:{ns}:{name}`. A bare
+2. SAR in the tenant workspace with **kcp's native cross-workspace SA identity**
+   `system:kcp:serviceaccount:{homeCluster}:{ns}:{name}`. A bare
    `system:serviceaccount:{ns}:{name}` is ambiguous — any tenant could create a same-named
-   SA in their own workspace and satisfy the binding. kedge controls both the SAR call and
-   the grant objects, so it can choose an unforgeable encoding.
+   SA in their own workspace and satisfy the binding. The qualified format is not invented:
+   kcp's **GlobalServiceAccount** feature gate (beta, default-on since kube 1.35 in the kcp
+   fork) makes kcp's own RBAC resolution alias every SA to exactly this form
+   (`EffectiveUsers` in the fork's `pkg/registry/rbac/validation/kcp.go`; proven
+   cross-workspace by kcp's e2e `TestAPIResourceSchemaVirtualWorkspaceAuthorization`).
+   Emitting the same format means the Enable-time grant binding also authorizes the
+   provider SA on kcp-native paths, not just kedge's delegated SAR.
 
 **Authz — materialize the grant on Enable.**
 

--- a/docs/kuery-provider-architecture.md
+++ b/docs/kuery-provider-architecture.md
@@ -199,8 +199,13 @@ cluster). Extend authorize() the same way:
   your edges" — same consent model as tenant-scoped claims.
 - The existing server-side Enable endpoint (`pkg/hub/restapi/providers_enable.go`, which
   already creates the APIBinding) additionally applies in the tenant workspace:
-  - ClusterRole `kedge:provider:{name}:edges-proxy` — group `kedge.faros.sh`, resource
-    `edges`, verb `proxy`
+  - ClusterRole `kedge:provider:{name}:edges-proxy` — **two rules**: verb `proxy` on
+    `edges.kedge.faros.sh`, plus verb `access` on nonResourceURL `/`. The second is
+    required: kcp's workspaceContentAuthorizer checks `access` before any resource RBAC,
+    and a foreign SA is not covered by the tenant workspace's `system:authenticated`
+    grants (the SAR also drops its groups). kcp's own cross-workspace SA e2e pairs the
+    rules the same way. Verified end-to-end by
+    `TestIEdgeProxyGrantAuthorizesProviderSA` in `test/e2e/suites/provider`.
   - ClusterRoleBinding to the qualified subject above
 - Disable deletes both. Out-of-band APIBindings (kubectl) don't get the grant in v1; a
   reconciling binding-watcher can come later if needed.

--- a/docs/kuery-provider-architecture.md
+++ b/docs/kuery-provider-architecture.md
@@ -1,0 +1,259 @@
+# Kuery provider: fleet-wide object query for MCP, search, and impact analysis
+
+Status: **Design proposal.**
+Author: 2026-06-11
+Related: [kuery](https://github.com/faroshq/kuery) (the query engine this wraps),
+`providers/infrastructure/` (the standalone-provider pattern this is modeled on),
+`pkg/hub/providers/` (CatalogEntry provisioning), `pkg/virtual/builder/edges_proxy_builder.go`
+(edge data path), `docs/providers.md`, `docs/code-provider-architecture.md`.
+
+## Summary
+
+The **`kuery`** provider gives tenants — and, most importantly, **AI agents via MCP** — a
+single query surface over every object across their connected edge clusters. One structured
+query against a local SQL-backed index replaces N kubectl round-trips through N reverse
+tunnels: "which of my 50 edges run image X / still have the old ConfigMap / are missing CRD
+Y" becomes one cheap call instead of a fan-out over slow edge links. On top of that index it
+offers relationship traversal for impact analysis ("who consumes this Secret — safe to
+rotate?") and a portal UI.
+
+Realistic value ranking, which drives the phasing below:
+
+1. **Fleet-wide search/inventory** — the differentiated piece; nothing in kedge answers
+   cross-edge questions today without per-edge fan-out.
+2. **MCP query tools** — a far better agent surface than the per-edge `kubernetes_*` tools:
+   one query instead of dozens of tunneled kubectl calls (latency *and* token cost).
+3. **Config-rotation impact** — reliable for declared coupling (ownerRefs, spec references,
+   selectors); NOT a full dependency map (network calls, DNS-name references, and dynamic
+   operator reads are invisible to it). Cross-edge relations additionally require
+   `kuery.io/relates-to` / `kuery.io/group` instrumentation, which manifests won't have by
+   default.
+4. **Graph visualization** — demo layer on top; single-cluster object graphs are commodity
+   (Lens, Headlamp, ArgoCD tree).
+
+It wraps [kuery](https://github.com/faroshq/kuery): a read-only, multi-cluster Kubernetes
+query engine that syncs objects from N clusters into SQLite/Postgres via dynamic informers
+and exposes a single POST-only API (`kuery.io/v1alpha1 Query`) supporting relationship
+traversal that plain list/watch can't do:
+
+- `owners` / `owners+` and `descendants` / `descendants+` (ownerReference chains, transitive
+  via recursive CTE)
+- `references` — spec-field extraction (Pod→Secret/ConfigMap/PVC/SA, Ingress→Service, …),
+  extensible per-CRD via the `kuery.io/refs` annotation
+- `selects` / `selected-by` — label-selector containment, both directions
+- `events` — involvedObject matches
+- `linked` / `linked+` and `grouped` — **cross-cluster** relations via the
+  `kuery.io/relates-to` annotation and the `kuery.io/group` label
+
+Kuery is already kcp-aware (APIExport identity disambiguation in `internal/sync/kcp.go`) and
+has an Engage/Disengage cluster lifecycle. It has **no UI and no authz** — both are this
+provider's job:
+
+- kedge supplies the **clusters** (connected edges, reachable through the hub's edges-proxy)
+  and the **tenant boundary**;
+- the provider supplies **tenant-scoped query access** and the **visualization** (inventory,
+  object graph, impact view).
+
+## Architecture
+
+```
+Browser / MCP client
+   │  bearer
+   ▼
+hub /services/providers/kuery/{api/*, mcp, mcp/sse}
+   │  proxy injects X-Kedge-Tenant + X-Kedge-User
+   ▼
+kuery provider pod
+   │
+   ├── engagement controller ── watches Edge CRs (permission claim, tenant-scoped)
+   │     on connect:    Engage("{tenantCluster}/{edgeName}", cluster.Cluster via edges-proxy)
+   │     on disconnect: Disengage → kuery GC reaps stale objects
+   │
+   ├── embedded kuery ── informers stream edge objects through reverse tunnels
+   │     into one local store (SQLite PVC; Postgres for production)
+   │
+   └── tenant-scoped query API ── rewrites spec.cluster on every Query to the
+         caller's tenant prefix before handing it to the kuery engine
+```
+
+### Repository layout
+
+```
+providers/kuery/                      module github.com/faroshq/provider-kuery
+├── main.go                           init | serve (same pattern as infrastructure provider)
+├── engagement/                       controller: watch Edge CRs → Engage/Disengage kuery clusters
+├── server/                           tenant-scoped REST: /api/query, /api/impact, /api/edges
+├── mcpserver/                        kuery_query, kuery_impact MCP tools
+├── portal/                           Vue 3 + cytoscape.js graph UI
+├── apis/v1alpha1/                    SavedView CRD (tenant-facing, satisfies the APIExport requirement)
+├── manifest.yaml                     CatalogEntry
+├── deploy/chart/
+└── Dockerfile
+```
+
+### Data path: edges-proxy as the cluster endpoint
+
+For every connected `Edge` in a tenant workspace, the engagement controller builds a
+`rest.Config` with
+
+```
+Host = apiurl.EdgeProxyURL(hubBase, cluster, edgeName, "k8s")
+```
+
+— the exact pattern `pkg/virtual/builder/mcp_provider.go` already uses for the kubernetes
+MCP tools — wraps it in a controller-runtime `cluster.Cluster`, and `Engage`s it into
+kuery's sync controller under the name `{tenantCluster}/{edgeName}`. Kuery's discovery +
+dynamic informers then stream the edge's objects through the existing reverse tunnel into
+the local store. On Edge disconnect/delete the controller `Disengage`s; kuery's GC handles
+stale-cluster and stale-object cleanup (TTL-based).
+
+### Tenant isolation
+
+Kuery has no authorization of its own, so its API is **never exposed directly**. The
+provider backend is the only entry point: it takes `X-Kedge-Tenant` (injected by the hub's
+backend proxy) and forcibly rewrites every query's `spec.cluster` filter to the tenant's own
+cluster-name prefix (`{tenantCluster}/…`) before forwarding to the engine. One shared store,
+isolation enforced at the single choke point. `KEDGE_DEV_ALLOW_TENANT_QUERY` mirrors the
+infrastructure provider's dev escape hatch.
+
+### MCP tools (the primary consumer)
+
+The provider serves `/mcp` + `/mcp/sse` (proxied at `/services/providers/kuery/mcp`) and
+registers in the aggregate. Tools:
+
+- `kuery_query` — full QuerySpec passthrough (tenant-scoped): fleet-wide filter by
+  kind/labels/conditions/jsonpath, with optional relations and sparse projection.
+- `kuery_impact` — convenience wrapper: given one object ref, runs
+  `[descendants+, references, selected-by, events, linked+]` and returns the related set.
+
+For an agent, this collapses "check all edges for X" from dozens of tunneled kubectl calls
+into one query — the main practical justification for syncing the data at all.
+
+### Impact view
+
+Select any object in the UI → the same `kuery_impact` query → render an interactive graph
+with the blast radius highlighted. Because `linked`/`grouped` are cross-cluster, this can
+show e.g. "this ConfigMap feeds 4 Pods on edge-a and is grouped with a Deployment on
+edge-b". Present it as *declared* coupling, not a complete dependency map (see Summary).
+Sparse projection (kuery's field projection compiled to SQL JSON functions) keeps payloads
+small enough for interactive use.
+
+### SavedView CRD
+
+`CatalogEntry.spec.apiExport` requires at least one schema. The provider exports a small
+**SavedView** CRD: a named, tenant-authored query + layout (root object, relation set, depth,
+filters) that the portal can list and re-open. This gives tenants GitOps-able saved graphs
+and gives the APIExport a real, useful schema — same "tenant-authored CRDs" stance as the
+code provider (no CachedResource, no virtual storage).
+
+## Key decisions
+
+### 1. Embed kuery as a library — don't sidecar it
+
+Kuery's engine/sync/store live under `internal/`, so the provider cannot import them today,
+and the kuery binary only accepts `--kubeconfigs` at startup — there is no dynamic cluster
+add/remove over the wire. Since both repos are ours, the cleanest path is a small upstream
+kuery refactor moving `internal/{engine,sync,store,gc}` to `pkg/`, after which the provider
+embeds kuery: single container, programmatic Engage/Disengage, one process, no
+credential-passing hop. The alternative (sidecar + a new kuery admin API for cluster
+registration) adds a network boundary and an auth surface for no benefit.
+
+During development, `go replace` against the kuery checkout works even with the monorepo
+submodule layout.
+
+### 2. Edges-proxy authorization — the Enable-time grant
+
+The edges-proxy SAR-checks the caller for verb **`proxy`** on resource **`edges`** in the
+tenant workspace (`pkg/virtual/builder/edges_proxy_builder.go` → `auth.go` authorize()).
+Today only the kubernetesedges MCP path uses it, forwarding the *user's* bearer token
+per-request. Kuery needs a **long-lived credential for background watches** — a user token
+is the wrong shape — and permission claims don't help: they grant access via the APIExport
+virtual workspace, not direct SAR passes in tenant workspaces.
+
+There are two halves, both small:
+
+**Authn — teach authorize() about provider SA tokens.** authorize() currently runs the
+TokenReview *in the target tenant workspace*. kcp SA tokens are logical-cluster-scoped, so
+the provider's SA token (home: `root:kedge:providers:kuery`) fails authentication there
+before RBAC is consulted. The front proxy already handles this pattern
+(`pkg/server/proxy/proxy.go`: `parseServiceAccountToken` → route to the token's home
+cluster). Extend authorize() the same way:
+
+1. If the token parses as an SA token, TokenReview in the SA's **home cluster** (kcp
+   verifies the signature there, so the home cluster is verified, not just claimed).
+2. SAR in the tenant workspace with a **cluster-qualified synthetic identity**, e.g.
+   `system:kedge:provider-sa:{homeCluster}:{ns}:{name}`. A bare
+   `system:serviceaccount:{ns}:{name}` is ambiguous — any tenant could create a same-named
+   SA in their own workspace and satisfy the binding. kedge controls both the SAR call and
+   the grant objects, so it can choose an unforgeable encoding.
+
+**Authz — materialize the grant on Enable.**
+
+- CatalogEntry declares intent next to `permissionClaims` (e.g. `spec.edgeProxyAccess:
+  true`) so the portal's Enable dialog shows "this provider gets proxied read access to
+  your edges" — same consent model as tenant-scoped claims.
+- The existing server-side Enable endpoint (`pkg/hub/restapi/providers_enable.go`, which
+  already creates the APIBinding) additionally applies in the tenant workspace:
+  - ClusterRole `kedge:provider:{name}:edges-proxy` — group `kedge.faros.sh`, resource
+    `edges`, verb `proxy`
+  - ClusterRoleBinding to the qualified subject above
+- Disable deletes both. Out-of-band APIBindings (kubectl) don't get the grant in v1; a
+  reconciling binding-watcher can come later if needed.
+- v1 grants all edges in the workspace; `resourceNames` gives per-edge narrowing later.
+
+Runtime properties: the SAR runs once per proxied request, and kuery's watches are
+long-lived streams — one TokenReview+SAR per watch (re)establishment, negligible.
+Revocation self-heals: Disable deletes the APIBinding → the provider's claimed Edge watch
+dies → engagement controller Disengages → kuery GC purges the tenant's rows; the RBAC
+deletion only cuts off already-established proxy streams at reconnect.
+
+Rejected alternative: hub-minted provider tokens checked against a registry allowlist of
+enabled tenants (piggybacking on the proxy's static-token bypass). Simpler, but a bespoke
+authz path with a powerful bearer secret and no kcp-native audit trail — RBAC keeps "what
+can this provider touch" answerable with kubectl.
+
+### 3. Sync scale and defaults
+
+Full-object sync of every edge through the tunnels is the cost center.
+
+- Default to a resource **whitelist** (workloads, config, RBAC, networking — not every CR),
+  not kuery's blacklist: edge links are often the scarcest resource in the system, and
+  continuous full-object sync is the cost center. Make the list a chart value. (Note:
+  excluding events disables the `events` relation.)
+- Per-tenant object quotas (engagement controller refuses/flags edges past a budget).
+- SQLite on a PVC by default; Postgres as the production chart option (kuery supports both,
+  with GIN indexes on Postgres).
+- Kuery's safety limits (30s query timeout, 10k row cap, depth cap 20) stay as-is.
+
+## Phasing
+
+- **Phase 0 — unblock.** Kuery upstream refactor (`internal/` → `pkg/`) — **done**
+  ([kuery#3](https://github.com/faroshq/kuery/pull/3), merged 2026-06-11); hub-side
+  `proxy`-on-`edges` grant for provider ServiceAccounts on tenant Enable — **implemented**
+  (design above, key decision 2): SA-aware `authorize()` in
+  `pkg/virtual/builder/auth.go`, qualified identities in `pkg/util/identity`,
+  `CatalogEntry.spec.edgeProxyAccess`, grant lifecycle in the server-side
+  enable/disable endpoints (`pkg/hub/restapi/providers_enable.go`).
+- **Phase 1 — skeleton.** Clone the quickstart pattern: binary with `/healthz` + heartbeat,
+  CatalogEntry with the SavedView schema, Helm chart, Makefile targets
+  (`build-kuery-provider`, `run-provider-kuery`, `install-provider-kuery`, …). Visible in
+  the portal catalog.
+- **Phase 2 — data + MCP.** Engagement controller (watch Edges via permission claim
+  `edges.kedge.faros.sh` get/list/watch, tenantScoped) + embedded kuery sync +
+  tenant-scoped `/api/query` + MCP tools (`kuery_query`, `kuery_impact`) into the
+  aggregator. This is the value milestone: agents can query the fleet.
+- **Phase 3 — UI.** Portal micro-frontend: edge/object **inventory table with filters**
+  first (covers most human use), then the cytoscape object graph and impact view with
+  blast-radius highlighting.
+- **Phase 4 — polish.** SavedView reconciliation, Postgres chart option,
+  `split-kuery.yaml` workflow + `faroshq/provider-kuery` mirror with deploy key (see
+  `docs/provider-publishing.md`).
+
+## Open questions
+
+- Whether the engagement controller watches Edges through the provider's APIExport virtual
+  workspace (one watch across all bound tenants) or per-tenant — VW is the natural fit.
+- Cross-shard behavior: tenant workspaces on a different shard than the provider workspace
+  may hit the known CachedResource/discovery issues; SavedView is plain APIBinding-bound
+  CRDs so it should be unaffected, but verify during Phase 2.
+- Event sync: opt-in per tenant? Events are high-churn and the relation is per-cluster only.

--- a/pkg/hub/bootstrap/crds/providers.kedge.faros.sh_catalogentries.yaml
+++ b/pkg/hub/bootstrap/crds/providers.kedge.faros.sh_catalogentries.yaml
@@ -175,6 +175,17 @@ spec:
                   catalog.
                 maxLength: 128
                 type: string
+              edgeProxyAccess:
+                description: |-
+                  EdgeProxyAccess requests that, when a tenant enables this provider,
+                  the hub grants the provider's ServiceAccount the "proxy" verb on
+                  edges.kedge.faros.sh in the tenant's workspace. This lets the
+                  provider open background connections to the tenant's edge clusters
+                  through the hub's edges-proxy (e.g. the kuery provider's informer
+                  sync). The grant is materialized as a ClusterRole/ClusterRoleBinding
+                  in the tenant workspace on Enable and removed on Disable; like
+                  permission claims, it is surfaced in the portal's Enable dialog.
+                type: boolean
               iconURL:
                 description: |-
                   IconURL is a portal-relative path to an icon for the catalog card.

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -1492,6 +1492,16 @@ func (b *Bootstrapper) EnsureProviderEdgeProxyGrant(ctx context.Context, orgUUID
 		"kind":       "ClusterRole",
 		"metadata":   map[string]any{"name": name},
 		"rules": []any{
+			// Workspace access: kcp's workspaceContentAuthorizer requires
+			// the "access" verb on "/" before any resource RBAC is even
+			// consulted, and a foreign SA is not covered by the tenant
+			// workspace's system:authenticated grants (kedge's SAR also
+			// drops its groups). Same pairing kcp's own cross-workspace SA
+			// e2e uses (TestAPIResourceSchemaVirtualWorkspaceAuthorization).
+			map[string]any{
+				"nonResourceURLs": []any{"/"},
+				"verbs":           []any{"access"},
+			},
 			map[string]any{
 				"apiGroups": []any{"kedge.faros.sh"},
 				"resources": []any{"edges"},

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -1435,6 +1435,138 @@ func (b *Bootstrapper) ListProviderAPIBindings(ctx context.Context, orgUUID, wsU
 	return out, nil
 }
 
+// DeleteProviderAPIBinding removes the named provider APIBinding from the
+// child workspace root:kedge:orgs:{orgUUID}:{wsUUID}. NotFound is a no-op so
+// the Disable action is idempotent. Counterpart to EnsureProviderAPIBinding.
+func (b *Bootstrapper) DeleteProviderAPIBinding(ctx context.Context, orgUUID, wsUUID, bindingName string) error {
+	if orgUUID == "" || wsUUID == "" || bindingName == "" {
+		return fmt.Errorf("DeleteProviderAPIBinding: orgUUID, wsUUID, bindingName are required")
+	}
+	wsConfig := configForPath(b.config, childWorkspacePath(orgUUID, wsUUID))
+	wsClient, err := dynamic.NewForConfig(wsConfig)
+	if err != nil {
+		return fmt.Errorf("creating child workspace client: %w", err)
+	}
+	if err := wsClient.Resource(apiBindingGVR).Delete(ctx, bindingName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting APIBinding %q in %s/%s: %w", bindingName, orgUUID, wsUUID, err)
+	}
+	return nil
+}
+
+var clusterRoleGVR = schema.GroupVersionResource{
+	Group:    "rbac.authorization.k8s.io",
+	Version:  "v1",
+	Resource: "clusterroles",
+}
+
+// edgeProxyGrantName is the name of both the ClusterRole and the
+// ClusterRoleBinding the Enable-time edges-proxy grant materializes in the
+// tenant workspace, parameterized by provider name so multiple providers'
+// grants coexist.
+func edgeProxyGrantName(providerName string) string {
+	return "kedge:provider:" + providerName + ":edges-proxy"
+}
+
+// EnsureProviderEdgeProxyGrant grants `subject` (the provider SA's
+// cluster-qualified identity — see pkg/util/identity) the "proxy" verb on
+// edges.kedge.faros.sh in the child workspace root:kedge:orgs:{orgUUID}:
+// {wsUUID}. The edges-proxy virtual workspace SAR-checks exactly this tuple
+// (pkg/virtual/builder/edges_proxy_builder.go), so the grant is what lets a
+// provider with CatalogEntry spec.edgeProxyAccess open background
+// connections to the tenant's edges. Idempotent; subjects are reconciled on
+// re-Enable so a provider workspace re-provision (new cluster ID → new
+// qualified subject) heals on the next Enable.
+func (b *Bootstrapper) EnsureProviderEdgeProxyGrant(ctx context.Context, orgUUID, wsUUID, providerName, subject string) error {
+	if orgUUID == "" || wsUUID == "" || providerName == "" || subject == "" {
+		return fmt.Errorf("EnsureProviderEdgeProxyGrant: orgUUID, wsUUID, providerName, subject are required")
+	}
+	wsConfig := configForPath(b.config, childWorkspacePath(orgUUID, wsUUID))
+	wsClient, err := dynamic.NewForConfig(wsConfig)
+	if err != nil {
+		return fmt.Errorf("creating child workspace client: %w", err)
+	}
+
+	name := edgeProxyGrantName(providerName)
+	role := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]any{"name": name},
+		"rules": []any{
+			map[string]any{
+				"apiGroups": []any{"kedge.faros.sh"},
+				"resources": []any{"edges"},
+				"verbs":     []any{"proxy"},
+			},
+		},
+	}}
+	if _, err := wsClient.Resource(clusterRoleGVR).Create(ctx, role, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating ClusterRole %q: %w", name, err)
+	}
+
+	wantSubjects := []any{
+		map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "User",
+			"name":     subject,
+		},
+	}
+	crb := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": name},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     name,
+		},
+		"subjects": wantSubjects,
+	}}
+	_, err = wsClient.Resource(clusterRoleBindingGVR).Create(ctx, crb, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating ClusterRoleBinding %q: %w", name, err)
+	}
+	existing, getErr := wsClient.Resource(clusterRoleBindingGVR).Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("getting ClusterRoleBinding %q: %w", name, getErr)
+	}
+	gotSubjects, _, _ := unstructured.NestedSlice(existing.Object, "subjects")
+	if reflect.DeepEqual(gotSubjects, wantSubjects) {
+		return nil
+	}
+	if err := unstructured.SetNestedSlice(existing.Object, wantSubjects, "subjects"); err != nil {
+		return fmt.Errorf("rewriting ClusterRoleBinding subjects: %w", err)
+	}
+	if _, err := wsClient.Resource(clusterRoleBindingGVR).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating ClusterRoleBinding %q: %w", name, err)
+	}
+	return nil
+}
+
+// RemoveProviderEdgeProxyGrant deletes the ClusterRole/ClusterRoleBinding
+// pair EnsureProviderEdgeProxyGrant created. NotFound is a no-op — Disable
+// must succeed for providers that never had the grant.
+func (b *Bootstrapper) RemoveProviderEdgeProxyGrant(ctx context.Context, orgUUID, wsUUID, providerName string) error {
+	if orgUUID == "" || wsUUID == "" || providerName == "" {
+		return fmt.Errorf("RemoveProviderEdgeProxyGrant: orgUUID, wsUUID, providerName are required")
+	}
+	wsConfig := configForPath(b.config, childWorkspacePath(orgUUID, wsUUID))
+	wsClient, err := dynamic.NewForConfig(wsConfig)
+	if err != nil {
+		return fmt.Errorf("creating child workspace client: %w", err)
+	}
+	name := edgeProxyGrantName(providerName)
+	if err := wsClient.Resource(clusterRoleBindingGVR).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting ClusterRoleBinding %q: %w", name, err)
+	}
+	if err := wsClient.Resource(clusterRoleGVR).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting ClusterRole %q: %w", name, err)
+	}
+	return nil
+}
+
 func acceptedClaim(group, resource, identityHash string, verbs []string) apisv1alpha2.AcceptablePermissionClaim {
 	return apisv1alpha2.AcceptablePermissionClaim{
 		ScopedPermissionClaim: apisv1alpha2.ScopedPermissionClaim{

--- a/pkg/hub/providers/api.go
+++ b/pkg/hub/providers/api.go
@@ -61,6 +61,11 @@ type providerDTO struct {
 	// what the provider's controllers will be able to access in their
 	// workspace before they accept.
 	PermissionClaims []permissionClaimDTO `json:"permissionClaims,omitempty"`
+	// EdgeProxyAccess mirrors CatalogEntry.spec.edgeProxyAccess. Shown in
+	// the Enable confirmation dialog: enabling such a provider grants its
+	// ServiceAccount proxied access to the workspace's edge clusters (verb
+	// "proxy" on edges) for background connections.
+	EdgeProxyAccess bool `json:"edgeProxyAccess,omitempty"`
 	// Builtin is true for first-party providers (those that registered via
 	// providers.RegisterBuiltin) regardless of how they surface their UI
 	// (legacy BuiltinRoute or new LocalUIAssets custom element). The portal
@@ -153,6 +158,7 @@ func NewListHandler(reg *Registry) http.Handler {
 				APIExportPath:    p.APIExportPath,
 				APIExportName:    p.APIExportName,
 				PermissionClaims: claims,
+				EdgeProxyAccess:  p.EdgeProxyAccess,
 				Builtin:          isBuiltin,
 			})
 		}

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -142,6 +142,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		Category:    entry.Spec.Category,
 		Version:     entry.Spec.Version,
 	}
+	prov.EdgeProxyAccess = entry.Spec.EdgeProxyAccess
 	if entry.Spec.APIExport != nil {
 		prov.APIExportName = entry.Spec.APIExport.Name
 		prov.APIExportPath = providersParentWorkspace + ":" + entry.Name
@@ -259,11 +260,15 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 // provision runs the kcp-side side-effects: sub-workspace, schemas, and
 // APIExport. Mutates entry.Status to record the resolved kcp coordinates.
 func (r *CatalogReconciler) provision(ctx context.Context, entry *providersv1alpha1.CatalogEntry) error {
-	if err := r.prov.EnsureProviderWorkspace(ctx, entry.Name); err != nil {
+	workspaceCluster, err := r.prov.EnsureProviderWorkspace(ctx, entry.Name)
+	if err != nil {
 		return fmt.Errorf("ensuring sub-workspace: %w", err)
 	}
 	workspacePath := providersParentWorkspace + ":" + entry.Name
 	entry.Status.Workspace = workspacePath
+	// Record the logical cluster ID so the Enable endpoint can build the
+	// qualified RBAC subject for the edges-proxy grant.
+	r.reg.SetWorkspaceCluster(entry.Name, workspaceCluster)
 
 	schemaNames, err := r.prov.ApplySchemas(ctx, entry.Name, entry.Spec.APIExport.Schemas)
 	if err != nil {

--- a/pkg/hub/providers/provision.go
+++ b/pkg/hub/providers/provision.go
@@ -76,6 +76,11 @@ var (
 // kubeconfig minted from this SA's token.
 const ProviderSAName = "provider"
 
+// ProviderSANamespace is the namespace ProviderSAName lives in. The
+// Enable-time edge-proxy grant derives the SA's qualified identity from
+// this tuple, so it must stay in lockstep with EnsureProviderSA.
+const ProviderSANamespace = "default"
+
 // ProviderTokenSecretSuffix is appended to the SA name to form the
 // kubernetes.io/service-account-token Secret that holds the provider's
 // long-lived bearer. kcp's token controller populates it; the token does
@@ -95,10 +100,10 @@ func (p *provisioner) EnsureProviderSA(ctx context.Context, providerName string)
 	sa := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ServiceAccount",
-		"metadata":   map[string]any{"name": ProviderSAName, "namespace": "default"},
+		"metadata":   map[string]any{"name": ProviderSAName, "namespace": ProviderSANamespace},
 	}}
-	if _, err := cl.Resource(serviceAccountGVR).Namespace("default").Create(ctx, sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("creating ServiceAccount %s/%s: %w", "default", ProviderSAName, err)
+	if _, err := cl.Resource(serviceAccountGVR).Namespace(ProviderSANamespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating ServiceAccount %s/%s: %w", ProviderSANamespace, ProviderSAName, err)
 	}
 
 	// cluster-admin in the sub-workspace only. The provider pod reaches
@@ -226,11 +231,14 @@ func EncodeKubeconfig(kc []byte) string {
 }
 
 // EnsureProviderWorkspace creates root:kedge:providers/{name} if it does not
-// exist and waits for it to reach phase Ready. Idempotent.
-func (p *provisioner) EnsureProviderWorkspace(ctx context.Context, name string) error {
+// exist and waits for it to reach phase Ready. Idempotent. Returns the
+// workspace's logical cluster ID (Workspace.spec.cluster) — the cluster name
+// kcp embeds in the provider SA's token claims, which the Enable-time
+// edges-proxy grant needs to build the qualified RBAC subject.
+func (p *provisioner) EnsureProviderWorkspace(ctx context.Context, name string) (string, error) {
 	parent, err := p.clientFor(providersParentWorkspace)
 	if err != nil {
-		return err
+		return "", err
 	}
 	ws := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "tenancy.kcp.io/v1alpha1",
@@ -241,18 +249,24 @@ func (p *provisioner) EnsureProviderWorkspace(ctx context.Context, name string) 
 		},
 	}}
 	if _, err := parent.Resource(workspaceGVR).Create(ctx, ws, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("creating sub-workspace %s: %w", name, err)
+		return "", fmt.Errorf("creating sub-workspace %s: %w", name, err)
 	}
 
-	// Wait for Ready so subsequent schema/export writes target a live workspace.
-	return wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+	// Wait for Ready so subsequent schema/export writes target a live
+	// workspace; spec.cluster is populated by then.
+	var cluster string
+	if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		got, err := parent.Resource(workspaceGVR).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
 		phase, _, _ := unstructured.NestedString(got.Object, "status", "phase")
+		cluster, _, _ = unstructured.NestedString(got.Object, "spec", "cluster")
 		return phase == "Ready", nil
-	})
+	}); err != nil {
+		return "", err
+	}
+	return cluster, nil
 }
 
 // ApplySchemas parses each inline APIResourceSchema body and applies it to

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -54,6 +54,17 @@ type Provider struct {
 	APIExportName    string     // APIExport name (e.g. cost.providers.kedge.faros.sh)
 	PermissionClaims []PermissionClaim
 
+	// EdgeProxyAccess mirrors CatalogEntry.spec.edgeProxyAccess: on tenant
+	// Enable, the hub grants the provider SA the "proxy" verb on edges in
+	// the tenant workspace (see pkg/hub/restapi/providers_enable.go).
+	EdgeProxyAccess bool
+	// WorkspaceCluster is the logical cluster ID of the provider's
+	// sub-workspace (Workspace.spec.cluster of root:kedge:providers:{name}).
+	// It anchors the qualified RBAC subject the edge-proxy grant binds —
+	// the same cluster ID kcp puts in the provider SA's token claims. Set
+	// via SetWorkspaceCluster after provisioning; empty until then.
+	WorkspaceCluster string
+
 	// LocalUIAssets, when non-nil, is an embedded fs.FS that the UI proxy
 	// serves under /ui/providers/{Name}/* instead of forwarding to UIURL.
 	// Populated for first-party providers whose Vite-built portal/dist is
@@ -163,9 +174,29 @@ func (r *Registry) Upsert(p Provider) {
 		p.ReportedVersion = existing.ReportedVersion
 		p.HeartbeatRequired = existing.HeartbeatRequired
 		p.HeartbeatStale = existing.HeartbeatStale
+		if p.WorkspaceCluster == "" {
+			// Provisioning sets this after the Upsert in the same reconcile;
+			// don't lose it on the next reconcile's fresh Provider value.
+			p.WorkspaceCluster = existing.WorkspaceCluster
+		}
 	}
 	cp := p
 	r.byName[p.Name] = &cp
+}
+
+// SetWorkspaceCluster records the logical cluster ID of the provider's
+// sub-workspace. Called by the catalog controller once provisioning has
+// resolved it (the workspace must be Ready before spec.cluster is set).
+// Returns false if the name is not in the registry.
+func (r *Registry) SetWorkspaceCluster(name, cluster string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.byName[name]
+	if !ok {
+		return false
+	}
+	p.WorkspaceCluster = cluster
+	return true
 }
 
 // Heartbeat records a heartbeat for a known provider. Returns false if the

--- a/pkg/hub/restapi/providers_enable.go
+++ b/pkg/hub/restapi/providers_enable.go
@@ -28,6 +28,8 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/faroshq/faros-kedge/pkg/hub/kcp"
+	"github.com/faroshq/faros-kedge/pkg/hub/providers"
+	"github.com/faroshq/faros-kedge/pkg/util/identity"
 )
 
 // EnableProviderRequest is the body of POST .../providers/{name}/enable.
@@ -136,9 +138,61 @@ func (h *Handler) enableProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Providers that declared spec.edgeProxyAccess additionally get the
+	// "proxy"-on-edges grant in this workspace, bound to the provider SA's
+	// cluster-qualified identity (the Enable dialog surfaced the request —
+	// clicking Enable is the consent). WorkspaceCluster is resolved by the
+	// catalog controller during provisioning; a provider whose CatalogEntry
+	// hasn't finished provisioning can't meaningfully be enabled yet, so an
+	// empty value is an error rather than a silent skip.
+	if prov.EdgeProxyAccess {
+		if prov.WorkspaceCluster == "" {
+			writeStatus(w, http.StatusConflict, "Conflict", "provider "+providerName+" requests edge proxy access but its workspace is not provisioned yet — retry shortly")
+			return
+		}
+		subject := identity.QualifiedServiceAccount(prov.WorkspaceCluster, providers.ProviderSANamespace, providers.ProviderSAName)
+		if err := h.mgr.bootstrapper.EnsureProviderEdgeProxyGrant(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, providerName, subject); err != nil {
+			writeStatus(w, http.StatusInternalServerError, "InternalError", "ensure edge-proxy grant: "+err.Error())
+			return
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(EnableProviderResponse{BindingName: providerName})
+}
+
+// disableProvider handles POST /api/orgs/{org}/workspaces/{ws}/providers/{name}/disable.
+// Inverse of enableProvider: deletes the provider's APIBinding and, always,
+// the edge-proxy grant pair (also for providers that no longer declare
+// spec.edgeProxyAccess — a leftover grant from an older CatalogEntry version
+// must not survive a Disable). Idempotent: NotFound at every step is
+// success, so the portal can re-issue on retry.
+//
+// Lives server-side for the same proxy-avoidance reason as enableProvider,
+// plus a new one: the RBAC teardown must happen with kcp-admin credentials
+// the tenant doesn't hold.
+func (h *Handler) disableProvider(w http.ResponseWriter, r *http.Request) {
+	tc, ok := h.requireTenantContext(w, r, true /* workspace */, false /* admin not required */)
+	if !ok {
+		return
+	}
+	providerName := mux.Vars(r)["name"]
+	if providerName == "" {
+		writeError(w, newValidationError("provider name is required"))
+		return
+	}
+
+	if err := h.mgr.bootstrapper.DeleteProviderAPIBinding(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, providerName); err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", "delete APIBinding: "+err.Error())
+		return
+	}
+	if err := h.mgr.bootstrapper.RemoveProviderEdgeProxyGrant(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, providerName); err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", "remove edge-proxy grant: "+err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // ListEnabledProvidersResponse is the body of GET .../providers/enabled.

--- a/pkg/hub/restapi/restapi.go
+++ b/pkg/hub/restapi/restapi.go
@@ -109,6 +109,19 @@ type WorkspaceOps interface {
 	// "enabled providers" sidebar set on every workspace switch
 	// without 403'ing through the kcp user-proxy.
 	ListProviderAPIBindings(ctx context.Context, orgUUID, wsUUID string) (map[string]string, error)
+
+	// DeleteProviderAPIBinding removes a provider APIBinding from the
+	// target workspace. Used by the POST .../providers/{name}/disable
+	// handler. NotFound is a no-op.
+	DeleteProviderAPIBinding(ctx context.Context, orgUUID, wsUUID, bindingName string) error
+
+	// EnsureProviderEdgeProxyGrant / RemoveProviderEdgeProxyGrant manage
+	// the ClusterRole/ClusterRoleBinding pair that lets a provider's SA
+	// (under its cluster-qualified identity) use the "proxy" verb on
+	// edges in the tenant workspace. Applied on Enable when the provider
+	// declares spec.edgeProxyAccess; removed on Disable.
+	EnsureProviderEdgeProxyGrant(ctx context.Context, orgUUID, wsUUID, providerName, subject string) error
+	RemoveProviderEdgeProxyGrant(ctx context.Context, orgUUID, wsUUID, providerName string) error
 }
 
 // KubeconfigConfig configures the workspace-scoped kubeconfig download
@@ -261,6 +274,7 @@ func (h *Handler) RegisterTenantScoped(r *mux.Router) {
 	// via kcp-admin so the kcp user-proxy's defaultCluster pre-check
 	// doesn't block sibling-workspace operations). See providers_enable.go.
 	r.HandleFunc("/{org}/workspaces/{ws}/providers/{name}/enable", h.enableProvider).Methods(http.MethodPost)
+	r.HandleFunc("/{org}/workspaces/{ws}/providers/{name}/disable", h.disableProvider).Methods(http.MethodPost)
 
 	// Read-side counterpart: list the provider APIBindings in this
 	// workspace. Same proxy-avoidance rationale. Portal calls this

--- a/pkg/hub/restapi/restapi_test.go
+++ b/pkg/hub/restapi/restapi_test.go
@@ -168,6 +168,18 @@ func (f *fakeOps) ListProviderAPIBindings(_ context.Context, _, _ string) (map[s
 	return map[string]string{}, nil
 }
 
+func (f *fakeOps) DeleteProviderAPIBinding(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (f *fakeOps) EnsureProviderEdgeProxyGrant(_ context.Context, _, _, _, _ string) error {
+	return nil
+}
+
+func (f *fakeOps) RemoveProviderEdgeProxyGrant(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (f *fakeOps) ListChildWorkspaces(_ context.Context, orgUUID string) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/util/identity/identity.go
+++ b/pkg/util/identity/identity.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package identity defines the synthetic identity encoding kedge uses when a
+// kcp ServiceAccount from one logical cluster is authorized in another.
+//
+// kcp ServiceAccount identities are logical-cluster-scoped: the username
+// "system:serviceaccount:default:provider" means a DIFFERENT principal in
+// every workspace, so binding RBAC to it in a tenant workspace would also
+// match a same-named SA the tenant created themselves. Kedge therefore
+// qualifies foreign SAs with their verified home cluster before running a
+// SubjectAccessReview, and grants (e.g. the provider edges-proxy grant
+// created on tenant Enable) bind the qualified form.
+//
+// Both sides — the SAR caller in pkg/virtual/builder and the grant writer in
+// pkg/hub/kcp — MUST use these helpers so the encodings cannot drift.
+package identity
+
+import "strings"
+
+// qualifiedSAPrefix deliberately does not collide with any kcp- or
+// kubernetes-issued username prefix ("system:serviceaccount:",
+// "system:kcp:", ...) so the qualified form can never be minted by an
+// authenticator — only synthesized by kedge after a successful TokenReview.
+const qualifiedSAPrefix = "system:kedge:foreign-sa:"
+
+// QualifyServiceAccount converts a TokenReview-resolved ServiceAccount
+// username ("system:serviceaccount:{ns}:{name}") plus its verified home
+// logical cluster into the qualified form
+// "system:kedge:foreign-sa:{homeCluster}:{ns}:{name}".
+//
+// Returns false when saUsername is not a ServiceAccount username.
+func QualifyServiceAccount(homeCluster, saUsername string) (string, bool) {
+	rest, ok := strings.CutPrefix(saUsername, "system:serviceaccount:")
+	if !ok || homeCluster == "" || rest == "" {
+		return "", false
+	}
+	return qualifiedSAPrefix + homeCluster + ":" + rest, true
+}
+
+// QualifiedServiceAccount builds the qualified username from parts. Used by
+// the grant writer, which knows the SA's coordinates rather than holding a
+// TokenReview result.
+func QualifiedServiceAccount(homeCluster, namespace, name string) string {
+	return qualifiedSAPrefix + homeCluster + ":" + namespace + ":" + name
+}

--- a/pkg/util/identity/identity.go
+++ b/pkg/util/identity/identity.go
@@ -14,16 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package identity defines the synthetic identity encoding kedge uses when a
-// kcp ServiceAccount from one logical cluster is authorized in another.
+// Package identity builds the cross-workspace ServiceAccount identity kedge
+// authorizes foreign SAs under.
 //
-// kcp ServiceAccount identities are logical-cluster-scoped: the username
-// "system:serviceaccount:default:provider" means a DIFFERENT principal in
+// kcp ServiceAccount usernames ("system:serviceaccount:{ns}:{name}") are
+// logical-cluster-scoped — the same string means a DIFFERENT principal in
 // every workspace, so binding RBAC to it in a tenant workspace would also
-// match a same-named SA the tenant created themselves. Kedge therefore
-// qualifies foreign SAs with their verified home cluster before running a
-// SubjectAccessReview, and grants (e.g. the provider edges-proxy grant
-// created on tenant Enable) bind the qualified form.
+// match a same-named SA the tenant created themselves.
+//
+// kcp already defines the disambiguated form: the GlobalServiceAccount
+// feature gate (beta, default-on since kube 1.35 in the kcp fork) makes
+// kcp's RBAC resolution alias every SA to
+//
+//	system:kcp:serviceaccount:{cluster}:{ns}:{name}
+//
+// (see EffectiveUsers in the fork's pkg/registry/rbac/validation/kcp.go and
+// kcp's e2e TestAPIResourceSchemaVirtualWorkspaceAuthorization, which binds
+// exactly this subject across workspaces). Kedge emits the same format —
+// after verifying the home cluster via TokenReview — so the grant objects
+// created on tenant Enable use kcp-native subjects: the same binding that
+// satisfies kedge's delegated SAR also authorizes the SA on kcp-native
+// paths.
 //
 // Both sides — the SAR caller in pkg/virtual/builder and the grant writer in
 // pkg/hub/kcp — MUST use these helpers so the encodings cannot drift.
@@ -31,16 +42,16 @@ package identity
 
 import "strings"
 
-// qualifiedSAPrefix deliberately does not collide with any kcp- or
-// kubernetes-issued username prefix ("system:serviceaccount:",
-// "system:kcp:", ...) so the qualified form can never be minted by an
-// authenticator — only synthesized by kedge after a successful TokenReview.
-const qualifiedSAPrefix = "system:kedge:foreign-sa:"
+// globalSAPrefix is kcp's cross-workspace ServiceAccount username prefix.
+// kcp's authenticators never mint usernames under it directly (it is an
+// RBAC-resolution alias), so kedge synthesizing it after a successful
+// TokenReview cannot collide with or be forged through any token.
+const globalSAPrefix = "system:kcp:serviceaccount:"
 
 // QualifyServiceAccount converts a TokenReview-resolved ServiceAccount
 // username ("system:serviceaccount:{ns}:{name}") plus its verified home
-// logical cluster into the qualified form
-// "system:kedge:foreign-sa:{homeCluster}:{ns}:{name}".
+// logical cluster into kcp's global form
+// "system:kcp:serviceaccount:{homeCluster}:{ns}:{name}".
 //
 // Returns false when saUsername is not a ServiceAccount username.
 func QualifyServiceAccount(homeCluster, saUsername string) (string, bool) {
@@ -48,12 +59,12 @@ func QualifyServiceAccount(homeCluster, saUsername string) (string, bool) {
 	if !ok || homeCluster == "" || rest == "" {
 		return "", false
 	}
-	return qualifiedSAPrefix + homeCluster + ":" + rest, true
+	return globalSAPrefix + homeCluster + ":" + rest, true
 }
 
-// QualifiedServiceAccount builds the qualified username from parts. Used by
+// QualifiedServiceAccount builds the global username from parts. Used by
 // the grant writer, which knows the SA's coordinates rather than holding a
 // TokenReview result.
 func QualifiedServiceAccount(homeCluster, namespace, name string) string {
-	return qualifiedSAPrefix + homeCluster + ":" + namespace + ":" + name
+	return globalSAPrefix + homeCluster + ":" + namespace + ":" + name
 }

--- a/pkg/virtual/builder/auth.go
+++ b/pkg/virtual/builder/auth.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/faroshq/faros-kedge/pkg/apiurl"
+	"github.com/faroshq/faros-kedge/pkg/util/identity"
 )
 
 // saTokenClaims holds the claims extracted from a kcp ServiceAccount JWT.
@@ -90,18 +91,37 @@ func extractBearerToken(r *http.Request) string {
 //  2. SubjectAccessReview — checks if the authenticated user is allowed to
 //     perform the given verb on the resource in the target workspace.
 //
-// Both calls use admin credentials scoped to the target workspace.
+// Both calls use admin credentials scoped to the target workspace, with one
+// exception: kcp ServiceAccount tokens only authenticate in their home
+// logical cluster, so for SA tokens the TokenReview runs against the token's
+// clusterName claim. The home cluster is still VERIFIED — kcp checks the
+// token signature there, and a forged claim just fails the review. The
+// SubjectAccessReview always runs in the target workspace (clusterName from
+// the request URL — the #68 invariant), under a cluster-qualified synthetic
+// identity (see pkg/util/identity) with the SA's groups dropped, so a
+// foreign SA passes only when the target workspace explicitly bound that
+// exact qualified identity (e.g. the provider edges-proxy grant created on
+// tenant Enable).
 func authorize(ctx context.Context, kcpConfig *rest.Config, token, clusterName, verb, resource, name string) error {
-	cfg := rest.CopyConfig(kcpConfig)
-	cfg.Host = apiurl.KCPClusterURL(cfg.Host, clusterName)
+	reviewCluster := clusterName
+	saClaims, isForeignSA := parseServiceAccountToken(token)
+	if isForeignSA && saClaims.ClusterName == clusterName {
+		// Same-cluster SA: the plain path below already handles it.
+		isForeignSA = false
+	}
+	if isForeignSA {
+		reviewCluster = saClaims.ClusterName
+	}
 
-	client, err := kubernetes.NewForConfig(cfg)
+	trCfg := rest.CopyConfig(kcpConfig)
+	trCfg.Host = apiurl.KCPClusterURL(trCfg.Host, reviewCluster)
+	trClient, err := kubernetes.NewForConfig(trCfg)
 	if err != nil {
 		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
 	// 1. Authenticate: TokenReview with admin creds.
-	tr, err := client.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+	tr, err := trClient.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{Token: token},
 	}, metav1.CreateOptions{})
 	if err != nil {
@@ -111,11 +131,38 @@ func authorize(ctx context.Context, kcpConfig *rest.Config, token, clusterName, 
 		return fmt.Errorf("token not authenticated")
 	}
 
-	// 2. Authorize: SubjectAccessReview with the resolved identity.
+	sarUser := tr.Status.User.Username
+	sarGroups := tr.Status.User.Groups
+	if isForeignSA {
+		qualified, ok := identity.QualifyServiceAccount(reviewCluster, tr.Status.User.Username)
+		if !ok {
+			// Token claimed to be an SA token but the home cluster resolved
+			// it to a non-SA identity — refuse rather than authorize an
+			// identity we can't encode unambiguously.
+			return fmt.Errorf("token review: expected ServiceAccount identity, got %q", tr.Status.User.Username)
+		}
+		sarUser = qualified
+		// Drop groups: system:serviceaccounts et al. would match
+		// group-targeted bindings the tenant wrote for their OWN SAs.
+		sarGroups = nil
+	}
+
+	client := trClient
+	if reviewCluster != clusterName {
+		sarCfg := rest.CopyConfig(kcpConfig)
+		sarCfg.Host = apiurl.KCPClusterURL(sarCfg.Host, clusterName)
+		client, err = kubernetes.NewForConfig(sarCfg)
+		if err != nil {
+			return fmt.Errorf("creating kubernetes client: %w", err)
+		}
+	}
+
+	// 2. Authorize: SubjectAccessReview with the resolved identity, always
+	// in the target workspace.
 	sar, err := client.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authorizationv1.SubjectAccessReview{
 		Spec: authorizationv1.SubjectAccessReviewSpec{
-			User:   tr.Status.User.Username,
-			Groups: tr.Status.User.Groups,
+			User:   sarUser,
+			Groups: sarGroups,
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Verb:     verb,
 				Group:    "kedge.faros.sh",

--- a/pkg/virtual/builder/auth_test.go
+++ b/pkg/virtual/builder/auth_test.go
@@ -120,7 +120,9 @@ func TestAuthorize_ForeignSAToken(t *testing.T) {
 	if fake.sarCluster != targetCluster {
 		t.Errorf("SAR cluster = %q, want target cluster %q (the #68 invariant)", fake.sarCluster, targetCluster)
 	}
-	wantUser := "system:kedge:foreign-sa:" + homeCluster + ":default:provider"
+	// kcp.s native cross-workspace SA form (GlobalServiceAccount aliasing) —
+	// the same subject kcp.s own RBAC resolution would match.
+	wantUser := "system:kcp:serviceaccount:" + homeCluster + ":default:provider"
 	if fake.sarUser != wantUser {
 		t.Errorf("SAR user = %q, want qualified %q", fake.sarUser, wantUser)
 	}

--- a/pkg/virtual/builder/auth_test.go
+++ b/pkg/virtual/builder/auth_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/rest"
+)
+
+// fakeKCP simulates the two kcp endpoints authorize() talks to —
+// TokenReview and SubjectAccessReview — per logical cluster, recording
+// which cluster each review was created in and what identity the SAR
+// carried.
+type fakeKCP struct {
+	// identities maps "cluster|token" to the username TokenReview resolves.
+	// Tokens without an entry for the requested cluster are unauthenticated
+	// (mirrors kcp's cluster-scoped SA authn).
+	identities map[string]string
+
+	trCluster  string // cluster the TokenReview was created in
+	sarCluster string // cluster the SAR was created in
+	sarUser    string
+	sarGroups  []string
+	sarAllowed bool
+}
+
+func (f *fakeKCP) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Paths look like /clusters/{cluster}/apis/{group}/v1/{resource}.
+		parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/clusters/"), "/", 2)
+		if len(parts) != 2 {
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		cluster := parts[0]
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/tokenreviews"):
+			var tr authenticationv1.TokenReview
+			if err := json.NewDecoder(r.Body).Decode(&tr); err != nil {
+				t.Errorf("decoding TokenReview: %v", err)
+			}
+			f.trCluster = cluster
+			username, ok := f.identities[cluster+"|"+tr.Spec.Token]
+			tr.Status.Authenticated = ok
+			tr.Status.User.Username = username
+			if ok {
+				tr.Status.User.Groups = []string{"system:serviceaccounts", "system:authenticated"}
+			}
+			_ = json.NewEncoder(w).Encode(&tr)
+		case strings.HasSuffix(r.URL.Path, "/subjectaccessreviews"):
+			var sar authorizationv1.SubjectAccessReview
+			if err := json.NewDecoder(r.Body).Decode(&sar); err != nil {
+				t.Errorf("decoding SAR: %v", err)
+			}
+			f.sarCluster = cluster
+			f.sarUser = sar.Spec.User
+			f.sarGroups = sar.Spec.Groups
+			sar.Status.Allowed = f.sarAllowed
+			_ = json.NewEncoder(w).Encode(&sar)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestAuthorize_ForeignSAToken verifies the provider-SA path: the
+// TokenReview runs in the token's home cluster (kcp SA authn is cluster-
+// scoped), while the SAR runs in the TARGET cluster — the #68 invariant —
+// under the cluster-qualified synthetic identity with groups dropped.
+func TestAuthorize_ForeignSAToken(t *testing.T) {
+	const (
+		homeCluster   = "provider-ws-cluster"
+		targetCluster = "tenant-ws-cluster"
+	)
+	token := fakeSAToken(homeCluster)
+
+	fake := &fakeKCP{
+		identities: map[string]string{
+			// The token only authenticates in its home cluster.
+			homeCluster + "|" + token: "system:serviceaccount:default:provider",
+		},
+		sarAllowed: true,
+	}
+	srv := fake.server(t)
+	defer srv.Close()
+
+	err := authorize(context.Background(), &rest.Config{Host: srv.URL}, token, targetCluster, "proxy", "edges", "my-edge")
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if fake.trCluster != homeCluster {
+		t.Errorf("TokenReview cluster = %q, want home cluster %q", fake.trCluster, homeCluster)
+	}
+	if fake.sarCluster != targetCluster {
+		t.Errorf("SAR cluster = %q, want target cluster %q (the #68 invariant)", fake.sarCluster, targetCluster)
+	}
+	wantUser := "system:kedge:foreign-sa:" + homeCluster + ":default:provider"
+	if fake.sarUser != wantUser {
+		t.Errorf("SAR user = %q, want qualified %q", fake.sarUser, wantUser)
+	}
+	if len(fake.sarGroups) != 0 {
+		t.Errorf("SAR groups = %v, want none (foreign SA groups must be dropped)", fake.sarGroups)
+	}
+}
+
+// TestAuthorize_ForeignSADenied verifies a foreign SA without the grant is
+// refused: the SAR runs but RBAC says no.
+func TestAuthorize_ForeignSADenied(t *testing.T) {
+	const homeCluster = "provider-ws-cluster"
+	token := fakeSAToken(homeCluster)
+	fake := &fakeKCP{
+		identities: map[string]string{
+			homeCluster + "|" + token: "system:serviceaccount:default:provider",
+		},
+		sarAllowed: false,
+	}
+	srv := fake.server(t)
+	defer srv.Close()
+
+	if err := authorize(context.Background(), &rest.Config{Host: srv.URL}, token, "tenant-ws", "proxy", "edges", "e"); err == nil {
+		t.Fatal("authorize succeeded, want denial")
+	}
+}
+
+// TestAuthorize_ForeignSANonSAIdentity verifies a token that CLAIMS to be a
+// kcp SA token but resolves to a non-SA identity in its home cluster is
+// refused rather than authorized under an unqualifiable name.
+func TestAuthorize_ForeignSANonSAIdentity(t *testing.T) {
+	const homeCluster = "weird-cluster"
+	token := fakeSAToken(homeCluster)
+	fake := &fakeKCP{
+		identities: map[string]string{
+			homeCluster + "|" + token: "alice@example.com",
+		},
+		sarAllowed: true,
+	}
+	srv := fake.server(t)
+	defer srv.Close()
+
+	if err := authorize(context.Background(), &rest.Config{Host: srv.URL}, token, "tenant-ws", "proxy", "edges", "e"); err == nil {
+		t.Fatal("authorize succeeded for SA-claimed token with non-SA identity, want refusal")
+	}
+}
+
+// TestAuthorize_NonSAToken verifies the pre-existing path is untouched:
+// both reviews run in the target cluster and the SAR carries the
+// TokenReview identity verbatim.
+func TestAuthorize_NonSAToken(t *testing.T) {
+	const targetCluster = "tenant-ws-cluster"
+	token := "opaque-oidc-token"
+	fake := &fakeKCP{
+		identities: map[string]string{
+			targetCluster + "|" + token: "alice@example.com",
+		},
+		sarAllowed: true,
+	}
+	srv := fake.server(t)
+	defer srv.Close()
+
+	if err := authorize(context.Background(), &rest.Config{Host: srv.URL}, token, targetCluster, "proxy", "edges", "e"); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if fake.trCluster != targetCluster {
+		t.Errorf("TokenReview cluster = %q, want %q", fake.trCluster, targetCluster)
+	}
+	if fake.sarCluster != targetCluster {
+		t.Errorf("SAR cluster = %q, want %q", fake.sarCluster, targetCluster)
+	}
+	if fake.sarUser != "alice@example.com" {
+		t.Errorf("SAR user = %q, want alice@example.com", fake.sarUser)
+	}
+	if len(fake.sarGroups) == 0 {
+		t.Errorf("SAR groups empty, want TokenReview groups passed through for non-SA tokens")
+	}
+}
+
+// TestAuthorize_SameClusterSAToken verifies an SA token whose home IS the
+// target cluster takes the plain path: no qualification, groups intact.
+func TestAuthorize_SameClusterSAToken(t *testing.T) {
+	const cluster = "tenant-ws-cluster"
+	token := fakeSAToken(cluster)
+	fake := &fakeKCP{
+		identities: map[string]string{
+			cluster + "|" + token: "system:serviceaccount:default:tenant-sa",
+		},
+		sarAllowed: true,
+	}
+	srv := fake.server(t)
+	defer srv.Close()
+
+	if err := authorize(context.Background(), &rest.Config{Host: srv.URL}, token, cluster, "proxy", "edges", "e"); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if fake.sarUser != "system:serviceaccount:default:tenant-sa" {
+		t.Errorf("SAR user = %q, want unqualified local SA name", fake.sarUser)
+	}
+	if len(fake.sarGroups) == 0 {
+		t.Errorf("SAR groups empty, want groups intact for same-cluster SA")
+	}
+}

--- a/portal/src/components/ProviderEnableDialog.vue
+++ b/portal/src/components/ProviderEnableDialog.vue
@@ -111,6 +111,21 @@ function onConfirm() {
           </li>
         </ul>
 
+        <div
+          v-if="provider.edgeProxyAccess"
+          class="mt-3 rounded-lg border border-border-subtle bg-surface-overlay/30 px-3 py-2"
+        >
+          <div class="flex items-center gap-2">
+            <ShieldCheck class="h-3.5 w-3.5 text-success" :stroke-width="2" />
+            <span class="text-[11px] font-medium text-text-primary">Edge cluster access</span>
+          </div>
+          <p class="mt-0.5 text-[10px] text-text-muted">
+            This provider will get proxied read access to the edge clusters
+            connected to this workspace (background connections through the
+            hub's edges-proxy). Removed when you disable the provider.
+          </p>
+        </div>
+
         <div v-if="hasUntrustedAccepted" class="mt-3 rounded-md border border-warning/30 bg-warning-subtle px-3 py-2 text-[11px] text-warning">
           You've accepted at least one claim that isn't tenant-scoped. The
           provider's controllers will be able to read or write the indicated

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { STORAGE_KEYS } from '@/lib/constants'
-import { graphqlMutate } from '@/composables/useGraphQL'
 
 // ProviderDTO is the wire shape returned by the hub's GET /api/providers.
 // Keep it aligned with pkg/hub/providers/api.go:providerDTO.
@@ -13,6 +12,10 @@ export interface ProviderDTO {
   hasUI: boolean
   hasBackend: boolean
   iconURL?: string
+  // True when the provider requests background access to the workspace's
+  // edge clusters (verb "proxy" on edges) on Enable. Rendered in the
+  // Enable confirmation dialog alongside permission claims.
+  edgeProxyAccess?: boolean
   // When set, the portal renders this Vue Router route name in-tree
   // instead of loading /main.js. First-party providers (mcp, kubernetes-
   // edges, server-edges) use this to surface their existing SPA pages
@@ -306,16 +309,24 @@ export const useProvidersStore = defineStore('providers', () => {
   async function disable(p: ProviderDTO): Promise<void> {
     const bindingName = bindingNamesByProvider.value[p.name]
     if (!bindingName) return
-    // Disable = remove the tenant's APIBinding, via the GraphQL gateway (like
-    // every other kcp call). Idempotent: an already-gone binding is fine.
-    try {
-      await graphqlMutate(
-        'mutation($n: String!) { apis_kcp_io { v1alpha2 { deleteAPIBinding(name: $n) } } }',
-        { n: bindingName },
-      )
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
-      if (!/not\s*found/i.test(msg)) throw new Error(`disable ${p.name} failed: ${msg}`)
+    // Disable = server-side endpoint (mirror of enable). It deletes the
+    // APIBinding AND tears down the edge-proxy RBAC grant — the latter
+    // needs kcp-admin credentials the tenant doesn't hold, so a direct
+    // GraphQL deleteAPIBinding would leave the grant dangling.
+    const t = readTenantSelection()
+    if (!t.orgUUID || !t.workspaceUUID) {
+      throw new Error('select an organization and workspace before disabling a provider')
+    }
+    const url = `/api/orgs/${encodeURIComponent(t.orgUUID)}/workspaces/${encodeURIComponent(t.workspaceUUID)}/providers/${encodeURIComponent(p.name)}/disable`
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: authHeaders(),
+      credentials: 'same-origin',
+    })
+    // Idempotent server-side; 404 means the route target is already gone.
+    if (!res.ok && res.status !== 404) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(`disable ${p.name} failed: ${res.status} ${res.statusText} ${detail}`)
     }
     const next = { ...bindingNamesByProvider.value }
     delete next[p.name]

--- a/test/e2e/suites/provider/provider_test.go
+++ b/test/e2e/suites/provider/provider_test.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
+
+	"github.com/faroshq/faros-kedge/pkg/util/identity"
 )
 
 // providersWorkspaceClient returns a dynamic client targeting
@@ -629,16 +631,28 @@ func httpGetJSON(t *testing.T, url, token string) map[string]any {
 // returned kubeconfig.
 func loginStaticTokenAndGetCluster(t *testing.T) string {
 	t.Helper()
-	req, _ := http.NewRequest(http.MethodPost, hubURL+"/auth/token-login", nil)
-	req.Header.Set("Authorization", "Bearer "+staticToken)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("token-login: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	b, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 200 {
-		t.Fatalf("token-login: status %d body=%s", resp.StatusCode, string(b))
+	// The hub reports /readyz before the users APIBinding in
+	// root:kedge:users is fully usable, so the first logins after startup
+	// can 500 with "failed to create user" (the handler's user list hits
+	// "the server could not find the requested resource"). Retry until the
+	// binding settles rather than failing the suite on the race.
+	var (
+		b    []byte
+		code int
+	)
+	if !waitForCondition(t, 90*time.Second, func() (bool, string) {
+		req, _ := http.NewRequest(http.MethodPost, hubURL+"/auth/token-login", nil)
+		req.Header.Set("Authorization", "Bearer "+staticToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false, "token-login: " + err.Error()
+		}
+		defer func() { _ = resp.Body.Close() }()
+		b, _ = io.ReadAll(resp.Body)
+		code = resp.StatusCode
+		return code == 200, fmt.Sprintf("token-login: status %d body=%s", code, string(b))
+	}) {
+		t.Fatalf("token-login never succeeded: last status %d body=%s", code, string(b))
 	}
 	var out struct {
 		Kubeconfig string `json:"kubeconfig"`
@@ -684,4 +698,156 @@ func waitForCondition(t *testing.T, timeout time.Duration, cond func() (bool, st
 	}
 	t.Logf("wait timeout after %s; last status: %s", timeout, lastMsg)
 	return false
+}
+
+// TestIEdgeProxyGrantAuthorizesProviderSA proves the Enable-time edges-proxy
+// grant end-to-end against REAL kcp — the parts the auth.go unit tests can
+// only mock:
+//
+//  1. The provider's minted SA token (root:kedge:providers:quickstart,
+//     default/provider) authenticates via TokenReview even though the
+//     edges-proxy request targets the TENANT workspace (kcp SA authn
+//     resolves the token in its home cluster).
+//  2. kcp RBAC in the tenant workspace matches the cross-workspace subject
+//     system:kcp:serviceaccount:{providerCluster}:default:provider that
+//     pkg/util/identity emits and the Enable grant binds.
+//  3. Removing the grant revokes access again.
+//
+// The test never needs a connected edge: a 403 means authorization failed,
+// while a 502 ("upstream unavailable") means authorization PASSED and only
+// the tunnel lookup failed — exactly the boundary under test.
+func TestIEdgeProxyGrantAuthorizesProviderSA(t *testing.T) {
+	tenantWS := loginStaticTokenAndGetCluster(t)
+
+	// Resolve the provider workspace's logical cluster ID — the value kcp
+	// embeds in the SA token claims and the grant subject must carry.
+	providersWS := providersWorkspaceClient(t)
+	workspaceGVR := schema.GroupVersionResource{Group: "tenancy.kcp.io", Version: "v1alpha1", Resource: "workspaces"}
+	ws, err := providersWS.Resource(workspaceGVR).Get(ctxWithTimeout(t, 10*time.Second), "quickstart", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get provider workspace: %v", err)
+	}
+	providerCluster, _, _ := unstructured.NestedString(ws.Object, "spec", "cluster")
+	if providerCluster == "" {
+		t.Fatal("provider workspace has no spec.cluster")
+	}
+
+	// Fetch the provider SA's minted long-lived token (the same credential
+	// the provider pod mounts via kedge-provider-kubeconfig).
+	sub := providerSubClient(t, "quickstart")
+	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	var saToken string
+	if !waitForCondition(t, 30*time.Second, func() (bool, string) {
+		sec, err := sub.Resource(secretGVR).Namespace("default").Get(ctxWithTimeout(t, 5*time.Second), "provider-token", metav1.GetOptions{})
+		if err != nil {
+			return false, "get provider-token Secret: " + err.Error()
+		}
+		tok, _, _ := unstructured.NestedString(sec.Object, "data", "token")
+		if tok == "" {
+			return false, "token not yet populated"
+		}
+		raw, err := base64.StdEncoding.DecodeString(tok)
+		if err != nil {
+			return false, "decode token: " + err.Error()
+		}
+		saToken = string(raw)
+		return true, ""
+	}) {
+		t.Fatal("provider SA token never appeared")
+	}
+
+	// The edge name is irrelevant: authorization runs BEFORE the tunnel
+	// lookup, and the grant has no resourceNames restriction.
+	proxyURL := hubURL + "/services/edges-proxy/clusters/" + tenantWS +
+		"/apis/kedge.faros.sh/v1alpha1/edges/e2e-no-such-edge/k8s/api"
+	probe := func() int {
+		req, _ := http.NewRequest(http.MethodGet, proxyURL, nil)
+		req.Header.Set("Authorization", "Bearer "+saToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("edges-proxy probe: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+
+	// 1. No grant → authorization must fail.
+	if code := probe(); code != http.StatusForbidden {
+		t.Fatalf("expected 403 before grant, got %d", code)
+	}
+
+	// 2. Materialize the grant in the tenant workspace exactly as the
+	// Enable endpoint does (same names, same qualified subject).
+	tenantAdmin := kcpDynamic(t, tenantWS, adminToken)
+	subject := identity.QualifiedServiceAccount(providerCluster, "default", "provider")
+	t.Logf("grant subject = %s", subject)
+
+	grantName := "kedge:provider:quickstart:edges-proxy"
+	clusterRoleGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	clusterRoleBindingGVR := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+
+	role := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]any{"name": grantName},
+		"rules": []any{
+			// "access" on "/" satisfies kcp's workspaceContentAuthorizer for
+			// the foreign SA — same pairing as the Enable-endpoint grant and
+			// kcp's own cross-workspace SA e2e.
+			map[string]any{
+				"nonResourceURLs": []any{"/"},
+				"verbs":           []any{"access"},
+			},
+			map[string]any{
+				"apiGroups": []any{"kedge.faros.sh"},
+				"resources": []any{"edges"},
+				"verbs":     []any{"proxy"},
+			},
+		},
+	}}
+	if _, err := tenantAdmin.Resource(clusterRoleGVR).Create(ctxWithTimeout(t, 10*time.Second), role, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create ClusterRole: %v", err)
+	}
+	crb := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": grantName},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     grantName,
+		},
+		"subjects": []any{map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "User",
+			"name":     subject,
+		}},
+	}}
+	if _, err := tenantAdmin.Resource(clusterRoleBindingGVR).Create(ctxWithTimeout(t, 10*time.Second), crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create ClusterRoleBinding: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tenantAdmin.Resource(clusterRoleBindingGVR).Delete(context.Background(), grantName, metav1.DeleteOptions{})
+		_ = tenantAdmin.Resource(clusterRoleGVR).Delete(context.Background(), grantName, metav1.DeleteOptions{})
+	})
+
+	// 3. With the grant: authorization passes, tunnel lookup fails → 502.
+	if !waitForCondition(t, 30*time.Second, func() (bool, string) {
+		code := probe()
+		return code == http.StatusBadGateway, fmt.Sprintf("status=%d (want 502)", code)
+	}) {
+		t.Fatal("edges-proxy never authorized the provider SA after grant")
+	}
+
+	// 4. Revoke → 403 again.
+	if err := tenantAdmin.Resource(clusterRoleBindingGVR).Delete(ctxWithTimeout(t, 5*time.Second), grantName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete ClusterRoleBinding: %v", err)
+	}
+	if !waitForCondition(t, 30*time.Second, func() (bool, string) {
+		code := probe()
+		return code == http.StatusForbidden, fmt.Sprintf("status=%d (want 403)", code)
+	}) {
+		t.Fatal("edges-proxy still authorizes the provider SA after revocation")
+	}
 }


### PR DESCRIPTION
## Summary

Phase 0 (hub side) for the **kuery provider** ([design doc](docs/kuery-provider-architecture.md), included in this PR): providers that need long-lived background access to a tenant's edge clusters — kuery's informer sync through the edges-proxy — get an **Enable-time grant** instead of forwarding per-request user tokens.

### Authn: SA-aware `authorize()` (`pkg/virtual/builder/auth.go`)

kcp SA tokens are logical-cluster-scoped, so a provider SA token from `root:kedge:providers:{name}` failed the TokenReview in the tenant workspace before RBAC was ever consulted. `authorize()` now:

- detects kcp SA tokens (same `parseServiceAccountToken` the front proxy uses) and runs the **TokenReview in the token's home cluster** — kcp verifies the signature there, so the home cluster is verified, not just claimed;
- keeps the **SubjectAccessReview in the target workspace** (the #68 invariant is untouched — there's a dedicated test asserting it);
- adopts **kcp's native cross-workspace SA identity** `system:kcp:serviceaccount:{homeCluster}:{ns}:{name}` (`pkg/util/identity`) — the same form kcp's GlobalServiceAccount feature gate (beta, default-on since kube 1.35 in the kcp fork) aliases SAs to during RBAC resolution, proven cross-workspace by kcp's e2e `TestAPIResourceSchemaVirtualWorkspaceAuthorization`. The grant binding therefore also authorizes the provider SA on kcp-native paths and **drops groups**, so a foreign SA passes only when the target workspace explicitly bound that exact identity. Bare SA usernames are ambiguous across workspaces — any tenant could mint a same-named SA.

### Authz: grant lifecycle on Enable/Disable

- `CatalogEntry.spec.edgeProxyAccess` declares the request; surfaced in the portal's Enable confirmation dialog alongside permission claims.
- The Enable endpoint additionally applies `ClusterRole`/`ClusterRoleBinding` `kedge:provider:{name}:edges-proxy` (verb `proxy` on `edges.kedge.faros.sh`) in the tenant workspace, bound to the qualified subject. Subjects are reconciled on re-Enable.
- New server-side **Disable endpoint** removes the APIBinding and the grant. The portal's `disable()` switches from the direct GraphQL `deleteAPIBinding` to this endpoint — the GraphQL path would have left the grant dangling (tenants don't hold the kcp-admin creds the teardown needs).
- The catalog controller records the provider workspace's logical cluster ID (`Workspace.spec.cluster`) in the registry during provisioning so the Enable endpoint can build the subject.

## Test plan

- **End-to-end against real kcp** (`TestIEdgeProxyGrantAuthorizesProviderSA`, provider e2e suite): the provider's minted SA token hits the edges-proxy targeting the tenant workspace — 403 with no grant, 502 (authorization passed, tunnel absent) once the grant exists, 403 again after revocation. This caught a real gap: the grant ClusterRole also needs the `access` verb on nonResourceURL `/` for kcp's workspaceContentAuthorizer (foreign SAs aren't in the tenant's `system:authenticated` grants) — same rule pairing as kcp's own cross-workspace SA e2e.

- New `auth_test.go`: foreign-SA happy path (TokenReview in home cluster, SAR in target, qualified user, groups dropped), denial without grant, SA-claimed-token-with-non-SA-identity refusal, non-SA tokens untouched, same-cluster SA untouched.
- `go test ./pkg/... ./apis/... ./cmd/...` — all pass; `make lint` clean; `make codegen` re-run (new versioned APIResourceSchema name, kcp immutability respected); portal `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

