### PR TITLE
providers/code,infrastructure: per-provider image+chart release workflows

### DIFF
--- a/docs/application-template-architecture.md
+++ b/docs/application-template-architecture.md
@@ -84,9 +84,9 @@ provider binary
   ├─ Template controller        ← establishes the application CRD + APIExport schema entry
   ├─ kro backend                ← authors the RGD on the runtime cluster from backendConfig,
   │                               after a token-substitution pass (§5)
-  ├─ create-path handler        ← injects spec.expose.fqdn + spec.credentialsSecretName;
-  │                               (Platform SSO) mints a Dex client and bridges its secret
-  └─ Dex gRPC helper            ← CreateClient on provision / DeleteClient on teardown
+  └─ application controller     ← cross-tenant (APIExport VW); stamps spec.expose.fqdn +
+                                  spec.credentialsSecretName, bridges the BYO OIDC client
+                                  secret onto the runtime cluster (Platform SSO / Dex: §7.2)
 
 
 runtime cluster (shared kro cluster)            per-tenant namespace kedge-tenants-<hash>
@@ -149,11 +149,11 @@ spec:
     hostnamePrefix: my-app       # optional DNS label; defaults to .name
     fqdn: ""                     # SERVER-INJECTED — do not set
   oidc:
-    mode: platform               # platform (default) | byo
+    mode: byo                    # byo (default, supported) | platform (deferred — §7.2)
     emailDomains: ["*"]
     scopes: "openid email profile"
-    issuerURL: ""                # BYO: required;  platform: server-injected
-    clientID: ""                 # BYO: required;  platform: server-injected
+    issuerURL: ""                # BYO: required (platform mode is deferred — §7.2)
+    clientID: ""                 # BYO: required (platform mode is deferred — §7.2)
   credentialsSecretName: ""      # SERVER-INJECTED — name of the bridged Secret
 status:
   url: https://my-app-9f2db7ed8014.apps.example.com
@@ -248,24 +248,28 @@ issuer is **Dex**, deployed alongside (`hack/dex/`, `hack/dev/dex/dex-config-dev
 exposes full OIDC endpoints and a **gRPC client-management API**. So "platform SSO" points
 oauth2-proxy at **Dex**, not at the hub.
 
-### 7.1 Mode A — Platform SSO (default)
-The app is guarded by the same identity that guards kedge. At provision time the create-path
-handler calls Dex gRPC `CreateClient` with redirect URI `https://<fqdn>/oauth2/callback`,
-receives a `client_id` + secret, injects `spec.oidc.issuerURL`/`clientID`, and bridges the
-secret in under the `oidc_client_secret` key. On instance delete it calls Dex `DeleteClient`
-(finalizer + orphan sweeper for the failure window). The tenant supplies nothing.
+### 7.1 Mode B — BYO external IdP (default; supported)
+The supported v1 mode. The tenant registers their own OAuth2 client (Google/Entra/Okta) with
+redirect `https://<fqdn>/oauth2/callback`, supplies `oidc.issuerURL` + `oidc.clientID` in the
+CR, and puts the client secret under key `oidc_client_secret` in their workspace
+`cloud-credentials` Secret. The **Application instance controller** reads that Secret through
+the APIExport VW and writes the bridged `cloud-credentials-<name>` Secret into the runtime
+per-tenant namespace; oauth2-proxy reads it via `secretKeyRef`. No new permission claim is
+needed — the `secrets` `tenantScoped` claim in `manifest.yaml` already covers it.
 
-A per-app Dex client is required because **Dex matches redirect URIs exactly — no wildcards**
-— so one shared client can't serve many apps.
+### 7.2 Mode A — Platform SSO (deferred; NOT yet supported)
+The intended "guard with kedge's own identity" mode. Because the hub is a relying party (not
+an issuer), oauth2-proxy would target the platform **Dex**, and the controller would mint a
+per-app Dex OAuth2 client (Dex matches redirect URIs exactly — no wildcards — so one shared
+client can't serve many apps), inject `spec.oidc.issuerURL`/`clientID`, bridge the secret, and
+`DeleteClient` on teardown.
 
-### 7.2 Mode B — BYO external IdP
-The tenant registers their own OAuth2 client (Google/Entra/Okta) with redirect
-`https://<fqdn>/oauth2/callback`, supplies `oidc.issuerURL` + `oidc.clientID` in the CR, and
-puts the client secret under key `oidc_client_secret` in their workspace `cloud-credentials`
-Secret. The existing bridge (`kro/instance.go` `CreateInstance`) copies that into
-`cloud-credentials-<instance>` on the runtime cluster; oauth2-proxy reads it via
-`secretKeyRef`. No new permission claim is needed — the `secrets` `tenantScoped` claim in
-`manifest.yaml` already covers it.
+**This is not implemented.** It requires hub-wide infrastructure that doesn't exist today: the
+kedge Dex deployment has **no gRPC client-management API enabled** and uses **ephemeral
+storage** (so minted clients wouldn't survive a restart). Wiring Dex (gRPC + persistent storage
++ a Service + TLS, plus a security review of the client-admin API) is tracked as a separate
+epic. Until then `oidc.mode=platform` is rejected by the controller with an `OIDCConfigured`
+condition pointing the tenant at BYO.
 
 ### 7.3 Secret handling (no clear text through kcp)
 Both modes converge on the same bridged Secret key, so the RGD is identical; only *who writes
@@ -273,7 +277,7 @@ the value* differs. The oauth2-proxy **cookie secret** is generated in-graph by 
 (the `redis-cache` pwgen pattern) — kro only ever sees a reference, never the value.
 
 The bridged Secret is named from the instance CR's `metadata.name`, which can differ from
-`spec.name`; the create-path handler therefore injects `spec.credentialsSecretName` so the RGD
+`spec.name`; the application controller therefore injects `spec.credentialsSecretName` so the RGD
 references the right name unambiguously.
 
 ## 8. Exposure layer prerequisites (runtime cluster, admin-installed once)
@@ -293,17 +297,20 @@ ingress class for a different controller.
 
 ## 9. PR breakdown
 
+**Status:** the BYO slice landed in one PR (#270 + a config/docs follow-up): the `apps` host
+helper, the `${kedge.ingressClass}` substitution in `backend/kro`, the `application` template,
+and the cross-tenant **application controller** (fqdn stamp + BYO secret bridge), plus chart/env
+plumbing. Remaining items below are follow-ups; AP-5 (Platform SSO) is **deferred** behind the
+Dex-infra work in §7.2.
+
 | PR | Title | Acceptance criteria |
 |---|---|---|
-| **AP-1** | Exposure layer (Cloudflare Tunnel) | cloudflared + cloudflare-tunnel ingress controller on the runtime cluster against a Cloudflare zone; a test Ingress (cloudflare class) auto-creates the DNS record + tunnel route and serves `https://x.apps.<base>` with edge TLS; `providers/infrastructure/docs/runtime-ingress.md` covers setup + how to swap the class. (Ops/doc, not kedge code.) |
-| **AP-2** | Config + host computation + spec injection | `KEDGE_APP_BASE_DOMAIN`/`KEDGE_INGRESS_CLASS` plumbed; create-path injects `spec.expose.fqdn` + `spec.credentialsSecretName`; host formula + DNS-label prefix validation; token-substitution pass in `backend/kro`. Unit tests for the formula + substitution. |
-| **AP-3** | `Application` Template seed | `install/templates/application.yaml` added; applying it establishes `applications.infrastructure.kedge.faros.sh`, lists it in `APIExport.spec.schemas`, and kro accepts the RGD; `kubectl get templates` shows it. |
-| **AP-4** | E2E — BYO mode | `docs/credentials.md` gains an `oidc_client_secret` row; a tenant with `cloud-credentials` (incl. `oidc_client_secret`) applies an `Application` with `oidc.mode=byo`; all tiers Ready; `status.url`/`redirectURL` set; the URL 302s to the tenant's IdP; post-login lands on the frontend; frontend→backend→Postgres works; delete GCs everything. |
-| **AP-5** | Platform SSO mode (Dex client minting) | provider `dex/` gRPC helper; `KEDGE_OIDC_ISSUER_URL` + `KEDGE_DEX_GRPC_ADDR` plumbed; create-path mints a Dex client + injects issuer/clientID/secret; teardown deletes it; orphan sweeper for the failure window; an `oidc.mode=platform` app is reachable only after kedge/Dex login. |
-| **AP-6** | Portal/MCP surfacing (light) | instance detail renders `url` + `redirectURL` (copyable) + per-tier readiness; redirect URL shown at create time (BYO); a mode selector in the provision form. |
-
-Core: AP-1/2/3 (~1.5 weeks). AP-4 BYO e2e + docs. AP-5 platform SSO. AP-6 polish. AP-5 can
-land independently of AP-4; if Dex gRPC wiring slips, BYO mode ships first.
+| **AP-1** | Exposure layer (Cloudflare Tunnel) — *ops, follow-up* | cloudflared + cloudflare-tunnel ingress controller on the runtime cluster against a Cloudflare zone; a test Ingress (cloudflare class) auto-creates the DNS record + tunnel route and serves `https://x.apps.<base>` with edge TLS; a `runtime-ingress.md` covers setup + how to swap the class. (Ops/doc, not kedge code.) |
+| **AP-2** | Config + host computation + controller stamping — *landed* | `KEDGE_APP_BASE_DOMAIN`/`KEDGE_INGRESS_CLASS` plumbed; the controller injects `spec.expose.fqdn` + `spec.credentialsSecretName`; host formula + DNS-label prefix validation; token-substitution pass in `backend/kro`. Unit tests for the formula + substitution. |
+| **AP-3** | `Application` Template seed — *landed* | `install/templates/application.yaml` added; applying it establishes `applications.infrastructure.kedge.faros.sh`, lists it in `APIExport.spec.schemas`, and kro accepts the RGD; `kubectl get templates` shows it. |
+| **AP-4** | E2E — BYO mode — *follow-up* | `docs/credentials.md` gains an `oidc_client_secret` row; a tenant with `cloud-credentials` (incl. `oidc_client_secret`) applies an `Application` with `oidc.mode=byo`; all tiers Ready; `status.url`/`redirectURL` set; the URL 302s to the tenant's IdP; post-login lands on the frontend; frontend→backend→Postgres works; delete GCs everything. |
+| **AP-5** | Platform SSO mode (Dex client minting) — *deferred (needs Dex infra, §7.2)* | hub Dex gRPC + persistent storage + Service + TLS (separate epic); provider `dex/` gRPC helper; `KEDGE_OIDC_ISSUER_URL` + `KEDGE_DEX_GRPC_ADDR` plumbed; the controller mints a Dex client + injects issuer/clientID/secret; teardown deletes it; orphan sweeper for the failure window. |
+| **AP-6** | Portal/MCP surfacing (light) — *follow-up* | instance detail renders `url` + `redirectURL` (copyable) + per-tier readiness; redirect URL shown at create time (BYO). |
 
 ## 10. Risks and open questions
 
@@ -344,7 +351,8 @@ land independently of AP-4; if Dex gRPC wiring slips, BYO mode ships first.
 - **Target** = the existing shared kro runtime cluster, per-tenant namespace. No edge targeting.
 - **Exposure** = an abstracted plain `Ingress`; concrete impl = Cloudflare Tunnel; swappable
   via `ingressClassName` config.
-- **Auth** = per-app oauth2-proxy with two modes: Platform SSO (Dex, default) and BYO IdP.
+- **Auth** = per-app oauth2-proxy. v1 supports **BYO external IdP** (default). Platform SSO
+  (Dex-minted clients) is designed but deferred — it needs hub Dex gRPC + persistent storage.
 - **Template** = one opinionated `Application` kind, not composable blocks.
 - **Secrets** = OIDC client secret rides the existing tenant→data-plane bridge; cookie secret
   and DB password are generated in-graph. Nothing sensitive transits kcp.

--- a/providers/code/.github/workflows/chart.yaml
+++ b/providers/code/.github/workflows/chart.yaml
@@ -1,0 +1,57 @@
+name: Chart
+
+# Packages the Helm chart (deploy/chart) and publishes it to GHCR as an OCI
+# artifact under a dedicated `charts/` namespace, so it's clearly distinct from
+# the container image (ghcr.io/<owner>/provider-code) and doesn't collide
+# with the kedge monorepo's own chart publish (ghcr.io/<owner>/charts):
+#
+#   image: ghcr.io/<owner>/provider-code
+#   chart: ghcr.io/<owner>/provider-code/charts/kedge-code-provider
+#
+# Like image.yaml, this runs only in the standalone mirror (see README).
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.16.0'
+
+      - name: Package and push chart (OCI)
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+          # Tags publish the released version (no leading v in the chart
+          # version, per OCI/semver); main pushes get a 0.0.0-<sha> dev version.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            CHART_VERSION="${GITHUB_REF_NAME#v}"
+            APP_VERSION="${GITHUB_REF_NAME}"
+          else
+            CHART_VERSION="0.0.0-${GITHUB_SHA}"
+            APP_VERSION="${CHART_VERSION}"
+          fi
+
+          chart_dir=deploy/chart
+          name="$(grep -E '^name:' "${chart_dir}/Chart.yaml" | head -1 | awk '{print $2}')"
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}/Chart.yaml"
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}/Chart.yaml"
+
+          helm package "${chart_dir}" --version "${CHART_VERSION}"
+          helm push "${name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ github.repository }}/charts"
+          echo "Pushed oci://ghcr.io/${{ github.repository }}/charts/${name}:${CHART_VERSION}"

--- a/providers/code/.github/workflows/image.yaml
+++ b/providers/code/.github/workflows/image.yaml
@@ -1,0 +1,68 @@
+name: Image
+
+# Builds and publishes the code provider container image to GHCR.
+#
+# This workflow lives in the standalone faroshq/provider-code mirror
+# (synced from the kedge monorepo at providers/code/ — see README). It is
+# inert in the monorepo: GitHub only runs workflows from the repo-root
+# .github/workflows/, and in the mirror this path IS the root.
+#
+# Pushes on every sync to main and on v* release tags; PRs build-only.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # The image is scoped to this repo: ghcr.io/<owner>/provider-code.
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          # Mirror root holds the Dockerfile + Go module + portal/, so the
+          # build context is the repo root.
+          context: .
+          file: ./Dockerfile
+          # Multi-arch on release/push; single-arch build-only on PRs.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/providers/infrastructure/.github/workflows/chart.yaml
+++ b/providers/infrastructure/.github/workflows/chart.yaml
@@ -1,0 +1,57 @@
+name: Chart
+
+# Packages the Helm chart (deploy/chart) and publishes it to GHCR as an OCI
+# artifact under a dedicated `charts/` namespace, so it's clearly distinct from
+# the container image (ghcr.io/<owner>/provider-infrastructure) and doesn't
+# collide with the kedge monorepo's own chart publish (ghcr.io/<owner>/charts):
+#
+#   image: ghcr.io/<owner>/provider-infrastructure
+#   chart: ghcr.io/<owner>/provider-infrastructure/charts/kedge-infrastructure-provider
+#
+# Like image.yaml, this runs only in the standalone mirror (see README).
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.16.0'
+
+      - name: Package and push chart (OCI)
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+          # Tags publish the released version (no leading v in the chart
+          # version, per OCI/semver); main pushes get a 0.0.0-<sha> dev version.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            CHART_VERSION="${GITHUB_REF_NAME#v}"
+            APP_VERSION="${GITHUB_REF_NAME}"
+          else
+            CHART_VERSION="0.0.0-${GITHUB_SHA}"
+            APP_VERSION="${CHART_VERSION}"
+          fi
+
+          chart_dir=deploy/chart
+          name="$(grep -E '^name:' "${chart_dir}/Chart.yaml" | head -1 | awk '{print $2}')"
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}/Chart.yaml"
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}/Chart.yaml"
+
+          helm package "${chart_dir}" --version "${CHART_VERSION}"
+          helm push "${name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ github.repository }}/charts"
+          echo "Pushed oci://ghcr.io/${{ github.repository }}/charts/${name}:${CHART_VERSION}"

--- a/providers/infrastructure/.github/workflows/image.yaml
+++ b/providers/infrastructure/.github/workflows/image.yaml
@@ -1,0 +1,68 @@
+name: Image
+
+# Builds and publishes the infrastructure provider container image to GHCR.
+#
+# This workflow lives in the standalone faroshq/provider-infrastructure mirror
+# (synced from the kedge monorepo at providers/infrastructure/ — see README). It
+# is inert in the monorepo: GitHub only runs workflows from the repo-root
+# .github/workflows/, and in the mirror this path IS the root.
+#
+# Pushes on every sync to main and on v* release tags; PRs build-only.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # The image is scoped to this repo: ghcr.io/<owner>/provider-infrastructure.
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          # Mirror root holds the Dockerfile + Go module + portal/, so the
+          # build context is the repo root.
+          context: .
+          file: ./Dockerfile
+          # Multi-arch on release/push; single-arch build-only on PRs.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/providers/infrastructure/controller/application/controller.go
+++ b/providers/infrastructure/controller/application/controller.go
@@ -31,6 +31,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -228,9 +229,16 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 			return ctrl.Result{}, err
 		}
 	case modePlatform:
-		// Platform SSO (Dex client minting) is wired in a follow-up. Until
-		// then the oauth2-proxy pod stays pending on the missing secret.
-		log.Info("oidc.mode=platform: Dex client minting not yet wired; skipping secret bridge")
+		// Platform SSO needs the hub Dex gRPC client-management API, which
+		// isn't provisioned yet. Surface that clearly on the instance rather
+		// than silently leaving the oauth2-proxy pod stuck on a missing
+		// secret. Tracked as a separate Dex-infra epic; use oidc.mode=byo.
+		log.Info("oidc.mode=platform is not yet supported; set oidc.mode=byo")
+		if err := c.setOIDCCondition(ctx, tenantClient, app, "False", "PlatformSSOUnsupported",
+			"oidc.mode=platform is not yet supported (needs the hub Dex gRPC API); use oidc.mode=byo"); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil // terminal: nothing to retry until BYO is chosen
 	default:
 		return ctrl.Result{}, fmt.Errorf("unknown oidc.mode %q", mode)
 	}
@@ -378,4 +386,47 @@ func (c *Controller) deleteBridgedSecret(ctx context.Context, tenant, name strin
 func nestedString(u *unstructured.Unstructured, fields ...string) string {
 	s, _, _ := unstructured.NestedString(u.Object, fields...)
 	return s
+}
+
+// oidcConditionType is the condition the controller owns on an Application to
+// report OIDC-gate readiness. Distinct from kro's own conditions (kro owns
+// Ready/ResourcesReady), so the two writers don't clash.
+const oidcConditionType = "OIDCConfigured"
+
+// setOIDCCondition upserts the OIDCConfigured condition on the instance's
+// status (by type), leaving any kro-written conditions intact. Idempotent: a
+// no-op when the condition already matches, so it doesn't churn the object.
+func (c *Controller) setOIDCCondition(ctx context.Context, tenantClient client.Client, app *unstructured.Unstructured, status, reason, message string) error {
+	conds, _, _ := unstructured.NestedSlice(app.Object, "status", "conditions")
+
+	for _, raw := range conds {
+		if m, ok := raw.(map[string]any); ok && m["type"] == oidcConditionType {
+			if m["status"] == status && m["reason"] == reason && m["message"] == message {
+				return nil // already current
+			}
+		}
+	}
+
+	next := make([]any, 0, len(conds)+1)
+	for _, raw := range conds {
+		if m, ok := raw.(map[string]any); ok && m["type"] == oidcConditionType {
+			continue // drop the stale one; re-added below
+		}
+		next = append(next, raw)
+	}
+	next = append(next, map[string]any{
+		"type":               oidcConditionType,
+		"status":             status,
+		"reason":             reason,
+		"message":            message,
+		"lastTransitionTime": metav1.Now().UTC().Format(time.RFC3339),
+		"observedGeneration": app.GetGeneration(),
+	})
+	if err := unstructured.SetNestedSlice(app.Object, next, "status", "conditions"); err != nil {
+		return fmt.Errorf("set status.conditions: %w", err)
+	}
+	if err := tenantClient.Status().Update(ctx, app); err != nil {
+		return fmt.Errorf("updating OIDC condition: %w", err)
+	}
+	return nil
 }

--- a/providers/infrastructure/deploy/chart/templates/deployment.yaml
+++ b/providers/infrastructure/deploy/chart/templates/deployment.yaml
@@ -104,6 +104,20 @@ spec:
             - name: KRO_KUBECONFIG
               value: /var/run/secrets/kro/kubeconfig
             {{- end }}
+            {{- with .Values.application.baseDomain }}
+            # Enables the Application instance controller (fqdn stamp + OIDC
+            # client-secret bridge). Without it (and KRO_KUBECONFIG) the
+            # controller stays disabled. The zone apps are served under, e.g.
+            # "apps.example.com".
+            - name: KEDGE_APP_BASE_DOMAIN
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.application.ingressClass }}
+            # Exposure-layer ingress class substituted into Application RGDs
+            # (${kedge.ingressClass}); defaults to "cloudflare" in-binary.
+            - name: KEDGE_INGRESS_CLASS
+              value: {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -41,6 +41,19 @@ centralKro:
     name: ""   # set to use an external Secret
     key: kubeconfig
 
+# The "application" template (3-tier app exposed on an OIDC-guarded URL).
+# The Application instance controller is OFF unless baseDomain is set AND a
+# central kro kubeconfig is configured (the controller bridges secrets onto
+# that runtime cluster). See docs/application-template-architecture.md.
+application:
+  # Zone apps are served under, e.g. "apps.example.com". Each app gets
+  # <prefix|name>-<tenantHash>.<baseDomain>. Empty → feature disabled.
+  baseDomain: ""
+  # Exposure-layer ingress class substituted into Application RGDs. Defaults
+  # to "cloudflare" (Cloudflare Tunnel) in-binary; override to swap the
+  # ingress controller without touching the template.
+  ingressClass: "cloudflare"
+
 # Secret the provider mounts read-only at
 # /var/run/secrets/kedge/kedge-provider-kubeconfig to reach kcp. How it is
 # populated depends on bootstrap.enabled:

--- a/providers/infrastructure/install/templates/application.yaml
+++ b/providers/infrastructure/install/templates/application.yaml
@@ -93,14 +93,14 @@ spec:
           mode:
             type: string
             enum: ["platform", "byo"]
-            default: "platform"
-            description: "platform = guard with kedge SSO (a Dex client is minted for you). byo = your own IdP; set issuerURL + clientID and put the client secret in your cloud-credentials Secret under key oidc_client_secret."
+            default: "byo"
+            description: "byo (default, supported) = your own IdP; set issuerURL + clientID and put the client secret in your cloud-credentials Secret under key oidc_client_secret. platform = guard with kedge SSO — NOT yet supported (requires the hub Dex gRPC client-management API; tracked separately)."
           issuerURL:
             type: string
-            description: "BYO mode: your IdP's OIDC issuer URL. Platform mode: populated by the controller."
+            description: "BYO mode: your IdP's OIDC issuer URL (required)."
           clientID:
             type: string
-            description: "BYO mode: your OAuth2 client ID. Platform mode: populated by the controller."
+            description: "BYO mode: your OAuth2 client ID (required)."
           emailDomains:
             type: array
             items:


### PR DESCRIPTION
## Why

Only `providers/quickstart` shipped `.github/workflows/{image,chart}.yaml`. Those split out into the standalone mirror (`faroshq/provider-quickstart`), become repo-root workflows, and publish the container image + Helm chart on `v*` tags. The **code** and **infrastructure** mirrors had no such files, so a per-provider tag (`providers/code/vX.Y.Z`, `providers/infrastructure/vX.Y.Z`) split out but built **no artifacts**.

## What

Add the same `image.yaml` + `chart.yaml` pair for both providers, modeled byte-for-byte on quickstart:
- multi-arch image on tag / single-arch build-only on PR → `ghcr.io/<owner>/provider-{code,infrastructure}`
- OCI chart publish under `charts/` → `ghcr.io/<owner>/provider-{code,infrastructure}/charts/<chart>`

Both providers already have the layout the workflows assume (root `Dockerfile`, `deploy/chart/Chart.yaml`). Workflows use `${{ github.repository }}`, so nothing is hardcoded — only comments are provider-specific.

## Notes
- Inert in the monorepo (GitHub runs only repo-root workflows); they activate once `split-code`/`split-infrastructure` seeds them into the mirrors.
- Requires the mirror repos `faroshq/provider-code` and `faroshq/provider-infrastructure` to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)