### PR TITLE
feat(kedge-release): register kuery and app-studio release lines

### DIFF
--- a/cmd/kedge-release/main.go
+++ b/cmd/kedge-release/main.go
@@ -60,11 +60,13 @@ type component struct {
 	triggers string
 }
 
-var componentOrder = []string{"hub", "quickstart", "infrastructure", "code"}
+var componentOrder = []string{"hub", "quickstart", "kuery", "app-studio", "infrastructure", "code"}
 
 var components = map[string]component{
 	"hub":            {"v", "goreleaser CLI release + hub/agent/provider images + Helm charts (ghcr.io/faroshq)"},
 	"quickstart":     {"providers/quickstart/v", "split → faroshq/provider-quickstart; the mirror builds its image + chart"},
+	"kuery":          {"providers/kuery/v", "split → faroshq/provider-kuery; the mirror builds its image + chart"},
+	"app-studio":     {"providers/app-studio/v", "split → faroshq/provider-app-studio; the mirror builds its image + chart"},
 	"infrastructure": {"providers/infrastructure/v", "tag only — no split/release workflow wired up yet"},
 	"code":           {"providers/code/v", "tag only — no split/release workflow wired up yet"},
 }


### PR DESCRIPTION
## What

`kedge-release` could not tag the `kuery` and `app-studio` providers because they were never registered in the tool's hard-coded `components` map — only `hub`, `quickstart`, `infrastructure`, and `code` were known. As a result they did not appear as release providers in `kedge-release all`.

This adds both to `componentOrder` and the `components` map, using the same `providers/<name>/v*` tag prefix scheme as `quickstart`.

## Why this is safe

Both providers are already fully wired for release; only the tagging helper was missing them:
- `providers/kuery/` and `providers/app-studio/` are full providers (Dockerfile + manifest)
- `.github/workflows/split-kuery.yaml` triggers on `providers/kuery/v*`
- `.github/workflows/split-app-studio.yaml` triggers on `providers/app-studio/v*`

## Verification

`kedge-release all --dry-run` now lists both lines, each starting at `providers/<name>/v0.0.1`:

```
kuery           (none)  ->  providers/kuery/v0.0.1
app-studio      (none)  ->  providers/app-studio/v0.0.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)