### PR TITLE
providers/kuery: default to a sync whitelist (kuery whitelist support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,18 @@ _artifacts/
 
 # Portal build artifacts (copied from portal/dist for embed)
 pkg/hub/portal/
+# node_modules are never committed anywhere. dist/ is ignored for the hub
+# portal and the THIRD-PARTY providers (their images build it in Docker);
+# first-party providers (mcp, kubernetesedges, serveredges) COMMIT dist/
+# because it embeds into the hub binary — keep them out of this list.
+# (A slash in a pattern anchors it to the repo root, hence the explicit
+# per-provider entries.)
+**/portal/node_modules/
 portal/dist/
-portal/node_modules/
+providers/quickstart/portal/dist/
+providers/infrastructure/portal/dist/
+providers/code/portal/dist/
+providers/kuery/portal/dist/
 
 # Data dirs
 data/

--- a/docs/kuery-provider-architecture.md
+++ b/docs/kuery-provider-architecture.md
@@ -254,12 +254,12 @@ Full-object sync of every edge through the tunnels is the cost center.
   tenant-scoped `/api/query` + MCP tools (`kuery_query`, `kuery_impact`) into the
   aggregator. This is the value milestone: agents can query the fleet.
   Implementation notes vs. this design: tenant scoping rides on kuery *cluster
-  labels* (`tenant`, a bare identifier — kuery's SQLite dialect compiles label keys
-  into the `json_extract` path; the query API also REPLACES caller-supplied cluster
-  labels wholesale because those keys reach the generated SQL, which is an upstream
-  kuery hardening item). The resource *whitelist* is still pending upstream kuery
-  support — the chart exposes the blacklist for now. End-to-end suite with a real
-  connected edge is a Phase 3 work item.
+  labels* (`tenant`, a bare identifier). Both upstream kuery follow-ups are done:
+  label keys are bound SQL parameters ([kuery#4](https://github.com/faroshq/kuery/pull/4)
+  — the query API still replaces caller-supplied cluster labels wholesale, defense
+  in depth), and sync supports a whitelist ([kuery#5](https://github.com/faroshq/kuery/pull/5))
+  which the chart now defaults to the workloads/config/RBAC/networking set.
+  End-to-end suite with a real connected edge is a Phase 3 work item.
 - **Phase 3 — UI.** Portal micro-frontend: edge/object **inventory table with filters**
   first (covers most human use), then the cytoscape object graph and impact view with
   blast-radius highlighting.

--- a/providers/kuery/README.md
+++ b/providers/kuery/README.md
@@ -26,7 +26,10 @@ What works today:
 
 - **Embedded kuery engine** (`core/`): SQLite (default, on the chart's
   PVC) or Postgres store, the query engine, the multi-cluster sync
-  controller, and the stale-cluster GC.
+  controller, and the stale-cluster GC. Sync is whitelist-driven — the
+  chart defaults to the workloads/config/RBAC/networking set
+  (`sync.whitelist`); non-whitelisted types stay discoverable but ship no
+  objects.
 - **Edge engagement** (`engagement/`): watches `Edge` objects across every
   tenant workspace that Enabled the provider (APIExport virtual
   workspace), and syncs each connected kubernetes edge through the hub's

--- a/providers/kuery/core/core.go
+++ b/providers/kuery/core/core.go
@@ -35,11 +35,13 @@ type Config struct {
 	// Blacklist is a comma-separated list of "resource.group" entries
 	// excluded from sync (group empty for core resources). Defaults to
 	// kuery's own default (secrets, events) when empty.
-	//
-	// TODO(kuery upstream): switch to a whitelist once pkg/sync supports
-	// one — edge links are bandwidth-constrained and the default should be
-	// "workloads, config, RBAC, networking", not "everything but secrets".
 	Blacklist string
+	// Whitelist, when non-empty, restricts sync to exactly these
+	// "resource.group" entries (the blacklist still applies on top).
+	// Non-whitelisted types stay discoverable in resource_types but sync
+	// no objects — edge links are bandwidth-constrained, so the chart
+	// defaults this to workloads/config/RBAC/networking.
+	Whitelist string
 	// GCInterval is how often the stale-cluster GC runs. Default 5m.
 	GCInterval time.Duration
 }
@@ -76,12 +78,20 @@ func New(cfg Config) (*Core, error) {
 	if err != nil {
 		return nil, err
 	}
+	whitelist, err := parseWhitelist(cfg.Whitelist)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Core{
 		Store:  s,
 		Engine: engine.NewEngine(s),
-		Sync:   kuerysync.NewSyncController(kuerysync.Config{Store: s, Blacklist: blacklist}),
-		gc:     gc.NewGarbageCollector(s, cfg.GCInterval),
+		Sync: kuerysync.NewSyncController(kuerysync.Config{
+			Store:     s,
+			Blacklist: blacklist,
+			Whitelist: whitelist,
+		}),
+		gc: gc.NewGarbageCollector(s, cfg.GCInterval),
 	}, nil
 }
 
@@ -94,8 +104,34 @@ func (c *Core) StartGC(ctx context.Context) {
 // parseBlacklist converts a comma-separated "resource.group" list into
 // kuery's Blacklist. Empty input yields kuery's defaults (secrets, events).
 func parseBlacklist(raw string) (*kuerysync.Blacklist, error) {
-	if strings.TrimSpace(raw) == "" {
+	gvrs, err := parseGVRList(raw)
+	if err != nil {
+		return nil, err
+	}
+	if gvrs == nil {
 		return kuerysync.NewBlacklist(kuerysync.DefaultBlacklist), nil
+	}
+	return kuerysync.NewBlacklist(gvrs), nil
+}
+
+// parseWhitelist converts a comma-separated "resource.group" list into
+// kuery's Whitelist. Empty input yields nil — sync everything watchable.
+func parseWhitelist(raw string) (*kuerysync.Whitelist, error) {
+	gvrs, err := parseGVRList(raw)
+	if err != nil {
+		return nil, err
+	}
+	if gvrs == nil {
+		return nil, nil
+	}
+	return kuerysync.NewWhitelist(gvrs), nil
+}
+
+// parseGVRList parses comma-separated "resource" / "resource.group"
+// entries. Empty input returns nil.
+func parseGVRList(raw string) ([]schema.GroupVersionResource, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
 	}
 	var gvrs []schema.GroupVersionResource
 	for _, entry := range strings.Split(raw, ",") {
@@ -105,9 +141,9 @@ func parseBlacklist(raw string) (*kuerysync.Blacklist, error) {
 		}
 		resource, group, _ := strings.Cut(entry, ".")
 		if resource == "" {
-			return nil, fmt.Errorf("invalid blacklist entry %q", entry)
+			return nil, fmt.Errorf("invalid resource list entry %q", entry)
 		}
 		gvrs = append(gvrs, schema.GroupVersionResource{Group: group, Resource: resource})
 	}
-	return kuerysync.NewBlacklist(gvrs), nil
+	return gvrs, nil
 }

--- a/providers/kuery/core/core_test.go
+++ b/providers/kuery/core/core_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package core
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestParseGVRList(t *testing.T) {
+	gvrs, err := parseGVRList("pods, deployments.apps ,ingresses.networking.k8s.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []schema.GroupVersionResource{
+		{Resource: "pods"},
+		{Group: "apps", Resource: "deployments"},
+		{Group: "networking.k8s.io", Resource: "ingresses"},
+	}
+	if len(gvrs) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(gvrs), len(want))
+	}
+	for i := range want {
+		if gvrs[i] != want[i] {
+			t.Errorf("entry %d = %v, want %v", i, gvrs[i], want[i])
+		}
+	}
+}
+
+func TestParseWhitelist_EmptyMeansNil(t *testing.T) {
+	wl, err := parseWhitelist("  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wl != nil {
+		t.Fatal("empty whitelist must be nil (sync everything watchable)")
+	}
+}
+
+func TestParseGVRList_InvalidEntry(t *testing.T) {
+	if _, err := parseGVRList(".apps"); err == nil {
+		t.Fatal("expected error for entry with empty resource")
+	}
+}

--- a/providers/kuery/deploy/chart/templates/deployment.yaml
+++ b/providers/kuery/deploy/chart/templates/deployment.yaml
@@ -50,6 +50,12 @@ spec:
               value: {{ .Values.store.driver | quote }}
             - name: KUERY_STORE_DSN
               value: {{ .Values.store.dsn | quote }}
+            {{- if .Values.sync.whitelist }}
+            - name: KUERY_SYNC_WHITELIST
+              # Collapse the folded-block whitespace into the clean
+              # comma-separated form the binary parses.
+              value: {{ .Values.sync.whitelist | replace " " "" | replace "\n" "" | quote }}
+            {{- end }}
             {{- if .Values.sync.blacklist }}
             - name: KUERY_SYNC_BLACKLIST
               value: {{ .Values.sync.blacklist | quote }}

--- a/providers/kuery/deploy/chart/values.yaml
+++ b/providers/kuery/deploy/chart/values.yaml
@@ -44,12 +44,29 @@ store:
     size: 5Gi
     storageClassName: ""  # empty → cluster default
 
-# Resources excluded from edge sync, comma-separated "resource.group"
-# entries (empty group = core). Empty uses kuery's defaults: secrets and
-# events. Edge links are often bandwidth-constrained — extend this rather
-# than syncing everything if your edges run chatty CRDs.
-# TODO(upstream kuery): switch to a whitelist once pkg/sync supports one.
+# Edge sync resource selection, comma-separated "resource.group" entries
+# (empty group = core).
+#
+# whitelist: ONLY these resources sync; everything else stays discoverable
+# (kind resolution works) but ships no objects. Edge links are often
+# bandwidth-constrained, so the default is the workloads/config/RBAC/
+# networking set rather than everything. Set to "" to sync everything
+# watchable.
+# blacklist: skipped entirely, on top of the whitelist. Empty uses kuery's
+# defaults: secrets and events.
 sync:
+  whitelist: >-
+    pods,services,endpoints,configmaps,namespaces,nodes,
+    persistentvolumeclaims,persistentvolumes,serviceaccounts,
+    limitranges,resourcequotas,
+    deployments.apps,replicasets.apps,statefulsets.apps,daemonsets.apps,
+    jobs.batch,cronjobs.batch,
+    ingresses.networking.k8s.io,networkpolicies.networking.k8s.io,
+    roles.rbac.authorization.k8s.io,rolebindings.rbac.authorization.k8s.io,
+    clusterroles.rbac.authorization.k8s.io,clusterrolebindings.rbac.authorization.k8s.io,
+    storageclasses.storage.k8s.io,
+    customresourcedefinitions.apiextensions.k8s.io,
+    horizontalpodautoscalers.autoscaling
   blacklist: ""
 
 # When true, the chart also renders the CatalogEntry that registers the

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.7.1-0.20260515112510-8f4137891edf
 
 require (
-	github.com/faroshq/kuery v0.0.0-20260612040150-fee20d3fd467
+	github.com/faroshq/kuery v0.0.0-20260612114451-4faa46315aa7
 	github.com/kcp-dev/multicluster-provider v0.7.1
 	github.com/modelcontextprotocol/go-sdk v1.3.1
 	k8s.io/apimachinery v0.36.0

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -24,6 +24,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/faroshq/kuery v0.0.0-20260612040150-fee20d3fd467 h1:qV9mbZR0GGUfDr4G3Ktgm/tqqBcpQCVPumlicV1v08U=
 github.com/faroshq/kuery v0.0.0-20260612040150-fee20d3fd467/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
+github.com/faroshq/kuery v0.0.0-20260612114451-4faa46315aa7 h1:3muOYkFjkBfnK4/UYC1YoSbOOT/sBNbCZyhwi5Dq86k=
+github.com/faroshq/kuery v0.0.0-20260612114451-4faa46315aa7/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -115,6 +115,7 @@ func main() {
 		Driver:    storeDriver,
 		DSN:       envOr("KUERY_STORE_DSN", "kuery.db"),
 		Blacklist: os.Getenv("KUERY_SYNC_BLACKLIST"),
+		Whitelist: os.Getenv("KUERY_SYNC_WHITELIST"),
 	})
 	if err != nil {
 		log.Fatalf("kuery core: %v", err)


### PR DESCRIPTION
## Summary

Follow-up to #269, consuming both upstream kuery merges from today:

- **Dep bump** to kuery main: label keys as bound SQL parameters ([kuery#4](https://github.com/faroshq/kuery/pull/4) — the query API keeps replacing caller cluster labels wholesale as defense in depth) and sync whitelist support ([kuery#5](https://github.com/faroshq/kuery/pull/5)).
- **Whitelist wired through**: `core.Config.Whitelist` ← `KUERY_SYNC_WHITELIST`; empty means "sync everything watchable" (today's behavior).
- **Chart now defaults `sync.whitelist`** to the workloads/config/RBAC/networking set the design doc calls for — edge links are bandwidth-constrained, so "exactly these resources" beats "everything minus secrets". Non-whitelisted types stay discoverable in `resource_types` (kind/category resolution keeps working), they just sync no objects. `sync.whitelist=""` opts back into sync-everything.

### Drive-by fix

`.gitignore`'s `portal/dist/` / `portal/node_modules/` patterns contain a slash, which **anchors them to the repo root** — they never covered `providers/*/portal/`. Now: `**/portal/node_modules/` everywhere, plus explicit `dist/` entries for the third-party providers only — first-party providers (mcp, kubernetesedges, serveredges) deliberately COMMIT `dist/` for the hub-binary embed and stay un-ignored. (Caught the hard way: a fresh worktree's `git add -A` happily staged 627k lines of vite's node_modules.)

## Test plan

- New `core` parse tests (GVR list parsing, empty-whitelist-is-nil contract, invalid entry).
- `helm lint` + template render: the folded-block whitelist value collapses to a clean comma-separated env var.
- `GOWORK=off` build/test/vet across the module — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
