### PR TITLE
providers/kuery: Phase 3 UI — fleet inventory + impact drill-down

### DIFF
--- a/docs/kuery-provider-architecture.md
+++ b/docs/kuery-provider-architecture.md
@@ -260,9 +260,12 @@ Full-object sync of every edge through the tunnels is the cost center.
   in depth), and sync supports a whitelist ([kuery#5](https://github.com/faroshq/kuery/pull/5))
   which the chart now defaults to the workloads/config/RBAC/networking set.
   End-to-end suite with a real connected edge is a Phase 3 work item.
-- **Phase 3 — UI.** Portal micro-frontend: edge/object **inventory table with filters**
-  first (covers most human use), then the cytoscape object graph and impact view with
-  blast-radius highlighting.
+- **Phase 3 — UI.** **Implemented** (inventory + impact list): portal micro-frontend
+  with the edge/object inventory table (edge selector via the provider's new
+  `/api/edges`, kind/namespace/name filters) and the impact drill-down (declared blast
+  radius grouped by relation). The cytoscape graph remains a later enhancement — the
+  list view covers the daily-use cases; e2e with a real connected agent is the
+  remaining Phase 3 work item.
 - **Phase 4 — polish.** SavedView reconciliation, Postgres chart option,
   `split-kuery.yaml` workflow + `faroshq/provider-kuery` mirror with deploy key (see
   `docs/provider-publishing.md`).

--- a/providers/kuery/README.md
+++ b/providers/kuery/README.md
@@ -43,17 +43,21 @@ What works today:
 - **MCP tools** (`mcpserver/`): `kuery_query` (fleet-wide spec
   passthrough) and `kuery_impact` (declared blast radius of one object) at
   `/mcp` + `/mcp/sse`.
+- **Portal UI** (`portal/`): fleet inventory table (edge/kind/namespace/
+  name filters, click-through) and the impact view — the declared blast
+  radius of one object, grouped by relation. Edge selector fed by
+  `GET /api/edges` (engaged edges for the caller's tenant).
 - **Registration surface** from Phase 1: heartbeats, CatalogEntry
   (SavedView schema, `edges` claim, `edgeProxyAccess`), Helm chart.
 
-What lands next (Phase 3, see the design doc): the portal UI — inventory
-table first, then the object graph and impact view — plus an e2e suite
-asserting edge-object sync end to end.
+What lands next (see the design doc): an e2e suite asserting edge-object
+sync end to end with a real connected agent, SavedView reconciliation,
+and — as a later enhancement — the cytoscape object graph.
 
 ## Layout
 
 ```
-main.go          serve loop: healthz, /api/query, /api/status, /mcp, portal, heartbeat
+main.go          serve loop: healthz, /api/query, /api/edges, /api/status, /mcp, portal, heartbeat
 core/            embedded kuery wiring (store, engine, sync, gc)
 engagement/      Edge watcher → Engage/Disengage via the edges-proxy
 queryapi/        tenant-scoped POST /api/query (the store's only entry point)

--- a/providers/kuery/engagement/controller.go
+++ b/providers/kuery/engagement/controller.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -141,6 +142,22 @@ func (c *Controller) EngagedCount() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.engaged)
+}
+
+// TenantEdges lists the edge names currently engaged for one tenant —
+// the portal's edge selector. Engaged keys are "{tenantCluster}/{edge}".
+func (c *Controller) TenantEdges(tenant string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var edges []string
+	prefix := tenant + "/"
+	for key := range c.engaged {
+		if strings.HasPrefix(key, prefix) {
+			edges = append(edges, strings.TrimPrefix(key, prefix))
+		}
+	}
+	sort.Strings(edges)
+	return edges
 }
 
 // Reconcile maps one Edge's state to an Engage/Disengage of the

--- a/providers/kuery/engagement/controller_test.go
+++ b/providers/kuery/engagement/controller_test.go
@@ -8,7 +8,10 @@
 
 package engagement
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // TestEdgeProxyURL keeps the inlined URL pattern in lockstep with the kedge
 // monorepo's pkg/apiurl.EdgeProxyURL — the cases mirror its tests.
@@ -40,5 +43,20 @@ func TestTenantLabelIsBareIdentifier(t *testing.T) {
 		if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_') {
 			t.Fatalf("TenantLabel %q contains %q — must stay a bare identifier", TenantLabel, string(c))
 		}
+	}
+}
+
+func TestTenantEdges(t *testing.T) {
+	c := &Controller{engaged: map[string]context.CancelFunc{
+		"tenant-a/edge-2": func() {},
+		"tenant-a/edge-1": func() {},
+		"tenant-b/edge-9": func() {},
+	}}
+	got := c.TenantEdges("tenant-a")
+	if len(got) != 2 || got[0] != "edge-1" || got[1] != "edge-2" {
+		t.Fatalf("TenantEdges = %v, want sorted [edge-1 edge-2]", got)
+	}
+	if got := c.TenantEdges("tenant-c"); len(got) != 0 {
+		t.Fatalf("foreign tenant sees %v", got)
 	}
 }

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -160,6 +160,14 @@ func main() {
 	// Tenant-scoped query API — the only path to the kuery store.
 	mux.Handle("/api/query", &queryapi.Handler{Engine: kc.Engine})
 
+	// Engaged-edge listing for the portal's edge selector. The interface
+	// indirection keeps the nil case (engagement disabled) serving [].
+	var edgeLister queryapi.EdgeLister
+	if engagementCtl != nil {
+		edgeLister = engagementCtl
+	}
+	mux.Handle("/api/edges", &queryapi.EdgesHandler{Lister: edgeLister})
+
 	// MCP tools (kuery_query, kuery_impact); the hub proxies
 	// /services/providers/kuery/mcp{,/sse} here and the aggregate picks
 	// them up like the infrastructure provider's kro_* family.

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -1,19 +1,12 @@
-// KueryElement is the custom element the kedge portal renders for
-// this provider. The portal:
-//   1. Loads main.js via a one-shot <script> tag (this module's side effect
-//      registers the element with customElements.define).
-//   2. Appends the element to its DOM tree.
-//   3. Sets element.kedgeContext as a JS property (NOT an attribute) — the
-//      setter triggers a re-render.
-//   4. Listens for kedge-navigate CustomEvents bubbled from the element to
-//      push browser history within the portal SPA.
+// KueryElement — the kuery provider's portal UI: a fleet-wide object
+// inventory over every edge connected to the workspace, with an impact
+// drill-down (declared blast radius of one object). Backed by the
+// provider's tenant-scoped /api/query + /api/edges (proxied by the hub
+// at /services/providers/kuery/*, which injects X-Kedge-Tenant).
 //
-// The element runs in light DOM so the portal's :root CSS variables cascade
-// in — see style.css.
+// Plain custom element in light DOM (the portal's CSS variables cascade
+// in); see main.ts for registration and style.css for the rules.
 
-// KedgeContext is the shape the host portal sets on element.kedgeContext
-// once mounted. Fields are optional because the portal may push partial
-// updates (theme toggle, token rotation) and our render must cope.
 export interface KedgeContext {
   token?: string | null
   user?: { email?: string; sub?: string } | null
@@ -22,22 +15,63 @@ export interface KedgeContext {
   basePath?: string
 }
 
-interface APIState {
-  cls: 'ok' | 'warn'
-  label: string
-  dump: string
+// Minimal mirror of kuery's ObjectResult — only what the UI renders.
+interface ObjectResult {
+  id?: string
+  cluster?: string
+  object?: {
+    kind?: string
+    apiVersion?: string
+    metadata?: { name?: string; namespace?: string; creationTimestamp?: string }
+  }
+  relations?: Record<string, ObjectResult[]>
+}
+
+interface QueryStatus {
+  objects?: ObjectResult[]
+  incomplete?: boolean
+  warnings?: string[]
+}
+
+// The relation set the impact view expands — keep in lockstep with
+// mcpserver/tools.go impactRelations.
+const IMPACT_RELATIONS = ['descendants+', 'references', 'selects', 'selected-by', 'owners', 'linked+', 'grouped']
+
+const RELATION_TITLES: Record<string, string> = {
+  'descendants+': 'Descendants (transitive)',
+  references: 'References (spec fields)',
+  selects: 'Selects (label selectors)',
+  'selected-by': 'Selected by',
+  owners: 'Owners',
+  'linked+': 'Linked (cross-edge, transitive)',
+  grouped: 'Grouped (cross-edge)',
 }
 
 export class KueryElement extends HTMLElement {
   private _ctx: KedgeContext | null = null
-  private _calledAPI = false
-  private _apiState: APIState | null = null
+  private _booted = false
 
-  // Portal sets this property after appending; setter triggers a render so
-  // the panels reflect the new identity/theme without an explicit refresh.
+  private _edges: string[] = []
+  private _rows: ObjectResult[] = []
+  private _incomplete = false
+  private _queryError = ''
+  private _loading = false
+
+  // Impact drill-down state. null = inventory view.
+  private _impactOf: ObjectResult | null = null
+  private _impact: ObjectResult | null = null
+  private _impactError = ''
+
+  // Filter state survives re-renders.
+  private _fEdge = ''
+  private _fKind = ''
+  private _fNamespace = ''
+  private _fName = ''
+
   set kedgeContext(v: KedgeContext | null) {
     this._ctx = v
     this._render()
+    this._boot()
   }
   get kedgeContext(): KedgeContext | null {
     return this._ctx
@@ -45,88 +79,263 @@ export class KueryElement extends HTMLElement {
 
   connectedCallback(): void {
     this._render()
-    this._callAPI()
+    this._boot()
   }
+
+  // _boot waits for basePath (it can arrive on a later context push), then
+  // loads the edge list and the initial unfiltered inventory.
+  private _boot(): void {
+    if (this._booted || !this._ctx?.basePath) return
+    this._booted = true
+    void this._loadEdges()
+    void this._runQuery()
+  }
+
+  private _apiBase(): string {
+    return (this._ctx?.basePath || '').replace(/^\/ui\/providers\//, '/services/providers/')
+  }
+
+  private async _fetchJSON(path: string, init?: RequestInit): Promise<unknown> {
+    const res = await fetch(this._apiBase() + path, { credentials: 'same-origin', ...init })
+    const body = await res.text()
+    if (!res.ok) throw new Error(`${res.status} ${body.slice(0, 300)}`)
+    return body ? JSON.parse(body) : {}
+  }
+
+  private async _loadEdges(): Promise<void> {
+    try {
+      const out = (await this._fetchJSON('/api/edges')) as { edges?: string[] }
+      this._edges = out.edges ?? []
+    } catch {
+      this._edges = []
+    }
+    this._render()
+  }
+
+  private async _runQuery(): Promise<void> {
+    this._loading = true
+    this._queryError = ''
+    this._render()
+
+    const filter: Record<string, unknown> = {}
+    if (this._fKind) filter.groupKind = { kind: this._fKind }
+    if (this._fNamespace) filter.namespace = this._fNamespace
+    if (this._fName) filter.name = this._fName
+
+    const spec: Record<string, unknown> = {
+      limit: 100,
+      objects: { id: true, cluster: true },
+    }
+    if (this._fEdge) spec.cluster = { name: this._fEdge }
+    if (Object.keys(filter).length > 0) spec.filter = { objects: [filter] }
+
+    try {
+      const status = (await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })) as QueryStatus
+      this._rows = status.objects ?? []
+      this._incomplete = !!status.incomplete
+    } catch (e) {
+      this._rows = []
+      this._queryError = e instanceof Error ? e.message : String(e)
+    }
+    this._loading = false
+    this._render()
+  }
+
+  private async _runImpact(row: ObjectResult): Promise<void> {
+    this._impactOf = row
+    this._impact = null
+    this._impactError = ''
+    this._render()
+
+    const relations: Record<string, unknown> = {}
+    for (const rel of IMPACT_RELATIONS) relations[rel] = {}
+
+    const o = row.object ?? {}
+    const meta = o.metadata ?? {}
+    const group = (o.apiVersion || '').includes('/') ? (o.apiVersion as string).split('/')[0] : ''
+    const filter: Record<string, unknown> = { name: meta.name }
+    if (o.kind) filter.groupKind = { apiGroup: group, kind: o.kind }
+    if (meta.namespace) filter.namespace = meta.namespace
+
+    const spec: Record<string, unknown> = {
+      maxDepth: 5,
+      filter: { objects: [filter] },
+      objects: { id: true, cluster: true, relations },
+    }
+    // row.cluster is "{tenant}/{edge}" — the API re-pins the prefix, so
+    // passing it back verbatim is fine and keeps the anchor unambiguous.
+    if (row.cluster) spec.cluster = { name: row.cluster }
+
+    try {
+      const status = (await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })) as QueryStatus
+      this._impact = status.objects?.[0] ?? null
+      if (!this._impact) this._impactError = 'object not found (sync may be catching up)'
+    } catch (e) {
+      this._impactError = e instanceof Error ? e.message : String(e)
+    }
+    this._render()
+  }
+
+  // ── rendering ────────────────────────────────────────────────────────
 
   private _render(): void {
-    const ctx = this._ctx
-    const apiStateDump = this._apiState ? this._apiState.dump : '(no response yet)'
-    const apiStateLabel = this._apiState ? this._apiState.label : 'Calling…'
-    const ctxDump = ctx
-      ? JSON.stringify(
-          { user: ctx.user, tenant: ctx.tenant, theme: ctx.theme, basePath: ctx.basePath },
-          null,
-          2,
-        )
-      : '(no context yet)'
+    if (this._impactOf) {
+      this.innerHTML = this._renderImpact()
+      this.querySelector('#impact-back')?.addEventListener('click', () => {
+        this._impactOf = null
+        this._impact = null
+        this._render()
+      })
+      return
+    }
+    this.innerHTML = this._renderInventory()
+    this._bindInventory()
+  }
 
-    this.innerHTML = `
-      <div class="grid">
-        <div class="panel">
-          <div class="panel-head">
-            <h2 class="panel-title">Portal handshake</h2>
-            <span class="badge ${ctx ? 'ok' : 'warn'}">${ctx ? 'Connected' : 'Waiting'}</span>
-          </div>
-          <p class="meta">Context delivered by the shell as a JS property — no postMessage shuttle.</p>
-          <pre class="${ctx ? '' : 'muted'}" id="ctx-dump">${escapeHTML(ctxDump)}</pre>
-        </div>
+  private _renderInventory(): string {
+    const edgeOptions = ['<option value="">all edges</option>']
+      .concat(this._edges.map((e) => `<option value="${esc(e)}"${e === this._fEdge ? ' selected' : ''}>${esc(e)}</option>`))
+      .join('')
 
-        <div class="panel">
-          <div class="panel-head">
-            <h2 class="panel-title">Backend proxy</h2>
-            <span class="badge warn" id="api-status">${escapeHTML(apiStateLabel)}</span>
-          </div>
-          <p class="meta">GET <code id="api-url">${escapeHTML(this._apiURL())}</code></p>
-          <pre class="${this._apiState ? '' : 'muted'}" id="api-dump">${escapeHTML(apiStateDump)}</pre>
+    let body: string
+    if (this._loading) {
+      body = `<tr><td colspan="5" class="muted">querying the fleet…</td></tr>`
+    } else if (this._queryError) {
+      body = `<tr><td colspan="5" class="error">${esc(this._queryError)}</td></tr>`
+    } else if (this._rows.length === 0) {
+      body = `<tr><td colspan="5" class="muted">no objects match — connect an edge or relax the filters</td></tr>`
+    } else {
+      body = this._rows.map((r, i) => {
+        const o = r.object ?? {}
+        const m = o.metadata ?? {}
+        return `<tr data-row="${i}" class="row">
+          <td><code>${esc(edgeOf(r.cluster))}</code></td>
+          <td>${esc(o.kind || '?')}</td>
+          <td>${esc(m.namespace || '—')}</td>
+          <td class="name">${esc(m.name || '?')}</td>
+          <td class="muted">${esc(age(m.creationTimestamp))}</td>
+        </tr>`
+      }).join('')
+    }
+
+    return `
+      <div class="panel">
+        <div class="panel-head">
+          <h2 class="panel-title">Fleet inventory</h2>
+          <span class="badge ${this._edges.length ? 'ok' : 'warn'}">${this._edges.length} edge${this._edges.length === 1 ? '' : 's'} engaged</span>
         </div>
+        <p class="meta">One query across every connected edge. Click a row for its impact (declared blast radius).</p>
+        <div class="toolbar">
+          <select id="f-edge">${edgeOptions}</select>
+          <input id="f-kind" placeholder="kind (e.g. Deployment)" value="${esc(this._fKind)}" />
+          <input id="f-ns" placeholder="namespace" value="${esc(this._fNamespace)}" />
+          <input id="f-name" placeholder="name (exact)" value="${esc(this._fName)}" />
+          <button id="f-go">Search</button>
+        </div>
+        <table class="objects">
+          <thead><tr><th>edge</th><th>kind</th><th>namespace</th><th>name</th><th>age</th></tr></thead>
+          <tbody>${body}</tbody>
+        </table>
+        ${this._incomplete ? '<p class="meta">result truncated — narrow the filters</p>' : ''}
       </div>
     `
-
-    // The status badge's class is overwritten by the innerHTML template
-    // above; restore the resolved color class once the API call settles.
-    if (this._apiState) {
-      const s = this.querySelector<HTMLElement>('#api-status')
-      if (s) s.className = 'badge ' + this._apiState.cls
-    }
   }
 
-  // The backend proxy lives at /services/providers/{name}/* — derive the
-  // URL from the basePath the portal hands us so the same code works when
-  // running behind a non-default mount point.
-  private _apiURL(): string {
-    const base = (this._ctx?.basePath || '').replace(/^\/ui\/providers\//, '/services/providers/')
-    return base + '/api/status'
+  private _bindInventory(): void {
+    const read = () => {
+      this._fEdge = (this.querySelector('#f-edge') as HTMLSelectElement | null)?.value ?? ''
+      this._fKind = (this.querySelector('#f-kind') as HTMLInputElement | null)?.value.trim() ?? ''
+      this._fNamespace = (this.querySelector('#f-ns') as HTMLInputElement | null)?.value.trim() ?? ''
+      this._fName = (this.querySelector('#f-name') as HTMLInputElement | null)?.value.trim() ?? ''
+    }
+    this.querySelector('#f-go')?.addEventListener('click', () => {
+      read()
+      void this._runQuery()
+    })
+    this.querySelectorAll('input').forEach((el) =>
+      el.addEventListener('keydown', (ev) => {
+        if ((ev as KeyboardEvent).key === 'Enter') {
+          read()
+          void this._runQuery()
+        }
+      }),
+    )
+    this.querySelectorAll('tr.row').forEach((tr) =>
+      tr.addEventListener('click', () => {
+        const i = Number((tr as HTMLElement).dataset.row)
+        const row = this._rows[i]
+        if (row) void this._runImpact(row)
+      }),
+    )
   }
 
-  private _callAPI(): void {
-    if (this._calledAPI) return
-    this._calledAPI = true
-    // basePath may arrive on a later kedgeContext set; poll briefly so we
-    // don't issue the call against a partial URL on the first paint.
-    const tryFetch = () => {
-      if (!this._ctx?.basePath) {
-        setTimeout(tryFetch, 50)
-        return
-      }
-      const url = this._apiURL()
-      fetch(url, { credentials: 'same-origin' })
-        .then((r) => r.json().then((j) => ({ ok: r.ok, code: r.status, j })))
-        .then(({ ok, code, j }) => {
-          this._apiState = ok
-            ? { cls: 'ok', label: code + ' OK', dump: JSON.stringify(j, null, 2) }
-            : { cls: 'warn', label: code + ' ' + (j.reason || 'Error'), dump: JSON.stringify(j, null, 2) }
-          this._render()
-        })
-        .catch((e: Error) => {
-          this._apiState = { cls: 'warn', label: 'Error', dump: 'fetch error: ' + e.message }
-          this._render()
-        })
+  private _renderImpact(): string {
+    const o = this._impactOf?.object ?? {}
+    const m = o.metadata ?? {}
+    const title = `${o.kind || '?'} ${m.namespace ? m.namespace + '/' : ''}${m.name || '?'}`
+
+    let body: string
+    if (this._impactError) {
+      body = `<p class="error">${esc(this._impactError)}</p>`
+    } else if (!this._impact) {
+      body = `<p class="muted">expanding declared coupling…</p>`
+    } else {
+      const rels = this._impact.relations ?? {}
+      const sections = IMPACT_RELATIONS.filter((r) => (rels[r] ?? []).length > 0).map((r) => {
+        const items = (rels[r] ?? []).map((rr) => {
+          const ro = rr.object ?? {}
+          const rm = ro.metadata ?? {}
+          return `<li><code>${esc(edgeOf(rr.cluster))}</code> ${esc(ro.kind || '?')} <span class="name">${esc(rm.namespace ? rm.namespace + '/' : '')}${esc(rm.name || '?')}</span></li>`
+        }).join('')
+        return `<h3 class="rel-title">${esc(RELATION_TITLES[r] ?? r)} <span class="muted">(${(rels[r] ?? []).length})</span></h3><ul class="rel-list">${items}</ul>`
+      })
+      body = sections.length > 0
+        ? sections.join('')
+        : '<p class="muted">no declared coupling found — nothing references, selects, or descends from this object (network-level dependencies are not visible to kuery)</p>'
     }
-    tryFetch()
+
+    return `
+      <div class="panel">
+        <div class="panel-head">
+          <h2 class="panel-title">Impact: ${esc(title)}</h2>
+          <button id="impact-back">← inventory</button>
+        </div>
+        <p class="meta">Declared blast radius on <code>${esc(edgeOf(this._impactOf?.cluster))}</code> — owners, descendants, spec references, selector matches, and cross-edge links. Not a network dependency map.</p>
+        ${body}
+      </div>
+    `
   }
 }
 
-function escapeHTML(s: string): string {
+// ── helpers ───────────────────────────────────────────────────────────
+
+// edgeOf strips the "{tenant}/" prefix from an engaged cluster key.
+function edgeOf(cluster?: string): string {
+  if (!cluster) return '?'
+  const i = cluster.lastIndexOf('/')
+  return i === -1 ? cluster : cluster.slice(i + 1)
+}
+
+function age(ts?: string): string {
+  if (!ts) return ''
+  const ms = Date.now() - new Date(ts).getTime()
+  if (!Number.isFinite(ms) || ms < 0) return ''
+  const mins = Math.floor(ms / 60000)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  if (hours < 48) return `${hours}h`
+  return `${Math.floor(hours / 24)}d`
+}
+
+function esc(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -109,3 +109,97 @@ kedge-provider-kuery .meta {
 kedge-provider-kuery .muted {
   color: var(--color-text-muted, inherit);
 }
+
+/* ── inventory toolbar ─────────────────────────────────────────────── */
+
+kedge-provider-kuery .toolbar {
+  display: flex;
+  gap: 6px;
+  margin: 0 0 10px;
+  flex-wrap: wrap;
+}
+
+kedge-provider-kuery .toolbar input,
+kedge-provider-kuery .toolbar select {
+  background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04));
+  color: var(--color-text-primary, inherit);
+  border: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.15));
+  border-radius: 6px;
+  padding: 5px 8px;
+  font-size: 11px;
+  min-width: 120px;
+}
+
+kedge-provider-kuery button {
+  background: var(--color-accent-subtle, rgba(109, 79, 224, 0.12));
+  color: var(--color-accent, #6d4fe0);
+  border: 1px solid var(--color-accent, #6d4fe0);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+kedge-provider-kuery button:hover {
+  filter: brightness(1.1);
+}
+
+/* ── inventory table ───────────────────────────────────────────────── */
+
+kedge-provider-kuery table.objects {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+kedge-provider-kuery table.objects th {
+  text-align: left;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, inherit);
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.15));
+}
+
+kedge-provider-kuery table.objects td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.08));
+}
+
+kedge-provider-kuery tr.row {
+  cursor: pointer;
+}
+
+kedge-provider-kuery tr.row:hover td {
+  background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04));
+}
+
+kedge-provider-kuery .name {
+  font-weight: 600;
+  color: var(--color-text-primary, inherit);
+}
+
+kedge-provider-kuery .error {
+  color: var(--color-danger, #d33);
+  font-size: 11px;
+}
+
+/* ── impact view ───────────────────────────────────────────────────── */
+
+kedge-provider-kuery .rel-title {
+  font-size: 12px;
+  margin: 14px 0 4px;
+  color: var(--color-text-primary, inherit);
+}
+
+kedge-provider-kuery .rel-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12px;
+}
+
+kedge-provider-kuery .rel-list li {
+  padding: 2px 0;
+}

--- a/providers/kuery/queryapi/edges.go
+++ b/providers/kuery/queryapi/edges.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package queryapi
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// EdgeLister is the slice of the engagement controller the edges endpoint
+// needs. Nil-able: with engagement disabled the endpoint serves an empty
+// list rather than 404, so the portal renders consistently in dev.
+type EdgeLister interface {
+	TenantEdges(tenant string) []string
+}
+
+// EdgesHandler serves GET /api/edges: the caller's currently-engaged edge
+// names (the portal's edge selector source).
+type EdgesHandler struct {
+	Lister EdgeLister
+}
+
+type edgesResponse struct {
+	Edges []string `json:"edges"`
+}
+
+func (h *EdgesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := IdentityFromRequest(r)
+	if id.Tenant == "" {
+		http.Error(w, "missing tenant identity (X-Kedge-Tenant)", http.StatusUnauthorized)
+		return
+	}
+	resp := edgesResponse{Edges: []string{}}
+	if h.Lister != nil {
+		if edges := h.Lister.TenantEdges(id.Tenant); edges != nil {
+			resp.Edges = edges
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}


### PR DESCRIPTION
## Summary

Replaces the Phase 1 placeholder portal element with the real UI, per the design doc's value ranking (inventory table first; cytoscape graph stays a later enhancement):

- **Fleet inventory**: one tenant-scoped `/api/query` across every connected edge — edge selector, kind/namespace/name filters, age column, truncation notice, click-through per row.
- **Impact view**: declared blast radius of one object (`descendants+`, `references`, `selects`/`selected-by`, `owners`, `linked+`, `grouped`) rendered as relation-grouped lists, explicitly framed as *declared coupling, not a network dependency map*. Relation set kept in lockstep with the `kuery_impact` MCP tool.
- **New `GET /api/edges`**: engaged edge names for the caller's tenant, from the engagement controller (sorted; `[]` when engagement is disabled so dev UX stays consistent). Same identity rules as `/api/query`.

Still a plain custom element in light DOM — no framework added; the bundle grows 5.3 kB → 12.8 kB.

## Test plan

- `TestTenantEdges` (tenant prefix filtering + sort + foreign-tenant isolation); existing queryapi/engagement/core suites pass.
- `tsc --noEmit` + Vite build clean.
- Smoke: binary boots, `/api/edges` returns `{"edges":[]}` with tenant header (401 without), `/api/query` round-trips, new `main.js` bundle serves.

Remaining Phase 3 item (next PR): e2e with a real connected agent asserting edge-object sync → query end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)