### PR TITLE
feat(admin): show workspaces and enabled providers per org in /bonkers

### DIFF
--- a/pkg/hub/admin/handler.go
+++ b/pkg/hub/admin/handler.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,9 +92,18 @@ func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
 }
 
 type orgDTO struct {
-	Name          string `json:"name"`
-	DisplayName   string `json:"displayName"`
-	WorkspacePath string `json:"workspacePath"`
+	Name          string         `json:"name"`
+	DisplayName   string         `json:"displayName"`
+	WorkspacePath string         `json:"workspacePath"`
+	Workspaces    []workspaceDTO `json:"workspaces"`
+}
+
+type workspaceDTO struct {
+	UUID                string   `json:"uuid"`
+	DisplayName         string   `json:"displayName"`
+	ClusterName         string   `json:"clusterName"`
+	Providers           []string `json:"providers"`
+	DeletionRequestedAt *string  `json:"deletionRequestedAt,omitempty"`
 }
 
 func (h *Handler) listOrganizations(w http.ResponseWriter, r *http.Request) {
@@ -105,11 +115,34 @@ func (h *Handler) listOrganizations(w http.ResponseWriter, r *http.Request) {
 	items := make([]orgDTO, 0, len(list.Items))
 	for i := range list.Items {
 		o := &list.Items[i]
-		items = append(items, orgDTO{
+		dto := orgDTO{
 			Name:          o.Name,
 			DisplayName:   o.Spec.DisplayName,
 			WorkspacePath: o.Status.WorkspacePath,
-		})
+			Workspaces:    []workspaceDTO{},
+		}
+		// Best-effort: enumerate the org's child workspaces and their
+		// enabled providers. An org whose workspace tree can't be read
+		// (e.g. mid-provisioning) still renders with an empty list.
+		if wss, err := h.svc.ListOrgWorkspaces(r.Context(), o.Name); err == nil {
+			for _, ws := range wss {
+				wd := workspaceDTO{
+					UUID:        ws.UUID,
+					DisplayName: ws.DisplayName,
+					ClusterName: ws.ClusterName,
+					Providers:   ws.Providers,
+				}
+				if wd.Providers == nil {
+					wd.Providers = []string{}
+				}
+				if ws.DeletionRequestedAt != nil {
+					s := ws.DeletionRequestedAt.UTC().Format(time.RFC3339)
+					wd.DeletionRequestedAt = &s
+				}
+				dto.Workspaces = append(dto.Workspaces, wd)
+			}
+		}
+		items = append(items, dto)
 	}
 	writeJSON(w, map[string]any{"items": items})
 }

--- a/pkg/hub/admin/service.go
+++ b/pkg/hub/admin/service.go
@@ -25,6 +25,8 @@ package admin
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/faroshq/faros-kedge/pkg/apiurl"
+	"github.com/faroshq/faros-kedge/pkg/hub/kcp"
 	"github.com/faroshq/faros-kedge/pkg/hub/providers"
 	"github.com/faroshq/faros-kedge/pkg/kcppaths"
 )
@@ -146,6 +149,10 @@ type Service struct {
 	// kcpConfig is the admin kcp rest.Config (used for cross-workspace reads
 	// like root-identity discovery).
 	kcpConfig *rest.Config
+	// bootstrapper walks the tenant workspace hierarchy with kcp-admin
+	// credentials so the admin surface can enumerate every org's child
+	// workspaces and their enabled provider bindings.
+	bootstrapper *kcp.Bootstrapper
 }
 
 // NewService returns an admin Service. hubExternalURL/providerInternalURL are
@@ -154,9 +161,58 @@ type Service struct {
 // Provider CR reconciler.
 func NewService(kcpConfig *rest.Config, _, _ string) *Service {
 	return &Service{
-		prov:      providers.NewProvisioner(kcpConfig),
-		kcpConfig: kcpConfig,
+		prov:         providers.NewProvisioner(kcpConfig),
+		kcpConfig:    kcpConfig,
+		bootstrapper: kcp.NewBootstrapper(kcpConfig),
 	}
+}
+
+// OrgWorkspace is a child Workspace of an organization together with the
+// provider names enabled in it (derived from the workspace's provider
+// APIBindings).
+type OrgWorkspace struct {
+	UUID                string     `json:"uuid"`
+	DisplayName         string     `json:"displayName"`
+	ClusterName         string     `json:"clusterName"`
+	Providers           []string   `json:"providers"`
+	DeletionRequestedAt *time.Time `json:"deletionRequestedAt,omitempty"`
+}
+
+// ListOrgWorkspaces returns every child Workspace under the org at
+// root:kedge:tenants:{orgUUID}, enriched with display name, cluster name,
+// soft-delete timestamp and the set of enabled provider names. Reads run
+// with kcp-admin credentials, so the admin surface sees all workspaces
+// regardless of per-user RBAC. Per-workspace lookups are best-effort: a
+// workspace that hasn't reached Ready (no cluster) or whose provider
+// listing fails still appears with whatever fields resolved.
+func (s *Service) ListOrgWorkspaces(ctx context.Context, orgUUID string) ([]OrgWorkspace, error) {
+	names, err := s.bootstrapper.ListChildWorkspaces(ctx, orgUUID)
+	if err != nil {
+		return nil, fmt.Errorf("listing child workspaces for org %s: %w", orgUUID, err)
+	}
+	out := make([]OrgWorkspace, 0, len(names))
+	for _, wsUUID := range names {
+		ws := OrgWorkspace{UUID: wsUUID, Providers: []string{}}
+		if dn, err := s.bootstrapper.GetWorkspaceDisplayName(ctx, orgUUID, wsUUID); err == nil {
+			ws.DisplayName = dn
+		}
+		if cluster, err := s.bootstrapper.GetChildWorkspaceClusterName(ctx, orgUUID, wsUUID); err == nil {
+			ws.ClusterName = cluster
+		}
+		if t, found, err := s.bootstrapper.GetWorkspaceDeletionRequestedAt(ctx, orgUUID, wsUUID); err == nil && found && t != nil {
+			tt := *t
+			ws.DeletionRequestedAt = &tt
+		}
+		if bindings, err := s.bootstrapper.ListProviderAPIBindings(ctx, orgUUID, wsUUID); err == nil {
+			for name := range bindings {
+				ws.Providers = append(ws.Providers, name)
+			}
+			sort.Strings(ws.Providers)
+		}
+		out = append(out, ws)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].UUID < out[j].UUID })
+	return out, nil
 }
 
 // OnboardedWorkspace mirrors providers.OnboardedWorkspace for the admin API.

--- a/portal/src/pages/bonkers/OrgsSection.vue
+++ b/portal/src/pages/bonkers/OrgsSection.vue
@@ -7,25 +7,77 @@ const admin = useAdminStore()
 <template>
   <section>
     <h2 class="mb-1 text-base font-semibold text-text-primary">Organizations</h2>
-    <p class="mb-4 text-sm text-text-muted">All organizations registered on the hub.</p>
-    <table class="w-full text-sm">
-      <thead class="text-left text-[11px] uppercase text-text-muted">
-        <tr>
-          <th class="py-1 pr-4">Display name</th>
-          <th class="py-1 pr-4">UUID</th>
-          <th class="py-1">Workspace path</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="o in admin.orgs" :key="o.name" class="border-t border-border-subtle/50">
-          <td class="py-1.5 pr-4 text-text-primary">{{ o.displayName || '—' }}</td>
-          <td class="py-1.5 pr-4 font-mono text-[11px] text-text-muted">{{ o.name }}</td>
-          <td class="py-1.5 text-text-muted">{{ o.workspacePath || '—' }}</td>
-        </tr>
-        <tr v-if="!admin.orgs.length && !admin.loading">
-          <td colspan="3" class="py-3 text-text-muted">No organizations found.</td>
-        </tr>
-      </tbody>
-    </table>
+    <p class="mb-4 text-sm text-text-muted">
+      All organizations registered on the hub, with their workspaces and enabled providers.
+    </p>
+
+    <div v-if="!admin.orgs.length && !admin.loading" class="text-sm text-text-muted">
+      No organizations found.
+    </div>
+
+    <div class="space-y-4">
+      <div
+        v-for="o in admin.orgs"
+        :key="o.name"
+        class="rounded-lg border border-border-subtle/60 p-4"
+      >
+        <!-- Org header -->
+        <div class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span class="text-sm font-semibold text-text-primary">{{ o.displayName || '—' }}</span>
+          <span class="font-mono text-[11px] text-text-muted">{{ o.name }}</span>
+          <span v-if="o.workspacePath" class="font-mono text-[11px] text-text-muted">
+            {{ o.workspacePath }}
+          </span>
+        </div>
+
+        <!-- Workspaces -->
+        <table class="w-full text-sm">
+          <thead class="text-left text-[11px] uppercase text-text-muted">
+            <tr>
+              <th class="py-1 pr-4">Workspace</th>
+              <th class="py-1 pr-4">UUID</th>
+              <th class="py-1 pr-4">Cluster</th>
+              <th class="py-1">Providers</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="ws in o.workspaces"
+              :key="ws.uuid"
+              class="border-t border-border-subtle/40"
+              :class="{ 'opacity-50': ws.deletionRequestedAt }"
+            >
+              <td class="py-1.5 pr-4 text-text-primary">
+                {{ ws.displayName || '—' }}
+                <span
+                  v-if="ws.deletionRequestedAt"
+                  class="ml-1 text-[10px] uppercase text-red-500"
+                  >deleting</span
+                >
+              </td>
+              <td class="py-1.5 pr-4 font-mono text-[11px] text-text-muted">{{ ws.uuid }}</td>
+              <td class="py-1.5 pr-4 font-mono text-[11px] text-text-muted">
+                {{ ws.clusterName || '—' }}
+              </td>
+              <td class="py-1.5">
+                <div v-if="ws.providers.length" class="flex flex-wrap gap-1">
+                  <span
+                    v-for="p in ws.providers"
+                    :key="p"
+                    class="rounded border border-border-subtle bg-surface-overlay px-1.5 py-0.5 text-[11px] text-text-secondary"
+                  >
+                    {{ p }}
+                  </span>
+                </div>
+                <span v-else class="text-[11px] text-text-muted">—</span>
+              </td>
+            </tr>
+            <tr v-if="!o.workspaces.length">
+              <td colspan="4" class="py-2 text-[11px] text-text-muted">No workspaces.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </section>
 </template>

--- a/portal/src/stores/admin.ts
+++ b/portal/src/stores/admin.ts
@@ -26,10 +26,18 @@ export interface AdminUser {
   displayName: string
   rbacIdentity: string
 }
+export interface AdminWorkspace {
+  uuid: string
+  displayName: string
+  clusterName: string
+  providers: string[]
+  deletionRequestedAt?: string
+}
 export interface AdminOrg {
   name: string
   displayName: string
   workspacePath: string
+  workspaces: AdminWorkspace[]
 }
 export interface AdminProvider {
   name: string


### PR DESCRIPTION
## What

The admin portal (`/bonkers`) Organizations view only listed orgs as flat rows. This adds, under each org, its **workspaces** (display name, UUID, cluster) and the **providers enabled** in each workspace.

## Changes

### Backend
- **`pkg/hub/admin/service.go`** — the admin `Service` gains a `*kcp.Bootstrapper` (built from the existing admin `kcpConfig`) and a new `ListOrgWorkspaces(ctx, orgUUID)` helper. It walks `root:kedge:tenants:{orgUUID}` via `ListChildWorkspaces`, then per child resolves display name, cluster name, soft-delete timestamp, and enabled providers (from `ListProviderAPIBindings` — the same source the per-workspace sidebar uses). Per-workspace lookups are best-effort so a mid-provisioning workspace still renders.
- **`pkg/hub/admin/handler.go`** — `orgDTO` now carries a `workspaces` array (`uuid`, `displayName`, `clusterName`, `providers`, `deletionRequestedAt`); `listOrganizations` populates it per org.

### Frontend
- **`portal/src/stores/admin.ts`** — added `AdminWorkspace` and a `workspaces` field on `AdminOrg`. Rides the existing `/api/admin/organizations` fetch — no new request.
- **`portal/src/pages/bonkers/OrgsSection.vue`** — replaced the flat table with one card per org (display name + UUID + workspace path), each containing a workspaces table: Workspace, UUID, Cluster, and Providers as chips. Soft-deleting workspaces are dimmed with a "deleting" tag.

## Notes
- The org-list endpoint now does N+ kcp reads per org (one list + a few gets per workspace). Fine for an admin screen; could be parallelized or lazy-loaded on expand if org/workspace counts grow.

## Verification
- `go build ./pkg/... ./cmd/...` passes.
- `vue-tsc -b --force` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)