### PR TITLE
tilt: wire the kuery provider into both Tiltfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery install-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
+.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery install-provider-kuery init-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
 
 BINDIR ?= bin
 GOFLAGS ?=
@@ -609,16 +609,27 @@ KUERY_TOKEN ?= $(STATIC_AUTH_TOKEN)
 KUERY_KCP_KUBECONFIG ?= $(KCP_DATA_DIR)/admin.kubeconfig
 KUERY_KCP_SERVER ?= https://localhost:6443
 KUERY_MANIFEST ?= providers/kuery/manifest.yaml
+KUERY_WORKSPACE_PATH ?= root:kedge:providers:kuery
+# Dev runtime kubeconfig for the engagement controller, written by
+# init-provider-kuery from the provider SA token the hub mints.
+KUERY_RUNTIME_KUBECONFIG ?= $(KCP_DATA_DIR)/kuery-runtime.kubeconfig
 
-run-provider-kuery: build-kuery-provider ## Run the kuery provider (requires: make run-hub-embedded-static + make install-provider-kuery)
+run-provider-kuery: build-kuery-provider ## Run the kuery provider (requires: make run-hub-embedded-static + make install-provider-kuery; engagement needs init-provider-kuery)
 	@echo "Starting kuery provider on :$(KUERY_PORT)"
 	@echo "  hub:   $(KUERY_HUB_URL)"
 	@echo "  token: $(KUERY_TOKEN)"
+	@if [ -f $(KUERY_RUNTIME_KUBECONFIG) ]; then \
+		echo "  engagement: $(KUERY_RUNTIME_KUBECONFIG)"; \
+	else \
+		echo "  engagement: DISABLED (run 'make init-provider-kuery' after install-provider-kuery)"; \
+	fi
 	PORT=$(KUERY_PORT) \
 	KEDGE_HUB_URL=$(KUERY_HUB_URL) \
 	KEDGE_HUB_TOKEN=$(KUERY_TOKEN) \
 	KEDGE_HUB_INSECURE=true \
 	KEDGE_PROVIDER_NAME=kuery \
+	KEDGE_PROVIDER_KUBECONFIG=$(KUERY_RUNTIME_KUBECONFIG) \
+	KEDGE_DEV_ALLOW_TENANT_QUERY=true \
 		$(BINDIR)/kuery-provider
 
 install-provider-kuery: ## Apply kuery CatalogEntry into root:kedge:providers
@@ -631,6 +642,36 @@ install-provider-kuery: ## Apply kuery CatalogEntry into root:kedge:providers
 		--server=$(KUERY_KCP_SERVER)/clusters/root:kedge:providers \
 		--insecure-skip-tls-verify \
 		apply -f $(KUERY_MANIFEST)
+
+## Dev bootstrap for the engagement controller. The hub-provisioned flow
+## delivers the minted kubeconfig as a host-cluster Secret, which doesn't
+## exist in host-binary dev — so mint the same thing from the provider SA
+## token Secret the catalog controller created, and ensure the
+## APIExportEndpointSlice the engagement watcher discovers VW URLs from.
+## Order: install-provider-kuery (CatalogEntry reconciled) → this → the
+## kuery Tilt resource restarts on the kubeconfig file appearing.
+init-provider-kuery: ## Ensure kuery APIExportEndpointSlice + write dev runtime kubeconfig
+	@test -f $(KUERY_KCP_KUBECONFIG) || { \
+		echo "kubeconfig not found at $(KUERY_KCP_KUBECONFIG)"; \
+		echo "start the hub first with: make run-hub-embedded-static"; \
+		exit 1; \
+	}
+	@echo "Ensuring APIExportEndpointSlice in $(KUERY_WORKSPACE_PATH)"
+	@printf 'apiVersion: apis.kcp.io/v1alpha1\nkind: APIExportEndpointSlice\nmetadata:\n  name: kuery.providers.kedge.faros.sh\nspec:\n  export:\n    path: $(KUERY_WORKSPACE_PATH)\n    name: kuery.providers.kedge.faros.sh\n' | \
+		kubectl --kubeconfig=$(KUERY_KCP_KUBECONFIG) \
+			--server=$(KUERY_KCP_SERVER)/clusters/$(KUERY_WORKSPACE_PATH) \
+			--insecure-skip-tls-verify apply -f -
+	@echo "Writing $(KUERY_RUNTIME_KUBECONFIG) (server $(KUERY_HUB_URL)/clusters/$(KUERY_WORKSPACE_PATH))"
+	@TOKEN=$$(kubectl --kubeconfig=$(KUERY_KCP_KUBECONFIG) \
+		--server=$(KUERY_KCP_SERVER)/clusters/$(KUERY_WORKSPACE_PATH) \
+		--insecure-skip-tls-verify \
+		get secret -n default provider-token -o jsonpath='{.data.token}' | base64 -d); \
+	test -n "$$TOKEN" || { echo "provider-token Secret empty — wait for the catalog controller to reconcile"; exit 1; }; \
+	mkdir -p $(KCP_DATA_DIR); \
+	printf 'apiVersion: v1\nkind: Config\nclusters:\n- name: kedge\n  cluster:\n    server: %s\n    insecure-skip-tls-verify: true\ncontexts:\n- name: kedge\n  context:\n    cluster: kedge\n    user: kedge\ncurrent-context: kedge\nusers:\n- name: kedge\n  user:\n    token: %s\n' \
+		"$(KUERY_HUB_URL)/clusters/$(KUERY_WORKSPACE_PATH)" "$$TOKEN" \
+		> $(KUERY_RUNTIME_KUBECONFIG)
+	@echo "wrote $(KUERY_RUNTIME_KUBECONFIG)"
 
 uninstall-provider-kuery: ## Delete kuery CatalogEntry
 	-kubectl --kubeconfig=$(KUERY_KCP_KUBECONFIG) \

--- a/Tiltfile
+++ b/Tiltfile
@@ -79,6 +79,7 @@ go build -o bin/kedge-hub ./cmd/kedge-hub
 #   providers-quickstart   — the reference example (port :8081)
 #   providers-kro          — infrastructure broker (port :8082) +
 #                            management kind cluster that kro runs in
+#   providers-kuery        — fleet query engine (port :8084)
 #
 # Each provider has three resources:
 #   <name>            build + serve; auto-restarts on src change
@@ -205,6 +206,67 @@ local_resource(
     auto_init=False,
     resource_deps=['hub'],
     labels=['providers-code'],
+)
+
+# --- providers-kuery (fleet query engine) ---
+# Long-lived provider embedding the kuery engine. Serves the portal +
+# /api/query + MCP on :8084 immediately; the edge engagement controller
+# additionally needs the dev runtime kubeconfig, minted by ▶ kuery-init
+# AFTER ▶ kuery-register has been applied and reconciled. Tilt restarts
+# the serve process when the kubeconfig file appears (it's in deps).
+local_resource(
+    'kuery',
+    cmd='make build-kuery-provider',
+    serve_cmd='make run-provider-kuery',
+    deps=[
+        'providers/kuery/main.go',
+        'providers/kuery/assets.go',
+        'providers/kuery/core',
+        'providers/kuery/engagement',
+        'providers/kuery/queryapi',
+        'providers/kuery/mcpserver',
+        'providers/kuery/portal/src',
+        'providers/kuery/portal/package.json',
+        'providers/kuery/go.mod',
+        'providers/kuery/go.sum',
+        '.kcp/kuery-runtime.kubeconfig',
+    ],
+    resource_deps=['hub'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=8084, path='/healthz'),
+    ),
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-register',
+    cmd='make install-provider-kuery',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['providers-kuery'],
+)
+
+# Mints the dev runtime kubeconfig from the provider SA token (created by
+# the catalog controller on register) and ensures the
+# APIExportEndpointSlice the engagement controller discovers VW URLs from.
+local_resource(
+    'kuery-init',
+    cmd='make init-provider-kuery',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub', 'kuery-register'],
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-unregister',
+    cmd='make uninstall-provider-kuery',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['hub'],
+    labels=['providers-kuery'],
 )
 
 # --- providers-kro ---

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -357,6 +357,7 @@ kubectl create secret generic kcp-static-tokens -n default \
 #   providers-quickstart   — reference example (port :8081)
 #   providers-kro          — infrastructure broker (port :8082) +
 #                            management kind cluster that kro runs in
+#   providers-kuery        — fleet query engine (port :8084)
 #
 # Each provider has three resources:
 #   <name>            build + serve; auto-restarts on src change
@@ -400,6 +401,7 @@ def rewrite_manifest_cmd(src):
 QUICKSTART_REWRITE_CMD, QUICKSTART_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/quickstart/manifest.yaml')
 INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/infrastructure/manifest.yaml')
 CODE_REWRITE_CMD, CODE_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/code/manifest.yaml')
+KUERY_REWRITE_CMD, KUERY_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/kuery/manifest.yaml')
 
 # --- providers-quickstart ---
 local_resource(
@@ -445,6 +447,71 @@ local_resource(
     auto_init=False,
     resource_deps=['kedge-hub'],
     labels=['providers-quickstart'],
+)
+
+# --- providers-kuery (fleet query engine, port :8084) ---
+# Same shape as the embedded Tiltfile: serve immediately; engagement
+# needs ▶ kuery-register then ▶ kuery-init (mints the runtime kubeconfig
+# from the provider SA token + ensures the APIExportEndpointSlice).
+local_resource(
+    'kuery',
+    cmd='make build-kuery-provider',
+    serve_cmd='make run-provider-kuery',
+    deps=[
+        'providers/kuery/main.go',
+        'providers/kuery/assets.go',
+        'providers/kuery/core',
+        'providers/kuery/engagement',
+        'providers/kuery/queryapi',
+        'providers/kuery/mcpserver',
+        'providers/kuery/portal/src',
+        'providers/kuery/portal/package.json',
+        'providers/kuery/go.mod',
+        '.kcp/kuery-runtime.kubeconfig',
+    ],
+    resource_deps=['kedge-hub'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=8084, path='/healthz'),
+    ),
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-register',
+    cmd=('{rewrite} && KUERY_KCP_KUBECONFIG={kc} ' +
+         'KUERY_KCP_SERVER={sv} KUERY_MANIFEST={mf} ' +
+         'make install-provider-kuery').format(
+             rewrite=KUERY_REWRITE_CMD, kc=KCP_ADMIN_KUBECONFIG,
+             sv=KCP_ADMIN_SERVER, mf=KUERY_MANIFEST_REWRITTEN),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kedge-hub'],
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-init',
+    cmd=('KUERY_KCP_KUBECONFIG={kc} KUERY_KCP_SERVER={sv} ' +
+         'make init-provider-kuery').format(
+             kc=KCP_ADMIN_KUBECONFIG, sv=KCP_ADMIN_SERVER),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kedge-hub', 'kuery-register'],
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-unregister',
+    cmd=('{rewrite} && KUERY_KCP_KUBECONFIG={kc} ' +
+         'KUERY_KCP_SERVER={sv} KUERY_MANIFEST={mf} ' +
+         'make uninstall-provider-kuery').format(
+             rewrite=KUERY_REWRITE_CMD, kc=KCP_ADMIN_KUBECONFIG,
+             sv=KCP_ADMIN_SERVER, mf=KUERY_MANIFEST_REWRITTEN),
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kedge-hub'],
+    labels=['providers-kuery'],
 )
 
 # --- providers-kro ---

--- a/providers/kuery/README.md
+++ b/providers/kuery/README.md
@@ -73,3 +73,17 @@ make build-kuery-provider        # portal build + go build
 make run-provider-kuery          # run against a local hub
 make install-provider-kuery      # apply manifest.yaml to embedded kcp
 ```
+
+## Tilt
+
+Both Tiltfiles (embedded-kcp `Tiltfile` and in-cluster `Tiltfile.cluster`)
+include a `providers-kuery` group:
+
+1. `kuery` — builds + serves on :8084 (auto-restarts on source change).
+2. ▶ `kuery-register` — applies the CatalogEntry; the hub provisions the
+   workspace, APIExport, SA, and token.
+3. ▶ `kuery-init` — mints `.kcp/kuery-runtime.kubeconfig` from the
+   provider SA token and ensures the APIExportEndpointSlice; Tilt then
+   restarts `kuery` with edge engagement enabled.
+4. Connect an edge and open the portal — the Kuery tab shows the fleet
+   inventory. (▶ `kuery-unregister` tears the CatalogEntry down.)


### PR DESCRIPTION
## Summary

The kuery provider had no Tilt story, so it couldn't be exercised locally. This adds the `providers-kuery` group to **both** Tiltfiles (embedded-kcp `Tiltfile` and in-cluster `Tiltfile.cluster`), mirroring the quickstart/code pattern:

- **`kuery`** — build + serve on :8084 with a `/healthz` readiness probe; auto-restarts on Go/portal source change *and* when the runtime kubeconfig appears.
- **▶ `kuery-register` / `kuery-unregister`** — apply/delete the CatalogEntry (cluster mode rewrites `localhost` → `host.docker.internal` like the other providers).
- **▶ `kuery-init`** (new `make init-provider-kuery`) — the dev substitute for the hub's HostSecretWriter delivery, which needs a host cluster that host-binary dev doesn't have. It mints `.kcp/kuery-runtime.kubeconfig` from the `provider-token` Secret the catalog controller created, and ensures the **APIExportEndpointSlice** the engagement controller discovers virtual-workspace URLs from (the hub creates the APIExport but not the slice — same gap the code provider's init closes).

`make run-provider-kuery` now exports `KEDGE_PROVIDER_KUBECONFIG` (tolerated when the file is absent — engagement stays disabled with a visible hint) and `KEDGE_DEV_ALLOW_TENANT_QUERY=true` so `/api/query?tenant=…` is curl-able in dev.

### Local flow

```
tilt up                      # hub + portal + providers
▶ kuery-register             # CatalogEntry → hub provisions workspace/APIExport/SA
▶ kuery-init                 # runtime kubeconfig + endpoint slice → kuery restarts engaged
kedge dev edge create …      # connect an edge; inventory fills in
```

## Test plan

- `make -n init-provider-kuery` / `run-provider-kuery` — targets parse, env wiring correct.
- Both Tiltfiles pass a Starlark-compatible syntax check.
- `/healthz` probe path + port match the provider defaults (8084, consistent with the Makefile block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)