### PR TITLE
[codex] fix app-studio provider build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ build-app-studio-provider-portal: ## Build the App Studio provider's micro-front
 	cd providers/app-studio/portal && npm install --no-audit --no-fund && npm run build
 
 build-app-studio-provider: build-app-studio-provider-portal ## Build the App Studio provider binary (portal embedded)
-	go build $(GOFLAGS) -o $(CURDIR)/$(BINDIR)/app-studio-provider ./providers/app-studio
+	cd providers/app-studio && go build $(GOFLAGS) -o $(CURDIR)/$(BINDIR)/app-studio-provider .
 
 build-code-provider-portal: ## Build the code provider's micro-frontend (Vite + Vue → portal/dist)
 	cd providers/code/portal && npm install --no-audit --no-fund && npm run build


### PR DESCRIPTION
## Summary

- Build the App Studio provider from inside its standalone Go module, matching the other standalone provider targets.
- Keep the output binary path unchanged at `bin/app-studio-provider`.

## Root Cause

`providers/app-studio` declares its own module, `github.com/faroshq/provider-app-studio`. The Makefile was invoking `go build ./providers/app-studio` from the root `github.com/faroshq/faros-kedge` module, so Go tried to resolve it as a root-module package and failed with:

```text
main module (github.com/faroshq/faros-kedge) does not contain package github.com/faroshq/faros-kedge/providers/app-studio
```

Changing the target to `cd providers/app-studio && go build ... .` uses the provider's own module context.

## Validation

- `make build-app-studio-provider`
