### PR TITLE
hub: claim apibindings on core.faros.sh so GraphQL schema rebuilds on new bindings

### DIFF
--- a/config/kcp/apiexport-core.faros.sh.yaml
+++ b/config/kcp/apiexport-core.faros.sh.yaml
@@ -6,6 +6,12 @@ metadata:
   name: core.faros.sh
 spec:
   permissionClaims:
+  - group: apis.kcp.io
+    resource: apibindings
+    verbs:
+    - get
+    - list
+    - watch
   - resource: secrets
     verbs:
     - get

--- a/hack/gen-core-apiexport/main.go
+++ b/hack/gen-core-apiexport/main.go
@@ -65,6 +65,23 @@ func main() {
 	var mergedClaims []map[string]interface{}
 	var mergedResources []map[string]interface{}
 
+	// core.faros.sh always claims apibindings (apis.kcp.io) — not because any
+	// provider consumes the data, but so the GraphQL listener's APIExport
+	// virtual workspace surfaces EVERY APIBinding in a consumer workspace.
+	// The listener watches apibindings through this VW to know when to rebuild
+	// the GraphQL schema; without the claim the VW exposes only the consumer's
+	// own core.faros.sh binding (kcp's reflexive fallback), so enabling another
+	// provider — a new APIBinding to a different APIExport — produces no event
+	// and the schema goes stale until the next informer resync. The consumer
+	// binding must accept this claim (see EnsureChildWorkspaceKedgeBinding).
+	// Ref: kcp pkg/virtual/apiexport/controllers/apireconciler (claimsAPIBindings).
+	mergedClaims = append(mergedClaims, map[string]interface{}{
+		"group":    "apis.kcp.io",
+		"resource": "apibindings",
+		"verbs":    []interface{}{"get", "list", "watch"},
+	})
+	seenClaims[claimKey{group: "apis.kcp.io", resource: "apibindings"}] = true
+
 	// Process files alphabetically, skip the output file itself and non-apiexport files.
 	outputBase := filepath.Base(*output)
 

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -578,6 +578,16 @@ func (b *Bootstrapper) EnsureChildWorkspaceKedgeBinding(ctx context.Context, org
 				// Owns(&Workspace{}) the per-edge mount workspaces, so it needs
 				// the full verb set the export offers.
 				acceptedClaim("tenancy.kcp.io", "workspaces", b.workspaceIdentityHash, allVerbs),
+				// apibindings (apis.kcp.io): accepted so kcp labels EVERY
+				// APIBinding in this workspace with core.faros.sh's claim label,
+				// making them visible through the core.faros.sh APIExport virtual
+				// workspace. The GraphQL listener watches apibindings over that VW
+				// to trigger a schema rebuild; without this claim the VW shows
+				// only this reflexive binding, so enabling another provider would
+				// not rebuild the schema until the next informer resync. Must
+				// stay in sync with the matching claim core.faros.sh declares
+				// (see hack/gen-core-apiexport).
+				acceptedClaim("apis.kcp.io", "apibindings", "", []string{"get", "list", "watch"}),
 			},
 		},
 	}


### PR DESCRIPTION
## Problem

Enabling a provider (e.g. `code`) creates a new APIBinding and the binding goes `Ready`, but the GraphQL schema does **not** rebuild — the new API group is missing from the playground until ~10h later (or never, until the listener restarts). Intermittent, looks like "the gateway doesn't react to the new APIBinding."

## Root cause

The GraphQL listener watches APIBindings through the **`core.faros.sh` APIExport virtual workspace** to trigger a schema rebuild (schema *content* is discovered against the full workspace via the front-proxy; the *trigger* comes from the VW watch).

But a kcp APIExport VW only surfaces APIBindings that carry the export's permission-claim label, plus the reflexive self-binding (`pkg/virtual/apiexport/controllers/apireconciler` → `claimsAPIBindings`; reflexive fallback in `sdk/.../permissionclaims/labels.go`). `core.faros.sh` did **not** claim `apibindings`, so the VW exposed only the consumer's own `core.faros.sh` binding. A new binding to a *different* APIExport (`code`, `infrastructure`, …) never appears in that watch stream → no reconcile → stale schema.

## Fix (event-driven)

Claim `apis.kcp.io/apibindings` on `core.faros.sh` and accept it in the consumer binding. kcp's permission-claim labeler then labels **every** APIBinding in the workspace, the VW surfaces them all, and creating a binding fires the watch — schema rebuilds become instant.

- `hack/gen-core-apiexport`: seed the `apibindings` claim into the merged export (kept here so it lands only on `core.faros.sh`, with the rationale documented)
- `config/kcp/apiexport-core.faros.sh.yaml`: regenerated
- `pkg/hub/kcp/bootstrap.go`: accept the claim in `EnsureChildWorkspaceKedgeBinding`

### Why no `identityHash`
APIExport admission exempts the `apis.kcp.io` group (and built-in APIs) from the identity-hash requirement — `pkg/admission/apiexport/admission.go`: `if pc.IdentityHash == "" && !e.isBuiltIn(...) && pc.Group != apis.GroupName`. Same as the existing `secrets`/`namespaces` claims in this binding, which also carry no hash. (`tenancy.kcp.io/workspaces` needs one because it's neither built-in nor `apis.kcp.io`.)

## Pairs with

The graphql-gateway listener change that reacts to **any** APIBinding event (list-based regenerate-vs-cleanup) instead of only the anchor binding. Both are required: this PR makes the events visible; the gateway PR makes the listener act on them.

## Caveats

- **Existing workspaces don't auto-heal:** `EnsureChildWorkspaceKedgeBinding` uses `Create` (ignores `AlreadyExists`) and does not patch existing bindings, so already-provisioned workspaces keep their old accepted-claim set until their `kedge` binding is recreated/patched. New workspaces are correct immediately.
- Already-bound consumers will show the new claim as pending until accepted (benign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)