### PR TITLE
providers/kuery: Phase 1 skeleton (registration surface)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
+.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery install-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
 
 BINDIR ?= bin
 GOFLAGS ?=
@@ -118,6 +118,12 @@ build-quickstart-provider-portal: ## Build the quickstart provider's micro-front
 
 build-quickstart-provider: build-quickstart-provider-portal ## Build the quickstart reference provider binary (portal embedded)
 	cd providers/quickstart && go build $(GOFLAGS) -o $(CURDIR)/$(BINDIR)/quickstart-provider .
+
+build-kuery-provider-portal: ## Build the kuery provider's micro-frontend (Vite + TS → portal/dist)
+	cd providers/kuery/portal && npm install --no-audit --no-fund && npm run build
+
+build-kuery-provider: build-kuery-provider-portal ## Build the kuery provider binary (portal embedded)
+	cd providers/kuery && go build $(GOFLAGS) -o $(CURDIR)/$(BINDIR)/kuery-provider .
 
 build-infrastructure-provider-portal: ## Build the infrastructure provider's micro-frontend (Vite + Vue → portal/dist)
 	cd providers/infrastructure/portal && npm install --no-audit --no-fund && npm run build
@@ -591,6 +597,46 @@ uninstall-provider-quickstart: ## Delete quickstart CatalogEntry
 		--server=$(QUICKSTART_KCP_SERVER)/clusters/root:kedge:providers \
 		--insecure-skip-tls-verify \
 		delete -f $(QUICKSTART_MANIFEST)
+
+# --- Provider kuery (local dev) ---
+# Mirror of the quickstart pattern above. Distinct port (8084) so the demo
+# providers can run side-by-side. Phase 1 skeleton — see
+# docs/kuery-provider-architecture.md for the phasing.
+
+KUERY_PORT ?= 8084
+KUERY_HUB_URL ?= https://localhost:9443
+KUERY_TOKEN ?= $(STATIC_AUTH_TOKEN)
+KUERY_KCP_KUBECONFIG ?= $(KCP_DATA_DIR)/admin.kubeconfig
+KUERY_KCP_SERVER ?= https://localhost:6443
+KUERY_MANIFEST ?= providers/kuery/manifest.yaml
+
+run-provider-kuery: build-kuery-provider ## Run the kuery provider (requires: make run-hub-embedded-static + make install-provider-kuery)
+	@echo "Starting kuery provider on :$(KUERY_PORT)"
+	@echo "  hub:   $(KUERY_HUB_URL)"
+	@echo "  token: $(KUERY_TOKEN)"
+	PORT=$(KUERY_PORT) \
+	KEDGE_HUB_URL=$(KUERY_HUB_URL) \
+	KEDGE_HUB_TOKEN=$(KUERY_TOKEN) \
+	KEDGE_HUB_INSECURE=true \
+	KEDGE_PROVIDER_NAME=kuery \
+		$(BINDIR)/kuery-provider
+
+install-provider-kuery: ## Apply kuery CatalogEntry into root:kedge:providers
+	@test -f $(KUERY_KCP_KUBECONFIG) || { \
+		echo "kubeconfig not found at $(KUERY_KCP_KUBECONFIG)"; \
+		echo "start the hub first with: make run-hub-embedded-static"; \
+		exit 1; \
+	}
+	kubectl --kubeconfig=$(KUERY_KCP_KUBECONFIG) \
+		--server=$(KUERY_KCP_SERVER)/clusters/root:kedge:providers \
+		--insecure-skip-tls-verify \
+		apply -f $(KUERY_MANIFEST)
+
+uninstall-provider-kuery: ## Delete kuery CatalogEntry
+	-kubectl --kubeconfig=$(KUERY_KCP_KUBECONFIG) \
+		--server=$(KUERY_KCP_SERVER)/clusters/root:kedge:providers \
+		--insecure-skip-tls-verify \
+		delete -f $(KUERY_MANIFEST)
 
 # --- Provider infrastructure (local dev) ---
 # Mirror of the quickstart pattern above. Distinct port (8082) so both

--- a/providers/kuery/.github/workflows/chart.yaml
+++ b/providers/kuery/.github/workflows/chart.yaml
@@ -1,0 +1,57 @@
+name: Chart
+
+# Packages the Helm chart (deploy/chart) and publishes it to GHCR as an OCI
+# artifact under a dedicated `charts/` namespace, so it's clearly distinct from
+# the container image (ghcr.io/<owner>/provider-kuery) and doesn't collide
+# with the kedge monorepo's own chart publish (ghcr.io/<owner>/charts):
+#
+#   image: ghcr.io/<owner>/provider-kuery
+#   chart: ghcr.io/<owner>/provider-kuery/charts/kedge-kuery-provider
+#
+# Like image.yaml, this runs only in the standalone mirror (see README).
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.16.0'
+
+      - name: Package and push chart (OCI)
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+          # Tags publish the released version (no leading v in the chart
+          # version, per OCI/semver); main pushes get a 0.0.0-<sha> dev version.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            CHART_VERSION="${GITHUB_REF_NAME#v}"
+            APP_VERSION="${GITHUB_REF_NAME}"
+          else
+            CHART_VERSION="0.0.0-${GITHUB_SHA}"
+            APP_VERSION="${CHART_VERSION}"
+          fi
+
+          chart_dir=deploy/chart
+          name="$(grep -E '^name:' "${chart_dir}/Chart.yaml" | head -1 | awk '{print $2}')"
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}/Chart.yaml"
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}/Chart.yaml"
+
+          helm package "${chart_dir}" --version "${CHART_VERSION}"
+          helm push "${name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ github.repository }}/charts"
+          echo "Pushed oci://ghcr.io/${{ github.repository }}/charts/${name}:${CHART_VERSION}"

--- a/providers/kuery/.github/workflows/image.yaml
+++ b/providers/kuery/.github/workflows/image.yaml
@@ -1,0 +1,68 @@
+name: Image
+
+# Builds and publishes the kuery provider container image to GHCR.
+#
+# This workflow lives in the standalone faroshq/provider-kuery mirror
+# (synced from the kedge monorepo at providers/kuery/ — see README). It is
+# inert in the monorepo: GitHub only runs workflows from the repo-root
+# .github/workflows/, and in the mirror this path IS the root.
+#
+# Pushes on every sync to main and on v* release tags; PRs build-only.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # The image is scoped to this repo: ghcr.io/<owner>/provider-kuery.
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          # Mirror root holds the Dockerfile + Go module + portal/, so the
+          # build context is the repo root.
+          context: .
+          file: ./Dockerfile
+          # Multi-arch on release/push; single-arch build-only on PRs.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/providers/kuery/Dockerfile
+++ b/providers/kuery/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+# 1. Build the portal micro-frontend (Vite + TS → portal/dist) in a node
+#    stage. portal/ is a self-contained npm project so we only need its
+#    package.json/lockfile + source — no host-side npm install required.
+FROM node:22-alpine AS portal
+WORKDIR /portal
+COPY portal/package.json portal/package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY portal/ ./
+RUN npm run build
+
+# 2. Build the Go binary. assets.go embeds portal/dist via //go:embed, so
+#    the dist/ output from the previous stage has to land at the right
+#    relative path before `go build` runs.
+FROM golang:1.24-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY main.go assets.go ./
+COPY --from=portal /portal/dist ./portal/dist
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/kuery-provider .
+
+# 3. Minimal runtime image. The portal assets are baked into the binary, so
+#    there is nothing else to copy.
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /out/kuery-provider /kuery-provider
+EXPOSE 8081
+ENV PORT=8081
+USER nonroot:nonroot
+ENTRYPOINT ["/kuery-provider"]

--- a/providers/kuery/README.md
+++ b/providers/kuery/README.md
@@ -1,0 +1,57 @@
+# Kuery provider
+
+> [!IMPORTANT]
+> **Read-only mirror — do not push or open PRs here.**
+> The standalone [`faroshq/provider-kuery`](https://github.com/faroshq/provider-kuery)
+> repository is **automatically synced** from the kedge monorepo
+> [`faroshq/kedge`](https://github.com/faroshq/kedge) (path `providers/kuery/`)
+> via [splitsh-lite](https://github.com/splitsh/lite). Every sync force-updates
+> the mirror, so any direct change here is overwritten. File issues and PRs
+> against [`faroshq/kedge`](https://github.com/faroshq/kedge) instead.
+
+Fleet-wide object search, relationship traversal, and impact analysis across
+the edge clusters connected to a kedge workspace — built on
+[kuery](https://github.com/faroshq/kuery), a multi-cluster query engine that
+syncs objects into a local SQL store and answers relationship queries
+(owners, descendants, spec references, selector matches, cross-cluster
+links) that plain list/watch can't.
+
+The full design — architecture, tenant isolation, the Enable-time
+edges-proxy grant, value ranking, and phasing — lives in the kedge repo at
+[`docs/kuery-provider-architecture.md`](../../docs/kuery-provider-architecture.md).
+
+## Status: Phase 1 skeleton
+
+What works today:
+
+- **Registration surface**: `/healthz`, hub heartbeats, the `CatalogEntry`
+  (`manifest.yaml`) with the SavedView APIResourceSchema, the
+  `edges` permission claim, and `spec.edgeProxyAccess: true`.
+- **Portal placeholder**: a custom element showing the portal handshake and
+  the backend proxy round-trip (`/api/status`).
+- **Helm chart** (`deploy/chart/`) targeting the host cluster.
+
+What lands next (Phase 2, see the design doc): the embedded kuery engine,
+the Edge engagement controller (informer sync through the hub's
+edges-proxy), the tenant-scoped `/api/query`, and the `kuery_query` /
+`kuery_impact` MCP tools.
+
+## Layout
+
+```
+main.go          serve loop: healthz, /api/status, portal assets, heartbeat
+assets.go        //go:embed of portal/dist
+manifest.yaml    CatalogEntry (SavedView schema, edges claim, edgeProxyAccess)
+portal/          Vite + TS micro-frontend (custom element)
+deploy/chart/    Helm chart (host cluster only)
+```
+
+## Local development
+
+From the kedge repo root:
+
+```bash
+make build-kuery-provider        # portal build + go build
+make run-provider-kuery          # run against a local hub
+make install-provider-kuery      # apply manifest.yaml to embedded kcp
+```

--- a/providers/kuery/assets.go
+++ b/providers/kuery/assets.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"embed"
+	"errors"
+	"io"
+	"io/fs"
+	"log"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+)
+
+// portalFS embeds the Vite build output. The portal/ subdirectory holds a
+// standalone npm project (Vite + TypeScript); see portal/README.md.
+//
+// `all:` so dotfiles (.gitkeep) are bundled too — without that the embed
+// would fail at compile time when the dist/ directory exists but is empty.
+// Run `npm --prefix portal install && npm --prefix portal run build` (or
+// `make build-kuery-provider` from the repo root) to populate dist/
+// before `go build`; the Makefile target chains the two.
+//
+//go:embed all:portal/dist
+var portalFS embed.FS
+
+// portalHandler serves portal/dist as static files. Returns the served
+// http.Handler and a sub-FS rooted at the dist directory so the index
+// fallback at "/" can read index.html without the "portal/dist/" prefix.
+func portalHandler() (http.Handler, fs.FS, error) {
+	distFS, err := fs.Sub(portalFS, "portal/dist")
+	if err != nil {
+		return nil, nil, err
+	}
+	return http.FileServer(http.FS(distFS)), distFS, nil
+}
+
+// servePortalAsset writes the file at name from distFS to w. Returns false
+// (and writes nothing) if the file isn't present, letting the caller fall
+// through to its own handling — typically the index fallback. Content-Type
+// is set from the path extension because http.FileServer's auto-sniff
+// doesn't apply when we're reading bytes ourselves.
+func servePortalAsset(w http.ResponseWriter, _ *http.Request, distFS fs.FS, name string) bool {
+	name = strings.TrimPrefix(name, "/")
+	if name == "" {
+		return false
+	}
+	f, err := distFS.Open(name)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			log.Printf("portal asset %s: %v", name, err)
+		}
+		return false
+	}
+	defer f.Close()
+
+	ct := mime.TypeByExtension(path.Ext(name))
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", ct)
+	w.Header().Set("Cache-Control", "no-cache")
+	if _, err := io.Copy(w, f); err != nil {
+		log.Printf("portal asset %s write: %v", name, err)
+	}
+	return true
+}

--- a/providers/kuery/deploy/chart/Chart.yaml
+++ b/providers/kuery/deploy/chart/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: kedge-kuery-provider
+description: |
+  Kedge provider for fleet-wide object search, relationship traversal, and
+  impact analysis across connected edge clusters (built on faroshq/kuery).
+  Ships the provider Deployment, ClusterIP Service, and the CatalogEntry
+  that registers the provider (UI + backend + the SavedView APIExport +
+  edgeProxyAccess) with the kedge hub. Phase 1 skeleton.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: https://example.com/kedge-icon.png
+keywords:
+  - kedge
+  - provider
+  - kuery
+  - observability
+home: https://github.com/faroshq/kedge
+sources:
+  - https://github.com/faroshq/kedge/tree/main/providers/kuery
+maintainers:
+  - name: kedge maintainers

--- a/providers/kuery/deploy/chart/templates/_helpers.tpl
+++ b/providers/kuery/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Shared helpers. fullName follows the standard
+{{ release-name }}-{{ chart-name }} pattern unless the user overrides
+.Values.fullnameOverride.
+*/}}
+
+{{- define "kuery.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kuery.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kuery.labels" -}}
+app.kubernetes.io/name: {{ include "kuery.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "kuery.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kuery.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "kuery.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "kuery.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/providers/kuery/deploy/chart/templates/catalogentry.yaml
+++ b/providers/kuery/deploy/chart/templates/catalogentry.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.catalogEntry.enabled -}}
+# CatalogEntry registers this provider with the kedge hub. The hub's catalog
+# controller materializes root:kedge:providers:kuery, mints
+# kedge-provider-kubeconfig into our serviceAccountNamespace, applies the
+# inline APIResourceSchema(s), and creates the APIExport tenants APIBind to.
+#
+# This mirrors providers/kuery/manifest.yaml, but the ui/backend URLs
+# point at the in-cluster Service DNS (the manifest defaults to localhost for
+# host-side dev). See manifest.yaml for the full field-by-field reference.
+apiVersion: providers.kedge.faros.sh/v1alpha1
+kind: CatalogEntry
+metadata:
+  name: kuery
+  labels:
+    {{- include "kuery.labels" . | nindent 4 }}
+spec:
+  displayName: "Kuery"
+  description: "Fleet-wide object search, relationships, and impact analysis across connected edge clusters."
+  vendor: "faros"
+  version: {{ .Chart.AppVersion | quote }}
+  category: "Observability"
+  iconURL: "/ui/providers/kuery/icon.svg"
+  serviceAccountNamespace: {{ .Release.Namespace }}
+  ui:
+    url: "http://{{ include "kuery.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+    indexPath: "/"
+  backend:
+    url: "http://{{ include "kuery.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+    healthPath: "/healthz"
+
+  # Kuery's engagement controller opens BACKGROUND connections to the
+  # tenant's edge clusters through the hub's edges-proxy (informer sync).
+  # On Enable the hub grants the provider SA the "proxy" verb on edges in
+  # the tenant workspace; removed again on Disable.
+  edgeProxyAccess: true
+
+  apiExport:
+    name: "kuery.providers.kedge.faros.sh"
+    # The engagement controller watches the tenant's Edge objects (via the
+    # APIExport virtual workspace) to know which edges to engage/disengage.
+    permissionClaims:
+      - resource: edges
+        group: kedge.faros.sh
+        verbs: [get, list, watch]
+        tenantScoped: true
+    schemas:
+      # SavedView: a named, tenant-authored query + layout the portal can
+      # list and re-open. The schema name embeds a content-version segment
+      # because kcp treats APIResourceSchemas as immutable; a body change
+      # requires a new name. Keep in lockstep with manifest.yaml.
+      - groupResource: "savedviews.kuery.providers.kedge.faros.sh"
+        body: |
+          apiVersion: apis.kcp.io/v1alpha1
+          kind: APIResourceSchema
+          metadata:
+            name: v260612-001.savedviews.kuery.providers.kedge.faros.sh
+          spec:
+            group: kuery.providers.kedge.faros.sh
+            names:
+              kind: SavedView
+              listKind: SavedViewList
+              plural: savedviews
+              singular: savedview
+            scope: Namespaced
+            versions:
+              - name: v1alpha1
+                served: true
+                storage: true
+                subresources:
+                  status: {}
+                schema:
+                  type: object
+                  properties:
+                    apiVersion: { type: string }
+                    kind: { type: string }
+                    metadata: { type: object }
+                    spec:
+                      type: object
+                      properties:
+                        displayName:
+                          description: Human-readable name shown in the portal.
+                          type: string
+                          maxLength: 128
+                        description:
+                          type: string
+                          maxLength: 512
+                        root:
+                          description: >-
+                            The object the view is anchored on. Cluster is the
+                            kedge edge name; empty matches any engaged edge.
+                          type: object
+                          properties:
+                            cluster: { type: string, maxLength: 256 }
+                            apiGroup: { type: string, maxLength: 256 }
+                            kind: { type: string, maxLength: 128 }
+                            namespace: { type: string, maxLength: 63 }
+                            name: { type: string, maxLength: 253 }
+                        relations:
+                          description: >-
+                            Kuery relation names to expand from the root
+                            (owners, owners+, descendants, descendants+,
+                            references, selects, selected-by, events, linked,
+                            linked+, grouped).
+                          type: array
+                          maxItems: 16
+                          items:
+                            type: string
+                            maxLength: 32
+                        maxDepth:
+                          description: Transitive relation depth cap.
+                          type: integer
+                          format: int32
+                          minimum: 1
+                          maximum: 20
+                    status:
+                      type: object
+                      properties:
+                        lastOpenedAt:
+                          type: string
+                          format: date-time
+{{- end }}

--- a/providers/kuery/deploy/chart/templates/deployment.yaml
+++ b/providers/kuery/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kuery.fullname" . }}
+  labels:
+    {{- include "kuery.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kuery.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kuery.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "kuery.serviceAccountName" . }}
+      containers:
+        - name: provider
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 5
+          env:
+            - name: PORT
+              value: "8081"
+            - name: KEDGE_HUB_URL
+              value: {{ .Values.hub.url | quote }}
+            - name: KEDGE_PROVIDER_NAME
+              value: "kuery"
+            {{- if .Values.hub.insecure }}
+            - name: KEDGE_HUB_INSECURE
+              value: "true"
+            {{- end }}
+            {{- if .Values.hub.tokenSecretRef.name }}
+            - name: KEDGE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.hub.tokenSecretRef.name }}
+                  key: {{ .Values.hub.tokenSecretRef.key }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/providers/kuery/deploy/chart/templates/service.yaml
+++ b/providers/kuery/deploy/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kuery.fullname" . }}
+  labels:
+    {{- include "kuery.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "kuery.selectorLabels" . | nindent 4 }}

--- a/providers/kuery/deploy/chart/templates/serviceaccount.yaml
+++ b/providers/kuery/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kuery.serviceAccountName" . }}
+  labels:
+    {{- include "kuery.labels" . | nindent 4 }}
+{{- end }}

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -1,0 +1,3 @@
+module github.com/faroshq/provider-kuery
+
+go 1.24

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -1,0 +1,234 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// kuery is the kedge provider for fleet-wide object search, relationship
+// traversal, and impact analysis across connected edge clusters, built on
+// github.com/faroshq/kuery. See docs/kuery-provider-architecture.md in the
+// kedge repo for the design and phasing.
+//
+// Phase 1 skeleton: registration surface only (healthz, heartbeat, portal
+// placeholder, /api/status). Phase 2 embeds the kuery engine + the Edge
+// engagement controller and adds the tenant-scoped /api/query.
+//
+// It serves three groups of routes on the same port:
+//
+//   - /, /main.js, /icon.svg, /assets/* — the portal-side micro-frontend
+//     built by Vite from portal/src/* and embedded via portal/dist (see
+//     assets.go and portal/README.md). Mounted in the portal under
+//     /ui/providers/kuery/.
+//   - /healthz, /api/status — the provider's "backend HTTP API". Mounted
+//     via /services/providers/kuery/.
+//
+// In production these two surfaces are split only by URL — a single
+// Service exposes the port and the CatalogEntry routes the same URL to
+// both the UI proxy and the backend proxy. For local dev, the binary
+// listens on PORT and the hub proxies in front.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type statusResponse struct {
+	Message     string    `json:"message"`
+	Provider    string    `json:"provider"`
+	ServedAt    time.Time `json:"servedAt"`
+	UserHeader  string    `json:"userHeader,omitempty"`
+	TokenLength int       `json:"tokenLength,omitempty"`
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8081"
+	}
+
+	mux := http.NewServeMux()
+
+	// Health: gates Ready=true in the hub when wired via spec.backend.healthPath.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	// Status endpoint the placeholder portal calls. Echoes which user header
+	// arrived (proves the hub forwarded Authorization) and how long the token
+	// was (without echoing the token itself).
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := statusResponse{
+			Message:    "kuery provider: Phase 1 skeleton — sync engine lands in Phase 2",
+			Provider:   "kuery",
+			ServedAt:   time.Now().UTC(),
+			UserHeader: r.Header.Get("X-Kedge-User"),
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			resp.TokenLength = len(auth)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// Static portal assets (main.js, icon.svg, /assets/*) come from the
+	// embedded Vite build output. The "/" fallback serves index.html so
+	// direct browser visits get the standalone debug page.
+	fileServer, distFS, err := portalHandler()
+	if err != nil {
+		log.Fatalf("portal embed: %v", err)
+	}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// GET for full responses; HEAD for cache/preflight checks the
+		// browser may issue when loading <img> or <script> assets.
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// /api/status and /healthz are registered explicitly and won't get
+		// here. For anything else: try the embedded FS first (catches
+		// /main.js, /icon.svg, /assets/foo-abc.js). If that misses, serve
+		// the index.html fallback so a browser visit to e.g. /anything
+		// shows the debug page rather than 404.
+		clean := strings.TrimPrefix(r.URL.Path, "/")
+		if clean != "" {
+			if servePortalAsset(w, r, distFS, clean) {
+				return
+			}
+		}
+		// Index fallback. Reuse the http.FileServer so caching headers and
+		// Last-Modified are handled correctly. Clone the request so we
+		// can override URL.Path to "/" without mutating the caller's r.
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/"
+		fileServer.ServeHTTP(w, r2)
+	})
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           logMiddleware(mux),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Printf("kuery provider listening on :%s", port)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("server: %v", err)
+		}
+	}()
+
+	// Heartbeat goroutine — POSTs to the hub every 30s so the catalog
+	// controller's TTL doesn't flip us to NotReady. Configurable via env:
+	//   KEDGE_HUB_URL   - base URL of the hub (e.g. http://localhost:19443)
+	//   KEDGE_HUB_TOKEN - bearer token for the heartbeat request
+	//   KEDGE_PROVIDER_NAME - this provider's CatalogEntry name (default: kuery)
+	// All empty → heartbeats disabled (useful for tests / dry-run).
+	go runHeartbeat(ctx)
+
+	<-ctx.Done()
+	log.Printf("shutting down")
+	shutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdown); err != nil {
+		log.Printf("shutdown error: %v", err)
+	}
+}
+
+func logMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+		_ = fmt.Sprintf
+	})
+}
+
+const (
+	heartbeatVersion  = "0.1.0" // align with manifest.yaml spec.version
+	heartbeatInterval = 30 * time.Second
+)
+
+// runHeartbeat POSTs to /api/providers/{name}/heartbeat every 30s. Skips
+// silently when KEDGE_HUB_URL is empty so test invocations don't need a hub.
+// Logs errors but keeps trying — losing a beat just means the hub flips us
+// to NotReady until the next successful POST.
+//
+// Env:
+//
+//	KEDGE_HUB_URL        - hub base URL (https://localhost:9443 in dev)
+//	KEDGE_HUB_TOKEN      - bearer token for the heartbeat request
+//	KEDGE_PROVIDER_NAME  - this provider's CatalogEntry name (default: kuery)
+//	KEDGE_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
+func runHeartbeat(ctx context.Context) {
+	hub := os.Getenv("KEDGE_HUB_URL")
+	token := os.Getenv("KEDGE_HUB_TOKEN")
+	name := os.Getenv("KEDGE_PROVIDER_NAME")
+	if name == "" {
+		name = "kuery"
+	}
+	if hub == "" {
+		log.Printf("heartbeat disabled (set KEDGE_HUB_URL to enable)")
+		return
+	}
+	url := hub + "/api/providers/" + name + "/heartbeat"
+	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	if os.Getenv("KEDGE_HUB_INSECURE") == "true" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // dev-only; opt-in via KEDGE_HUB_INSECURE
+		}
+	}
+
+	// First beat immediately so the hub sees us as healthy as soon as the
+	// CatalogEntry exists; subsequent beats on the ticker.
+	send := func() {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			log.Printf("heartbeat build req: %v", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Printf("heartbeat send: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			log.Printf("heartbeat %s: %d %s", url, resp.StatusCode, resp.Status)
+		}
+	}
+	send()
+
+	t := time.NewTicker(heartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			send()
+		}
+	}
+}

--- a/providers/kuery/manifest.yaml
+++ b/providers/kuery/manifest.yaml
@@ -1,0 +1,130 @@
+# Kuery provider — register with the kedge hub.
+#
+# Kuery gives tenants (and AI agents via MCP) a single query surface over
+# every object across their connected edge clusters: fleet-wide search,
+# relationship traversal, and impact analysis. See
+# docs/kuery-provider-architecture.md in the kedge repo for the design.
+#
+# Apply this against the kcp workspace where the kedge.faros.sh APIExport is
+# bound (typically root:kedge:providers when running embedded kcp for
+# development):
+#
+#   kubectl --kubeconfig kcp-admin.kubeconfig apply -f manifest.yaml
+#
+# For local dev with the provider binary running on the host machine the
+# URLs below point at the loopback the hub can reach. For in-cluster
+# deployment, the Helm chart renders the Service DNS instead, e.g.
+#   url: http://kuery.kuery.svc.cluster.local:8081
+---
+apiVersion: providers.kedge.faros.sh/v1alpha1
+kind: CatalogEntry
+metadata:
+  name: kuery
+spec:
+  displayName: "Kuery"
+  description: "Fleet-wide object search, relationships, and impact analysis across connected edge clusters."
+  vendor: "faros"
+  version: "0.1.0"
+  category: "Observability"
+  iconURL: "/ui/providers/kuery/icon.svg"
+  serviceAccountNamespace: "kuery"
+  ui:
+    url: "http://localhost:8081"
+    indexPath: "/"
+  backend:
+    url: "http://localhost:8081"
+    healthPath: "/healthz"
+
+  # Kuery's engagement controller opens BACKGROUND connections to the
+  # tenant's edge clusters through the hub's edges-proxy (informer sync).
+  # This flag asks the hub to grant the provider SA the "proxy" verb on
+  # edges in the tenant workspace when the tenant clicks Enable; the
+  # Enable dialog surfaces the request. Removed again on Disable.
+  edgeProxyAccess: true
+
+  apiExport:
+    name: "kuery.providers.kedge.faros.sh"
+    # The engagement controller watches the tenant's Edge objects (via the
+    # APIExport virtual workspace) to know which edges to engage/disengage.
+    permissionClaims:
+      - resource: edges
+        group: kedge.faros.sh
+        verbs: [get, list, watch]
+        tenantScoped: true
+    schemas:
+      # SavedView: a named, tenant-authored query + layout the portal can
+      # list and re-open (root object, relation set, depth, filters).
+      # Tenant-authored CRDs only — no CachedResource, no virtual storage.
+      #
+      # The schema name embeds a content-version segment because kcp treats
+      # APIResourceSchemas as immutable; a body change requires a new name.
+      - groupResource: "savedviews.kuery.providers.kedge.faros.sh"
+        body: |
+          apiVersion: apis.kcp.io/v1alpha1
+          kind: APIResourceSchema
+          metadata:
+            name: v260612-001.savedviews.kuery.providers.kedge.faros.sh
+          spec:
+            group: kuery.providers.kedge.faros.sh
+            names:
+              kind: SavedView
+              listKind: SavedViewList
+              plural: savedviews
+              singular: savedview
+            scope: Namespaced
+            versions:
+              - name: v1alpha1
+                served: true
+                storage: true
+                subresources:
+                  status: {}
+                schema:
+                  type: object
+                  properties:
+                    apiVersion: { type: string }
+                    kind: { type: string }
+                    metadata: { type: object }
+                    spec:
+                      type: object
+                      properties:
+                        displayName:
+                          description: Human-readable name shown in the portal.
+                          type: string
+                          maxLength: 128
+                        description:
+                          type: string
+                          maxLength: 512
+                        root:
+                          description: >-
+                            The object the view is anchored on. Cluster is the
+                            kedge edge name; empty matches any engaged edge.
+                          type: object
+                          properties:
+                            cluster: { type: string, maxLength: 256 }
+                            apiGroup: { type: string, maxLength: 256 }
+                            kind: { type: string, maxLength: 128 }
+                            namespace: { type: string, maxLength: 63 }
+                            name: { type: string, maxLength: 253 }
+                        relations:
+                          description: >-
+                            Kuery relation names to expand from the root
+                            (owners, owners+, descendants, descendants+,
+                            references, selects, selected-by, events, linked,
+                            linked+, grouped).
+                          type: array
+                          maxItems: 16
+                          items:
+                            type: string
+                            maxLength: 32
+                        maxDepth:
+                          description: Transitive relation depth cap.
+                          type: integer
+                          format: int32
+                          minimum: 1
+                          maximum: 20
+                    status:
+                      type: object
+                      properties:
+                        lastOpenedAt:
+                          type: string
+                          format: date-time

--- a/providers/kuery/portal/README.md
+++ b/providers/kuery/portal/README.md
@@ -1,0 +1,18 @@
+# Kuery provider portal
+
+Self-contained Vite + TypeScript project that builds the custom element the
+kedge portal loads under `/ui/providers/kuery/`. The build output
+(`dist/`) is embedded into the provider binary via `//go:embed` (see
+`../assets.go`), so `npm run build` must run before `go build` — the
+`make build-kuery-provider` target from the kedge repo root chains the two.
+
+Phase 1 renders a placeholder: the portal-handshake panel and a backend
+round-trip against `/api/status`. The Phase 3 UI (inventory table, object
+graph, impact view) replaces it — see
+`docs/kuery-provider-architecture.md` in the kedge repo.
+
+```bash
+npm install
+npm run build      # → dist/ (main.js + icon.svg + index.html)
+npm run dev        # standalone debug page on the Vite dev server
+```

--- a/providers/kuery/portal/package-lock.json
+++ b/providers/kuery/portal/package-lock.json
@@ -1,0 +1,1119 @@
+{
+  "name": "kedge-provider-kuery-portal",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kedge-provider-kuery-portal",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.6.3",
+        "vite": "^6.4.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/providers/kuery/portal/package.json
+++ b/providers/kuery/portal/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "kedge-provider-kuery-portal",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Kuery provider's portal-side micro-frontend. Built with Vite into a single main.js custom-element bundle plus static assets the kedge hub serves under /ui/providers/kuery/.",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/providers/kuery/portal/public/icon.svg
+++ b/providers/kuery/portal/public/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+  stroke="#7c5bf5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7l9-4 9 4-9 4-9-4z"/>
+  <path d="M3 12l9 4 9-4"/>
+  <path d="M3 17l9 4 9-4"/>
+</svg>

--- a/providers/kuery/portal/public/index.html
+++ b/providers/kuery/portal/public/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<!--
+  Standalone fallback shown when a user visits the provider's URL directly
+  (outside the kedge portal). The real entry point is /main.js; this page
+  exists so debugging the provider's HTTP server in a browser shows
+  something readable instead of a 404.
+
+  Lives in public/ so Vite copies it to dist/ verbatim — it is NOT a Vite
+  HTML entry, since the bundle is built in library mode (see vite.config.ts).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Kuery provider · kedge</title>
+<style>
+  body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 540px; margin: 4em auto; padding: 0 1em; line-height: 1.6; color: #0f172a; background: #f5f7fa; }
+  @media (prefers-color-scheme: dark) { body { color: #eeeef3; background: #06060b; } code { background: #14141f; } a { color: #7c5bf5; } }
+  h1 { font-size: 16px; }
+  code, a { color: #6d4fe0; }
+  code { padding: 1px 5px; border-radius: 4px; background: #eef1f6; font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+</style>
+</head>
+<body>
+<h1>kedge kuery provider</h1>
+<p>This binary is a kedge <em>provider</em>. It's designed to mount inside
+the kedge portal as a custom element (<code>&lt;kedge-provider-kuery&gt;</code>),
+loaded from <code>/main.js</code>. You're seeing this fallback page because
+you opened the provider URL directly.</p>
+<p>Visit the portal at <a href="/ui/providers">/ui/providers</a> to see it
+mounted natively, or fetch <a href="/main.js">/main.js</a> to inspect the
+custom-element bundle.</p>
+</body>
+</html>

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -1,0 +1,136 @@
+// KueryElement is the custom element the kedge portal renders for
+// this provider. The portal:
+//   1. Loads main.js via a one-shot <script> tag (this module's side effect
+//      registers the element with customElements.define).
+//   2. Appends the element to its DOM tree.
+//   3. Sets element.kedgeContext as a JS property (NOT an attribute) — the
+//      setter triggers a re-render.
+//   4. Listens for kedge-navigate CustomEvents bubbled from the element to
+//      push browser history within the portal SPA.
+//
+// The element runs in light DOM so the portal's :root CSS variables cascade
+// in — see style.css.
+
+// KedgeContext is the shape the host portal sets on element.kedgeContext
+// once mounted. Fields are optional because the portal may push partial
+// updates (theme toggle, token rotation) and our render must cope.
+export interface KedgeContext {
+  token?: string | null
+  user?: { email?: string; sub?: string } | null
+  tenant?: string | null
+  theme?: 'light' | 'dark' | 'system'
+  basePath?: string
+}
+
+interface APIState {
+  cls: 'ok' | 'warn'
+  label: string
+  dump: string
+}
+
+export class KueryElement extends HTMLElement {
+  private _ctx: KedgeContext | null = null
+  private _calledAPI = false
+  private _apiState: APIState | null = null
+
+  // Portal sets this property after appending; setter triggers a render so
+  // the panels reflect the new identity/theme without an explicit refresh.
+  set kedgeContext(v: KedgeContext | null) {
+    this._ctx = v
+    this._render()
+  }
+  get kedgeContext(): KedgeContext | null {
+    return this._ctx
+  }
+
+  connectedCallback(): void {
+    this._render()
+    this._callAPI()
+  }
+
+  private _render(): void {
+    const ctx = this._ctx
+    const apiStateDump = this._apiState ? this._apiState.dump : '(no response yet)'
+    const apiStateLabel = this._apiState ? this._apiState.label : 'Calling…'
+    const ctxDump = ctx
+      ? JSON.stringify(
+          { user: ctx.user, tenant: ctx.tenant, theme: ctx.theme, basePath: ctx.basePath },
+          null,
+          2,
+        )
+      : '(no context yet)'
+
+    this.innerHTML = `
+      <div class="grid">
+        <div class="panel">
+          <div class="panel-head">
+            <h2 class="panel-title">Portal handshake</h2>
+            <span class="badge ${ctx ? 'ok' : 'warn'}">${ctx ? 'Connected' : 'Waiting'}</span>
+          </div>
+          <p class="meta">Context delivered by the shell as a JS property — no postMessage shuttle.</p>
+          <pre class="${ctx ? '' : 'muted'}" id="ctx-dump">${escapeHTML(ctxDump)}</pre>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h2 class="panel-title">Backend proxy</h2>
+            <span class="badge warn" id="api-status">${escapeHTML(apiStateLabel)}</span>
+          </div>
+          <p class="meta">GET <code id="api-url">${escapeHTML(this._apiURL())}</code></p>
+          <pre class="${this._apiState ? '' : 'muted'}" id="api-dump">${escapeHTML(apiStateDump)}</pre>
+        </div>
+      </div>
+    `
+
+    // The status badge's class is overwritten by the innerHTML template
+    // above; restore the resolved color class once the API call settles.
+    if (this._apiState) {
+      const s = this.querySelector<HTMLElement>('#api-status')
+      if (s) s.className = 'badge ' + this._apiState.cls
+    }
+  }
+
+  // The backend proxy lives at /services/providers/{name}/* — derive the
+  // URL from the basePath the portal hands us so the same code works when
+  // running behind a non-default mount point.
+  private _apiURL(): string {
+    const base = (this._ctx?.basePath || '').replace(/^\/ui\/providers\//, '/services/providers/')
+    return base + '/api/status'
+  }
+
+  private _callAPI(): void {
+    if (this._calledAPI) return
+    this._calledAPI = true
+    // basePath may arrive on a later kedgeContext set; poll briefly so we
+    // don't issue the call against a partial URL on the first paint.
+    const tryFetch = () => {
+      if (!this._ctx?.basePath) {
+        setTimeout(tryFetch, 50)
+        return
+      }
+      const url = this._apiURL()
+      fetch(url, { credentials: 'same-origin' })
+        .then((r) => r.json().then((j) => ({ ok: r.ok, code: r.status, j })))
+        .then(({ ok, code, j }) => {
+          this._apiState = ok
+            ? { cls: 'ok', label: code + ' OK', dump: JSON.stringify(j, null, 2) }
+            : { cls: 'warn', label: code + ' ' + (j.reason || 'Error'), dump: JSON.stringify(j, null, 2) }
+          this._render()
+        })
+        .catch((e: Error) => {
+          this._apiState = { cls: 'warn', label: 'Error', dump: 'fetch error: ' + e.message }
+          this._render()
+        })
+    }
+    tryFetch()
+  }
+}
+
+function escapeHTML(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/providers/kuery/portal/src/main.ts
+++ b/providers/kuery/portal/src/main.ts
@@ -1,0 +1,33 @@
+// Entry point loaded by the kedge portal as a single <script> tag. The
+// build emits this as IIFE (see vite.config.ts) so the side effects below
+// run immediately — registering the custom element and the per-element
+// stylesheet — without waiting on the module loader.
+//
+// For "more complex" providers this is the seam to plug in a real
+// framework: import a Vue app factory, a React root, or a Lit element
+// here, then register a thin wrapping HTMLElement that mounts it into
+// `this` (light DOM). The build pipeline (Vite + TS + chunked imports)
+// scales up; the contract with the portal stays one entry script + one
+// custom element.
+
+import { KueryElement } from './element'
+import styles from './style.css?raw'
+
+const TAG = 'kedge-provider-kuery'
+
+// Hot-reload safety: customElements.define throws on a second registration
+// for the same tag. The portal can re-execute this script after a version
+// bump (cache-busted by ?v=), and we want that to be a no-op.
+if (!customElements.get(TAG)) {
+  // Attach the per-element stylesheet once. Light DOM means the rules live
+  // in the portal's stylesheet scope; namespacing every selector under TAG
+  // (see style.css) keeps the cascade contained.
+  const styleId = `${TAG}-css`
+  if (!document.getElementById(styleId)) {
+    const s = document.createElement('style')
+    s.id = styleId
+    s.textContent = styles
+    document.head.appendChild(s)
+  }
+  customElements.define(TAG, KueryElement)
+}

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -1,0 +1,111 @@
+/*
+ * Kuery provider element styles.
+ *
+ * Imported as a string by main.ts and injected as a single <style> tag in
+ * the host document. The element renders in LIGHT DOM (no Shadow DOM) so
+ * the portal's :root CSS custom properties (--color-accent, etc.) cascade
+ * in for free — palette parity with the portal without re-declaring tokens.
+ *
+ * Every selector is namespaced under the kedge-provider-kuery tag so
+ * these styles cannot leak into the portal even though they live in the
+ * portal's stylesheet scope.
+ */
+
+kedge-provider-kuery {
+  display: block;
+}
+
+kedge-provider-kuery .grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 720px) {
+  kedge-provider-kuery .grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+kedge-provider-kuery .panel {
+  background: var(--color-surface-raised, #0d0d14);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.04));
+  border-radius: 12px;
+  padding: 14px 16px;
+  color: var(--color-text-primary, inherit);
+}
+
+kedge-provider-kuery .panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+kedge-provider-kuery .panel-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary, currentColor);
+  text-transform: uppercase;
+}
+
+kedge-provider-kuery .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-default, transparent);
+  background: var(--color-surface-overlay, transparent);
+  color: var(--color-text-muted, inherit);
+}
+
+kedge-provider-kuery .badge.ok {
+  border-color: var(--color-success);
+  color: var(--color-success);
+  background: var(--color-success-subtle);
+}
+
+kedge-provider-kuery .badge.warn {
+  border-color: var(--color-warning);
+  color: var(--color-warning);
+  background: transparent;
+}
+
+kedge-provider-kuery pre {
+  margin: 0;
+  background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04));
+  color: var(--color-text-primary, inherit);
+  border: 1px solid var(--color-border-subtle, transparent);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  overflow-x: auto;
+}
+
+kedge-provider-kuery code {
+  background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04));
+  color: var(--color-text-secondary, currentColor);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-size: 11px;
+}
+
+kedge-provider-kuery .meta {
+  margin: 0 0 8px;
+  font-size: 11px;
+  color: var(--color-text-muted, inherit);
+}
+
+kedge-provider-kuery .muted {
+  color: var(--color-text-muted, inherit);
+}

--- a/providers/kuery/portal/tsconfig.json
+++ b/providers/kuery/portal/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "vite.config.ts"]
+}

--- a/providers/kuery/portal/vite.config.ts
+++ b/providers/kuery/portal/vite.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from 'vite'
+
+// The kedge hub serves this provider under /ui/providers/kuery/. The
+// ProviderFrame component injects a <script src="/ui/providers/kuery/main.js">
+// tag once and waits for the kedge-provider-kuery custom element to be
+// defined. So the build needs to:
+//
+//   1. Emit the entry script at exactly /main.js (no hash, no /assets/ prefix)
+//      so the hard-coded portal URL keeps working across rebuilds.
+//   2. Bundle in IIFE format — the script tag runs before module loaders are
+//      ready and we want to register the custom element as a side effect.
+//   3. Place lazy-loaded chunks under /assets/ — the hub's UI proxy already
+//      treats requests with a "." in the last segment as assets, so dynamic
+//      import() URLs round-trip fine without further config.
+//
+// `base: '/ui/providers/kuery/'` makes Vite emit asset URLs relative to
+// the portal's mount prefix so dynamic chunks resolve via the hub's UI proxy
+// even when the page itself was navigated to from inside the portal SPA.
+export default defineConfig({
+  base: '/ui/providers/kuery/',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    target: 'es2022',
+    lib: {
+      entry: 'src/main.ts',
+      formats: ['iife'],
+      name: 'KedgeProviderKuery',
+      fileName: () => 'main.js',
+    },
+    rollupOptions: {
+      output: {
+        // Code-split chunks land in /assets/ alongside other static files;
+        // the hub's isAssetPath heuristic routes them to this binary.
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Phase 1 of the **kuery provider** — fleet-wide object search, relationship traversal, and impact analysis across connected edge clusters, built on [kuery](https://github.com/faroshq/kuery). Design doc: `docs/kuery-provider-architecture.md` (lands with #267).

Cloned from the quickstart pattern:

- **Binary** (`providers/kuery/`, module `github.com/faroshq/provider-kuery`): `/healthz`, `/api/status`, embedded Vite portal placeholder (handshake + backend round-trip panels), hub heartbeats.
- **CatalogEntry** (`manifest.yaml` + chart template, kept in lockstep):
  - `SavedView` APIResourceSchema — tenant-authored saved queries (root object + relation set + depth), the portal lists and re-opens them
  - tenant-scoped permission claim on `edges.kedge.faros.sh` (get/list/watch) — the Phase 2 engagement controller's watch source
  - `spec.edgeProxyAccess: true` — pairs with #267's Enable-time grant
- **Helm chart** (`deploy/chart/`): host-cluster only; `replicaCount: 1` with a note that Phase 2's local store pins it there.
- **Makefile**: `build-kuery-provider[-portal]`, `run-provider-kuery` (port 8084), `install/uninstall-provider-kuery`.

Stacks conceptually on #267 (the `edgeProxyAccess` field); without it the field is simply dropped by CRD validation, so merge order is flexible.

Phase 2 (next): embed the kuery engine, Edge engagement controller through the edges-proxy, tenant-scoped `/api/query`, and `kuery_query`/`kuery_impact` MCP tools.

## Test plan

- `make build-kuery-provider` — portal + binary build
- Smoke-tested the binary: `/healthz` 200, `/api/status` JSON, `/` placeholder page, `/main.js` served from the embedded dist
- `helm lint` + `helm template` on the chart — clean, 8 objects rendered
- `go vet ./...` in the module — clean; zero leftover `quickstart` strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)