### PR TITLE
[codex] Restore upstream kcp extract and fix App Studio build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ build-app-studio-provider-portal: ## Build the App Studio provider's micro-front
 	cd providers/app-studio/portal && npm install --no-audit --no-fund && npm run build
 
 build-app-studio-provider: build-app-studio-provider-portal ## Build the App Studio provider binary (portal embedded)
-	go build $(GOFLAGS) -o $(CURDIR)/$(BINDIR)/app-studio-provider ./providers/app-studio
+	cd providers/app-studio && go build $(GOFLAGS) -o $(CURDIR)/$(BINDIR)/app-studio-provider .
 
 build-code-provider-portal: ## Build the code provider's micro-frontend (Vite + Vue → portal/dist)
 	cd providers/code/portal && npm install --no-audit --no-fund && npm run build

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -240,38 +240,6 @@ RUN chmod 0755 /tmp/kedge-hub
 )
 
 # --- kcp kubeconfig → in-cluster Secret the chart mounts ---
-#
-# The included upstream `kcp-admin extract` resource can race CRD discovery on
-# fresh CI clusters: it only waits for "some" operator.kcp.io resource, then
-# immediately calls `kubectl wait kubeconfig/...`, which fails if the
-# Kubeconfig CRD has not reached discovery yet. Keep our hub dependency on a
-# local extractor that waits for the exact CRD and objects it needs.
-local_resource(
-    'kedge-kcp-admin-extract',
-    cmd='''
-set -eu
-
-echo "waiting for Kubeconfig CRD"
-kubectl wait crd/kubeconfigs.operator.kcp.io --for=condition=Established --timeout=10m
-
-extract_kubeconfig() {
-  name="$1"
-  echo "waiting for Kubeconfig/${name}"
-  kubectl wait "kubeconfigs.operator.kcp.io/${name}" --for=create --timeout=10m
-  kubectl wait "kubeconfigs.operator.kcp.io/${name}" --for=condition=Available --timeout=10m
-  kubectl wait "secret/kcp-${name}-kubeconfig" --for=create --timeout=10m
-  kubeconfig_data="$(kubectl get "secret/kcp-${name}-kubeconfig" -o jsonpath='{.data.kubeconfig}')"
-  printf '%s' "${kubeconfig_data}" | base64 -d > "tilt-${name}.kubeconfig"
-}
-
-extract_kubeconfig frontproxy
-extract_kubeconfig root
-extract_kubeconfig theseus
-''',
-    labels=['hub'],
-    allow_parallel=True,
-)
-
 # We use ONLY the front-proxy kubeconfig, for both the primary connection AND
 # the GraphQL listener. The listener locates the APIExportEndpointSlice by
 # workspace PATH (root:kedge:providers); only the front-proxy resolves paths to
@@ -286,7 +254,7 @@ kubectl create secret generic kcp-frontproxy-admin -n %s \
   --dry-run=client -o yaml | kubectl apply -f -
 ''' % (hub_namespace, hub_namespace),
     deps=['tilt-frontproxy.kubeconfig'],
-    resource_deps=['kedge-kcp-admin-extract'],
+    resource_deps=['kcp-admin extract'],
     labels=['hub'],
 )
 


### PR DESCRIPTION
## Summary

- Remove the kedge-local `kedge-kcp-admin-extract` Tilt resource and restore `hub-kcp-secrets` to depend on upstream `kcp-admin extract`.
- Build the App Studio provider from inside its standalone Go module, matching the other provider build targets.

## Why

The Tiltfile should rely on the upstream kcp kubeconfig extraction flow again. Separately, the App Studio Tilt job was failing because `make build-app-studio-provider` invoked `go build ./providers/app-studio` from the root module, but `providers/app-studio` is its own module. Building from that directory fixes the nested-module package lookup error.

## Validation

- `make build-app-studio-provider`
- `git diff --check`