### PR TITLE
Extract App Studio assistant engine seam

### DIFF
--- a/providers/app-studio/api/assistant_contract.go
+++ b/providers/app-studio/api/assistant_contract.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"time"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
@@ -40,6 +41,7 @@ type projectAssistantEngine interface {
 
 type projectAssistantRunRequest struct {
 	Identity                 identity
+	HTTPRequest              *http.Request
 	Client                   *asclient.Client
 	Project                  *aiv1alpha1.Project
 	Repository               *ProjectRepositoryView
@@ -50,6 +52,7 @@ type projectAssistantRunRequest struct {
 	History                  []store.Message
 	MCPBaseURL               string
 	MCPInsecureSkipTLSVerify bool
+	StreamCallbacks          projectAssistantStreamCallbacks
 }
 
 type projectAssistantRunResult struct {

--- a/providers/app-studio/api/assistant_engine.go
+++ b/providers/app-studio/api/assistant_engine.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "context"
+
+type projectChatCompletionAssistantEngine struct {
+	server *Server
+}
+
+func (e projectChatCompletionAssistantEngine) StreamProjectAssistant(
+	ctx context.Context,
+	req projectAssistantRunRequest,
+	sink projectAssistantEventSink,
+) (projectAssistantRunResult, error) {
+	_ = sink
+	if err := ctx.Err(); err != nil {
+		return projectAssistantRunResult{}, err
+	}
+	reply, err := e.server.runProjectAssistantChatLoop(ctx, req)
+	if err != nil {
+		return projectAssistantRunResult{}, err
+	}
+	return projectAssistantRunResult{Content: reply}, nil
+}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -308,11 +308,33 @@ func (s *Server) generateProjectAssistantStream(
 	if err != nil {
 		return "", err
 	}
-	repository := projectRepositoryView(ctx, c, p)
-	workspaceScope := projectWorkspaceScope(id, p.Name)
-	projectRepositoryRef := projectLinkedRepositoryRef(p)
-	messages := projectPromptMessages(p, repository, recent)
-	tools, toolsErr := s.loadProjectMCPTools(r, id, settings)
+	req := projectAssistantRunRequest{
+		Identity:                 id,
+		HTTPRequest:              r,
+		Client:                   c,
+		Project:                  p,
+		Repository:               projectRepositoryView(ctx, c, p),
+		WorkspaceScope:           projectWorkspaceScope(id, p.Name),
+		Workspace:                s.workspaces,
+		MessageScope:             projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name),
+		LLM:                      settings,
+		History:                  recent,
+		MCPBaseURL:               s.hubBase,
+		MCPInsecureSkipTLSVerify: s.mcpInsecureSkipTLSVerify,
+		StreamCallbacks:          callbacks,
+	}
+	result, err := projectChatCompletionAssistantEngine{server: s}.StreamProjectAssistant(ctx, req, nil)
+	if err != nil {
+		return "", err
+	}
+	return result.Content, nil
+}
+
+func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAssistantRunRequest) (string, error) {
+	settings := req.LLM
+	projectRepositoryRef := projectLinkedRepositoryRef(req.Project)
+	messages := projectPromptMessages(req.Project, req.Repository, req.History)
+	tools, toolsErr := s.loadProjectMCPTools(req.HTTPRequest, req.Identity, settings)
 	if toolsErr == nil {
 		if toolPrompt := projectMCPToolsPrompt(tools); toolPrompt != "" {
 			messages = append(messages, chatMessage{
@@ -357,7 +379,7 @@ func (s *Server) generateProjectAssistantStream(
 		}
 		maybeInjectGoogleThoughtSignature(settings, reqBody.Messages)
 
-		reply, err := callProjectChatCompletionStream(ctx, settings, reqBody, callbacks.OnChunk, callbacks.OnStatus)
+		reply, err := callProjectChatCompletionStream(ctx, settings, reqBody, req.StreamCallbacks.OnChunk, req.StreamCallbacks.OnStatus)
 		if err != nil {
 			if repeatedToolLoop && errors.Is(err, errProjectLLMNoStreamedChoice) {
 				return projectRepeatedToolLoopFallback(lastToolMessages), nil
@@ -384,7 +406,7 @@ func (s *Server) generateProjectAssistantStream(
 				Role:      aiv1alpha1.ProjectMessageRoleAssistant,
 				ToolCalls: reply.ToolCalls,
 			})
-			nextMessages, callErr := s.resolveProjectToolCalls(ctx, id, workspaceScope, projectRepositoryRef, reply.ToolCalls, r, callbacks.OnToolCall)
+			nextMessages, callErr := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, reply.ToolCalls, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if callErr != nil {
 				return "", callErr
 			}
@@ -393,12 +415,12 @@ func (s *Server) generateProjectAssistantStream(
 
 			if commitReply, ok := projectCommitToolReply(nextMessages); ok {
 				logger.Info("project assistant completed a project commit handoff attempt; forcing a final text answer",
-					"turn", i, "project", p.Name)
+					"turn", i, "project", req.Project.Name)
 				return commitReply, nil
 			}
 			if repeated {
 				logger.Info("project assistant repeated an identical tool call across turns; forcing a final text answer",
-					"turn", i, "project", p.Name)
+					"turn", i, "project", req.Project.Name)
 				forceTextAnswer = true
 				repeatedToolLoop = true
 			}


### PR DESCRIPTION
## Summary

- Add the current chat-completion assistant engine behind App Studio's private projectAssistantEngine contract.
- Move request assembly into projectAssistantRunRequest and keep generateProjectAssistantStream as the existing adapter.
- Preserve current tool loop, SSE callbacks, MCP tool loading, and commit handoff behavior without adding Eino runtime behavior.

## Verification

- cd providers/app-studio && go test ./api -run 'TestGenerateProjectAssistantStream|TestResolveProjectToolCalls|TestProjectTool' -count=1
- cd providers/app-studio && go test ./... -count=1
- git diff --check
- Independent review: no findings; checked current-engine naming and no legacy/backcompat engine path.

## Stack

PR 2 of the App Studio Eino harness stack. Base is PR 1: #298.