### PR TITLE
fix(hub): make provider Enable tolerate in-flight APIExport creation

### DIFF
--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -1430,6 +1430,13 @@ func (b *Bootstrapper) exportClaimIdentities(ctx context.Context, exportPath, ex
 	out := map[string]string{}
 	lookup := func(ctx context.Context) (bool, error) {
 		ex, err := exportClient.Resource(apiExportGVR).Get(ctx, exportName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			// The export itself doesn't exist yet. After the bootstrap split the
+			// provider's own init (Helm init-container) creates the APIExport, and
+			// that races a tenant clicking Enable — so keep polling until it
+			// appears rather than hard-failing the whole Enable on the first miss.
+			return false, nil
+		}
 		if err != nil {
 			return false, fmt.Errorf("getting APIExport %q in %s: %w", exportName, exportPath, err)
 		}
@@ -1458,7 +1465,7 @@ func (b *Bootstrapper) exportClaimIdentities(ctx context.Context, exportPath, ex
 	// immediate=true returns on the first hit in the common case where the
 	// export is already fully provisioned; otherwise poll until it is.
 	if err := wait.PollUntilContextTimeout(ctx, time.Second, 90*time.Second, true, lookup); err != nil {
-		return nil, fmt.Errorf("APIExport %q (%s) permissionClaims not yet stamped with identityHashes by the provisioner: %w", exportName, exportPath, err)
+		return nil, fmt.Errorf("APIExport %q (%s) not yet created, or its permissionClaims not yet stamped with identityHashes, by the provider init: %w", exportName, exportPath, err)
 	}
 	return out, nil
 }

--- a/providers/infrastructure/init_cmd.go
+++ b/providers/infrastructure/init_cmd.go
@@ -64,6 +64,41 @@ func runInitCmd(ctx context.Context) error {
 		return fmt.Errorf("install CRDs: %w", err)
 	}
 
+	// dynCl targets the provider workspace (adminConfig.Host is retargeted from
+	// INFRASTRUCTURE_WORKSPACE_PATH). Reused for the APIExport shell, bind grant,
+	// and CatalogEntry self-registration below.
+	dynCl, err := dynamic.NewForConfig(adminConfig)
+	if err != nil {
+		return fmt.Errorf("dynamic client: %w", err)
+	}
+
+	// Materialize the APIExport shell BEFORE any APIExportEndpointSlice. The hub
+	// catalog controller used to create this; in the bootstrap split it is the
+	// provider init's job. It must exist first because the slice carries
+	// spec.export.path, which makes kcp's APIExportEndpointSlice admission resolve
+	// the export by path — a missing export surfaces as the misleading
+	// "no permission to bind to export" forbidden, not a NotFound.
+	//
+	// Empty spec.resources: PlatformSchemaInAPIExport (below) upserts the
+	// Templates entry once the CachedResource identityHash is ready, and the
+	// Template controller adds per-template entries at runtime. The secrets claim
+	// (built-in type → no identityHash) lets the provider read each tenant's
+	// cloud-credentials Secret; tenantScoped auto-accept is a CatalogEntry/Enable
+	// concept and is not part of the kcp APIExport spec.
+	log.Printf("init: materializing APIExport shell %q", apiExportName)
+	if err := sdkinstall.ApplyAPIExport(ctx, dynCl, apiExportName, nil, []sdkinstall.PermissionClaim{
+		{Resource: "secrets", Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		return fmt.Errorf("materialize APIExport: %w", err)
+	}
+
+	// Bind grant: let any authenticated tenant bind this APIExport from their own
+	// workspace. Applied before the slice so the export reference is fully wired.
+	log.Printf("init: applying APIExport bind grant")
+	if err := sdkinstall.ApplyBindGrant(ctx, dynCl, apiExportName); err != nil {
+		return fmt.Errorf("apply bind grant: %w", err)
+	}
+
 	// CachedResource MUST precede APIExport wiring: the APIExport's
 	// templates entry uses storage.virtual backed by an EndpointSlice
 	// over this CachedResource. Order = CachedResource → EndpointSlice
@@ -100,20 +135,6 @@ func runInitCmd(ctx context.Context) error {
 	log.Printf("init: registering platform schemas on APIExport (templates storage=%s)", storageLabel(templatesIdentityHash))
 	if err := install.PlatformSchemaInAPIExport(ctx, adminConfig, templatesIdentityHash); err != nil {
 		return fmt.Errorf("register APIExport schemas: %w", err)
-	}
-
-	// Bind grant: let any authenticated tenant bind this APIExport from their
-	// own workspace. The hub catalog controller used to create this; in the new
-	// bootstrap split it is the provider init's responsibility. adminConfig.Host
-	// already targets the provider workspace (retargeted from
-	// INFRASTRUCTURE_WORKSPACE_PATH), so the SDK call lands there.
-	log.Printf("init: applying APIExport bind grant")
-	dynCl, err := dynamic.NewForConfig(adminConfig)
-	if err != nil {
-		return fmt.Errorf("dynamic client for bind grant: %w", err)
-	}
-	if err := sdkinstall.ApplyBindGrant(ctx, dynCl, apiExportName); err != nil {
-		return fmt.Errorf("apply bind grant: %w", err)
 	}
 
 	// CatalogEntry self-registration: apply the provider's CatalogEntry into its


### PR DESCRIPTION
## Problem

Enabling a provider (e.g. `infrastructure`) failed with a 500:

```
APIExport "infrastructure.providers.kedge.faros.sh" (root:kedge:providers:infrastructure)
permissionClaims not yet stamped with identityHashes by the provisioner:
... apiexports.apis.kcp.io "infrastructure.providers.kedge.faros.sh" not found
```

After the bootstrap split the hub no longer creates provider APIExports — each
provider's own `init` does (Helm init-container / `make init-provider-*`). That
init runs async and **races** a tenant clicking Enable, so the export may not
exist yet when `EnsureProviderAPIBinding` looks up its claim identities.

## Fix

**Hub side** (`pkg/hub/kcp/bootstrap.go`):
- `exportClaimIdentities` returned the `Get`'s `NotFound` as an error, which made
  `wait.PollUntilContextTimeout` bail on the first miss instead of waiting — and
  the failure was wrapped in the misleading "not yet stamped with identityHashes"
  message. Now NotFound means "keep polling", so Enable waits up to 90s for the
  provider init to create the export (matching the function's stated intent).
- Reworded the timeout error to cover both not-created and not-stamped cases.

**Provider side** (`providers/infrastructure/init_cmd.go`):
- Materialize the APIExport shell (+ bind grant) at the **start** of init, before
  any APIExportEndpointSlice. The slice carries `spec.export.path` and admission
  resolves the export by path — a missing export otherwise surfaces as a
  misleading forbidden rather than a NotFound. `PlatformSchemaInAPIExport` still
  upserts the Templates entry later once the CachedResource identityHash is ready.

## Testing

- `go build ./pkg/hub/...` and `go build ./...` in `providers/infrastructure` both pass.
- Verified against the running Tilt cluster: after init completed, the
  `infrastructure.providers.kedge.faros.sh` APIExport, its `status.identityHash`,
  the `kedge:providers:bind:*` ClusterRole, and the runtime kubeconfig are all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)