### PR TITLE
feat(kuery): query playground + queryable API surface

### DIFF
--- a/docs/kuery-query-api.md
+++ b/docs/kuery-query-api.md
@@ -1,0 +1,91 @@
+# kuery query API
+
+The kuery provider exposes a fleet-wide query API over every edge cluster
+engaged for your workspace. The portal's **Playground** tab is a UI on top of
+it; this document is the programmatic reference.
+
+## Endpoint
+
+```
+POST  {hub}/services/providers/kuery/api/query        # run a query
+GET   {hub}/services/providers/kuery/api/query-schema  # JSON Schema for the body
+GET   {hub}/services/providers/kuery/api/edges          # engaged edge names
+```
+
+- **Body** of `/api/query` is a kuery `QuerySpec` (JSON). The response is a
+  `QueryStatus` with `objects[]`.
+- **Tenanting is automatic.** The hub authenticates your bearer token, resolves
+  your workspace, and injects the tenant scope server-side. Any
+  `X-Kedge-Tenant` you send is stripped — you cannot query another tenant.
+
+## Auth
+
+Send `Authorization: Bearer <token>`:
+
+- **OIDC user token** — works today. Use the token your portal session uses.
+- **Service-account token** — non-interactive/bot access. (In progress: the hub
+  needs to resolve a kcp ServiceAccount token to its workspace path before this
+  works through the provider proxy.)
+
+```bash
+curl -sS "$HUB/services/providers/kuery/api/query" \
+  -H "Authorization: Bearer $KEDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"filter":{"objects":[{"groupKind":{"kind":"Deployment"}}]},"objects":{"cluster":true}}'
+```
+
+## QuerySpec essentials
+
+Fetch the full schema from `/api/query-schema`. Key fields:
+
+| field | meaning |
+|---|---|
+| `root` | `objects` (default) or `clusters` (one node per edge; expand `members`). |
+| `cluster.name` | restrict to one edge. |
+| `filter.objects[]` | OR-ed filters: `groupKind{apiGroup,kind}`, `name`, `namespace`, `labels`, `categories`, `jsonpath`. |
+| `limit`, `maxDepth` | root cap (def 100), transitive depth for `+` relations (def 10). |
+| `objects` | response shape: `id`, `cluster`, `mutablePath`, sparse `object` projection, and `relations`. |
+
+### Relations and impact direction
+
+`objects.relations` follows coupling. Each relation has an **impact direction**
+— `A→B` means *deleting A breaks B*:
+
+- **Upstream** (the target depends on these; deleting them breaks it):
+  `owners`, `references`, `selects`, `namespace`.
+- **Downstream** (the target's blast radius; break if it's deleted):
+  `descendants`, `selected-by`, `namespaced`, `members`.
+- **Lateral**: `linked`, `grouped`.
+
+Append `+` for the transitive form (`descendants+`, `owners+`, `linked+`).
+
+Coupling is **declared** (ownerRefs, spec field references, label selectors,
+namespace membership) — not runtime traffic — so an empty result is not proof
+nothing depends on the object at runtime.
+
+## Examples
+
+All objects in a namespace:
+
+```json
+{ "filter": { "objects": [{ "namespace": "default" }] },
+  "objects": { "cluster": true, "object": { "kind": true, "metadata": { "name": true, "namespace": true } } } }
+```
+
+Impact of a ConfigMap (who breaks if I change it + what it needs):
+
+```json
+{ "filter": { "objects": [{ "groupKind": { "kind": "ConfigMap" }, "namespace": "default", "name": "app-config" }] },
+  "objects": { "cluster": true, "relations": { "references": {}, "selected-by": {}, "namespace": {} } } }
+```
+
+Per-cluster tree:
+
+```json
+{ "root": "clusters",
+  "objects": { "cluster": true, "relations": { "members": { "limit": 50,
+    "objects": { "object": { "kind": true, "metadata": { "name": true, "namespace": true } } } } } } }
+```
+
+For agent/LLM use, the `kuery_impact` MCP tool wraps the impact query and
+returns the upstream/downstream split directly.

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -161,6 +161,10 @@ func main() {
 	// Tenant-scoped query API — the only path to the kuery store.
 	mux.Handle("/api/query", &queryapi.Handler{Engine: kc.Engine})
 
+	// QuerySpec JSON Schema — powers the playground editor's autocomplete and
+	// doubles as external API docs. Unauthenticated (the schema is public).
+	mux.Handle("/api/query-schema", queryapi.SchemaHandler{})
+
 	// Engaged-edge listing for the portal's edge selector. The interface
 	// indirection keeps the nil case (engagement disabled) serving [].
 	var edgeLister queryapi.EdgeLister

--- a/providers/kuery/portal/package-lock.json
+++ b/providers/kuery/portal/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/cytoscape": "^3.21.9",
+        "codemirror": "^5.65.16",
         "cytoscape": "^3.34.0",
         "typescript": "^5.6.3",
         "vite": "^6.4.1"
@@ -817,6 +818,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.21",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
+      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/providers/kuery/portal/package.json
+++ b/providers/kuery/portal/package.json
@@ -5,13 +5,15 @@
   "description": "Kuery provider's portal-side micro-frontend. Built with Vite into a single main.js custom-element bundle plus static assets the kedge hub serves under /ui/providers/kuery/.",
   "type": "module",
   "scripts": {
-    "build": "vite build && npm run vendor-cytoscape",
+    "build": "vite build && npm run vendor-cytoscape && npm run vendor-codemirror",
     "vendor-cytoscape": "node -e \"require('fs').copyFileSync('node_modules/cytoscape/dist/cytoscape.min.js','dist/cytoscape.min.js')\"",
+    "vendor-codemirror": "node vendor-codemirror.cjs",
     "dev": "vite",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/cytoscape": "^3.21.9",
+    "codemirror": "^5.65.16",
     "cytoscape": "^3.34.0",
     "typescript": "^5.6.3",
     "vite": "^6.4.1"

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -18,6 +18,7 @@ import {
   RELATION_DIR,
   type GraphHandle,
 } from './graph'
+import { loadCodeMirror, collectSchemaWords, createEditor, EXAMPLES, type EditorHandle } from './playground'
 
 export interface KedgeContext {
   token?: string | null
@@ -80,7 +81,7 @@ export class KueryElement extends HTMLElement {
 
   // Top-level view. Topology (edge-centric fleet tree) is the landing view;
   // Inventory (flat table) is the alternate. Each loads its data lazily.
-  private _view: 'topology' | 'inventory' = 'topology'
+  private _view: 'topology' | 'inventory' | 'playground' = 'topology'
   private _inventoryLoaded = false
   private _topology: ObjectResult[] = []
   private _topologyError = ''
@@ -95,6 +96,15 @@ export class KueryElement extends HTMLElement {
   private _expandingAll = false
   private _boundKeyHandler = (ev: KeyboardEvent) => this._onKeyDown(ev)
   private _boundFsHandler = () => this._onFullscreenChange()
+
+  // Playground state: the live editor, last result/error, and the schema
+  // vocabulary that drives autocomplete (fetched once).
+  private _pgEditor: EditorHandle | null = null
+  private _pgResult = ''
+  private _pgError = ''
+  private _pgRunning = false
+  private _pgWords: string[] = []
+  private _pgDoc = JSON.stringify(EXAMPLES[0].spec, null, 2)
 
   // Impact drill-down state. null = inventory view.
   private _impactOf: ObjectResult | null = null
@@ -140,6 +150,8 @@ export class KueryElement extends HTMLElement {
     window.removeEventListener('keydown', this._boundKeyHandler)
     document.removeEventListener('fullscreenchange', this._boundFsHandler)
     this._destroyGraph()
+    this._pgEditor?.destroy()
+    this._pgEditor = null
   }
 
   // _boot waits for basePath (it can arrive on a later context push), then
@@ -448,8 +460,13 @@ export class KueryElement extends HTMLElement {
   // ── rendering ────────────────────────────────────────────────────────
 
   private _render(): void {
-    // Tear down any live graph before its container is replaced by innerHTML.
+    // Tear down any live graph/editor before innerHTML replaces their host.
     this._destroyGraph()
+    if (this._pgEditor) {
+      this._pgDoc = this._pgEditor.getValue() // keep the user's draft across renders
+      this._pgEditor.destroy()
+      this._pgEditor = null
+    }
 
     if (this._impactOf) {
       this.innerHTML = this._renderImpact()
@@ -468,22 +485,27 @@ export class KueryElement extends HTMLElement {
       if (this._topology.length && !this._topologyError && !this._loading) void this._mountTopologyGraph()
       return
     }
+    if (this._view === 'playground') {
+      this.innerHTML = this._renderPlayground()
+      this._bindPlayground()
+      void this._mountEditor()
+      return
+    }
     this.innerHTML = this._renderInventory()
     this._bindInventory()
   }
 
-  // _viewToggle is the top-level Topology/Inventory switch shown in both views.
+  // _viewToggle is the top-level Topology/Inventory/Playground switch.
   private _viewToggle(): string {
-    return `<div class="seg">
-      <button class="seg-btn${this._view === 'topology' ? ' on' : ''}" data-topview="topology">Topology</button>
-      <button class="seg-btn${this._view === 'inventory' ? ' on' : ''}" data-topview="inventory">Inventory</button>
-    </div>`
+    const btn = (v: string, label: string) =>
+      `<button class="seg-btn${this._view === v ? ' on' : ''}" data-topview="${v}">${label}</button>`
+    return `<div class="seg">${btn('topology', 'Topology')}${btn('inventory', 'Inventory')}${btn('playground', 'Playground')}</div>`
   }
 
   private _bindViewToggle(): void {
     this.querySelectorAll('[data-topview]').forEach((b) =>
       b.addEventListener('click', () => {
-        const v = (b as HTMLElement).dataset.topview as 'topology' | 'inventory' | undefined
+        const v = (b as HTMLElement).dataset.topview as 'topology' | 'inventory' | 'playground' | undefined
         if (!v || v === this._view) return
         this._view = v
         // Load the target view's data on first visit; otherwise just re-render.
@@ -782,6 +804,130 @@ export class KueryElement extends HTMLElement {
       default: handled = false
     }
     if (handled) ev.preventDefault()
+  }
+
+  // ── playground ────────────────────────────────────────────────────────
+
+  private _renderPlayground(): string {
+    const exampleOpts = ['<option value="">examples…</option>']
+      .concat(EXAMPLES.map((e, i) => `<option value="${i}">${esc(e.label)}</option>`))
+      .join('')
+    const results = this._pgError
+      ? `<pre class="pg-result error">${esc(this._pgError)}</pre>`
+      : `<pre class="pg-result">${esc(this._pgResult || '// results appear here')}</pre>`
+    return `
+      <div class="panel">
+        <div class="panel-head">
+          <h2 class="panel-title">Query playground</h2>
+          <div class="head-actions">${this._viewToggle()}</div>
+        </div>
+        <p class="meta">Write a kuery QuerySpec and run it against your fleet. Editor autocompletes from the schema (Ctrl/Cmd-Space). Every query is scoped to your workspace automatically.</p>
+        <div class="toolbar">
+          <select id="pg-example">${exampleOpts}</select>
+          <button id="pg-run">${this._pgRunning ? 'Running…' : 'Run ▸'}</button>
+          <button id="pg-docs-toggle" type="button">API &amp; access</button>
+        </div>
+        <div class="pg-split">
+          <div id="kuery-editor" class="pg-editor"></div>
+          ${results}
+        </div>
+        <details id="pg-docs" class="pg-docs">
+          <summary>Use this API from outside the portal</summary>
+          ${this._renderApiDocs()}
+        </details>
+      </div>
+    `
+  }
+
+  private _renderApiDocs(): string {
+    const base = this._apiBase()
+    const origin = location.origin
+    return `
+      <p>The same query API is reachable programmatically. The hub authenticates your bearer token and scopes the query to your workspace — you never send a tenant header yourself.</p>
+      <pre class="pg-result">curl -sS ${esc(origin)}${esc(base)}/api/query \\
+  -H "Authorization: Bearer $KEDGE_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"filter":{"objects":[{"groupKind":{"kind":"Deployment"}}]},"objects":{"cluster":true}}'</pre>
+      <ul class="rel-list">
+        <li><b>Endpoint</b>: <code>POST ${esc(base)}/api/query</code> (body = QuerySpec, response = QueryStatus)</li>
+        <li><b>Schema</b>: <code>GET ${esc(base)}/api/query-schema</code> (JSON Schema for the request body)</li>
+        <li><b>Auth</b>: an OIDC bearer token works today. Non-interactive service-account tokens are coming.</li>
+        <li><b>Relations</b> carry impact direction: upstream (owners, references, namespace, selects) vs downstream (descendants, selected-by, namespaced, members).</li>
+      </ul>`
+  }
+
+  private _bindPlayground(): void {
+    this._bindViewToggle()
+    this.querySelector('#pg-run')?.addEventListener('click', () => void this._runPlayground())
+    this.querySelector('#pg-example')?.addEventListener('change', (ev) => {
+      const i = Number((ev.target as HTMLSelectElement).value)
+      if (Number.isInteger(i) && EXAMPLES[i]) {
+        this._pgDoc = JSON.stringify(EXAMPLES[i].spec, null, 2)
+        this._pgEditor?.setValue(this._pgDoc)
+        this._pgEditor?.refresh()
+      }
+    })
+    this.querySelector('#pg-docs-toggle')?.addEventListener('click', () => {
+      const d = this.querySelector('#pg-docs') as HTMLDetailsElement | null
+      if (d) d.open = !d.open
+    })
+  }
+
+  // _mountEditor lazy-loads CodeMirror (and the schema vocabulary, once) and
+  // builds the editor into #kuery-editor. Falls back to a plain textarea if the
+  // vendored bundle can't load.
+  private async _mountEditor(): Promise<void> {
+    const host = this.querySelector('#kuery-editor') as HTMLElement | null
+    if (!host || this._pgEditor) return
+    const baseUI = (this._ctx?.basePath || '').replace(/\/?$/, '/')
+    try {
+      if (this._pgWords.length === 0) {
+        try {
+          const schema = await this._fetchJSON('/api/query-schema')
+          this._pgWords = collectSchemaWords(schema)
+        } catch {
+          this._pgWords = []
+        }
+      }
+      const CM = await loadCodeMirror(`${baseUI}codemirror.bundle.js`, `${baseUI}codemirror.bundle.css`)
+      if (!this.querySelector('#kuery-editor')) return // re-rendered while loading
+      this._pgEditor = createEditor(CM, host, this._pgDoc, this._pgWords)
+      this._pgEditor.refresh()
+    } catch {
+      host.innerHTML = `<textarea id="kuery-editor-fallback" class="pg-fallback">${esc(this._pgDoc)}</textarea>`
+    }
+  }
+
+  private async _runPlayground(): Promise<void> {
+    const raw = this._pgEditor
+      ? this._pgEditor.getValue()
+      : (this.querySelector('#kuery-editor-fallback') as HTMLTextAreaElement | null)?.value ?? this._pgDoc
+    this._pgDoc = raw
+    let spec: unknown
+    try {
+      spec = JSON.parse(raw)
+    } catch (e) {
+      this._pgError = `invalid JSON: ${e instanceof Error ? e.message : String(e)}`
+      this._pgResult = ''
+      this._render()
+      return
+    }
+    this._pgRunning = true
+    this._pgError = ''
+    this._render()
+    try {
+      const status = await this._fetchJSON('/api/query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })
+      this._pgResult = JSON.stringify(status, null, 2)
+    } catch (e) {
+      this._pgError = e instanceof Error ? e.message : String(e)
+      this._pgResult = ''
+    }
+    this._pgRunning = false
+    this._render()
   }
 
   private _renderInventory(): string {

--- a/providers/kuery/portal/src/playground.ts
+++ b/providers/kuery/portal/src/playground.ts
@@ -1,0 +1,189 @@
+// Query playground support: a lazily-loaded CodeMirror editor with
+// schema-driven autocomplete, plus canned examples. CodeMirror (~CM5 UMD) is
+// vendored and injected on first use — same reason as cytoscape: the portal is
+// an IIFE library bundle with no runtime module loader, so a bundler dynamic
+// import() would get inlined. `import type` only here pulls in zero bytes.
+
+// The vendored UMD assigns this global.
+declare global {
+  interface Window {
+    // CM5 has no first-class ESM types here; treat as opaque.
+    CodeMirror?: CMFactory
+  }
+}
+
+// Minimal shape of the CodeMirror 5 factory + instance we use, so the rest of
+// the file stays typed without pulling @types/codemirror.
+type CMPos = { line: number; ch: number }
+interface CMInstance {
+  getValue(): string
+  setValue(v: string): void
+  getCursor(): CMPos
+  getLine(n: number): string
+  getWrapperElement(): HTMLElement
+  on(ev: string, fn: (...a: unknown[]) => void): void
+  showHint(opts: unknown): void
+  refresh(): void
+}
+interface CMFactory {
+  (host: HTMLElement, opts: Record<string, unknown>): CMInstance
+  Pos(line: number, ch: number): CMPos
+}
+
+let _cmPromise: Promise<CMFactory> | null = null
+
+// loadCodeMirror injects the vendored bundle (CSS + JS) once and resolves to
+// the window.CodeMirror factory. Concurrent callers share one in-flight load.
+export function loadCodeMirror(jsUrl: string, cssUrl: string): Promise<CMFactory> {
+  if (window.CodeMirror) return Promise.resolve(window.CodeMirror)
+  if (_cmPromise) return _cmPromise
+  _cmPromise = new Promise<CMFactory>((resolve, reject) => {
+    if (!document.querySelector('link[data-kuery-cm]')) {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'
+      link.href = cssUrl
+      link.setAttribute('data-kuery-cm', '')
+      document.head.appendChild(link)
+    }
+    const s = document.createElement('script')
+    s.src = jsUrl
+    s.async = true
+    s.onload = () => (window.CodeMirror ? resolve(window.CodeMirror) : reject(new Error('CodeMirror global missing after load')))
+    s.onerror = () => {
+      _cmPromise = null
+      reject(new Error(`failed to load ${jsUrl}`))
+    }
+    document.head.appendChild(s)
+  })
+  return _cmPromise
+}
+
+// collectSchemaWords walks a JSON Schema and gathers every property name and
+// string enum value, plus a few common kinds — the vocabulary the editor's
+// autocomplete offers. Not context-aware (no path tracking), but with the
+// QuerySpec's distinctive keys (relations, groupKind, maxDepth…) a prefix match
+// is enough to be genuinely useful.
+export function collectSchemaWords(schema: unknown): string[] {
+  const words = new Set<string>()
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return
+    const n = node as Record<string, unknown>
+    if (n.properties && typeof n.properties === 'object') {
+      for (const k of Object.keys(n.properties as object)) {
+        words.add(k)
+        walk((n.properties as Record<string, unknown>)[k])
+      }
+    }
+    if (Array.isArray(n.enum)) for (const v of n.enum) if (typeof v === 'string') words.add(v)
+    if (n.items) walk(n.items)
+    if (n.definitions && typeof n.definitions === 'object') {
+      for (const k of Object.keys(n.definitions as object)) walk((n.definitions as Record<string, unknown>)[k])
+    }
+    if (n.additionalProperties && typeof n.additionalProperties === 'object') walk(n.additionalProperties)
+  }
+  walk(schema)
+  for (const k of ['Deployment', 'Service', 'Pod', 'ConfigMap', 'Secret', 'Namespace', 'StatefulSet', 'DaemonSet', 'Ingress', 'ServiceAccount', 'Node', 'PersistentVolumeClaim', 'Job', 'CronJob']) {
+    words.add(k)
+  }
+  return [...words].sort()
+}
+
+export interface EditorHandle {
+  getValue(): string
+  setValue(v: string): void
+  destroy(): void
+  refresh(): void
+}
+
+// createEditor builds a JSON CodeMirror instance with prefix autocomplete over
+// the schema vocabulary. Hint fires as you type a word and on Ctrl/Cmd-Space.
+export function createEditor(CM: CMFactory, host: HTMLElement, doc: string, words: string[]): EditorHandle {
+  const cm = CM(host, {
+    value: doc,
+    mode: { name: 'javascript', json: true },
+    lineNumbers: true,
+    autoCloseBrackets: true,
+    matchBrackets: true,
+    tabSize: 2,
+    lineWrapping: true,
+    extraKeys: { 'Ctrl-Space': 'autocomplete', 'Cmd-Space': 'autocomplete' },
+  })
+
+  const hint = (editor: CMInstance) => {
+    const cur = editor.getCursor()
+    const line = editor.getLine(cur.line)
+    let start = cur.ch
+    while (start > 0 && /[\w-]/.test(line.charAt(start - 1))) start--
+    const token = line.slice(start, cur.ch).toLowerCase()
+    const list = token ? words.filter((w) => w.toLowerCase().includes(token)) : words
+    return { list, from: CM.Pos(cur.line, start), to: CM.Pos(cur.line, cur.ch) }
+  }
+  cm.on('inputRead', (...args: unknown[]) => {
+    const change = args[1] as { text?: string[] }
+    const first = change.text?.[0] ?? ''
+    if (/[A-Za-z]/.test(first)) cm.showHint({ hint, completeSingle: false })
+  })
+
+  return {
+    getValue: () => cm.getValue(),
+    setValue: (v: string) => cm.setValue(v),
+    refresh: () => cm.refresh(),
+    destroy: () => {
+      const w = cm.getWrapperElement()
+      w.parentNode?.removeChild(w)
+    },
+  }
+}
+
+export interface Example {
+  label: string
+  spec: unknown
+}
+
+// EXAMPLES seed the editor — one per common shape, ordered simplest-first.
+export const EXAMPLES: Example[] = [
+  {
+    label: 'List deployments (whole fleet)',
+    spec: {
+      filter: { objects: [{ groupKind: { apiGroup: 'apps', kind: 'Deployment' } }] },
+      objects: { cluster: true, object: { metadata: { name: true, namespace: true }, spec: { replicas: true } } },
+      limit: 50,
+    },
+  },
+  {
+    label: 'Everything in a namespace',
+    spec: {
+      filter: { objects: [{ namespace: 'default' }] },
+      objects: { cluster: true, object: { kind: true, metadata: { name: true, namespace: true } } },
+      limit: 100,
+    },
+  },
+  {
+    label: 'Restrict to one edge',
+    spec: {
+      cluster: { name: 'dev-edge-kube-1' },
+      objects: { cluster: true, object: { kind: true, metadata: { name: true, namespace: true } } },
+      limit: 100,
+    },
+  },
+  {
+    label: 'Impact of a ConfigMap (upstream + downstream)',
+    spec: {
+      filter: { objects: [{ groupKind: { kind: 'ConfigMap' }, namespace: 'default', name: 'app-config' }] },
+      objects: {
+        cluster: true,
+        relations: { references: {}, 'selected-by': {}, namespace: {}, 'descendants+': {} },
+      },
+    },
+  },
+  {
+    label: 'Per-cluster tree (root=clusters)',
+    spec: {
+      root: 'clusters',
+      objects: {
+        cluster: true,
+        relations: { members: { limit: 50, objects: { object: { kind: true, metadata: { name: true, namespace: true } } } } },
+      },
+    },
+  },
+]

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -279,6 +279,71 @@ kedge-provider-kuery .panel:fullscreen .kuery-graph {
   height: calc(100vh - 150px);
 }
 
+kedge-provider-kuery .pg-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  align-items: stretch;
+}
+
+@media (max-width: 820px) {
+  kedge-provider-kuery .pg-split {
+    grid-template-columns: 1fr;
+  }
+}
+
+kedge-provider-kuery .pg-editor {
+  min-height: 360px;
+  border: 1px solid var(--color-border-default, rgba(127, 127, 127, 0.45));
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+kedge-provider-kuery .pg-editor .CodeMirror {
+  height: 100%;
+  min-height: 360px;
+  font-size: 12px;
+}
+
+kedge-provider-kuery .pg-fallback {
+  width: 100%;
+  min-height: 360px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+kedge-provider-kuery .pg-result {
+  margin: 0;
+  min-height: 360px;
+  max-height: 520px;
+  overflow: auto;
+  padding: 10px;
+  border: 1px solid var(--color-border-subtle, rgba(127, 127, 127, 0.15));
+  border-radius: 8px;
+  background: var(--color-surface-base, rgba(0, 0, 0, 0.02));
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+kedge-provider-kuery .pg-result.error {
+  color: var(--color-text-error, #e0607a);
+}
+
+kedge-provider-kuery .pg-docs {
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+kedge-provider-kuery .pg-docs summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
 kedge-provider-kuery .rel-group {
   margin: 0 0 14px;
 }

--- a/providers/kuery/portal/vendor-codemirror.cjs
+++ b/providers/kuery/portal/vendor-codemirror.cjs
@@ -1,0 +1,24 @@
+// Concatenate the CodeMirror 5 UMD core + the addons we use into a single
+// vendored bundle (JS + CSS) under dist/, mirroring how cytoscape is vendored.
+// The portal build is IIFE library mode (no runtime module loader), so the
+// editor is lazy-injected via <script>/<link> on first playground open and read
+// off the window.CodeMirror global the UMD bundle defines.
+const fs = require('fs')
+const base = 'node_modules/codemirror/'
+
+const js = [
+  'lib/codemirror.js',
+  'mode/javascript/javascript.js', // JSON is javascript mode with json:true
+  'addon/hint/show-hint.js',
+  'addon/edit/closebrackets.js',
+  'addon/edit/matchbrackets.js',
+].map((f) => fs.readFileSync(base + f, 'utf8')).join('\n;\n')
+fs.writeFileSync('dist/codemirror.bundle.js', js)
+
+const css = [
+  'lib/codemirror.css',
+  'addon/hint/show-hint.css',
+].map((f) => fs.readFileSync(base + f, 'utf8')).join('\n')
+fs.writeFileSync('dist/codemirror.bundle.css', css)
+
+console.log('vendored codemirror.bundle.{js,css}')

--- a/providers/kuery/queryapi/schema.go
+++ b/providers/kuery/queryapi/schema.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package queryapi
+
+import (
+	"net/http"
+)
+
+// QuerySpecSchema is a JSON Schema (draft-07) for the kuery QuerySpec — the
+// body POSTed to /api/query. It is intentionally a curated, hand-authored
+// subset of the full kuery type (the fields a human or an editor actually
+// needs), not a generated dump: it powers the playground's editor
+// autocomplete/validation AND doubles as external API documentation. Keep the
+// relation enum in lockstep with the engine's relation set.
+const QuerySpecSchema = `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "kuery QuerySpec",
+  "description": "A single query across every edge cluster engaged for your workspace. POST to /api/query; the response is QueryStatus.objects[].",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "root": {
+      "type": "string",
+      "enum": ["objects", "clusters"],
+      "description": "What to root on. 'objects' (default) returns Kubernetes objects. 'clusters' returns one node per engaged edge, whose 'members' relation expands to its objects (the per-cluster tree)."
+    },
+    "cluster": {
+      "type": "object",
+      "description": "Restrict to one edge. The hub scopes every query to your tenant regardless; this narrows further to a single edge.",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "description": "Edge name, e.g. dev-edge-kube-1." }
+      }
+    },
+    "limit": { "type": "integer", "description": "Max root objects (default 100, max 10000)." },
+    "maxDepth": { "type": "integer", "description": "Transitive relation depth for '+' relations (default 10, max 20)." },
+    "count": { "type": "boolean", "description": "Also return the total count of matching root objects (expensive)." },
+    "filter": {
+      "type": "object",
+      "description": "Object-level filters. filter.objects[] entries are OR-ed; criteria within one entry are AND-ed.",
+      "additionalProperties": false,
+      "properties": {
+        "objects": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/objectFilter" }
+        }
+      }
+    },
+    "objects": { "$ref": "#/definitions/objectsSpec" }
+  },
+  "definitions": {
+    "objectFilter": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groupKind": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "apiGroup": { "type": "string", "description": "API group, empty string for core." },
+            "kind": { "type": "string", "description": "Kind, resource, singular, or short name (e.g. Deployment, deployments, deploy)." }
+          }
+        },
+        "name": { "type": "string", "description": "Exact object name." },
+        "namespace": { "type": "string", "description": "Namespace." },
+        "labels": { "type": "object", "description": "matchLabels-style key=value (AND).", "additionalProperties": { "type": "string" } },
+        "categories": { "type": "array", "items": { "type": "string" }, "description": "Resource categories, e.g. all." },
+        "id": { "type": "string", "description": "Opaque object id from a previous result." },
+        "jsonpath": { "type": "string", "description": "Boolean JSONPath filter (last resort), e.g. $.status.phase." }
+      }
+    },
+    "objectsSpec": {
+      "type": "object",
+      "description": "Response shape: which fields to return and which relations to expand.",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "boolean", "description": "Include the opaque object id." },
+        "cluster": { "type": "boolean", "description": "Include the edge/cluster name." },
+        "mutablePath": { "type": "boolean", "description": "Include the REST path for direct mutation." },
+        "object": { "type": "object", "description": "Sparse projection: { metadata: { name: true }, spec: { replicas: true } }. Omit for the full object." },
+        "relations": { "$ref": "#/definitions/relations" }
+      }
+    },
+    "relations": {
+      "type": "object",
+      "description": "Nested related objects, keyed by relation. Use '+' for the transitive form (descendants+, owners+, linked+).",
+      "additionalProperties": { "$ref": "#/definitions/relationSpec" },
+      "properties": {
+        "owners":       { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: objects that own this (deleting them impacts this)." },
+        "descendants":  { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: objects this owns (impacted if this is deleted)." },
+        "references":   { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: spec field refs, e.g. a Pod's ConfigMaps/Secrets/ServiceAccount." },
+        "selects":      { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: objects this selects via spec.selector." },
+        "selected-by":  { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: selectors that match this (e.g. Services)." },
+        "namespace":    { "$ref": "#/definitions/relationSpec", "description": "UPSTREAM: the Namespace this lives in." },
+        "namespaced":   { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: every object in this Namespace." },
+        "members":      { "$ref": "#/definitions/relationSpec", "description": "DOWNSTREAM: every object in this cluster (use with root=clusters)." },
+        "linked":       { "$ref": "#/definitions/relationSpec", "description": "LATERAL: kuery.io/relates-to annotation links (cross-edge)." },
+        "grouped":      { "$ref": "#/definitions/relationSpec", "description": "LATERAL: shared kuery.io/group label (cross-edge)." }
+      }
+    },
+    "relationSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limit": { "type": "integer", "description": "Max related objects per parent." },
+        "filters": { "type": "array", "items": { "$ref": "#/definitions/objectFilter" }, "description": "Restrict which related objects are returned." },
+        "objects": { "$ref": "#/definitions/objectsSpec" }
+      }
+    }
+  }
+}`
+
+// SchemaHandler serves the QuerySpec JSON Schema. It needs no tenant identity —
+// the schema is the same for everyone — so it's safe to call unauthenticated,
+// which lets external clients fetch it for codegen/docs.
+type SchemaHandler struct{}
+
+func (SchemaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/schema+json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write([]byte(QuerySpecSchema))
+}


### PR DESCRIPTION
## Summary

Adds a **Query Playground** to the kuery portal and the schema + docs that make the query API usable programmatically — the "explore, don't just visualize" piece.

Stacked on #284 (it adds a third view to the same `element.ts` view-toggle). Base will move to `main` once #284 merges.

## Playground (portal)
A third sub-tab next to Topology / Inventory:
- **CodeMirror editor** (vendored UMD, lazy-loaded like cytoscape — the bundle is IIFE) with **schema-driven autocomplete** (Ctrl/Cmd-Space) sourced from `/api/query-schema`.
- **Example queries** dropdown, **Run ▸** → `/api/query`, pretty-printed JSON results.
- **"API & access" panel**: curl example + endpoints, explaining tenanting is automatic/server-enforced.

## API surface (backend)
- `GET /api/query-schema` — curated JSON Schema for the QuerySpec; drives autocomplete and documents the request body. Unauthenticated (the schema is public).
- `docs/kuery-query-api.md` — external reference: endpoints, auth, fields, relation **impact directions**, examples.

## External access
Works **today** with an OIDC bearer token through the existing hub provider proxy (`/services/providers/kuery/api/query`) — the proxy injects the tenant scope from the verified identity and strips any client-supplied tenant header, so a caller can never query another tenant.

**Follow-up (flagged, not in this PR):** non-interactive **service-account-token** auth. `IdentifyUser` currently handles OIDC + static tokens but not kcp SA tokens; making SA tokens work needs the hub to resolve the token's `clusterName` → workspace path (via the LogicalCluster `kcp.io/path` annotation) before injecting the tenant. That's a security-sensitive change to the hub identity layer, best reviewed on its own.

## Test
- Provider `go build ./...` + `go test ./...` green; `/api/query-schema` JSON validated.
- Portal `tsc --noEmit` + `vite build` clean; codemirror vendored via `npm run build` (so CI embeds it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
