### PR TITLE
feat(kuery): edge-centric fleet graph with expandable explorer

### DIFF
--- a/docs/kuery-query-api.md
+++ b/docs/kuery-query-api.md
@@ -1,0 +1,91 @@
+# kuery query API
+
+The kuery provider exposes a fleet-wide query API over every edge cluster
+engaged for your workspace. The portal's **Playground** tab is a UI on top of
+it; this document is the programmatic reference.
+
+## Endpoint
+
+```
+POST  {hub}/services/providers/kuery/api/query        # run a query
+GET   {hub}/services/providers/kuery/api/query-schema  # JSON Schema for the body
+GET   {hub}/services/providers/kuery/api/edges          # engaged edge names
+```
+
+- **Body** of `/api/query` is a kuery `QuerySpec` (JSON). The response is a
+  `QueryStatus` with `objects[]`.
+- **Tenanting is automatic.** The hub authenticates your bearer token, resolves
+  your workspace, and injects the tenant scope server-side. Any
+  `X-Kedge-Tenant` you send is stripped — you cannot query another tenant.
+
+## Auth
+
+Send `Authorization: Bearer <token>`:
+
+- **OIDC user token** — works today. Use the token your portal session uses.
+- **Service-account token** — non-interactive/bot access. (In progress: the hub
+  needs to resolve a kcp ServiceAccount token to its workspace path before this
+  works through the provider proxy.)
+
+```bash
+curl -sS "$HUB/services/providers/kuery/api/query" \
+  -H "Authorization: Bearer $KEDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"filter":{"objects":[{"groupKind":{"kind":"Deployment"}}]},"objects":{"cluster":true}}'
+```
+
+## QuerySpec essentials
+
+Fetch the full schema from `/api/query-schema`. Key fields:
+
+| field | meaning |
+|---|---|
+| `root` | `objects` (default) or `clusters` (one node per edge; expand `members`). |
+| `cluster.name` | restrict to one edge. |
+| `filter.objects[]` | OR-ed filters: `groupKind{apiGroup,kind}`, `name`, `namespace`, `labels`, `categories`, `jsonpath`. |
+| `limit`, `maxDepth` | root cap (def 100), transitive depth for `+` relations (def 10). |
+| `objects` | response shape: `id`, `cluster`, `mutablePath`, sparse `object` projection, and `relations`. |
+
+### Relations and impact direction
+
+`objects.relations` follows coupling. Each relation has an **impact direction**
+— `A→B` means *deleting A breaks B*:
+
+- **Upstream** (the target depends on these; deleting them breaks it):
+  `owners`, `references`, `selects`, `namespace`.
+- **Downstream** (the target's blast radius; break if it's deleted):
+  `descendants`, `selected-by`, `namespaced`, `members`.
+- **Lateral**: `linked`, `grouped`.
+
+Append `+` for the transitive form (`descendants+`, `owners+`, `linked+`).
+
+Coupling is **declared** (ownerRefs, spec field references, label selectors,
+namespace membership) — not runtime traffic — so an empty result is not proof
+nothing depends on the object at runtime.
+
+## Examples
+
+All objects in a namespace:
+
+```json
+{ "filter": { "objects": [{ "namespace": "default" }] },
+  "objects": { "cluster": true, "object": { "kind": true, "metadata": { "name": true, "namespace": true } } } }
+```
+
+Impact of a ConfigMap (who breaks if I change it + what it needs):
+
+```json
+{ "filter": { "objects": [{ "groupKind": { "kind": "ConfigMap" }, "namespace": "default", "name": "app-config" }] },
+  "objects": { "cluster": true, "relations": { "references": {}, "selected-by": {}, "namespace": {} } } }
+```
+
+Per-cluster tree:
+
+```json
+{ "root": "clusters",
+  "objects": { "cluster": true, "relations": { "members": { "limit": 50,
+    "objects": { "object": { "kind": true, "metadata": { "name": true, "namespace": true } } } } } } }
+```
+
+For agent/LLM use, the `kuery_impact` MCP tool wraps the impact query and
+returns the upstream/downstream split directly.

--- a/pkg/hub/providers/provision.go
+++ b/pkg/hub/providers/provision.go
@@ -442,7 +442,7 @@ func (p *provisioner) resolveClaimIdentityHash(ctx context.Context, group, resou
 	// view; we poll that out rather than write an empty (permanently-invalid)
 	// hash. Built-in and kcp-system groups have no sibling export, so for those
 	// a miss is the terminal, correct "" answer. Mirrors
-	// Bootstrapper.resolveClaimIdentityHash on the binding side — keep both in
+	// Bootstrapper.exportClaimIdentities on the binding side — keep both in
 	// lockstep.
 	firstParty := strings.HasSuffix(group, ".faros.sh")
 

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.7.1-0.20260515112510-8f4137891edf
 
 require (
-	github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025
+	github.com/faroshq/kuery v0.0.0-20260614065711-08329d47d344
 	github.com/kcp-dev/multicluster-provider v0.7.1
 	github.com/kcp-dev/sdk v0.31.0
 	github.com/modelcontextprotocol/go-sdk v1.3.1

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.7.1-0.20260515112510-8f4137891edf
 
 require (
-	github.com/faroshq/kuery v0.0.0-20260612114451-4faa46315aa7
+	github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025
 	github.com/kcp-dev/multicluster-provider v0.7.1
 	github.com/kcp-dev/sdk v0.31.0
 	github.com/modelcontextprotocol/go-sdk v1.3.1

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -22,8 +22,8 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/kuery v0.0.0-20260612114451-4faa46315aa7 h1:3muOYkFjkBfnK4/UYC1YoSbOOT/sBNbCZyhwi5Dq86k=
-github.com/faroshq/kuery v0.0.0-20260612114451-4faa46315aa7/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
+github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025 h1:dCmGQg5UyHbgBi/N3nqtWs8J7QQaOFM/gquSA3KXuHE=
+github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -22,8 +22,8 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025 h1:dCmGQg5UyHbgBi/N3nqtWs8J7QQaOFM/gquSA3KXuHE=
-github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
+github.com/faroshq/kuery v0.0.0-20260614065711-08329d47d344 h1:Magn//NZd+GAeX3X1U8+kFJAwUiy/WkrzOU5lXoiB+c=
+github.com/faroshq/kuery v0.0.0-20260614065711-08329d47d344/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -161,6 +161,10 @@ func main() {
 	// Tenant-scoped query API — the only path to the kuery store.
 	mux.Handle("/api/query", &queryapi.Handler{Engine: kc.Engine})
 
+	// QuerySpec JSON Schema — powers the playground editor's autocomplete and
+	// doubles as external API docs. Unauthenticated (the schema is public).
+	mux.Handle("/api/query-schema", queryapi.SchemaHandler{})
+
 	// Engaged-edge listing for the portal's edge selector. The interface
 	// indirection keeps the nil case (engagement disabled) serving [].
 	var edgeLister queryapi.EdgeLister

--- a/providers/kuery/mcpserver/tools.go
+++ b/providers/kuery/mcpserver/tools.go
@@ -13,10 +13,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/faroshq/kuery/apis/query/v1alpha1"
+	"github.com/faroshq/kuery/pkg/engine"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/faroshq/provider-kuery/queryapi"
 )
@@ -42,14 +46,94 @@ type impactInput struct {
 	MaxDepth  int32  `json:"maxDepth,omitempty" jsonschema:"transitive traversal depth (default 5, max 20)"`
 }
 
-type impactOutput struct {
-	Status *v1alpha1.QueryStatus `json:"status"`
+// impactRef identifies one related object and the relation that links it to
+// the queried object.
+type impactRef struct {
+	Edge      string `json:"edge,omitempty"`
+	Group     string `json:"group,omitempty"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Relation  string `json:"relation" jsonschema:"the relation that links this object to the target (owners, references, descendants, namespace, …)"`
 }
 
-// impactRelations is the relation set the impact view expands: everything
-// that DECLARES coupling to the object. Events excluded by default — they
-// are blacklisted from sync.
+// impactOutput splits the target's declared coupling into the two impact
+// directions plus lateral peers, so the model can answer the right question
+// from the right list.
+type impactOutput struct {
+	Object impactRef `json:"object" jsonschema:"the object whose impact was mapped"`
+	Found  bool      `json:"found" jsonschema:"false if the object isn't in the store yet (sync may be catching up)"`
+	// ImpactedBy: UPSTREAM dependencies — deleting/breaking any of these breaks
+	// the target. Answers 'why is X broken?' / 'what does X need?'.
+	ImpactedBy []impactRef `json:"impactedBy"`
+	// Impacts: DOWNSTREAM blast radius — these break if the target is
+	// changed/deleted. Answers 'is it safe to change/delete X?'.
+	Impacts []impactRef `json:"impacts"`
+	// Associated: lateral peers (kuery.io/relates-to links, shared group label).
+	Associated []impactRef `json:"associated"`
+	Summary    string      `json:"summary" jsonschema:"one-line human-readable count of each direction"`
+}
+
+// impactRelations is the relation set the impact tool expands: everything that
+// DECLARES coupling to the object, in both impact directions. Events excluded
+// by default — they are blacklisted from sync.
 var impactRelations = []string{"descendants+", "references", "selects", "selected-by", "owners", "linked+", "grouped", "namespace", "namespaced"}
+
+// edgeName strips the "{tenant}/" prefix kuery records on a cluster key, so the
+// model sees the bare edge name it knows.
+func edgeName(cluster string) string {
+	if i := strings.LastIndex(cluster, "/"); i >= 0 {
+		return cluster[i+1:]
+	}
+	return cluster
+}
+
+// refOf flattens one related ObjectResult (projected with cluster + kind +
+// apiVersion + metadata) into an impactRef tagged with its relation.
+func refOf(it v1alpha1.ObjectResult, rel string) impactRef {
+	var o struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Metadata   struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if it.Object != nil {
+		_ = json.Unmarshal(it.Object.Raw, &o)
+	}
+	group := ""
+	if i := strings.Index(o.APIVersion, "/"); i >= 0 {
+		group = o.APIVersion[:i]
+	}
+	return impactRef{
+		Edge:      edgeName(it.Cluster),
+		Group:     group,
+		Kind:      o.Kind,
+		Namespace: o.Metadata.Namespace,
+		Name:      o.Metadata.Name,
+		Relation:  engine.BaseRelation(rel),
+	}
+}
+
+// classifyImpact buckets the anchor's relations by impact direction, using the
+// engine's canonical RelationDirections as the source of truth.
+func classifyImpact(anchor *v1alpha1.ObjectResult) (impactedBy, impacts, associated []impactRef) {
+	for rel, items := range anchor.Relations {
+		for i := range items {
+			ref := refOf(items[i], rel)
+			switch engine.DirectionOf(rel) {
+			case engine.DirectionUpstream:
+				impactedBy = append(impactedBy, ref)
+			case engine.DirectionDownstream:
+				impacts = append(impacts, ref)
+			default:
+				associated = append(associated, ref)
+			}
+		}
+	}
+	return
+}
 
 func registerTools(srv *mcp.Server, deps Deps, r *http.Request) {
 	ident := queryapi.IdentityFromRequest(r)
@@ -78,9 +162,13 @@ func registerTools(srv *mcp.Server, deps Deps, r *http.Request) {
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "kuery_impact",
-		Title:       "Blast radius of one object",
-		Description: "Expand the declared coupling of one object across the fleet: transitive descendants, spec references (e.g. pods mounting a ConfigMap), label-selector matches both ways, owners, and cross-edge links. Reliable for 'who consumes this — safe to change?' questions; does not see network-level dependencies.",
+		Name:  "kuery_impact",
+		Title: "Impact of one object (upstream deps + downstream blast radius)",
+		Description: "Map one object's DECLARED coupling across the edge fleet, split by impact direction so you query the right list:\n" +
+			"- impactedBy (UPSTREAM dependencies): deleting/breaking any of these breaks the target — its owners, the ConfigMaps/Secrets/ServiceAccounts it references, the Namespace it lives in, the selectors that target it. Use for 'why is X failing?' or 'what does X depend on?'.\n" +
+			"- impacts (DOWNSTREAM blast radius): what breaks if you change/delete the target — objects it owns (transitively), Services/endpoints that select it, and (for a Namespace) every object inside it. Use for 'is it safe to change/delete X?'.\n" +
+			"- associated: lateral peers (kuery.io/relates-to links, shared group label).\n" +
+			"Coupling is DECLARED — ownerRefs, spec field references, label selectors, namespace membership — NOT runtime traffic or network policy, so a clean result is not proof nothing else depends on it at runtime. Each related object is returned with its kind/namespace/name/edge and the relation that linked it. Prefer this over per-edge kubectl for change-safety and root-cause questions that span edges.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in impactInput) (*mcp.CallToolResult, impactOutput, error) {
 		if ident.Tenant == "" {
@@ -94,9 +182,20 @@ func registerTools(srv *mcp.Server, deps Deps, r *http.Request) {
 			maxDepth = 5
 		}
 
+		// Project just enough on related objects to identify them.
+		relProj, _ := json.Marshal(map[string]any{
+			"kind":       true,
+			"apiVersion": true,
+			"metadata":   map[string]any{"name": true, "namespace": true},
+		})
+		relObjects := &v1alpha1.ObjectsSpec{Cluster: true, Object: &runtime.RawExtension{Raw: relProj}}
 		relations := map[string]v1alpha1.RelationSpec{}
 		for _, rel := range impactRelations {
-			relations[rel] = v1alpha1.RelationSpec{}
+			rs := v1alpha1.RelationSpec{Objects: relObjects}
+			if rel == "namespaced" {
+				rs.Limit = 200 // a Namespace's membership can be large
+			}
+			relations[rel] = rs
 		}
 		spec := v1alpha1.QuerySpec{
 			Cluster:  &v1alpha1.ClusterFilter{Name: in.Edge},
@@ -122,6 +221,25 @@ func registerTools(srv *mcp.Server, deps Deps, r *http.Request) {
 		if err != nil {
 			return nil, impactOutput{}, fmt.Errorf("impact query failed: %w", err)
 		}
-		return nil, impactOutput{Status: status}, nil
+
+		target := impactRef{Edge: in.Edge, Group: in.Group, Kind: in.Kind, Namespace: in.Namespace, Name: in.Name}
+		if len(status.Objects) == 0 {
+			return nil, impactOutput{
+				Object:  target,
+				Found:   false,
+				Summary: fmt.Sprintf("%s/%s not found in the kuery store (sync may be catching up)", in.Kind, in.Name),
+			}, nil
+		}
+		impactedBy, impacts, associated := classifyImpact(&status.Objects[0])
+		out := impactOutput{
+			Object:     target,
+			Found:      true,
+			ImpactedBy: impactedBy,
+			Impacts:    impacts,
+			Associated: associated,
+			Summary: fmt.Sprintf("%s %s/%s: %d upstream dependency(ies) that can break it, %d downstream object(s) in its blast radius, %d associated.",
+				in.Kind, in.Namespace, in.Name, len(impactedBy), len(impacts), len(associated)),
+		}
+		return nil, out, nil
 	})
 }

--- a/providers/kuery/mcpserver/tools.go
+++ b/providers/kuery/mcpserver/tools.go
@@ -49,7 +49,7 @@ type impactOutput struct {
 // impactRelations is the relation set the impact view expands: everything
 // that DECLARES coupling to the object. Events excluded by default — they
 // are blacklisted from sync.
-var impactRelations = []string{"descendants+", "references", "selects", "selected-by", "owners", "linked+", "grouped"}
+var impactRelations = []string{"descendants+", "references", "selects", "selected-by", "owners", "linked+", "grouped", "namespace", "namespaced"}
 
 func registerTools(srv *mcp.Server, deps Deps, r *http.Request) {
 	ident := queryapi.IdentityFromRequest(r)

--- a/providers/kuery/portal/package-lock.json
+++ b/providers/kuery/portal/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/cytoscape": "^3.21.9",
+        "codemirror": "^5.65.16",
         "cytoscape": "^3.34.0",
         "typescript": "^5.6.3",
         "vite": "^6.4.1"
@@ -817,6 +818,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.21",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
+      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/providers/kuery/portal/package.json
+++ b/providers/kuery/portal/package.json
@@ -5,13 +5,15 @@
   "description": "Kuery provider's portal-side micro-frontend. Built with Vite into a single main.js custom-element bundle plus static assets the kedge hub serves under /ui/providers/kuery/.",
   "type": "module",
   "scripts": {
-    "build": "vite build && npm run vendor-cytoscape",
+    "build": "vite build && npm run vendor-cytoscape && npm run vendor-codemirror",
     "vendor-cytoscape": "node -e \"require('fs').copyFileSync('node_modules/cytoscape/dist/cytoscape.min.js','dist/cytoscape.min.js')\"",
+    "vendor-codemirror": "node vendor-codemirror.cjs",
     "dev": "vite",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/cytoscape": "^3.21.9",
+    "codemirror": "^5.65.16",
     "cytoscape": "^3.34.0",
     "typescript": "^5.6.3",
     "vite": "^6.4.1"

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -717,10 +717,17 @@ export class KueryElement extends HTMLElement {
   private _toggleFull(): void {
     const panel = this.querySelector('.panel') as HTMLElement | null
     if (!panel) return
+    // Exit whichever fullscreen mode is currently active first.
     if (document.fullscreenElement) {
       void document.exitFullscreen?.()
       return
     }
+    if (this._topoFull) {
+      // CSS-overlay fallback is active (no fullscreenElement) — exit it.
+      this._toggleFullCSS(panel)
+      return
+    }
+    // Enter: prefer the real Fullscreen API, fall back to the CSS overlay.
     if (panel.requestFullscreen) {
       panel.requestFullscreen().catch(() => this._toggleFullCSS(panel))
       return

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -15,6 +15,7 @@ import {
   mountGraph,
   RELATION_COLORS,
   RELATION_LABELS,
+  RELATION_DIR,
   type GraphHandle,
 } from './graph'
 
@@ -665,7 +666,7 @@ export class KueryElement extends HTMLElement {
             <span class="badge ${this._edges.length ? 'ok' : 'warn'}">${this._edges.length} edge${this._edges.length === 1 ? '' : 's'} engaged</span>
           </div>
         </div>
-        <p class="meta">Click a node to expand its dependencies, again to collapse; <b>Expand all</b> walks the whole net. Pan with arrow keys or WASD, zoom with +/−, <b>F</b> toggles full screen.</p>
+        <p class="meta">Click a node to expand, again to collapse; <b>Expand all</b> walks the whole net. Arrows show impact flow: <b>A→B</b> means deleting A breaks B — so a Namespace/owner points <i>into</i> its pods, not out. Pan with arrows/WASD, zoom +/−, <b>F</b> full screen.</p>
         <div class="toolbar">
           <select id="t-layout" title="layout">${layoutOptions}</select>
           <select id="f-edge" title="edge">${edgeOptions}</select>
@@ -926,15 +927,28 @@ export class KueryElement extends HTMLElement {
 
   private _renderImpactList(): string {
     const rels = this._impact?.relations ?? {}
-    const sections = IMPACT_RELATIONS.filter((r) => (rels[r] ?? []).length > 0).map((r) => {
+    const present = (r: string) => (rels[r] ?? []).length > 0
+    const section = (r: string) => {
       const items = (rels[r] ?? []).map((rr) => {
         const ro = rr.object ?? {}
         const rm = ro.metadata ?? {}
         return `<li><code>${esc(edgeOf(rr.cluster))}</code> ${esc(ro.kind || '?')} <span class="name">${esc(rm.namespace ? rm.namespace + '/' : '')}${esc(rm.name || '?')}</span></li>`
       }).join('')
       return `<h3 class="rel-title">${esc(RELATION_TITLES[r] ?? r)} <span class="muted">(${(rels[r] ?? []).length})</span></h3><ul class="rel-list">${items}</ul>`
-    })
-    return sections.join('')
+    }
+    // Two branches: what can break THIS object (upstream) vs what THIS object's
+    // deletion breaks (downstream). Lateral relations are peers.
+    const group = (dir: string) => IMPACT_RELATIONS.filter((r) => present(r) && (RELATION_DIR[r] ?? 'down') === dir)
+    const up = group('up')
+    const down = group('down')
+    const lat = group('lateral')
+    const block = (title: string, rs: string[]) =>
+      rs.length ? `<div class="rel-group"><h4 class="rel-group-title">${title}</h4>${rs.map(section).join('')}</div>` : ''
+    return (
+      block('Impacted by (delete these → breaks this)', up) +
+      block('Impacts (delete this → breaks these)', down) +
+      block('Associated', lat)
+    )
   }
 }
 

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -18,6 +18,7 @@ import {
   RELATION_DIR,
   type GraphHandle,
 } from './graph'
+import { loadCodeMirror, collectSchemaWords, createEditor, EXAMPLES, type EditorHandle } from './playground'
 
 export interface KedgeContext {
   token?: string | null
@@ -80,7 +81,7 @@ export class KueryElement extends HTMLElement {
 
   // Top-level view. Topology (edge-centric fleet tree) is the landing view;
   // Inventory (flat table) is the alternate. Each loads its data lazily.
-  private _view: 'topology' | 'inventory' = 'topology'
+  private _view: 'topology' | 'inventory' | 'playground' = 'topology'
   private _inventoryLoaded = false
   private _topology: ObjectResult[] = []
   private _topologyError = ''
@@ -95,6 +96,15 @@ export class KueryElement extends HTMLElement {
   private _expandingAll = false
   private _boundKeyHandler = (ev: KeyboardEvent) => this._onKeyDown(ev)
   private _boundFsHandler = () => this._onFullscreenChange()
+
+  // Playground state: the live editor, last result/error, and the schema
+  // vocabulary that drives autocomplete (fetched once).
+  private _pgEditor: EditorHandle | null = null
+  private _pgResult = ''
+  private _pgError = ''
+  private _pgRunning = false
+  private _pgWords: string[] = []
+  private _pgDoc = JSON.stringify(EXAMPLES[0].spec, null, 2)
 
   // Impact drill-down state. null = inventory view.
   private _impactOf: ObjectResult | null = null
@@ -140,6 +150,8 @@ export class KueryElement extends HTMLElement {
     window.removeEventListener('keydown', this._boundKeyHandler)
     document.removeEventListener('fullscreenchange', this._boundFsHandler)
     this._destroyGraph()
+    this._pgEditor?.destroy()
+    this._pgEditor = null
   }
 
   // _boot waits for basePath (it can arrive on a later context push), then
@@ -448,8 +460,13 @@ export class KueryElement extends HTMLElement {
   // ── rendering ────────────────────────────────────────────────────────
 
   private _render(): void {
-    // Tear down any live graph before its container is replaced by innerHTML.
+    // Tear down any live graph/editor before innerHTML replaces their host.
     this._destroyGraph()
+    if (this._pgEditor) {
+      this._pgDoc = this._pgEditor.getValue() // keep the user's draft across renders
+      this._pgEditor.destroy()
+      this._pgEditor = null
+    }
 
     if (this._impactOf) {
       this.innerHTML = this._renderImpact()
@@ -468,22 +485,27 @@ export class KueryElement extends HTMLElement {
       if (this._topology.length && !this._topologyError && !this._loading) void this._mountTopologyGraph()
       return
     }
+    if (this._view === 'playground') {
+      this.innerHTML = this._renderPlayground()
+      this._bindPlayground()
+      void this._mountEditor()
+      return
+    }
     this.innerHTML = this._renderInventory()
     this._bindInventory()
   }
 
-  // _viewToggle is the top-level Topology/Inventory switch shown in both views.
+  // _viewToggle is the top-level Topology/Inventory/Playground switch.
   private _viewToggle(): string {
-    return `<div class="seg">
-      <button class="seg-btn${this._view === 'topology' ? ' on' : ''}" data-topview="topology">Topology</button>
-      <button class="seg-btn${this._view === 'inventory' ? ' on' : ''}" data-topview="inventory">Inventory</button>
-    </div>`
+    const btn = (v: string, label: string) =>
+      `<button class="seg-btn${this._view === v ? ' on' : ''}" data-topview="${v}">${label}</button>`
+    return `<div class="seg">${btn('topology', 'Topology')}${btn('inventory', 'Inventory')}${btn('playground', 'Playground')}</div>`
   }
 
   private _bindViewToggle(): void {
     this.querySelectorAll('[data-topview]').forEach((b) =>
       b.addEventListener('click', () => {
-        const v = (b as HTMLElement).dataset.topview as 'topology' | 'inventory' | undefined
+        const v = (b as HTMLElement).dataset.topview as 'topology' | 'inventory' | 'playground' | undefined
         if (!v || v === this._view) return
         this._view = v
         // Load the target view's data on first visit; otherwise just re-render.
@@ -782,6 +804,130 @@ export class KueryElement extends HTMLElement {
       default: handled = false
     }
     if (handled) ev.preventDefault()
+  }
+
+  // ── playground ────────────────────────────────────────────────────────
+
+  private _renderPlayground(): string {
+    const exampleOpts = ['<option value="">examples…</option>']
+      .concat(EXAMPLES.map((e, i) => `<option value="${i}">${esc(e.label)}</option>`))
+      .join('')
+    const results = this._pgError
+      ? `<pre class="pg-result error">${esc(this._pgError)}</pre>`
+      : `<pre class="pg-result">${esc(this._pgResult || '// results appear here')}</pre>`
+    return `
+      <div class="panel">
+        <div class="panel-head">
+          <h2 class="panel-title">Query playground</h2>
+          <div class="head-actions">${this._viewToggle()}</div>
+        </div>
+        <p class="meta">Write a kuery QuerySpec and run it against your fleet. Editor autocompletes from the schema (Ctrl/Cmd-Space). Every query is scoped to your workspace automatically.</p>
+        <div class="toolbar">
+          <select id="pg-example">${exampleOpts}</select>
+          <button id="pg-run">${this._pgRunning ? 'Running…' : 'Run ▸'}</button>
+          <button id="pg-docs-toggle" type="button">API &amp; access</button>
+        </div>
+        <div class="pg-split">
+          <div id="kuery-editor" class="pg-editor"></div>
+          ${results}
+        </div>
+        <details id="pg-docs" class="pg-docs">
+          <summary>Use this API from outside the portal</summary>
+          ${this._renderApiDocs()}
+        </details>
+      </div>
+    `
+  }
+
+  private _renderApiDocs(): string {
+    const base = this._apiBase()
+    const origin = location.origin
+    return `
+      <p>The same query API is reachable programmatically. The hub authenticates your bearer token and scopes the query to your workspace — you never send a tenant header yourself.</p>
+      <pre class="pg-result">curl -sS ${esc(origin)}${esc(base)}/api/query \\
+  -H "Authorization: Bearer $KEDGE_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"filter":{"objects":[{"groupKind":{"kind":"Deployment"}}]},"objects":{"cluster":true}}'</pre>
+      <ul class="rel-list">
+        <li><b>Endpoint</b>: <code>POST ${esc(base)}/api/query</code> (body = QuerySpec, response = QueryStatus)</li>
+        <li><b>Schema</b>: <code>GET ${esc(base)}/api/query-schema</code> (JSON Schema for the request body)</li>
+        <li><b>Auth</b>: an OIDC bearer token works today. Non-interactive service-account tokens are coming.</li>
+        <li><b>Relations</b> carry impact direction: upstream (owners, references, namespace, selects) vs downstream (descendants, selected-by, namespaced, members).</li>
+      </ul>`
+  }
+
+  private _bindPlayground(): void {
+    this._bindViewToggle()
+    this.querySelector('#pg-run')?.addEventListener('click', () => void this._runPlayground())
+    this.querySelector('#pg-example')?.addEventListener('change', (ev) => {
+      const i = Number((ev.target as HTMLSelectElement).value)
+      if (Number.isInteger(i) && EXAMPLES[i]) {
+        this._pgDoc = JSON.stringify(EXAMPLES[i].spec, null, 2)
+        this._pgEditor?.setValue(this._pgDoc)
+        this._pgEditor?.refresh()
+      }
+    })
+    this.querySelector('#pg-docs-toggle')?.addEventListener('click', () => {
+      const d = this.querySelector('#pg-docs') as HTMLDetailsElement | null
+      if (d) d.open = !d.open
+    })
+  }
+
+  // _mountEditor lazy-loads CodeMirror (and the schema vocabulary, once) and
+  // builds the editor into #kuery-editor. Falls back to a plain textarea if the
+  // vendored bundle can't load.
+  private async _mountEditor(): Promise<void> {
+    const host = this.querySelector('#kuery-editor') as HTMLElement | null
+    if (!host || this._pgEditor) return
+    const baseUI = (this._ctx?.basePath || '').replace(/\/?$/, '/')
+    try {
+      if (this._pgWords.length === 0) {
+        try {
+          const schema = await this._fetchJSON('/api/query-schema')
+          this._pgWords = collectSchemaWords(schema)
+        } catch {
+          this._pgWords = []
+        }
+      }
+      const CM = await loadCodeMirror(`${baseUI}codemirror.bundle.js`, `${baseUI}codemirror.bundle.css`)
+      if (!this.querySelector('#kuery-editor')) return // re-rendered while loading
+      this._pgEditor = createEditor(CM, host, this._pgDoc, this._pgWords)
+      this._pgEditor.refresh()
+    } catch {
+      host.innerHTML = `<textarea id="kuery-editor-fallback" class="pg-fallback">${esc(this._pgDoc)}</textarea>`
+    }
+  }
+
+  private async _runPlayground(): Promise<void> {
+    const raw = this._pgEditor
+      ? this._pgEditor.getValue()
+      : (this.querySelector('#kuery-editor-fallback') as HTMLTextAreaElement | null)?.value ?? this._pgDoc
+    this._pgDoc = raw
+    let spec: unknown
+    try {
+      spec = JSON.parse(raw)
+    } catch (e) {
+      this._pgError = `invalid JSON: ${e instanceof Error ? e.message : String(e)}`
+      this._pgResult = ''
+      this._render()
+      return
+    }
+    this._pgRunning = true
+    this._pgError = ''
+    this._render()
+    try {
+      const status = await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })
+      this._pgResult = JSON.stringify(status, null, 2)
+    } catch (e) {
+      this._pgError = e instanceof Error ? e.message : String(e)
+      this._pgResult = ''
+    }
+    this._pgRunning = false
+    this._render()
   }
 
   private _renderInventory(): string {

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -7,7 +7,16 @@
 // Plain custom element in light DOM (the portal's CSS variables cascade
 // in); see main.ts for registration and style.css for the rules.
 
-import { buildElements, themeStyle, mountGraph, RELATION_COLORS, RELATION_LABELS, type GraphHandle } from './graph'
+import {
+  buildElements,
+  buildTopologyElements,
+  relationElements,
+  themeStyle,
+  mountGraph,
+  RELATION_COLORS,
+  RELATION_LABELS,
+  type GraphHandle,
+} from './graph'
 
 export interface KedgeContext {
   token?: string | null
@@ -44,7 +53,7 @@ interface QueryStatus {
 
 // The relation set the impact view expands — keep in lockstep with
 // mcpserver/tools.go impactRelations.
-const IMPACT_RELATIONS = ['descendants+', 'references', 'selects', 'selected-by', 'owners', 'linked+', 'grouped']
+const IMPACT_RELATIONS = ['descendants+', 'references', 'selects', 'selected-by', 'owners', 'linked+', 'grouped', 'namespace', 'namespaced']
 
 const RELATION_TITLES: Record<string, string> = {
   'descendants+': 'Descendants (transitive)',
@@ -54,6 +63,8 @@ const RELATION_TITLES: Record<string, string> = {
   owners: 'Owners',
   'linked+': 'Linked (cross-edge, transitive)',
   grouped: 'Grouped (cross-edge)',
+  namespace: 'Namespace',
+  namespaced: 'Contains (namespace members)',
 }
 
 export class KueryElement extends HTMLElement {
@@ -65,6 +76,24 @@ export class KueryElement extends HTMLElement {
   private _incomplete = false
   private _queryError = ''
   private _loading = false
+
+  // Top-level view. Topology (edge-centric fleet tree) is the landing view;
+  // Inventory (flat table) is the alternate. Each loads its data lazily.
+  private _view: 'topology' | 'inventory' = 'topology'
+  private _inventoryLoaded = false
+  private _topology: ObjectResult[] = []
+  private _topologyError = ''
+  private _topologyLoaded = false
+
+  // Topology graph controls — all client-side (no refetch): layout + facet
+  // filters re-render from the cached _topology. Edge filter does refetch.
+  private _topoLayout: 'breadthfirst' | 'concentric' | 'circle' | 'cose' = 'breadthfirst'
+  private _topoKind = ''
+  private _topoNamespace = ''
+  private _topoFull = false
+  private _expandingAll = false
+  private _boundKeyHandler = (ev: KeyboardEvent) => this._onKeyDown(ev)
+  private _boundFsHandler = () => this._onFullscreenChange()
 
   // Impact drill-down state. null = inventory view.
   private _impactOf: ObjectResult | null = null
@@ -78,6 +107,11 @@ export class KueryElement extends HTMLElement {
   // detect — and discard — itself if a newer render superseded it.
   private _cy: GraphHandle | null = null
   private _graphGen = 0
+
+  // Explorer state for the topology graph: node id → its ObjectResult (so a tap
+  // can query that object's relations) and which taps are in flight.
+  private _graphObjects = new Map<string, ObjectResult>()
+  private _expanding = new Set<string>()
 
   // Filter state survives re-renders.
   private _fEdge = ''
@@ -95,21 +129,25 @@ export class KueryElement extends HTMLElement {
   }
 
   connectedCallback(): void {
+    window.addEventListener('keydown', this._boundKeyHandler)
+    document.addEventListener('fullscreenchange', this._boundFsHandler)
     this._render()
     this._boot()
   }
 
   disconnectedCallback(): void {
+    window.removeEventListener('keydown', this._boundKeyHandler)
+    document.removeEventListener('fullscreenchange', this._boundFsHandler)
     this._destroyGraph()
   }
 
   // _boot waits for basePath (it can arrive on a later context push), then
-  // loads the edge list and the initial unfiltered inventory.
+  // loads the edge list and the initial (topology) view.
   private _boot(): void {
     if (this._booted || !this._ctx?.basePath) return
     this._booted = true
     void this._loadEdges()
-    void this._runQuery()
+    void this._runTopology()
   }
 
   private _apiBase(): string {
@@ -179,17 +217,65 @@ export class KueryElement extends HTMLElement {
       this._queryError = e instanceof Error ? e.message : String(e)
     }
     this._loading = false
+    this._inventoryLoaded = true
     this._render()
   }
 
-  private async _runImpact(row: ObjectResult): Promise<void> {
-    this._impactOf = row
-    this._impact = null
-    this._impactError = ''
+  // _runTopology fetches the fleet tree: a clusters-rooted query whose
+  // `members` relation expands each engaged cluster to its objects. The graph
+  // (buildTopologyElements) groups members under synthetic namespace tiers, so
+  // the result reads Edge → Namespace → object. Scoped to one edge if filtered.
+  private async _runTopology(): Promise<void> {
+    this._loading = true
+    this._topologyError = ''
     this._render()
 
+    const memberObjects = {
+      id: true,
+      cluster: true,
+      object: { kind: true, apiVersion: true, metadata: { name: true, namespace: true } },
+    }
+    const spec: Record<string, unknown> = {
+      root: 'clusters',
+      objects: {
+        id: true,
+        cluster: true,
+        relations: { members: { limit: 1000, objects: memberObjects } },
+      },
+    }
+    if (this._fEdge) spec.cluster = { name: this._fEdge }
+
+    try {
+      const status = (await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })) as QueryStatus
+      this._topology = status.objects ?? []
+      this._incomplete = !!status.incomplete
+    } catch (e) {
+      this._topology = []
+      this._topologyError = e instanceof Error ? e.message : String(e)
+    }
+    this._loading = false
+    this._topologyLoaded = true
+    this._render()
+  }
+
+  // _impactRelationsObj is the relations projection for the IMPACT_RELATIONS
+  // set. `namespaced` (a Namespace's members) can be large, so cap it; the
+  // others are naturally bounded by the object's coupling.
+  private _impactRelationsObj(): Record<string, unknown> {
     const relations: Record<string, unknown> = {}
-    for (const rel of IMPACT_RELATIONS) relations[rel] = {}
+    for (const rel of IMPACT_RELATIONS) relations[rel] = rel === 'namespaced' ? { limit: 200 } : {}
+    return relations
+  }
+
+  // _impactSpecFor builds the QuerySpec that expands one object's declared
+  // coupling (the IMPACT_RELATIONS set). Shared by the impact view and by
+  // in-graph expansion so both ask for exactly the same relations.
+  private _impactSpecFor(row: ObjectResult): Record<string, unknown> {
+    const relations = this._impactRelationsObj()
 
     const o = row.object ?? {}
     const meta = o.metadata ?? {}
@@ -206,12 +292,35 @@ export class KueryElement extends HTMLElement {
     // row.cluster is "{tenant}/{edge}" — the API re-pins the prefix, so
     // passing it back verbatim is fine and keeps the anchor unambiguous.
     if (row.cluster) spec.cluster = { name: row.cluster }
+    return spec
+  }
+
+  // _queryRelations fetches one object's coupling and returns the single result
+  // (with its relations populated), or null. Used by in-graph expansion.
+  private async _queryRelations(row: ObjectResult): Promise<ObjectResult | null> {
+    try {
+      const status = (await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(this._impactSpecFor(row)),
+      })) as QueryStatus
+      return status.objects?.[0] ?? null
+    } catch {
+      return null
+    }
+  }
+
+  private async _runImpact(row: ObjectResult): Promise<void> {
+    this._impactOf = row
+    this._impact = null
+    this._impactError = ''
+    this._render()
 
     try {
       const status = (await this._fetchJSON('/api/query', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(spec),
+        body: JSON.stringify(this._impactSpecFor(row)),
       })) as QueryStatus
       this._impact = status.objects?.[0] ?? null
       if (!this._impact) this._impactError = 'object not found (sync may be catching up)'
@@ -219,6 +328,120 @@ export class KueryElement extends HTMLElement {
       this._impactError = e instanceof Error ? e.message : String(e)
     }
     this._render()
+  }
+
+  // _expandInGraph grows the live topology graph in place: tapping a node
+  // queries its coupling and grafts the related objects on (deduping shared
+  // ones), so you can walk the dependency net without losing what you've
+  // already revealed. Tapping an already-expanded node collapses its subtree.
+  // _expandOne queries one node's coupling and grafts the related objects onto
+  // the live graph (no relayout — the caller batches that). Returns how many
+  // new nodes were added. Newly added objects join _graphObjects so they too
+  // become expandable.
+  private async _expandOne(id: string, handle: GraphHandle): Promise<number> {
+    const obj = this._graphObjects.get(id)
+    if (!obj || handle.isExpanded(id) || this._expanding.has(id)) return 0
+    this._expanding.add(id)
+    handle.markExpanded(id, true) // optimistic; reflects intent while the query runs
+    try {
+      const res = await this._queryRelations(obj)
+      if (this._cy !== handle) return 0 // a re-render replaced the graph mid-flight
+      if (!res) {
+        handle.markExpanded(id, false)
+        return 0
+      }
+      const { elements, nodeIndex } = relationElements(id, res)
+      const added = handle.add(elements)
+      for (const [nid, o] of Object.entries(nodeIndex)) {
+        if (!this._graphObjects.has(nid)) this._graphObjects.set(nid, o)
+      }
+      return added.length
+    } finally {
+      this._expanding.delete(id)
+    }
+  }
+
+  private async _expandInGraph(id: string): Promise<void> {
+    const handle = this._cy
+    if (!handle || !this._graphObjects.has(id)) return
+    if (handle.isExpanded(id)) {
+      handle.collapseFrom(id) // tap an expanded node to collapse its subtree
+      return
+    }
+    const added = await this._expandOne(id, handle)
+    if (added && this._cy === handle) handle.relayout(this._topoLayoutConfig())
+  }
+
+  // _expandBatch expands a whole frontier of nodes in ONE query: it filters by
+  // all their ids at once (filter.objects[] is OR-ed) and asks for each one's
+  // relations, instead of a request per node. Grafts every returned object's
+  // relations, marks the whole batch expanded (so empties aren't re-queried),
+  // and registers new nodes for further rounds. Returns nodes added.
+  private async _expandBatch(ids: string[], handle: GraphHandle): Promise<number> {
+    if (ids.length === 0) return 0
+    const spec: Record<string, unknown> = {
+      maxDepth: 5,
+      limit: Math.min(ids.length, 10000),
+      filter: { objects: ids.map((id) => ({ id })) },
+      objects: { id: true, cluster: true, relations: this._impactRelationsObj() },
+    }
+    let status: QueryStatus
+    try {
+      status = (await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })) as QueryStatus
+    } catch {
+      return 0
+    }
+    if (this._cy !== handle) return 0
+
+    let added = 0
+    for (const res of status.objects ?? []) {
+      const anchorId = res.id
+      if (!anchorId) continue
+      const { elements, nodeIndex } = relationElements(anchorId, res)
+      added += handle.add(elements).length
+      for (const [nid, o] of Object.entries(nodeIndex)) {
+        if (!this._graphObjects.has(nid)) this._graphObjects.set(nid, o)
+      }
+    }
+    // Mark the entire requested frontier expanded — including ids that returned
+    // nothing — so the next round doesn't re-query them.
+    for (const id of ids) handle.markExpanded(id, true)
+    return added
+  }
+
+  // _expandAll walks the whole reachable net by frontier: each round expands
+  // every currently-unexpanded node in a few batched queries (chunked so a
+  // single request stays bounded), until nothing new appears. Bounded by a node
+  // cap and round limit so a large fleet can't run away.
+  private async _expandAll(): Promise<void> {
+    const handle = this._cy
+    if (!handle || this._expandingAll) return
+    this._expandingAll = true
+    const btn = this.querySelector('#t-expand-all')
+    if (btn) btn.textContent = 'Expanding…'
+    const MAX_NODES = 4000
+    const CHUNK = 300
+    try {
+      for (let round = 0; round < 30; round++) {
+        if (this._cy !== handle || handle.nodeCount() >= MAX_NODES) break
+        const todo = [...this._graphObjects.keys()].filter((id) => handle.hasNode(id) && !handle.isExpanded(id))
+        if (todo.length === 0) break
+        const chunks: string[][] = []
+        for (let i = 0; i < todo.length; i += CHUNK) chunks.push(todo.slice(i, i + CHUNK))
+        const counts = await Promise.all(chunks.map((c) => this._expandBatch(c, handle)))
+        if (this._cy !== handle) break
+        handle.relayout(this._topoLayoutConfig())
+        if (counts.every((n) => n === 0)) break // frontier produced nothing new
+      }
+    } finally {
+      this._expandingAll = false
+      const b = this.querySelector('#t-expand-all')
+      if (b) b.textContent = 'Expand all'
+    }
   }
 
   // ── rendering ────────────────────────────────────────────────────────
@@ -238,8 +461,36 @@ export class KueryElement extends HTMLElement {
       if (this._impactView === 'graph' && this._impact && !this._impactError) void this._mountGraph()
       return
     }
+    if (this._view === 'topology') {
+      this.innerHTML = this._renderTopology()
+      this._bindTopology()
+      if (this._topology.length && !this._topologyError && !this._loading) void this._mountTopologyGraph()
+      return
+    }
     this.innerHTML = this._renderInventory()
     this._bindInventory()
+  }
+
+  // _viewToggle is the top-level Topology/Inventory switch shown in both views.
+  private _viewToggle(): string {
+    return `<div class="seg">
+      <button class="seg-btn${this._view === 'topology' ? ' on' : ''}" data-topview="topology">Topology</button>
+      <button class="seg-btn${this._view === 'inventory' ? ' on' : ''}" data-topview="inventory">Inventory</button>
+    </div>`
+  }
+
+  private _bindViewToggle(): void {
+    this.querySelectorAll('[data-topview]').forEach((b) =>
+      b.addEventListener('click', () => {
+        const v = (b as HTMLElement).dataset.topview as 'topology' | 'inventory' | undefined
+        if (!v || v === this._view) return
+        this._view = v
+        // Load the target view's data on first visit; otherwise just re-render.
+        if (v === 'topology' && !this._topologyLoaded) void this._runTopology()
+        else if (v === 'inventory' && !this._inventoryLoaded) void this._runQuery()
+        else this._render()
+      }),
+    )
   }
 
   private _destroyGraph(): void {
@@ -260,13 +511,17 @@ export class KueryElement extends HTMLElement {
     try {
       const { elements, nodeIndex } = buildElements(this._impact)
       // Vendored UMD bundle, served from this provider's own dist/ root
-      // (basePath is /ui/providers/kuery/). Injected on demand by graph.ts.
-      const libUrl = `${this._ctx?.basePath || ''}cytoscape.min.js`
+      // (basePath is /ui/providers/kuery). The hub hands basePath WITHOUT a
+      // trailing slash, so normalize to exactly one before appending — a naive
+      // concat yields /ui/providers/kuerycytoscape.min.js (404). Injected on
+      // demand by graph.ts.
+      const libUrl = `${(this._ctx?.basePath || '').replace(/\/?$/, '/')}cytoscape.min.js`
       const handle = await mountGraph(
         container,
         elements,
         themeStyle(this),
         (id) => {
+          if (id === this._impact?.id) return // tapping the anchor is a no-op
           const obj = nodeIndex[id]
           if (obj) void this._runImpact(obj)
         },
@@ -292,6 +547,233 @@ export class KueryElement extends HTMLElement {
         }
       }),
     )
+  }
+
+  // _mountTopologyGraph draws the fleet tree into #kuery-graph using a
+  // top-down breadthfirst layout (Edge at the root). Same lazy-load + _graphGen
+  // race guard as _mountGraph; tapping an object node drills into its impact.
+  private async _mountTopologyGraph(): Promise<void> {
+    const container = this.querySelector('#kuery-graph') as HTMLElement | null
+    if (!container) return
+    const gen = this._graphGen
+    try {
+      const { elements, nodeIndex } = buildTopologyElements(this._topology, {
+        kind: this._topoKind,
+        namespace: this._topoNamespace,
+      })
+      // Seed the explorer map from the base tree so any node can be expanded.
+      this._graphObjects = new Map(Object.entries(nodeIndex))
+      this._expanding = new Set()
+      const libUrl = `${(this._ctx?.basePath || '').replace(/\/?$/, '/')}cytoscape.min.js`
+      const handle = await mountGraph(
+        container,
+        elements,
+        themeStyle(this),
+        (id) => void this._expandInGraph(id),
+        libUrl,
+        this._topoLayoutConfig(),
+      )
+      if (gen !== this._graphGen) {
+        handle.destroy()
+        return
+      }
+      this._cy = handle
+    } catch (e) {
+      container.innerHTML = `<p class="error">graph failed to load: ${esc(e instanceof Error ? e.message : String(e))}</p>`
+    }
+  }
+
+  // _topoLayoutConfig maps the selected layout to a Cytoscape layout. cose is
+  // force-directed (draggable, physics-settled); concentric is radial by tier;
+  // circle rings everything; breadthfirst is the top-down tree.
+  private _topoLayoutConfig(): Record<string, unknown> {
+    switch (this._topoLayout) {
+      case 'concentric':
+        return {
+          name: 'concentric',
+          concentric: (n: { data: (k: string) => unknown }) =>
+            n.data('tier') === 'cluster' ? 3 : n.data('tier') === 'namespace' ? 2 : 1,
+          levelWidth: () => 1,
+          minNodeSpacing: 30,
+          padding: 20,
+        }
+      case 'circle':
+        return { name: 'circle', padding: 20 }
+      case 'cose':
+        return { name: 'cose', idealEdgeLength: 70, nodeRepulsion: 9000, padding: 20, animate: false }
+      default:
+        return { name: 'breadthfirst', directed: true, spacingFactor: 1.0, padding: 20 }
+    }
+  }
+
+  // _topologyFacets collects the kinds and namespaces actually present in the
+  // current fleet so the filter dropdowns offer real choices (pre-selects).
+  private _topologyFacets(): { kinds: string[]; namespaces: string[] } {
+    const kinds = new Set<string>()
+    const namespaces = new Set<string>()
+    for (const c of this._topology) {
+      for (const m of c.relations?.members ?? []) {
+        const o = m.object ?? {}
+        if (o.kind) kinds.add(o.kind)
+        const ns = o.metadata?.namespace
+        if (ns) namespaces.add(ns)
+      }
+    }
+    return { kinds: [...kinds].sort(), namespaces: [...namespaces].sort() }
+  }
+
+  private _renderTopology(): string {
+    const opt = (value: string, label: string, sel: string) =>
+      `<option value="${esc(value)}"${value === sel ? ' selected' : ''}>${esc(label)}</option>`
+    const edgeOptions = [opt('', 'all edges', this._fEdge)]
+      .concat(this._edges.map((e) => opt(e, e, this._fEdge)))
+      .join('')
+
+    const layouts: Array<[typeof this._topoLayout, string]> = [
+      ['breadthfirst', 'Tree'],
+      ['concentric', 'Radial'],
+      ['circle', 'Circle'],
+      ['cose', 'Force'],
+    ]
+    const layoutOptions = layouts.map(([v, l]) => opt(v, l, this._topoLayout)).join('')
+
+    const facets = this._topologyFacets()
+    const kindOptions = [opt('', 'all kinds', this._topoKind)]
+      .concat(facets.kinds.map((k) => opt(k, k, this._topoKind)))
+      .join('')
+    const nsOptions = [opt('', 'all namespaces', this._topoNamespace)]
+      .concat(facets.namespaces.map((n) => opt(n, n, this._topoNamespace)))
+      .join('')
+
+    let body: string
+    if (this._loading) {
+      body = `<p class="muted">building fleet topology…</p>`
+    } else if (this._topologyError) {
+      body = `<p class="error">${esc(this._topologyError)}</p>`
+    } else if (this._topology.length === 0) {
+      body = `<p class="muted">no clusters engaged — connect a kubernetes edge to see its tree</p>`
+    } else {
+      body = `<div id="kuery-graph" class="kuery-graph"></div>`
+    }
+
+    return `
+      <div class="panel${this._topoFull ? ' kuery-full' : ''}">
+        <div class="panel-head">
+          <h2 class="panel-title">Fleet topology</h2>
+          <div class="head-actions">
+            ${this._viewToggle()}
+            <span class="badge ${this._edges.length ? 'ok' : 'warn'}">${this._edges.length} edge${this._edges.length === 1 ? '' : 's'} engaged</span>
+          </div>
+        </div>
+        <p class="meta">Click a node to expand its dependencies, again to collapse; <b>Expand all</b> walks the whole net. Pan with arrow keys or WASD, zoom with +/−, <b>F</b> toggles full screen.</p>
+        <div class="toolbar">
+          <select id="t-layout" title="layout">${layoutOptions}</select>
+          <select id="f-edge" title="edge">${edgeOptions}</select>
+          <select id="t-kind" title="kind">${kindOptions}</select>
+          <select id="t-ns" title="namespace">${nsOptions}</select>
+          <button id="t-expand-all" type="button">Expand all</button>
+          <button id="t-reset" type="button">Reset</button>
+          <button id="t-full" type="button">${this._topoFull ? 'Exit full screen' : 'Full screen'}</button>
+        </div>
+        ${body}
+        ${this._incomplete ? '<p class="meta">tree truncated — filter to one edge to see all of it</p>' : ''}
+      </div>
+    `
+  }
+
+  private _bindTopology(): void {
+    this._bindViewToggle()
+    // Edge change refetches (it scopes the server query); layout/kind/namespace
+    // are pure client-side re-renders off the cached _topology.
+    this.querySelector('#f-edge')?.addEventListener('change', () => {
+      this._fEdge = (this.querySelector('#f-edge') as HTMLSelectElement | null)?.value ?? ''
+      void this._runTopology()
+    })
+    this.querySelector('#t-layout')?.addEventListener('change', () => {
+      this._topoLayout = ((this.querySelector('#t-layout') as HTMLSelectElement | null)?.value || 'breadthfirst') as typeof this._topoLayout
+      // Relayout the live graph in place so expansions survive a layout switch;
+      // only fall back to a full render if the graph isn't mounted yet.
+      if (this._cy) this._cy.relayout(this._topoLayoutConfig())
+      else this._render()
+    })
+    this.querySelector('#t-kind')?.addEventListener('change', () => {
+      this._topoKind = (this.querySelector('#t-kind') as HTMLSelectElement | null)?.value ?? ''
+      this._render()
+    })
+    this.querySelector('#t-ns')?.addEventListener('change', () => {
+      this._topoNamespace = (this.querySelector('#t-ns') as HTMLSelectElement | null)?.value ?? ''
+      this._render()
+    })
+    this.querySelector('#t-expand-all')?.addEventListener('click', () => void this._expandAll())
+    this.querySelector('#t-reset')?.addEventListener('click', () => this._render())
+    this.querySelector('#t-full')?.addEventListener('click', () => this._toggleFull())
+  }
+
+  // _toggleFull takes the graph panel truly full-page via the Fullscreen API,
+  // which escapes any transformed/filtered ancestor in the portal shell (a CSS
+  // `position: fixed` overlay would otherwise be trapped inside that ancestor
+  // and only fill its box). Falls back to the fixed overlay where the API is
+  // unavailable. State + refit are driven by the fullscreenchange event.
+  private _toggleFull(): void {
+    const panel = this.querySelector('.panel') as HTMLElement | null
+    if (!panel) return
+    if (document.fullscreenElement) {
+      void document.exitFullscreen?.()
+      return
+    }
+    if (panel.requestFullscreen) {
+      panel.requestFullscreen().catch(() => this._toggleFullCSS(panel))
+      return
+    }
+    this._toggleFullCSS(panel)
+  }
+
+  // _toggleFullCSS is the fallback overlay (fixed inset:0). Works unless a
+  // transformed ancestor traps it — hence the Fullscreen API is preferred.
+  private _toggleFullCSS(panel: HTMLElement): void {
+    this._topoFull = !this._topoFull
+    panel.classList.toggle('kuery-full', this._topoFull)
+    this._syncFullButton()
+    requestAnimationFrame(() => this._cy?.fit())
+  }
+
+  private _syncFullButton(): void {
+    const full = this.querySelector('#t-full')
+    if (full) full.textContent = this._topoFull ? 'Exit full screen' : 'Full screen'
+  }
+
+  // _onFullscreenChange keeps state, the button label, the styling class, and
+  // the graph's fitted view in sync when entering/exiting API fullscreen
+  // (including via the browser's Esc).
+  private _onFullscreenChange(): void {
+    const panel = this.querySelector('.panel') as HTMLElement | null
+    this._topoFull = !!document.fullscreenElement && document.fullscreenElement === panel
+    if (panel) panel.classList.toggle('kuery-full', this._topoFull)
+    this._syncFullButton()
+    requestAnimationFrame(() => this._cy?.fit())
+  }
+
+  // _onKeyDown gives the topology graph keyboard navigation: arrows/WASD pan,
+  // +/- zoom, F toggles full screen, Esc exits it. Ignored while typing in a
+  // form control or when the graph isn't the active view.
+  private _onKeyDown(ev: KeyboardEvent): void {
+    if (this._view !== 'topology' || this._impactOf || !this._cy) return
+    const t = ev.target as HTMLElement | null
+    if (t && /^(INPUT|SELECT|TEXTAREA)$/.test(t.tagName)) return
+    const PAN = 70
+    let handled = true
+    switch (ev.key) {
+      case 'ArrowUp': case 'w': case 'W': this._cy.panBy(0, PAN); break
+      case 'ArrowDown': case 's': case 'S': this._cy.panBy(0, -PAN); break
+      case 'ArrowLeft': case 'a': case 'A': this._cy.panBy(PAN, 0); break
+      case 'ArrowRight': case 'd': case 'D': this._cy.panBy(-PAN, 0); break
+      case '+': case '=': this._cy.zoomBy(1.15); break
+      case '-': case '_': this._cy.zoomBy(1 / 1.15); break
+      case 'f': case 'F': this._toggleFull(); break
+      case 'Escape': if (this._topoFull) this._toggleFull(); else handled = false; break
+      default: handled = false
+    }
+    if (handled) ev.preventDefault()
   }
 
   private _renderInventory(): string {
@@ -324,7 +806,10 @@ export class KueryElement extends HTMLElement {
       <div class="panel">
         <div class="panel-head">
           <h2 class="panel-title">Fleet inventory</h2>
-          <span class="badge ${this._edges.length ? 'ok' : 'warn'}">${this._edges.length} edge${this._edges.length === 1 ? '' : 's'} engaged</span>
+          <div class="head-actions">
+            ${this._viewToggle()}
+            <span class="badge ${this._edges.length ? 'ok' : 'warn'}">${this._edges.length} edge${this._edges.length === 1 ? '' : 's'} engaged</span>
+          </div>
         </div>
         <p class="meta">One query across every connected edge. Click a row for its impact (declared blast radius).</p>
         <div class="toolbar">
@@ -344,6 +829,7 @@ export class KueryElement extends HTMLElement {
   }
 
   private _bindInventory(): void {
+    this._bindViewToggle()
     const read = () => {
       this._fEdge = (this.querySelector('#f-edge') as HTMLSelectElement | null)?.value ?? ''
       this._fKind = (this.querySelector('#f-kind') as HTMLInputElement | null)?.value.trim() ?? ''
@@ -409,7 +895,7 @@ export class KueryElement extends HTMLElement {
           <h2 class="panel-title">Impact: ${esc(title)}</h2>
           <div class="head-actions">
             ${toggle}
-            <button id="impact-back">← inventory</button>
+            <button id="impact-back">← back</button>
           </div>
         </div>
         <p class="meta">Declared blast radius on <code>${esc(edgeOf(this._impactOf?.cluster))}</code> — owners, descendants, spec references, selector matches, and cross-edge links. Not a network dependency map.${hint}</p>

--- a/providers/kuery/portal/src/graph.ts
+++ b/providers/kuery/portal/src/graph.ts
@@ -48,6 +48,41 @@ export const RELATION_LABELS: Record<string, string> = {
   namespaced: 'contains',
 }
 
+// Impact direction per relation, from the anchor's point of view. An edge is
+// always drawn so the arrow means "deleting source impacts target":
+//   - 'up'   : the related object is UPSTREAM — deleting it impacts the anchor
+//              (anchor depends on it). Drawn related → anchor. e.g. a Pod's
+//              owners, references, the namespace it lives in.
+//   - 'down' : the related object is DOWNSTREAM — deleting the anchor impacts
+//              it (blast radius). Drawn anchor → related. e.g. a Deployment's
+//              descendants, a Namespace's members, who selects the anchor.
+//   - 'lateral': peer association with no clear deletion direction.
+// This is what keeps a Namespace as a Pod's PARENT (it impacts the pod), not a
+// child, splitting the graph into "impacted-by" vs "impacts" branches.
+//
+// Mirror of kuery's engine.RelationDirections (pkg/engine/relations.go) — the
+// authority. Keep in lockstep: up = engine "upstream", down = "downstream".
+export type RelDir = 'up' | 'down' | 'lateral'
+export const RELATION_DIR: Record<string, RelDir> = {
+  owners: 'up',
+  references: 'up',
+  selects: 'up',
+  namespace: 'up',
+  descendants: 'down',
+  'descendants+': 'down',
+  'selected-by': 'down',
+  namespaced: 'down',
+  linked: 'lateral',
+  'linked+': 'lateral',
+  grouped: 'lateral',
+}
+
+// orientEdge returns [source, target] for an edge between the anchor and a
+// related node, per the relation's impact direction (see RELATION_DIR).
+function orientEdge(anchorId: string, relatedId: string, rel: string): [string, string] {
+  return (RELATION_DIR[rel] ?? 'down') === 'up' ? [relatedId, anchorId] : [anchorId, relatedId]
+}
+
 export interface BuildResult {
   elements: cytoscape.ElementDefinition[]
   // nodeId → the source ObjectResult, so a node tap can re-anchor the graph
@@ -77,7 +112,8 @@ export function buildElements(anchor: ObjectResult): BuildResult {
     ;(items ?? []).forEach((it, i) => {
       const id = it.id || `${rel}:${i}`
       pushNode(elements, nodeIndex, seen, id, it, false)
-      elements.push({ data: { id: `${anchorId}|${rel}|${id}`, source: anchorId, target: id, rel } })
+      const [source, target] = orientEdge(anchorId, id, rel)
+      elements.push({ data: { id: `${source}>${target}`, source, target, rel } })
     })
   }
   return { elements, nodeIndex }
@@ -318,7 +354,12 @@ export function relationElements(anchorId: string, anchor: ObjectResult): BuildR
         data: { id, label: `${kind}\n${shortName(it)}`, tier: 'object', kind, name: shortName(it), edge: edgeOf(it.cluster) },
       })
       nodeIndex[id] = it
-      elements.push({ data: { id: `${anchorId}|${rel}|${id}`, source: anchorId, target: id, rel } })
+      // Orient by impact direction: upstream relations point INTO the anchor
+      // (related → anchor), downstream out of it. Endpoint-based edge id so a
+      // pair reached twice (e.g. the namespace already linked in the base tree)
+      // dedupes to one edge.
+      const [source, target] = orientEdge(anchorId, id, rel)
+      elements.push({ data: { id: `${source}>${target}`, source, target, rel } })
     })
   }
   return { elements, nodeIndex }

--- a/providers/kuery/portal/src/graph.ts
+++ b/providers/kuery/portal/src/graph.ts
@@ -31,6 +31,8 @@ export const RELATION_COLORS: Record<string, string> = {
   'selected-by': '#e07a4f',
   'linked+': '#e0519b',
   grouped: '#8a93a8',
+  namespace: '#5fae7a',
+  namespaced: '#5fae7a',
 }
 
 // Short legend labels (the impact list uses longer titles).
@@ -42,6 +44,8 @@ export const RELATION_LABELS: Record<string, string> = {
   'selected-by': 'selected-by',
   'linked+': 'linked',
   grouped: 'grouped',
+  namespace: 'namespace',
+  namespaced: 'contains',
 }
 
 export interface BuildResult {
@@ -75,6 +79,94 @@ export function buildElements(anchor: ObjectResult): BuildResult {
       pushNode(elements, nodeIndex, seen, id, it, false)
       elements.push({ data: { id: `${anchorId}|${rel}|${id}`, source: anchorId, target: id, rel } })
     })
+  }
+  return { elements, nodeIndex }
+}
+
+// buildTopologyElements turns a clusters-rooted query result (each cluster
+// with its `members` relation) into a fleet tree: Edge → Namespace → object,
+// with cluster-scoped objects hanging straight off the Edge. Structural edges
+// all use rel "namespace" so they share the containment color.
+//
+// A namespace's tier node IS the real `Namespace` object when one was synced
+// (so it carries children AND is clickable → its `namespaced` impact), rather
+// than rendering the Namespace both as a synthetic group and a childless leaf.
+// Falls back to a synthetic tier when the Namespace object isn't in the set.
+export function buildTopologyElements(
+  clusters: ObjectResult[],
+  opts?: { kind?: string; namespace?: string },
+): BuildResult {
+  const elements: cytoscape.ElementDefinition[] = []
+  const nodeIndex: Record<string, ObjectResult> = {}
+  const nodes = new Set<string>()
+  const edges = new Set<string>()
+  const wantKind = opts?.kind || ''
+  const wantNs = opts?.namespace || ''
+
+  const addNode = (id: string, data: Record<string, unknown>) => {
+    if (nodes.has(id)) return
+    nodes.add(id)
+    elements.push({ data: { id, ...data } })
+  }
+  const addEdge = (source: string, target: string) => {
+    const id = `${source}>${target}`
+    if (edges.has(id)) return
+    edges.add(id)
+    elements.push({ data: { id, source, target, rel: 'namespace' } })
+  }
+
+  for (const c of clusters) {
+    const cname = c.cluster || c.object?.metadata?.name || 'cluster'
+    const cid = `cluster:${cname}`
+    addNode(cid, { label: edgeOf(cname), tier: 'cluster', anchor: 'true', kind: 'Cluster', name: edgeOf(cname) })
+
+    const members = c.relations?.members ?? []
+
+    // Index the real Namespace objects so a tier can adopt one as its node.
+    const nsObjByName = new Map<string, ObjectResult>()
+    for (const mem of members) {
+      if (mem.object?.kind === 'Namespace') nsObjByName.set(mem.object.metadata?.name || '', mem)
+    }
+    // ensureNs returns the tier node id for a namespace, creating it (and the
+    // Edge→Namespace edge) on first use. Uses the real Namespace object's id
+    // when available so the tier is the object itself.
+    const ensureNs = (nsName: string): string => {
+      const real = nsObjByName.get(nsName)
+      const nid = real?.id || `ns:${cname}/${nsName}`
+      if (!nodes.has(nid)) {
+        addNode(nid, { label: nsName, tier: 'namespace', kind: 'Namespace', name: nsName })
+        if (real) nodeIndex[nid] = real
+        addEdge(cid, nid)
+      }
+      return nid
+    }
+
+    // Show every namespace as a tier — even empty ones — unless filtering to a
+    // different kind.
+    if (!wantKind || wantKind === 'Namespace') {
+      for (const nsName of nsObjByName.keys()) {
+        if (!nsName) continue
+        if (wantNs && nsName !== wantNs) continue
+        ensureNs(nsName)
+      }
+    }
+
+    for (const mem of members) {
+      const o = mem.object ?? {}
+      const kind = o.kind || '?'
+      if (kind === 'Namespace') continue // already represented as a tier node
+      const name = o.metadata?.name || '?'
+      const ns = o.metadata?.namespace || ''
+      // Client-side facet filters. Namespace "" (cluster-scoped) is excluded
+      // when a specific namespace is selected.
+      if (wantKind && kind !== wantKind) continue
+      if (wantNs && ns !== wantNs) continue
+      const oid = mem.id || `${cname}/${kind}/${ns}/${name}`
+      const parent = ns ? ensureNs(ns) : cid
+      addNode(oid, { label: `${kind}\n${name}`, tier: 'object', kind, name, edge: edgeOf(mem.cluster) })
+      nodeIndex[oid] = mem
+      addEdge(parent, oid)
+    }
   }
   return { elements, nodeIndex }
 }
@@ -148,6 +240,22 @@ export function themeStyle(host: Element): cytoscape.StylesheetStyle[] {
         'font-weight': 700,
       },
     },
+    // Topology tiers: the Edge (cluster) anchors as a hexagon; Namespaces are
+    // muted diamonds; objects keep the default round-rectangle.
+    {
+      selector: 'node[tier = "cluster"]',
+      style: { shape: 'hexagon', width: 44, height: 44 },
+    },
+    {
+      selector: 'node[tier = "namespace"]',
+      style: { shape: 'diamond', 'background-color': muted, 'border-color': border, width: 30, height: 30, 'font-size': 9 },
+    },
+    // Drilled nodes get an accent ring so you can see how far the net is
+    // already expanded vs. what's still collapsed.
+    {
+      selector: 'node[expanded = "true"]',
+      style: { 'border-color': accent, 'border-width': 3 },
+    },
     {
       selector: 'node:active',
       style: { 'overlay-color': accent, 'overlay-opacity': 0.15 },
@@ -172,6 +280,48 @@ export function themeStyle(host: Element): cytoscape.StylesheetStyle[] {
 
 export interface GraphHandle {
   destroy(): void
+  // add merges new nodes/edges into the live graph, skipping ids already
+  // present (so an object reached from two parents becomes one node with two
+  // edges — the real dependency net). Returns the elements actually added.
+  add(elements: cytoscape.ElementDefinition[]): cytoscape.ElementDefinition[]
+  hasNode(id: string): boolean
+  // markExpanded flags a node as already drilled so the UI can style it and
+  // skip re-querying. collapseFrom removes the subtree reachable only through
+  // the given node (leaves shared nodes alone).
+  markExpanded(id: string, expanded: boolean): void
+  isExpanded(id: string): boolean
+  collapseFrom(id: string): void
+  // relayout re-runs the layout after the graph grows/shrinks.
+  relayout(layout?: Record<string, unknown>): void
+  // Viewport controls for keyboard nav / fullscreen.
+  panBy(dx: number, dy: number): void
+  zoomBy(factor: number): void
+  fit(): void
+  nodeCount(): number
+}
+
+// relationElements builds the child nodes/edges for one already-placed node
+// (anchorId) from an impact result's relations. It does NOT emit the anchor
+// itself. Child node ids are the objects' stable kuery ids, so re-expanding or
+// reaching the same object from elsewhere dedupes to a single node. Edge ids
+// are per (parent, rel, child) so parallel relations stay distinct.
+export function relationElements(anchorId: string, anchor: ObjectResult): BuildResult {
+  const elements: cytoscape.ElementDefinition[] = []
+  const nodeIndex: Record<string, ObjectResult> = {}
+  const rels = anchor.relations ?? {}
+  for (const [rel, items] of Object.entries(rels)) {
+    ;(items ?? []).forEach((it, i) => {
+      const id = it.id || `${anchorId}:${rel}:${i}`
+      const o = it.object ?? {}
+      const kind = o.kind || '?'
+      elements.push({
+        data: { id, label: `${kind}\n${shortName(it)}`, tier: 'object', kind, name: shortName(it), edge: edgeOf(it.cluster) },
+      })
+      nodeIndex[id] = it
+      elements.push({ data: { id: `${anchorId}|${rel}|${id}`, source: anchorId, target: id, rel } })
+    })
+  }
+  return { elements, nodeIndex }
 }
 
 let _libPromise: Promise<typeof cytoscape> | null = null
@@ -206,28 +356,78 @@ export async function mountGraph(
   style: cytoscape.StylesheetStyle[],
   onNodeTap: (id: string) => void,
   libUrl: string,
+  // Loose object so callers can pass any built-in layout config (tree, radial,
+  // circle, force) without importing Cytoscape's layout union; cast below.
+  layout?: Record<string, unknown>,
 ): Promise<GraphHandle> {
   const cytoscape = await loadCytoscape(libUrl)
   const cy = cytoscape({
     container,
     elements,
     style,
-    layout: {
+    layout: (layout ?? {
       name: 'concentric',
       concentric: (node: cytoscape.NodeSingular) => (node.data('anchor') === 'true' ? 2 : 1),
       levelWidth: () => 1,
       minNodeSpacing: 34,
       padding: 16,
-    },
+    }) as unknown as cytoscape.LayoutOptions,
     wheelSensitivity: 0.2,
-    minZoom: 0.2,
+    // Allow zooming far out so a fully-expanded net still fits on screen.
+    minZoom: 0.02,
     maxZoom: 3,
   })
-  cy.on('tap', 'node', (evt: cytoscape.EventObject) => {
-    const n = evt.target
-    if (n.data('anchor') !== 'true') onNodeTap(n.id())
-  })
-  return { destroy: () => cy.destroy() }
+  // Every node is tappable; the caller decides what (if anything) to do — for
+  // the explorer that's expand/collapse, for the impact view it re-anchors.
+  cy.on('tap', 'node', (evt: cytoscape.EventObject) => onNodeTap(evt.target.id()))
+
+  return {
+    destroy: () => cy.destroy(),
+    hasNode: (id) => cy.getElementById(id).nonempty(),
+    isExpanded: (id) => cy.getElementById(id).data('expanded') === 'true',
+    markExpanded: (id, expanded) => {
+      const n = cy.getElementById(id)
+      if (n.nonempty()) n.data('expanded', expanded ? 'true' : 'false')
+    },
+    add: (els) => {
+      const fresh = els.filter((e) => {
+        const id = e.data?.id as string | undefined
+        return !!id && cy.getElementById(id).empty()
+      })
+      if (fresh.length) cy.add(fresh)
+      return fresh
+    },
+    collapseFrom: (id) => {
+      const root = cy.getElementById(id)
+      if (root.empty()) return
+      // Cut this node's outgoing edges, then cascade-remove any node left with
+      // no incoming edge (its exclusive subtree). Shared nodes keep an edge
+      // from elsewhere and survive; cluster roots are never removed.
+      cy.remove(root.connectedEdges().filter((e: cytoscape.EdgeSingular) => e.source().id() === id))
+      let changed = true
+      while (changed) {
+        changed = false
+        cy.nodes().forEach((n: cytoscape.NodeSingular) => {
+          if (n.id() === id || n.data('tier') === 'cluster') return
+          if (n.incomers('edge').empty()) {
+            cy.remove(n)
+            changed = true
+          }
+        })
+      }
+      root.data('expanded', 'false')
+    },
+    relayout: (layout) => {
+      cy.layout((layout ?? { name: 'breadthfirst', directed: true, spacingFactor: 1.0, padding: 20 }) as unknown as cytoscape.LayoutOptions).run()
+    },
+    panBy: (dx, dy) => cy.panBy({ x: dx, y: dy }),
+    zoomBy: (factor) => cy.zoom({ level: cy.zoom() * factor, renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 } }),
+    fit: () => {
+      cy.resize()
+      cy.fit(undefined, 24)
+    },
+    nodeCount: () => cy.nodes().length,
+  }
 }
 
 function shortName(o: ObjectResult): string {

--- a/providers/kuery/portal/src/playground.ts
+++ b/providers/kuery/portal/src/playground.ts
@@ -1,0 +1,189 @@
+// Query playground support: a lazily-loaded CodeMirror editor with
+// schema-driven autocomplete, plus canned examples. CodeMirror (~CM5 UMD) is
+// vendored and injected on first use — same reason as cytoscape: the portal is
+// an IIFE library bundle with no runtime module loader, so a bundler dynamic
+// import() would get inlined. `import type` only here pulls in zero bytes.
+
+// The vendored UMD assigns this global.
+declare global {
+  interface Window {
+    // CM5 has no first-class ESM types here; treat as opaque.
+    CodeMirror?: CMFactory
+  }
+}
+
+// Minimal shape of the CodeMirror 5 factory + instance we use, so the rest of
+// the file stays typed without pulling @types/codemirror.
+type CMPos = { line: number; ch: number }
+interface CMInstance {
+  getValue(): string
+  setValue(v: string): void
+  getCursor(): CMPos
+  getLine(n: number): string
+  getWrapperElement(): HTMLElement
+  on(ev: string, fn: (...a: unknown[]) => void): void
+  showHint(opts: unknown): void
+  refresh(): void
+}
+interface CMFactory {
+  (host: HTMLElement, opts: Record<string, unknown>): CMInstance
+  Pos(line: number, ch: number): CMPos
+}
+
+let _cmPromise: Promise<CMFactory> | null = null
+
+// loadCodeMirror injects the vendored bundle (CSS + JS) once and resolves to
+// the window.CodeMirror factory. Concurrent callers share one in-flight load.
+export function loadCodeMirror(jsUrl: string, cssUrl: string): Promise<CMFactory> {
+  if (window.CodeMirror) return Promise.resolve(window.CodeMirror)
+  if (_cmPromise) return _cmPromise
+  _cmPromise = new Promise<CMFactory>((resolve, reject) => {
+    if (!document.querySelector('link[data-kuery-cm]')) {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'
+      link.href = cssUrl
+      link.setAttribute('data-kuery-cm', '')
+      document.head.appendChild(link)
+    }
+    const s = document.createElement('script')
+    s.src = jsUrl
+    s.async = true
+    s.onload = () => (window.CodeMirror ? resolve(window.CodeMirror) : reject(new Error('CodeMirror global missing after load')))
+    s.onerror = () => {
+      _cmPromise = null
+      reject(new Error(`failed to load ${jsUrl}`))
+    }
+    document.head.appendChild(s)
+  })
+  return _cmPromise
+}
+
+// collectSchemaWords walks a JSON Schema and gathers every property name and
+// string enum value, plus a few common kinds — the vocabulary the editor's
+// autocomplete offers. Not context-aware (no path tracking), but with the
+// QuerySpec's distinctive keys (relations, groupKind, maxDepth…) a prefix match
+// is enough to be genuinely useful.
+export function collectSchemaWords(schema: unknown): string[] {
+  const words = new Set<string>()
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return
+    const n = node as Record<string, unknown>
+    if (n.properties && typeof n.properties === 'object') {
+      for (const k of Object.keys(n.properties as object)) {
+        words.add(k)
+        walk((n.properties as Record<string, unknown>)[k])
+      }
+    }
+    if (Array.isArray(n.enum)) for (const v of n.enum) if (typeof v === 'string') words.add(v)
+    if (n.items) walk(n.items)
+    if (n.definitions && typeof n.definitions === 'object') {
+      for (const k of Object.keys(n.definitions as object)) walk((n.definitions as Record<string, unknown>)[k])
+    }
+    if (n.additionalProperties && typeof n.additionalProperties === 'object') walk(n.additionalProperties)
+  }
+  walk(schema)
+  for (const k of ['Deployment', 'Service', 'Pod', 'ConfigMap', 'Secret', 'Namespace', 'StatefulSet', 'DaemonSet', 'Ingress', 'ServiceAccount', 'Node', 'PersistentVolumeClaim', 'Job', 'CronJob']) {
+    words.add(k)
+  }
+  return [...words].sort()
+}
+
+export interface EditorHandle {
+  getValue(): string
+  setValue(v: string): void
+  destroy(): void
+  refresh(): void
+}
+
+// createEditor builds a JSON CodeMirror instance with prefix autocomplete over
+// the schema vocabulary. Hint fires as you type a word and on Ctrl/Cmd-Space.
+export function createEditor(CM: CMFactory, host: HTMLElement, doc: string, words: string[]): EditorHandle {
+  const cm = CM(host, {
+    value: doc,
+    mode: { name: 'javascript', json: true },
+    lineNumbers: true,
+    autoCloseBrackets: true,
+    matchBrackets: true,
+    tabSize: 2,
+    lineWrapping: true,
+    extraKeys: { 'Ctrl-Space': 'autocomplete', 'Cmd-Space': 'autocomplete' },
+  })
+
+  const hint = (editor: CMInstance) => {
+    const cur = editor.getCursor()
+    const line = editor.getLine(cur.line)
+    let start = cur.ch
+    while (start > 0 && /[\w-]/.test(line.charAt(start - 1))) start--
+    const token = line.slice(start, cur.ch).toLowerCase()
+    const list = token ? words.filter((w) => w.toLowerCase().includes(token)) : words
+    return { list, from: CM.Pos(cur.line, start), to: CM.Pos(cur.line, cur.ch) }
+  }
+  cm.on('inputRead', (...args: unknown[]) => {
+    const change = args[1] as { text?: string[] }
+    const first = change.text?.[0] ?? ''
+    if (/[A-Za-z]/.test(first)) cm.showHint({ hint, completeSingle: false })
+  })
+
+  return {
+    getValue: () => cm.getValue(),
+    setValue: (v: string) => cm.setValue(v),
+    refresh: () => cm.refresh(),
+    destroy: () => {
+      const w = cm.getWrapperElement()
+      w.parentNode?.removeChild(w)
+    },
+  }
+}
+
+export interface Example {
+  label: string
+  spec: unknown
+}
+
+// EXAMPLES seed the editor — one per common shape, ordered simplest-first.
+export const EXAMPLES: Example[] = [
+  {
+    label: 'List deployments (whole fleet)',
+    spec: {
+      filter: { objects: [{ groupKind: { apiGroup: 'apps', kind: 'Deployment' } }] },
+      objects: { cluster: true, object: { metadata: { name: true, namespace: true }, spec: { replicas: true } } },
+      limit: 50,
+    },
+  },
+  {
+    label: 'Everything in a namespace',
+    spec: {
+      filter: { objects: [{ namespace: 'default' }] },
+      objects: { cluster: true, object: { kind: true, metadata: { name: true, namespace: true } } },
+      limit: 100,
+    },
+  },
+  {
+    label: 'Restrict to one edge',
+    spec: {
+      cluster: { name: 'dev-edge-kube-1' },
+      objects: { cluster: true, object: { kind: true, metadata: { name: true, namespace: true } } },
+      limit: 100,
+    },
+  },
+  {
+    label: 'Impact of a ConfigMap (upstream + downstream)',
+    spec: {
+      filter: { objects: [{ groupKind: { kind: 'ConfigMap' }, namespace: 'default', name: 'app-config' }] },
+      objects: {
+        cluster: true,
+        relations: { references: {}, 'selected-by': {}, namespace: {}, 'descendants+': {} },
+      },
+    },
+  },
+  {
+    label: 'Per-cluster tree (root=clusters)',
+    spec: {
+      root: 'clusters',
+      objects: {
+        cluster: true,
+        relations: { members: { limit: 50, objects: { object: { kind: true, metadata: { name: true, namespace: true } } } } },
+      },
+    },
+  },
+]

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -279,6 +279,21 @@ kedge-provider-kuery .panel:fullscreen .kuery-graph {
   height: calc(100vh - 150px);
 }
 
+kedge-provider-kuery .rel-group {
+  margin: 0 0 14px;
+}
+
+kedge-provider-kuery .rel-group-title {
+  margin: 12px 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #9aa0ad);
+  border-bottom: 1px solid var(--color-border-subtle, rgba(127, 127, 127, 0.15));
+  padding-bottom: 3px;
+}
+
 kedge-provider-kuery .legend {
   display: flex;
   flex-wrap: wrap;

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -249,6 +249,34 @@ kedge-provider-kuery .kuery-graph {
   border: 1px solid var(--color-border-subtle, rgba(127, 127, 127, 0.15));
   border-radius: 8px;
   background: var(--color-surface-base, rgba(0, 0, 0, 0.02));
+  outline: none;
+}
+
+/* Fullscreen: the panel fills the viewport and the graph grows to match. */
+kedge-provider-kuery .panel.kuery-full {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  margin: 0;
+  border-radius: 0;
+  overflow: auto;
+  background: var(--color-surface-overlay, var(--color-surface-base, #1b1b20));
+}
+
+kedge-provider-kuery .panel.kuery-full .kuery-graph {
+  height: calc(100vh - 150px);
+}
+
+/* Fullscreen API path: the panel itself is the fullscreen element. Give it a
+   solid background (the API default is black) and let the graph fill it. */
+kedge-provider-kuery .panel:fullscreen {
+  overflow: auto;
+  padding: 16px;
+  background: var(--color-surface-overlay, var(--color-surface-base, #1b1b20));
+}
+
+kedge-provider-kuery .panel:fullscreen .kuery-graph {
+  height: calc(100vh - 150px);
 }
 
 kedge-provider-kuery .legend {

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -279,6 +279,71 @@ kedge-provider-kuery .panel:fullscreen .kuery-graph {
   height: calc(100vh - 150px);
 }
 
+kedge-provider-kuery .pg-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  align-items: stretch;
+}
+
+@media (max-width: 820px) {
+  kedge-provider-kuery .pg-split {
+    grid-template-columns: 1fr;
+  }
+}
+
+kedge-provider-kuery .pg-editor {
+  min-height: 360px;
+  border: 1px solid var(--color-border-default, rgba(127, 127, 127, 0.45));
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+kedge-provider-kuery .pg-editor .CodeMirror {
+  height: 100%;
+  min-height: 360px;
+  font-size: 12px;
+}
+
+kedge-provider-kuery .pg-fallback {
+  width: 100%;
+  min-height: 360px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+kedge-provider-kuery .pg-result {
+  margin: 0;
+  min-height: 360px;
+  max-height: 520px;
+  overflow: auto;
+  padding: 10px;
+  border: 1px solid var(--color-border-subtle, rgba(127, 127, 127, 0.15));
+  border-radius: 8px;
+  background: var(--color-surface-base, rgba(0, 0, 0, 0.02));
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+kedge-provider-kuery .pg-result.error {
+  color: var(--color-text-error, #e0607a);
+}
+
+kedge-provider-kuery .pg-docs {
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+kedge-provider-kuery .pg-docs summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
 kedge-provider-kuery .rel-group {
   margin: 0 0 14px;
 }

--- a/providers/kuery/portal/vendor-codemirror.cjs
+++ b/providers/kuery/portal/vendor-codemirror.cjs
@@ -1,0 +1,24 @@
+// Concatenate the CodeMirror 5 UMD core + the addons we use into a single
+// vendored bundle (JS + CSS) under dist/, mirroring how cytoscape is vendored.
+// The portal build is IIFE library mode (no runtime module loader), so the
+// editor is lazy-injected via <script>/<link> on first playground open and read
+// off the window.CodeMirror global the UMD bundle defines.
+const fs = require('fs')
+const base = 'node_modules/codemirror/'
+
+const js = [
+  'lib/codemirror.js',
+  'mode/javascript/javascript.js', // JSON is javascript mode with json:true
+  'addon/hint/show-hint.js',
+  'addon/edit/closebrackets.js',
+  'addon/edit/matchbrackets.js',
+].map((f) => fs.readFileSync(base + f, 'utf8')).join('\n;\n')
+fs.writeFileSync('dist/codemirror.bundle.js', js)
+
+const css = [
+  'lib/codemirror.css',
+  'addon/hint/show-hint.css',
+].map((f) => fs.readFileSync(base + f, 'utf8')).join('\n')
+fs.writeFileSync('dist/codemirror.bundle.css', css)
+
+console.log('vendored codemirror.bundle.{js,css}')

--- a/providers/kuery/queryapi/schema.go
+++ b/providers/kuery/queryapi/schema.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package queryapi
+
+import (
+	"net/http"
+)
+
+// QuerySpecSchema is a JSON Schema (draft-07) for the kuery QuerySpec — the
+// body POSTed to /api/query. It is intentionally a curated, hand-authored
+// subset of the full kuery type (the fields a human or an editor actually
+// needs), not a generated dump: it powers the playground's editor
+// autocomplete/validation AND doubles as external API documentation. Keep the
+// relation enum in lockstep with the engine's relation set.
+const QuerySpecSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "kuery QuerySpec",
+  "description": "A single query across every edge cluster engaged for your workspace. POST to /api/query; the response is QueryStatus.objects[].",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "root": {
+      "type": "string",
+      "enum": ["objects", "clusters"],
+      "description": "What to root on. 'objects' (default) returns Kubernetes objects. 'clusters' returns one node per engaged edge, whose 'members' relation expands to its objects (the per-cluster tree)."
+    },
+    "cluster": {
+      "type": "object",
+      "description": "Restrict to one edge. The hub scopes every query to your tenant regardless; this narrows further to a single edge.",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Edge name, e.g. dev-edge-kube-1." }
+      }
+    },
+    "limit": { "type": "integer", "description": "Max root objects (default 100, max 10000)." },
+    "maxDepth": { "type": "integer", "description": "Transitive relation depth for '+' relations (default 10, max 20)." },
+    "count": { "type": "boolean", "description": "Also return the total count of matching root objects (expensive)." },
+    "filter": {
+      "type": "object",
+      "description": "Object-level filters. filter.objects[] entries are OR-ed; criteria within one entry are AND-ed.",
+      "additionalProperties": false,
+      "properties": {
+        "objects": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/objectFilter" }
+        }
+      }
+    },
+    "objects": { "$ref": "#/definitions/objectsSpec" }
+  },
+  "definitions": {
+    "objectFilter": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groupKind": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "apiGroup": { "type": "string", "description": "API group, empty string for core." },
+            "kind": { "type": "string", "description": "Kind, resource, singular, or short name (e.g. Deployment, deployments, deploy)." }
+          }
+        },
+        "name": { "type": "string", "description": "Exact object name." },
+        "namespace": { "type": "string", "description": "Namespace." },
+        "labels": { "type": "object", "description": "matchLabels-style key=value (AND).", "additionalProperties": { "type": "string" } },
+        "categories": { "type": "array", "items": { "type": "string" }, "description": "Resource categories, e.g. all." },
+        "id": { "type": "string", "description": "Opaque object id from a previous result." },
+        "jsonpath": { "type": "string", "description": "Boolean JSONPath filter (last resort), e.g. $.status.phase." }
+      }
+    },
+    "objectsSpec": {
+      "type": "object",
+      "description": "Response shape: which fields to return and which relations to expand.",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "boolean", "description": "Include the opaque object id." },
+        "cluster": { "type": "boolean", "description": "Include the edge/cluster name." },
+        "mutablePath": { "type": "boolean", "description": "Include the REST path for direct mutation." },
+        "object": { "type": "object", "description": "Sparse projection: { metadata: { name: true }, spec: { replicas: true } }. Omit for the full object." },
+        "relations": { "$ref": "#/definitions/relations" }
+      }
+    },
+    "relations": {
+      "type": "object",
+      "description": "Nested related objects, keyed by relation. Use '+' for the transitive form (descendants+, owners+, linked+).",
+      "additionalProperties": { "$ref": "#/definitions/relationSpec" },
+      "properties": {
+        "owners":       { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: objects that own this (deleting them impacts this)." },
+        "descendants":  { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: objects this owns (impacted if this is deleted)." },
+        "references":   { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: spec field refs, e.g. a Pod's ConfigMaps/Secrets/ServiceAccount." },
+        "selects":      { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: objects this selects via spec.selector." },
+        "selected-by":  { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: selectors that match this (e.g. Services)." },
+        "namespace":    { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: the Namespace this lives in." },
+        "namespaced":   { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: every object in this Namespace." },
+        "members":      { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: every object in this cluster (use with root=clusters)." },
+        "linked":       { "$ref": "#/definitions/relationSpec", "description": "LATERAL: kuery.io/relates-to annotation links (cross-edge)." },
+        "grouped":      { "$ref": "#/definitions/relationSpec", "description": "LATERAL: shared kuery.io/group label (cross-edge)." }
+      }
+    },
+    "relationSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limit": { "type": "integer", "description": "Max related objects per parent." },
+        "filters": { "type": "array", "items": { "$ref": "#/definitions/objectFilter" }, "description": "Restrict which related objects are returned." },
+        "objects": { "$ref": "#/definitions/objectsSpec" }
+      }
+    }
+  }
+}`
+
+// SchemaHandler serves the QuerySpec JSON Schema. It needs no tenant identity —
+// the schema is the same for everyone — so it's safe to call unauthenticated,
+// which lets external clients fetch it for codegen/docs.
+type SchemaHandler struct{}
+
+func (SchemaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/schema+json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write([]byte(QuerySpecSchema))
+}


### PR DESCRIPTION
## Summary

Makes the kuery provider's portal graph represent the fleet properly: an **edge-centric topology** you can **expand in place** to walk the real dependency net, instead of a flat per-object re-anchoring view. Builds on the merged kuery engine PR (faroshq/kuery#6).

Depends on **faroshq/kuery#6** (merged) — this PR pins `github.com/faroshq/kuery v0.0.0-20260613173553-8399b678c025` and drops the local `replace`.

## Engine capabilities consumed (from faroshq/kuery#6)
- `namespace` / `namespaced` relations (object ↔ its Namespace).
- `QuerySpec.Root="clusters"` + `members` relation — clusters (the multicluster-runtime anchor, via the clusters table) become first-class query roots, so one query yields the full per-cluster tree.

## Portal
- **Topology view** (new default): clusters-rooted query renders **Edge → Namespace → object**. The real `Namespace` object *is* the tier node (carries children, clickable) rather than a childless leaf beside a synthetic group.
- **Expandable explorer**: clicking a node grafts its coupling onto the live graph; shared objects dedupe to a single node (so you see the actual net and its depth). Click again to collapse the exclusive subtree; expanded nodes get an accent ring.
- **Dynamic controls**: layout switch (Tree / Radial / Circle / Force, applied in place), kind + namespace facet filters pre-populated from the data, per-edge scope.
- **Full screen** via the Fullscreen API (escapes the portal shell's transformed ancestor that traps a CSS overlay), **keyboard** pan (arrows + WASD) and zoom (+/-), lower `minZoom` so a fully-expanded net fits.
- **Expand all**: walks the whole net by frontier — one batched query per round (`filter.objects[]` OR-ed by id) instead of one request per node, so request count scales with depth, not node count.
- Adds `namespaced` to the impact relation set (portal + `mcpserver/tools.go`) so a Namespace's impact shows its contents.

## Notes
- `secrets`/`events` are blacklisted in kuery sync, so Pod->Secret refs won't resolve even though the ref-paths exist; ServiceAccount/ConfigMap/PVC do.
- `dist/` is built by the Makefile (`make build-kuery-provider`) in CI, not committed.

## Test
- Provider `go build ./...` + `go test ./...` green; portal `tsc --noEmit` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
