### PR TITLE
Add App Studio assistant event backbone

### DIFF
--- a/providers/app-studio/api/assistant_contract.go
+++ b/providers/app-studio/api/assistant_contract.go
@@ -94,12 +94,14 @@ const (
 )
 
 type projectAssistantToolCall struct {
-	ID      string          `json:"id"`
-	Name    string          `json:"name"`
-	Status  string          `json:"status,omitempty"`
-	Summary string          `json:"summary,omitempty"`
-	Input   json.RawMessage `json:"input,omitempty"`
-	Result  json.RawMessage `json:"result,omitempty"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Status    string          `json:"status,omitempty"`
+	Arguments string          `json:"arguments,omitempty"`
+	Summary   string          `json:"summary,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Result    json.RawMessage `json:"result,omitempty"`
 }
 
 type projectAssistantPermission struct {

--- a/providers/app-studio/api/assistant_events.go
+++ b/providers/app-studio/api/assistant_events.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "context"
+
+type projectAssistantStreamWriter struct {
+	assistantID string
+	write       func(projectMessageStreamEvent) error
+}
+
+func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
+	ctx context.Context,
+	event projectAssistantEvent,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	switch event.Type {
+	case projectAssistantEventMessageDelta:
+		if event.Delta == "" {
+			return nil
+		}
+		return w.write(projectMessageStreamEvent{
+			Type:               "chunk",
+			AssistantMessageID: w.assistantID,
+			Content:            event.Delta,
+		})
+	case projectAssistantEventStatus:
+		if event.Status == "" {
+			return nil
+		}
+		return w.write(projectMessageStreamEvent{
+			Type:   "status",
+			Status: event.Status,
+		})
+	case projectAssistantEventToolCallStarted, projectAssistantEventToolCallFinished:
+		if event.ToolCall == nil || event.ToolCall.ID == "" || event.ToolCall.Status == "" {
+			return nil
+		}
+		toolCall := event.ToolCall.streamEvent()
+		return w.write(projectMessageStreamEvent{
+			Type:               "tool_call",
+			AssistantMessageID: w.assistantID,
+			ToolCall:           &toolCall,
+		})
+	case projectAssistantEventRunFailed:
+		if event.Error == "" {
+			return nil
+		}
+		return w.write(projectMessageStreamEvent{
+			Type:  "error",
+			Error: event.Error,
+		})
+	case projectAssistantEventRunFinished:
+		return w.write(projectMessageStreamEvent{
+			Type:               "done",
+			AssistantMessageID: w.assistantID,
+		})
+	default:
+		return nil
+	}
+}
+
+func (tc projectAssistantToolCall) streamEvent() projectToolCallStreamEvent {
+	return projectToolCallStreamEvent{
+		ID:        tc.ID,
+		Name:      tc.Name,
+		Status:    tc.Status,
+		Arguments: tc.Arguments,
+		Summary:   tc.Summary,
+		Error:     tc.Error,
+	}
+}

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestProjectAssistantStreamWriterMapsDeltaToChunk(t *testing.T) {
+	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
+		Type:  projectAssistantEventMessageDelta,
+		Delta: "hello",
+	})
+	if err != nil {
+		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Type != "chunk" || got[0].Content != "hello" || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("events = %#v, want one assistant chunk event", got)
+	}
+}
+
+func TestProjectAssistantStreamWriterMapsStatus(t *testing.T) {
+	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
+		Type:   projectAssistantEventStatus,
+		Status: "Preparing action",
+	})
+	if err != nil {
+		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Type != "status" || got[0].Status != "Preparing action" || got[0].AssistantMessageID != "" {
+		t.Fatalf("events = %#v, want one status event without assistant id", got)
+	}
+}
+
+func TestProjectAssistantStreamWriterMapsToolCall(t *testing.T) {
+	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
+		Type: projectAssistantEventToolCallFinished,
+		ToolCall: &projectAssistantToolCall{
+			ID:        "tool-1",
+			Name:      "write_file",
+			Status:    "succeeded",
+			Summary:   "Wrote src/App.tsx",
+			Arguments: `{"path":"src/App.tsx"}`,
+			Error:     "warning only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Type != "tool_call" || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("events = %#v, want one assistant tool_call event", got)
+	}
+	if got[0].ToolCall == nil {
+		t.Fatalf("tool call event omitted payload: %#v", got[0])
+	}
+	if got[0].ToolCall.ID != "tool-1" || got[0].ToolCall.Name != "write_file" || got[0].ToolCall.Status != "succeeded" || got[0].ToolCall.Arguments != `{"path":"src/App.tsx"}` || got[0].ToolCall.Error != "warning only" {
+		t.Fatalf("tool call = %#v, want preserved current SSE payload", got[0].ToolCall)
+	}
+}
+
+func TestProjectAssistantStreamWriterMapsTerminalEvents(t *testing.T) {
+	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
+		Type:  projectAssistantEventRunFailed,
+		Error: "boom",
+	}, projectAssistantEvent{
+		Type: projectAssistantEventRunFinished,
+	})
+	if err != nil {
+		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("events = %#v, want error and done", got)
+	}
+	if got[0].Type != "error" || got[0].Error != "boom" {
+		t.Fatalf("first event = %#v, want error", got[0])
+	}
+	if got[1].Type != "done" || got[1].AssistantMessageID != "assistant-1" {
+		t.Fatalf("second event = %#v, want assistant done", got[1])
+	}
+}
+
+func TestProjectAssistantStreamWriterHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	writer := projectAssistantStreamWriter{write: func(projectMessageStreamEvent) error {
+		t.Fatal("write should not run after context cancellation")
+		return nil
+	}}
+	if err := writer.EmitProjectAssistantEvent(ctx, projectAssistantEvent{
+		Type:  projectAssistantEventMessageDelta,
+		Delta: "hello",
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("EmitProjectAssistantEvent error = %v, want context.Canceled", err)
+	}
+}
+
+func collectProjectAssistantStreamEvents(events ...projectAssistantEvent) ([]projectMessageStreamEvent, error) {
+	var got []projectMessageStreamEvent
+	writer := projectAssistantStreamWriter{
+		assistantID: "assistant-1",
+		write: func(event projectMessageStreamEvent) error {
+			got = append(got, event)
+			return nil
+		},
+	}
+	for _, event := range events {
+		if err := writer.EmitProjectAssistantEvent(context.Background(), event); err != nil {
+			return nil, err
+		}
+	}
+	return got, nil
+}

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -511,6 +511,18 @@ func (s *Server) streamProjectAssistant(
 	var streamErr error
 	var streamedToolCalls []projectToolCallStreamEvent
 	scope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
+	streamWriter := projectAssistantStreamWriter{
+		assistantID: assistantID,
+		write: func(event projectMessageStreamEvent) error {
+			return writeProjectMessageStreamEvent(w, flusher, event)
+		},
+	}
+	emitAssistantEvent := func(event projectAssistantEvent) {
+		if streamErr != nil {
+			return
+		}
+		streamErr = streamWriter.EmitProjectAssistantEvent(r.Context(), event)
+	}
 
 	streamChunk := func(chunk string) {
 		if streamErr != nil {
@@ -520,10 +532,9 @@ func (s *Server) streamProjectAssistant(
 			return
 		}
 		assistantContent.WriteString(chunk)
-		streamErr = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:               "chunk",
-			AssistantMessageID: assistantID,
-			Content:            chunk,
+		emitAssistantEvent(projectAssistantEvent{
+			Type:  projectAssistantEventMessageDelta,
+			Delta: chunk,
 		})
 	}
 	streamStatus := func(status string) {
@@ -533,8 +544,8 @@ func (s *Server) streamProjectAssistant(
 		if status == "" {
 			return
 		}
-		streamErr = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:   "status",
+		emitAssistantEvent(projectAssistantEvent{
+			Type:   projectAssistantEventStatus,
 			Status: status,
 		})
 	}
@@ -546,10 +557,16 @@ func (s *Server) streamProjectAssistant(
 			return
 		}
 		streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, toolCall)
-		streamErr = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:               "tool_call",
-			AssistantMessageID: assistantID,
-			ToolCall:           &toolCall,
+		emitAssistantEvent(projectAssistantEvent{
+			Type: projectAssistantEventToolCallFinished,
+			ToolCall: &projectAssistantToolCall{
+				ID:        toolCall.ID,
+				Name:      toolCall.Name,
+				Status:    toolCall.Status,
+				Arguments: toolCall.Arguments,
+				Summary:   toolCall.Summary,
+				Error:     toolCall.Error,
+			},
 		})
 	}
 
@@ -562,8 +579,8 @@ func (s *Server) streamProjectAssistant(
 		if shouldPersistInterruptedProjectAssistant(r.Context(), err, streamErr, assistantContent.String()) {
 			persistErr := appendInterruptedProjectAssistantMessage(r.Context(), msgStore, scope, assistantID, assistantContent.String())
 			if persistErr != nil && streamErr == nil {
-				_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-					Type:  "error",
+				_ = streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{
+					Type:  projectAssistantEventRunFailed,
 					Error: "assistant persistence failed: " + persistErr.Error(),
 				})
 			}
@@ -574,14 +591,14 @@ func (s *Server) streamProjectAssistant(
 			return
 		}
 		if errors.Is(err, errProjectLLMNotConfigured) {
-			_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-				Type:  "error",
+			_ = streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{
+				Type:  projectAssistantEventRunFailed,
 				Error: err.Error(),
 			})
 			return
 		}
-		_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:  "error",
+		_ = streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{
+			Type:  projectAssistantEventRunFailed,
 			Error: "assistant generation failed: " + err.Error(),
 		})
 		return
@@ -592,8 +609,8 @@ func (s *Server) streamProjectAssistant(
 	}
 	assistantReply := projectAssistantStoredContent(reply, assistantContent.String())
 	if strings.TrimSpace(assistantReply) == "" {
-		_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:  "error",
+		_ = streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{
+			Type:  projectAssistantEventRunFailed,
 			Error: "assistant generation returned an empty response",
 		})
 		return
@@ -607,16 +624,13 @@ func (s *Server) streamProjectAssistant(
 	}
 
 	if err := appendProjectAssistantMessage(r.Context(), msgStore, scope, assistantID, assistantReply, projectAssistantMessageMetadata("", streamedToolCalls)); err != nil {
-		_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:  "error",
+		_ = streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{
+			Type:  projectAssistantEventRunFailed,
 			Error: "assistant persistence failed: " + err.Error(),
 		})
 		return
 	}
-	if err := writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-		Type:               "done",
-		AssistantMessageID: assistantID,
-	}); err != nil {
+	if err := streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{Type: projectAssistantEventRunFinished}); err != nil {
 		return
 	}
 }


### PR DESCRIPTION
## Summary

- Add a typed assistant event writer that maps internal assistant events to the existing SSE wire shape.
- Route current assistant chunk/status/tool/error/done writes through the event adapter without changing portal-facing event payloads.
- Preserve tool-call arguments, summaries, and errors, with focused tests for each SSE mapping.

## Verification

- cd providers/app-studio && go test ./api -run 'TestProjectAssistantStreamWriter|TestGenerateProjectAssistantStream|TestProjectAssistantMessageMetadataToolCalls|TestResolveProjectToolCalls' -count=1
- cd providers/app-studio && go test ./... -count=1
- cd providers/app-studio && go mod tidy -diff
- git diff --check
- Independent review: one non-blocking test suggestion, addressed by asserting tool-call Error preservation.

## Stack

PR 3 of the App Studio Eino harness stack. Base is PR 2: #299.