### PR TITLE
fix(mcp): keep MCPServer Ready without connected edges

### DIFF
--- a/providers/mcp/controllers/controller.go
+++ b/providers/mcp/controllers/controller.go
@@ -156,20 +156,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	}
 	totalConnected := kubeConnected + linuxConnected
 
+	// The MCPServer is an aggregate endpoint: it serves regardless of how
+	// many edges currently match the selector. Tools simply report "no
+	// targets" when nothing is connected. So readiness reflects whether the
+	// endpoint is provisioned (URL + identity below), not the edge count.
+	// Connected-edge counts are informational and surfaced in the message
+	// and in status.KubernetesEdges / status.LinuxEdges.
 	readyCondition := metav1.Condition{
 		Type:               "Ready",
 		ObservedGeneration: srv.Generation,
 		LastTransitionTime: metav1.Now(),
-	}
-	if totalConnected > 0 {
-		readyCondition.Status = metav1.ConditionTrue
-		readyCondition.Reason = "EdgesConnected"
-		readyCondition.Message = fmt.Sprintf("%d edge(s) connected (kube=%d, linux=%d)",
-			totalConnected, kubeConnected, linuxConnected)
-	} else {
-		readyCondition.Status = metav1.ConditionFalse
-		readyCondition.Reason = "NoEdgesConnected"
-		readyCondition.Message = "No edges matching the selector are currently connected"
+		Status:             metav1.ConditionTrue,
+		Reason:             "EndpointReady",
+		Message: fmt.Sprintf("endpoint ready; %d edge(s) connected (kube=%d, linux=%d)",
+			totalConnected, kubeConnected, linuxConnected),
 	}
 
 	// Ensure the per-MCPServer ServiceAccount + long-lived (legacy) token

--- a/providers/mcp/controllers/controller.go
+++ b/providers/mcp/controllers/controller.go
@@ -187,8 +187,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	srv.Status.LinuxEdges = linuxConnected
 	srv.Status.TokenSecretRef = tokenRef
 
+	// Refresh the condition whenever any observable field drifts (status,
+	// reason, message or the observed generation) so the edge counts and
+	// ObservedGeneration don't go stale as edges connect/disconnect. Keep
+	// LastTransitionTime stable unless Status actually flips — per the
+	// metav1.Condition contract, transition time tracks Status changes only.
 	if existing := findCondition(srv.Status.Conditions, "Ready"); existing == nil ||
-		existing.Status != readyCondition.Status || existing.Reason != readyCondition.Reason {
+		existing.Status != readyCondition.Status ||
+		existing.Reason != readyCondition.Reason ||
+		existing.Message != readyCondition.Message ||
+		existing.ObservedGeneration != readyCondition.ObservedGeneration {
+		if existing != nil && existing.Status == readyCondition.Status {
+			readyCondition.LastTransitionTime = existing.LastTransitionTime
+		}
 		srv.Status.Conditions = setCondition(srv.Status.Conditions, readyCondition)
 	}
 


### PR DESCRIPTION
## What

The MCPServer is an aggregate endpoint that serves regardless of how many edges currently match its `edgeSelector`. Its tools simply report "no targets" when nothing is connected.

Previously the `Ready` condition was gated on the connected edge count, so a freshly-created MCPServer (or one whose edges briefly disconnect) reported `Ready=False` / `NoEdgesConnected` — which reads as broken/pending even though the endpoint is fully provisioned and serving.

## Change

- `Ready` now reflects **endpoint provisioning** (URL + identity), so it stays `True` even with zero connected edges (reason `EndpointReady`).
- Connected-edge counts are demoted to the condition message and remain available in `status.KubernetesEdges` / `status.LinuxEdges`.
- The `edgeSelector` is **unchanged** — it still scopes which edges the server aggregates.

## Test plan

- [x] `go build ./providers/mcp/...`
- [ ] Create an MCPServer with no matching edges → condition shows `Ready=True`, reason `EndpointReady`, counts `kube=0, linux=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)