### PR TITLE
Introduce App Studio assistant tool registry

### DIFF
--- a/providers/app-studio/api/assistant_tool.go
+++ b/providers/app-studio/api/assistant_tool.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+type projectAssistantToolRisk string
+
+const (
+	projectAssistantToolRiskRead   projectAssistantToolRisk = "read"
+	projectAssistantToolRiskWrite  projectAssistantToolRisk = "write"
+	projectAssistantToolRiskCommit projectAssistantToolRisk = "commit"
+)
+
+type projectAssistantToolSpec struct {
+	Name        string
+	Description string
+	Parameters  json.RawMessage
+	Risk        projectAssistantToolRisk
+}
+
+func (s projectAssistantToolSpec) chatTool() chatTool {
+	return chatTool{
+		Type: "function",
+		Function: chatToolFunction{
+			Name:        s.Name,
+			Description: s.Description,
+			Parameters:  s.Parameters,
+		},
+	}
+}
+
+type projectAssistantToolCallRequest struct {
+	Identity             identity
+	WorkspaceScope       workspace.Scope
+	ProjectRepositoryRef string
+	MCPEndpoint          string
+	HTTPRequest          *http.Request
+	Arguments            map[string]any
+}
+
+type projectAssistantTool interface {
+	Spec() projectAssistantToolSpec
+	Call(context.Context, projectAssistantToolCallRequest) (string, error)
+}
+
+type projectAssistantToolFunc struct {
+	spec projectAssistantToolSpec
+	call func(context.Context, projectAssistantToolCallRequest) (string, error)
+}
+
+func (t projectAssistantToolFunc) Spec() projectAssistantToolSpec {
+	return t.spec
+}
+
+func (t projectAssistantToolFunc) Call(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+	if t.call == nil {
+		return "", fmt.Errorf("project assistant tool %q is not callable", t.spec.Name)
+	}
+	return t.call(ctx, req)
+}
+
+func projectAssistantToolJSONResult(out any, err error) (string, error) {
+	if err != nil {
+		return "", err
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return "", fmt.Errorf("encode local tool result: %w", err)
+	}
+	return string(raw), nil
+}

--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+type projectAssistantToolRegistry struct {
+	tools  []projectAssistantTool
+	byName map[string]projectAssistantTool
+}
+
+func newProjectAssistantToolRegistry(tools ...projectAssistantTool) projectAssistantToolRegistry {
+	byName := map[string]projectAssistantTool{}
+	ordered := make([]projectAssistantTool, 0, len(tools))
+	for _, tool := range tools {
+		if tool == nil {
+			continue
+		}
+		spec := tool.Spec()
+		key := projectAssistantToolKey(spec.Name)
+		if key == "" {
+			continue
+		}
+		if _, exists := byName[key]; exists {
+			continue
+		}
+		byName[key] = tool
+		ordered = append(ordered, tool)
+	}
+	return projectAssistantToolRegistry{tools: ordered, byName: byName}
+}
+
+func (r projectAssistantToolRegistry) Get(name string) (projectAssistantTool, bool) {
+	tool, ok := r.byName[projectAssistantToolKey(name)]
+	return tool, ok
+}
+
+func (r projectAssistantToolRegistry) Has(name string) bool {
+	_, ok := r.Get(name)
+	return ok
+}
+
+func (r projectAssistantToolRegistry) ChatTool(name string) (chatTool, bool) {
+	tool, ok := r.Get(name)
+	if !ok {
+		return chatTool{}, false
+	}
+	return tool.Spec().chatTool(), true
+}
+
+func (r projectAssistantToolRegistry) ChatTools(includeCommitBridge bool) []chatTool {
+	out := make([]chatTool, 0, len(r.tools))
+	for _, tool := range r.tools {
+		spec := tool.Spec()
+		if spec.Risk == projectAssistantToolRiskCommit && !includeCommitBridge {
+			continue
+		}
+		out = append(out, spec.chatTool())
+	}
+	return out
+}
+
+func projectAssistantToolKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func (s *Server) projectAssistantToolRegistry() projectAssistantToolRegistry {
+	return projectAssistantLocalToolRegistry(s)
+}
+
+func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegistry {
+	return newProjectAssistantToolRegistry(
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolListProjectFiles,
+				Description: "List files in the App Studio project workspace. Use this before editing an existing project.",
+				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"limit":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum number of file paths to return."}}}`, workspace.MaxListLimit)),
+				Risk:        projectAssistantToolRiskRead,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				return projectAssistantToolJSONResult(s.workspaces.ListFiles(ctx, req.WorkspaceScope, workspace.ListOptions{Limit: projectToolInt(req.Arguments["limit"])}))
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolReadProjectFile,
+				Description: "Read a bounded UTF-8 text file from the App Studio project workspace.",
+				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative file path."},"maxBytes":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum bytes to return."}},"required":["path"]}`, workspace.MaxReadMaxBytes)),
+				Risk:        projectAssistantToolRiskRead,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				return projectAssistantToolJSONResult(s.workspaces.ReadFile(ctx, req.WorkspaceScope, workspace.ReadOptions{
+					Path:     projectToolString(req.Arguments["path"]),
+					MaxBytes: projectToolInt(req.Arguments["maxBytes"]),
+				}))
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolSearchProjectFiles,
+				Description: "Search text files in the App Studio project workspace and return bounded path/fragments results.",
+				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"query":{"type":"string","description":"Text to search for."},"maxResults":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum matching files to return."}},"required":["query"]}`, workspace.MaxSearchLimit)),
+				Risk:        projectAssistantToolRiskRead,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				return projectAssistantToolJSONResult(s.workspaces.SearchFiles(ctx, req.WorkspaceScope, workspace.SearchOptions{
+					Query:      projectToolString(req.Arguments["query"]),
+					MaxResults: projectToolInt(req.Arguments["maxResults"]),
+				}))
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolWriteFile,
+				Description: "Write a complete UTF-8 text file into the App Studio project workspace.",
+				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative file path."},"content":{"type":"string","description":"Complete UTF-8 text content to write. Maximum %d bytes."}},"required":["path","content"]}`, workspace.MaxWriteBytes)),
+				Risk:        projectAssistantToolRiskWrite,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				content, _ := projectToolRawString(req.Arguments["content"])
+				return projectAssistantToolJSONResult(s.workspaces.WriteFile(ctx, req.WorkspaceScope, workspace.WriteOptions{
+					Path:    projectToolString(req.Arguments["path"]),
+					Content: content,
+				}))
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolApplyPatch,
+				Description: "Apply an exact text replacement to one App Studio workspace file. oldText must match exactly once unless replaceAll is true.",
+				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative file path."},"oldText":{"type":"string","description":"Exact text to replace. Maximum patch payload %d bytes with newText."},"newText":{"type":"string","description":"Replacement text."},"replaceAll":{"type":"boolean","description":"Replace every exact match instead of requiring one match."}},"required":["path","oldText","newText"]}`, workspace.MaxPatchBytes)),
+				Risk:        projectAssistantToolRiskWrite,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				oldText, _ := projectToolRawString(req.Arguments["oldText"])
+				newText, _ := projectToolRawString(req.Arguments["newText"])
+				return projectAssistantToolJSONResult(s.workspaces.ApplyPatch(ctx, req.WorkspaceScope, workspace.PatchOptions{
+					Path:       projectToolString(req.Arguments["path"]),
+					OldText:    oldText,
+					NewText:    newText,
+					ReplaceAll: projectToolBool(req.Arguments["replaceAll"]),
+				}))
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolMkdir,
+				Description: "Create a directory in the App Studio project workspace for later file writes.",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative directory path."}},"required":["path"]}`),
+				Risk:        projectAssistantToolRiskWrite,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				return projectAssistantToolJSONResult(s.workspaces.Mkdir(ctx, req.WorkspaceScope, workspace.MkdirOptions{Path: projectToolString(req.Arguments["path"])}))
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
+				Name:        projectToolCommitProjectFiles,
+				Description: "Commit selected App Studio workspace text files to the managed git source through the Code provider.",
+				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"repositoryRef":{"type":"string","description":"Managed Code provider Repository resource name."},"paths":{"type":"array","items":{"type":"string"},"minItems":1,"maxItems":%d,"description":"Project-relative workspace file paths to commit."},"message":{"type":"string","description":"Commit message."},"branch":{"type":"string","description":"Optional branch override."}},"required":["repositoryRef","paths"]}`, projectCommitProjectFilesMax)),
+				Risk:        projectAssistantToolRiskCommit,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				return s.commitProjectWorkspaceFiles(ctx, req.Identity, req.WorkspaceScope, req.ProjectRepositoryRef, req.MCPEndpoint, req.HTTPRequest, req.Arguments)
+			},
+		},
+	)
+}
+
+func projectAssistantToolServer(server *Server) (*Server, error) {
+	if server == nil || server.workspaces == nil {
+		return nil, errors.New("project workspace store is not configured")
+	}
+	return server, nil
+}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -1079,56 +1079,18 @@ func projectLinkedRepositoryRef(p *aiv1alpha1.Project) string {
 }
 
 func (s *Server) callProjectLocalTool(ctx context.Context, id identity, scope workspace.Scope, projectRepositoryRef, mcpEndpoint string, r *http.Request, name string, args map[string]any) (string, error) {
-	if s.workspaces == nil {
-		return "", errors.New("project workspace store is not configured")
+	tool, ok := s.projectAssistantToolRegistry().Get(name)
+	if !ok {
+		return "", fmt.Errorf("unknown local project tool %q", name)
 	}
-	var (
-		out any
-		err error
-	)
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case projectToolListProjectFiles:
-		out, err = s.workspaces.ListFiles(ctx, scope, workspace.ListOptions{Limit: projectToolInt(args["limit"])})
-	case projectToolReadProjectFile:
-		out, err = s.workspaces.ReadFile(ctx, scope, workspace.ReadOptions{
-			Path:     projectToolString(args["path"]),
-			MaxBytes: projectToolInt(args["maxBytes"]),
-		})
-	case projectToolSearchProjectFiles:
-		out, err = s.workspaces.SearchFiles(ctx, scope, workspace.SearchOptions{
-			Query:      projectToolString(args["query"]),
-			MaxResults: projectToolInt(args["maxResults"]),
-		})
-	case projectToolWriteFile:
-		content, _ := projectToolRawString(args["content"])
-		out, err = s.workspaces.WriteFile(ctx, scope, workspace.WriteOptions{
-			Path:    projectToolString(args["path"]),
-			Content: content,
-		})
-	case projectToolApplyPatch:
-		oldText, _ := projectToolRawString(args["oldText"])
-		newText, _ := projectToolRawString(args["newText"])
-		out, err = s.workspaces.ApplyPatch(ctx, scope, workspace.PatchOptions{
-			Path:       projectToolString(args["path"]),
-			OldText:    oldText,
-			NewText:    newText,
-			ReplaceAll: projectToolBool(args["replaceAll"]),
-		})
-	case projectToolMkdir:
-		out, err = s.workspaces.Mkdir(ctx, scope, workspace.MkdirOptions{Path: projectToolString(args["path"])})
-	case projectToolCommitProjectFiles:
-		return s.commitProjectWorkspaceFiles(ctx, id, scope, projectRepositoryRef, mcpEndpoint, r, args)
-	default:
-		err = fmt.Errorf("unknown local project tool %q", name)
-	}
-	if err != nil {
-		return "", err
-	}
-	raw, err := json.Marshal(out)
-	if err != nil {
-		return "", fmt.Errorf("encode local tool result: %w", err)
-	}
-	return string(raw), nil
+	return tool.Call(ctx, projectAssistantToolCallRequest{
+		Identity:             id,
+		WorkspaceScope:       scope,
+		ProjectRepositoryRef: projectRepositoryRef,
+		MCPEndpoint:          mcpEndpoint,
+		HTTPRequest:          r,
+		Arguments:            args,
+	})
 }
 
 func (s *Server) commitProjectWorkspaceFiles(ctx context.Context, id identity, scope workspace.Scope, projectRepositoryRef, mcpEndpoint string, r *http.Request, args map[string]any) (string, error) {
@@ -1554,7 +1516,8 @@ func (s *Server) loadProjectMCPTools(r *http.Request, id identity, settings proj
 	if id.tenantPath == "" {
 		return nil, errors.New("tenant context missing")
 	}
-	out := projectLocalChatTools(false)
+	registry := s.projectAssistantToolRegistry()
+	out := registry.ChatTools(false)
 	mcpEndpoint := s.mcpEndpoint(id.tenantPath)
 	tools, err := fetchProjectMCPTools(r.Context(), mcpEndpoint, r, id.tenantPath, s.mcpInsecureSkipTLSVerify)
 	if err != nil {
@@ -1573,77 +1536,11 @@ func (s *Server) loadProjectMCPTools(r *http.Request, id identity, settings proj
 		}
 	}
 	if codeCommitAvailable {
-		out = append(out, projectCommitProjectFilesChatTool())
+		if tool, ok := registry.ChatTool(projectToolCommitProjectFiles); ok {
+			out = append(out, tool)
+		}
 	}
 	return out, nil
-}
-
-func projectLocalChatTools(includeCommitBridge bool) []chatTool {
-	tools := []chatTool{
-		{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        projectToolListProjectFiles,
-				Description: "List files in the App Studio project workspace. Use this before editing an existing project.",
-				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"limit":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum number of file paths to return."}}}`, workspace.MaxListLimit)),
-			},
-		},
-		{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        projectToolReadProjectFile,
-				Description: "Read a bounded UTF-8 text file from the App Studio project workspace.",
-				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative file path."},"maxBytes":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum bytes to return."}},"required":["path"]}`, workspace.MaxReadMaxBytes)),
-			},
-		},
-		{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        projectToolSearchProjectFiles,
-				Description: "Search text files in the App Studio project workspace and return bounded path/fragments results.",
-				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"query":{"type":"string","description":"Text to search for."},"maxResults":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum matching files to return."}},"required":["query"]}`, workspace.MaxSearchLimit)),
-			},
-		},
-		{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        projectToolWriteFile,
-				Description: "Write a complete UTF-8 text file into the App Studio project workspace.",
-				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative file path."},"content":{"type":"string","description":"Complete UTF-8 text content to write. Maximum %d bytes."}},"required":["path","content"]}`, workspace.MaxWriteBytes)),
-			},
-		},
-		{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        projectToolApplyPatch,
-				Description: "Apply an exact text replacement to one App Studio workspace file. oldText must match exactly once unless replaceAll is true.",
-				Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative file path."},"oldText":{"type":"string","description":"Exact text to replace. Maximum patch payload %d bytes with newText."},"newText":{"type":"string","description":"Replacement text."},"replaceAll":{"type":"boolean","description":"Replace every exact match instead of requiring one match."}},"required":["path","oldText","newText"]}`, workspace.MaxPatchBytes)),
-			},
-		},
-		{
-			Type: "function",
-			Function: chatToolFunction{
-				Name:        projectToolMkdir,
-				Description: "Create a directory in the App Studio project workspace for later file writes.",
-				Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Project-relative directory path."}},"required":["path"]}`),
-			},
-		},
-	}
-	if includeCommitBridge {
-		tools = append(tools, projectCommitProjectFilesChatTool())
-	}
-	return tools
-}
-
-func projectCommitProjectFilesChatTool() chatTool {
-	return chatTool{
-		Type: "function",
-		Function: chatToolFunction{
-			Name:        projectToolCommitProjectFiles,
-			Description: "Commit selected App Studio workspace text files to the managed git source through the Code provider.",
-			Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"repositoryRef":{"type":"string","description":"Managed Code provider Repository resource name."},"paths":{"type":"array","items":{"type":"string"},"minItems":1,"maxItems":%d,"description":"Project-relative workspace file paths to commit."},"message":{"type":"string","description":"Commit message."},"branch":{"type":"string","description":"Optional branch override."}},"required":["repositoryRef","paths"]}`, projectCommitProjectFilesMax)),
-		},
-	}
 }
 
 // mcpEndpoint returns the hub's unified MCPServer virtual-workspace endpoint for
@@ -2223,12 +2120,7 @@ func projectToolAllowed(name string) bool {
 }
 
 func projectLocalToolAllowed(name string) bool {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case projectToolListProjectFiles, projectToolReadProjectFile, projectToolSearchProjectFiles, projectToolWriteFile, projectToolApplyPatch, projectToolMkdir, projectToolCommitProjectFiles:
-		return true
-	default:
-		return false
-	}
+	return projectAssistantLocalToolRegistry(nil).Has(name)
 }
 
 func projectMCPToolAllowed(_ string) bool {

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -106,6 +106,45 @@ func TestProjectToolAllowlistSeparatesWorkspaceAndGitTools(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantToolRegistryListsLocalToolsInOrder(t *testing.T) {
+	registry := projectAssistantLocalToolRegistry(nil)
+	got := projectChatToolNames(registry.ChatTools(false))
+	want := []string{
+		"list_project_files",
+		"read_project_file",
+		"search_project_files",
+		"write_file",
+		"apply_patch",
+		"mkdir",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+
+	all := projectChatToolNames(registry.ChatTools(true))
+	if len(all) != len(want)+1 || all[len(all)-1] != "commit_project_files" {
+		t.Fatalf("tool names with commit bridge = %v, want commit_project_files last", all)
+	}
+	if !registry.Has(" COMMIT_PROJECT_FILES ") {
+		t.Fatal("registry should match tool names case-insensitively")
+	}
+	tool, ok := registry.Get("write_file")
+	if !ok {
+		t.Fatal("write_file missing from registry")
+	}
+	if got := tool.Spec().Risk; got != projectAssistantToolRiskWrite {
+		t.Fatalf("write_file risk = %q, want %q", got, projectAssistantToolRiskWrite)
+	}
+}
+
+func projectChatToolNames(tools []chatTool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Function.Name)
+	}
+	return names
+}
+
 func TestLoadProjectMCPToolsExposesCommitBridgeOnly(t *testing.T) {
 	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var envelope struct {


### PR DESCRIPTION
## Summary

- Add App Studio-owned assistant tool specs, risk metadata, and an ordered local tool registry.
- Route local assistant tool execution through the registry while preserving workspace tools and the Code provider commit bridge.
- Keep raw provider-code tools hidden; expose only commit_project_files when code__commit_files is discoverable.

## Verification

- cd providers/app-studio && go test ./api -run 'TestProjectToolAllowlistSeparatesWorkspaceAndGitTools|TestProjectAssistantToolRegistryListsLocalToolsInOrder|TestLoadProjectMCPToolsExposesCommitBridgeOnly|TestResolveProjectToolCallsCommitsWorkspaceFilesThroughCodeProvider|TestResolveProjectToolCallsRejectsDirectCodeCommitFiles|TestCommitProjectWorkspaceFilesBoundsPayloadBeforeProviderCode' -count=1
- cd providers/app-studio && go test ./... -count=1
- cd providers/app-studio && go mod tidy -diff
- git diff --check
- Independent review: no findings; checked tool order, commit filtering, and provider-code boundary.

## Stack

PR 4 of the App Studio Eino harness stack. Base is PR 3: #300.