### PR TITLE
Add App Studio assistant permission resume flow

### DIFF
--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -1,0 +1,517 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	"github.com/faroshq/provider-app-studio/store"
+)
+
+type projectAssistantCheckpointState struct {
+	ToolCalls            []chatToolCall `json:"toolCalls"`
+	CurrentIndex         int            `json:"currentIndex"`
+	ProjectRepositoryRef string         `json:"projectRepositoryRef,omitempty"`
+}
+
+type projectAssistantResumeRequest struct {
+	RequestID       string         `json:"requestID"`
+	Decision        string         `json:"decision"`
+	EditedArguments map[string]any `json:"editedArguments,omitempty"`
+}
+
+type projectAssistantResumeResponse struct {
+	RunID      string                             `json:"runID"`
+	RequestID  string                             `json:"requestID"`
+	Status     store.AssistantRunStatus           `json:"status"`
+	Decision   projectAssistantPermissionDecision `json:"decision"`
+	ToolCall   *projectToolCallStreamEvent        `json:"toolCall,omitempty"`
+	Permission *projectAssistantPermission        `json:"permission,omitempty"`
+	Checkpoint *projectAssistantCheckpoint        `json:"checkpoint,omitempty"`
+	Result     string                             `json:"result,omitempty"`
+}
+
+type projectAssistantRunAudit struct {
+	Decisions []projectAssistantPermissionAudit `json:"decisions,omitempty"`
+}
+
+type projectAssistantPermissionAudit struct {
+	RequestID       string                             `json:"requestID"`
+	Decision        projectAssistantPermissionDecision `json:"decision"`
+	Actor           string                             `json:"actor,omitempty"`
+	ToolCallID      string                             `json:"toolCallID,omitempty"`
+	ToolName        string                             `json:"toolName,omitempty"`
+	EditedArguments map[string]any                     `json:"editedArguments,omitempty"`
+	Result          string                             `json:"result,omitempty"`
+	Error           string                             `json:"error,omitempty"`
+	ResolvedAt      time.Time                          `json:"resolvedAt"`
+}
+
+func newProjectAssistantRunID() string {
+	return "run-" + uuid.NewString()
+}
+
+func newProjectAssistantPermissionRequestID() string {
+	return "perm-" + uuid.NewString()
+}
+
+func (s *Server) saveProjectAssistantPermissionCheckpoint(
+	ctx context.Context,
+	req projectAssistantRunRequest,
+	tool projectAssistantTool,
+	tc chatToolCall,
+	args map[string]any,
+	projectRepositoryRef string,
+) (*projectAssistantPermissionRequiredError, projectAssistantPermission, projectAssistantCheckpoint, error) {
+	return s.saveProjectAssistantPermissionCheckpointForToolCalls(ctx, req, tool, []chatToolCall{tc}, 0, projectRepositoryRef)
+}
+
+func (s *Server) saveProjectAssistantPermissionCheckpointForToolCalls(
+	ctx context.Context,
+	req projectAssistantRunRequest,
+	tool projectAssistantTool,
+	toolCalls []chatToolCall,
+	currentIndex int,
+	projectRepositoryRef string,
+) (*projectAssistantPermissionRequiredError, projectAssistantPermission, projectAssistantCheckpoint, error) {
+	if s.store == nil {
+		return nil, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("project message store not configured")
+	}
+	if currentIndex < 0 || currentIndex >= len(toolCalls) {
+		return nil, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("assistant checkpoint index out of range")
+	}
+	spec := tool.Spec()
+	runID := newProjectAssistantRunID()
+	requestID := newProjectAssistantPermissionRequestID()
+	now := time.Now().UTC()
+	state := projectAssistantCheckpointState{
+		ToolCalls:            cloneProjectAssistantToolCalls(toolCalls),
+		CurrentIndex:         currentIndex,
+		ProjectRepositoryRef: strings.TrimSpace(projectRepositoryRef),
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return nil, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("encode assistant checkpoint: %w", err)
+	}
+	run := store.AssistantRun{
+		ID:         runID,
+		Status:     store.AssistantRunStatusPendingPermission,
+		RequestID:  requestID,
+		Checkpoint: raw,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.store.SaveAssistantRun(ctx, req.MessageScope, run); err != nil {
+		return nil, projectAssistantPermission{}, projectAssistantCheckpoint{}, err
+	}
+
+	checkpointCreatedAt := now
+	permission := projectAssistantPermissionForCall(requestID, toolCalls[currentIndex], spec)
+	checkpoint := projectAssistantCheckpoint{
+		ID:        runID,
+		Reason:    "waiting_for_permission",
+		CreatedAt: &checkpointCreatedAt,
+	}
+	return &projectAssistantPermissionRequiredError{
+		RunID:     runID,
+		RequestID: requestID,
+		ToolName:  spec.Name,
+	}, permission, checkpoint, nil
+}
+
+func projectAssistantPermissionReason(spec projectAssistantToolSpec) string {
+	switch spec.Risk {
+	case projectAssistantToolRiskWrite:
+		return "This action will modify files in the App Studio workspace."
+	case projectAssistantToolRiskCommit:
+		return "This action will commit App Studio workspace changes to the linked repository."
+	default:
+		return "This action requires approval."
+	}
+}
+
+func projectAssistantPermissionForCall(requestID string, tc chatToolCall, spec projectAssistantToolSpec) projectAssistantPermission {
+	permissionInput := json.RawMessage(tc.Function.Arguments)
+	if !json.Valid(permissionInput) {
+		permissionInput = nil
+	}
+	return projectAssistantPermission{
+		ID:         requestID,
+		ToolCallID: tc.ID,
+		ToolName:   spec.Name,
+		Reason:     projectAssistantPermissionReason(spec),
+		Input:      permissionInput,
+	}
+}
+
+func (s *Server) resumeProjectAssistantRun(
+	ctx context.Context,
+	r *http.Request,
+	id identity,
+	p *aiv1alpha1.Project,
+	runID string,
+	req projectAssistantResumeRequest,
+) (projectAssistantResumeResponse, error) {
+	if s.store == nil {
+		return projectAssistantResumeResponse{}, fmt.Errorf("project message store not configured")
+	}
+	if p == nil || strings.TrimSpace(p.Name) == "" {
+		return projectAssistantResumeResponse{}, fmt.Errorf("project is required")
+	}
+	decision, err := parseProjectAssistantPermissionDecision(req.Decision)
+	if err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
+	run, err := s.store.ClaimAssistantRun(ctx, messageScope, runID, strings.TrimSpace(req.RequestID), time.Now().UTC())
+	if err != nil {
+		if strings.Contains(err.Error(), "not waiting") || strings.Contains(err.Error(), "request id is required") {
+			return projectAssistantResumeResponse{}, newValidationError(err.Error())
+		}
+		return projectAssistantResumeResponse{}, err
+	}
+	var state projectAssistantCheckpointState
+	if err := json.Unmarshal(run.Checkpoint, &state); err != nil {
+		return projectAssistantResumeResponse{}, fmt.Errorf("decode assistant checkpoint: %w", err)
+	}
+	if state.CurrentIndex < 0 || state.CurrentIndex >= len(state.ToolCalls) {
+		return projectAssistantResumeResponse{}, fmt.Errorf("assistant checkpoint index out of range")
+	}
+
+	out := projectAssistantResumeResponse{
+		RunID:     run.ID,
+		RequestID: run.RequestID,
+		Decision:  decision,
+	}
+	if projectAssistantCheckpointHasStaleRepositoryBinding(state, p) {
+		now := time.Now().UTC()
+		run.Status = store.AssistantRunStatusCompleted
+		run.UpdatedAt = now
+		run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
+			RequestID:  run.RequestID,
+			Decision:   decision,
+			Actor:      id.user,
+			ToolCallID: state.ToolCalls[state.CurrentIndex].ID,
+			ToolName:   state.ToolCalls[state.CurrentIndex].Function.Name,
+			Error:      "Project repository binding changed after permission was requested",
+			ResolvedAt: now,
+		})
+		if err != nil {
+			return projectAssistantResumeResponse{}, err
+		}
+		if saveErr := s.store.SaveAssistantRun(ctx, messageScope, run); saveErr != nil {
+			return projectAssistantResumeResponse{}, saveErr
+		}
+		return projectAssistantResumeResponse{}, newValidationError("Project repository binding changed after permission was requested")
+	}
+
+	run, out, err = s.resolveClaimedProjectAssistantRun(ctx, r, id, p, run, state, req, decision, out)
+	if err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
+	if err := s.store.SaveAssistantRun(ctx, messageScope, run); err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
+	out.Status = run.Status
+	return out, nil
+}
+
+func (s *Server) abortProjectAssistantRun(
+	ctx context.Context,
+	id identity,
+	p *aiv1alpha1.Project,
+	runID string,
+) (projectAssistantResumeResponse, error) {
+	if s.store == nil {
+		return projectAssistantResumeResponse{}, fmt.Errorf("project message store not configured")
+	}
+	if p == nil || strings.TrimSpace(p.Name) == "" {
+		return projectAssistantResumeResponse{}, fmt.Errorf("project is required")
+	}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
+	run, err := s.store.GetAssistantRun(ctx, messageScope, runID)
+	if err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
+	if run.Status != store.AssistantRunStatusPendingPermission {
+		return projectAssistantResumeResponse{}, newValidationError("assistant run is not waiting for permission")
+	}
+	now := time.Now().UTC()
+	run, err = s.store.ClaimAssistantRun(ctx, messageScope, run.ID, run.RequestID, now)
+	if err != nil {
+		if strings.Contains(err.Error(), "not waiting") {
+			return projectAssistantResumeResponse{}, newValidationError(err.Error())
+		}
+		return projectAssistantResumeResponse{}, err
+	}
+	run.Status = store.AssistantRunStatusAborted
+	run.UpdatedAt = now
+	run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
+		RequestID:  run.RequestID,
+		Decision:   projectAssistantPermissionDeny,
+		Actor:      id.user,
+		Error:      "aborted by user",
+		ResolvedAt: now,
+	})
+	if err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
+	if err := s.store.SaveAssistantRun(ctx, messageScope, run); err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
+	return projectAssistantResumeResponse{
+		RunID:     run.ID,
+		RequestID: run.RequestID,
+		Status:    run.Status,
+		Decision:  projectAssistantPermissionDeny,
+	}, nil
+}
+
+func (s *Server) resolveClaimedProjectAssistantRun(
+	ctx context.Context,
+	r *http.Request,
+	id identity,
+	p *aiv1alpha1.Project,
+	run store.AssistantRun,
+	state projectAssistantCheckpointState,
+	req projectAssistantResumeRequest,
+	decision projectAssistantPermissionDecision,
+	out projectAssistantResumeResponse,
+) (store.AssistantRun, projectAssistantResumeResponse, error) {
+	index := state.CurrentIndex
+	for index < len(state.ToolCalls) {
+		tc := state.ToolCalls[index]
+		currentDecision := decision
+		editedArguments := req.EditedArguments
+		if index != state.CurrentIndex {
+			tool, ok := s.projectAssistantToolRegistry().Get(tc.Function.Name)
+			if !ok {
+				currentDecision = projectAssistantPermissionAllow
+			} else {
+				currentDecision = projectAssistantPermissionForTool(tool.Spec())
+			}
+			editedArguments = nil
+		}
+		switch currentDecision {
+		case projectAssistantPermissionAllow:
+			var err error
+			tc, err = projectAssistantToolCallWithEditedArguments(tc, editedArguments)
+			if err != nil {
+				return run, out, err
+			}
+			result, toolCall, err := s.executeApprovedProjectAssistantToolCall(ctx, r, id, p, state.ProjectRepositoryRef, tc)
+			if err != nil {
+				return run, out, err
+			}
+			out.Result = result
+			out.ToolCall = toolCall
+			now := time.Now().UTC()
+			run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
+				RequestID:       run.RequestID,
+				Decision:        projectAssistantPermissionAllow,
+				Actor:           id.user,
+				ToolCallID:      tc.ID,
+				ToolName:        tc.Function.Name,
+				EditedArguments: cloneProjectAssistantToolArguments(editedArguments),
+				Result:          result,
+				Error:           projectAssistantToolResultError(result),
+				ResolvedAt:      now,
+			})
+			if err != nil {
+				return run, out, err
+			}
+			index++
+		case projectAssistantPermissionDeny:
+			msg := projectAssistantPermissionDeniedToolMessage(tc, "denied by user")
+			out.Result = msg.Content
+			now := time.Now().UTC()
+			var err error
+			run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
+				RequestID:       run.RequestID,
+				Decision:        projectAssistantPermissionDeny,
+				Actor:           id.user,
+				ToolCallID:      tc.ID,
+				ToolName:        tc.Function.Name,
+				EditedArguments: cloneProjectAssistantToolArguments(editedArguments),
+				Result:          msg.Content,
+				ResolvedAt:      now,
+			})
+			if err != nil {
+				return run, out, err
+			}
+			index++
+		case projectAssistantPermissionAsk:
+			tool, ok := s.projectAssistantToolRegistry().Get(tc.Function.Name)
+			if !ok {
+				index++
+				continue
+			}
+			nextRun, permission, checkpoint, err := prepareProjectAssistantNextPermission(run, state, index, tool)
+			if err != nil {
+				return run, out, err
+			}
+			out.RequestID = nextRun.RequestID
+			out.Status = nextRun.Status
+			out.Permission = &permission
+			out.Checkpoint = &checkpoint
+			return nextRun, out, nil
+		default:
+			return run, out, newValidationError("decision must be allow or deny")
+		}
+	}
+	run.Status = store.AssistantRunStatusCompleted
+	run.UpdatedAt = time.Now().UTC()
+	return run, out, nil
+}
+
+func (s *Server) executeApprovedProjectAssistantToolCall(
+	ctx context.Context,
+	r *http.Request,
+	id identity,
+	p *aiv1alpha1.Project,
+	projectRepositoryRef string,
+	tc chatToolCall,
+) (string, *projectToolCallStreamEvent, error) {
+	var streamed []projectToolCallStreamEvent
+	messages, err := s.resolveProjectToolCalls(
+		ctx,
+		id,
+		projectWorkspaceScope(id, p.Name),
+		projectRepositoryRef,
+		[]chatToolCall{tc},
+		r,
+		func(event projectToolCallStreamEvent) {
+			streamed = upsertProjectToolCallStreamEvent(streamed, event)
+		},
+	)
+	if err != nil {
+		return "", nil, err
+	}
+	var toolCall *projectToolCallStreamEvent
+	if len(streamed) > 0 {
+		last := streamed[len(streamed)-1]
+		toolCall = &last
+	}
+	var result string
+	if len(messages) > 0 {
+		result = messages[len(messages)-1].Content
+	}
+	return result, toolCall, nil
+}
+
+func prepareProjectAssistantNextPermission(
+	run store.AssistantRun,
+	state projectAssistantCheckpointState,
+	index int,
+	tool projectAssistantTool,
+) (store.AssistantRun, projectAssistantPermission, projectAssistantCheckpoint, error) {
+	if index < 0 || index >= len(state.ToolCalls) {
+		return store.AssistantRun{}, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("assistant checkpoint index out of range")
+	}
+	requestID := newProjectAssistantPermissionRequestID()
+	now := time.Now().UTC()
+	state.CurrentIndex = index
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return store.AssistantRun{}, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("encode assistant checkpoint: %w", err)
+	}
+	run.Status = store.AssistantRunStatusPendingPermission
+	run.RequestID = requestID
+	run.Checkpoint = raw
+	run.UpdatedAt = now
+	createdAt := now
+	return run, projectAssistantPermissionForCall(requestID, state.ToolCalls[index], tool.Spec()), projectAssistantCheckpoint{
+		ID:        run.ID,
+		Reason:    "waiting_for_permission",
+		CreatedAt: &createdAt,
+	}, nil
+}
+
+func projectAssistantToolCallWithEditedArguments(tc chatToolCall, editedArguments map[string]any) (chatToolCall, error) {
+	if len(editedArguments) == 0 {
+		return tc, nil
+	}
+	args := cloneProjectAssistantToolArguments(editedArguments)
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return chatToolCall{}, fmt.Errorf("encode edited arguments: %w", err)
+	}
+	tc.Function.Arguments = string(raw)
+	return tc, nil
+}
+
+func projectAssistantToolResultError(result string) string {
+	if strings.HasPrefix(result, "Tool call failed: ") {
+		return strings.TrimPrefix(result, "Tool call failed: ")
+	}
+	return ""
+}
+
+func projectAssistantCheckpointHasStaleRepositoryBinding(state projectAssistantCheckpointState, p *aiv1alpha1.Project) bool {
+	if state.CurrentIndex < 0 || state.CurrentIndex >= len(state.ToolCalls) {
+		return false
+	}
+	tc := state.ToolCalls[state.CurrentIndex]
+	if projectToolBaseName(tc.Function.Name) != projectToolCommitProjectFiles {
+		return false
+	}
+	return strings.TrimSpace(state.ProjectRepositoryRef) != projectLinkedRepositoryRef(p)
+}
+
+func appendProjectAssistantRunAudit(run store.AssistantRun, entry projectAssistantPermissionAudit) (store.AssistantRun, error) {
+	var audit projectAssistantRunAudit
+	if len(run.Audit) > 0 {
+		if err := json.Unmarshal(run.Audit, &audit); err != nil {
+			return store.AssistantRun{}, fmt.Errorf("decode assistant run audit: %w", err)
+		}
+	}
+	audit.Decisions = append(audit.Decisions, entry)
+	raw, err := json.Marshal(audit)
+	if err != nil {
+		return store.AssistantRun{}, fmt.Errorf("encode assistant run audit: %w", err)
+	}
+	run.Audit = raw
+	return run, nil
+}
+
+func cloneProjectAssistantToolArguments(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func cloneProjectAssistantToolCalls(src []chatToolCall) []chatToolCall {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]chatToolCall, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/providers/app-studio/api/assistant_events.go
+++ b/providers/app-studio/api/assistant_events.go
@@ -58,6 +58,24 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 			AssistantMessageID: w.assistantID,
 			ToolCall:           &toolCall,
 		})
+	case projectAssistantEventPermissionNeeded:
+		if event.Permission == nil || event.Permission.ID == "" {
+			return nil
+		}
+		return w.write(projectMessageStreamEvent{
+			Type:               string(projectAssistantEventPermissionNeeded),
+			AssistantMessageID: w.assistantID,
+			Permission:         event.Permission,
+		})
+	case projectAssistantEventCheckpointSaved:
+		if event.Checkpoint == nil || event.Checkpoint.ID == "" {
+			return nil
+		}
+		return w.write(projectMessageStreamEvent{
+			Type:               string(projectAssistantEventCheckpointSaved),
+			AssistantMessageID: w.assistantID,
+			Checkpoint:         event.Checkpoint,
+		})
 	case projectAssistantEventRunFailed:
 		if event.Error == "" {
 			return nil

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -74,6 +74,33 @@ func TestProjectAssistantStreamWriterMapsToolCall(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantStreamWriterMapsPermissionAndCheckpoint(t *testing.T) {
+	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
+		Type: projectAssistantEventPermissionNeeded,
+		Permission: &projectAssistantPermission{
+			ID:         "perm-1",
+			ToolCallID: "tool-1",
+			ToolName:   "write_file",
+			Reason:     "will write files",
+		},
+	}, projectAssistantEvent{
+		Type:       projectAssistantEventCheckpointSaved,
+		Checkpoint: &projectAssistantCheckpoint{ID: "run-1", Reason: "waiting_for_permission"},
+	})
+	if err != nil {
+		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("events = %#v, want permission and checkpoint", got)
+	}
+	if got[0].Type != "permission_required" || got[0].Permission == nil || got[0].Permission.ID != "perm-1" || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("permission event = %#v, want assistant permission payload", got[0])
+	}
+	if got[1].Type != "checkpoint_saved" || got[1].Checkpoint == nil || got[1].Checkpoint.ID != "run-1" || got[1].AssistantMessageID != "assistant-1" {
+		t.Fatalf("checkpoint event = %#v, want assistant checkpoint payload", got[1])
+	}
+}
+
 func TestProjectAssistantStreamWriterMapsTerminalEvents(t *testing.T) {
 	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
 		Type:  projectAssistantEventRunFailed,

--- a/providers/app-studio/api/assistant_permission.go
+++ b/providers/app-studio/api/assistant_permission.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+type projectAssistantPermissionDecision string
+
+const (
+	projectAssistantPermissionAllow projectAssistantPermissionDecision = "allow"
+	projectAssistantPermissionAsk   projectAssistantPermissionDecision = "ask"
+	projectAssistantPermissionDeny  projectAssistantPermissionDecision = "deny"
+)
+
+func projectAssistantPermissionForTool(spec projectAssistantToolSpec) projectAssistantPermissionDecision {
+	switch spec.Risk {
+	case projectAssistantToolRiskRead:
+		return projectAssistantPermissionAllow
+	case projectAssistantToolRiskWrite, projectAssistantToolRiskCommit:
+		return projectAssistantPermissionAsk
+	default:
+		return projectAssistantPermissionDeny
+	}
+}
+
+func parseProjectAssistantPermissionDecision(value string) (projectAssistantPermissionDecision, error) {
+	decision := projectAssistantPermissionDecision(strings.ToLower(strings.TrimSpace(value)))
+	switch decision {
+	case projectAssistantPermissionAllow, projectAssistantPermissionDeny:
+		return decision, nil
+	default:
+		return "", newValidationError("decision must be allow or deny")
+	}
+}
+
+type projectAssistantPermissionRequiredError struct {
+	RunID     string
+	RequestID string
+	ToolName  string
+}
+
+func (e *projectAssistantPermissionRequiredError) Error() string {
+	if e == nil {
+		return "assistant tool permission required"
+	}
+	if e.ToolName != "" {
+		return fmt.Sprintf("assistant tool %q requires permission", e.ToolName)
+	}
+	return "assistant tool permission required"
+}
+
+func projectAssistantPermissionDeniedToolMessage(tc chatToolCall, reason string) chatMessage {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "permission denied"
+	}
+	return chatMessage{
+		Role:       "tool",
+		Name:       tc.Function.Name,
+		ToolCallID: tc.ID,
+		Content:    "Tool call failed: permission denied: " + reason,
+	}
+}

--- a/providers/app-studio/api/assistant_permission_test.go
+++ b/providers/app-studio/api/assistant_permission_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProjectAssistantPermissionPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		risk projectAssistantToolRisk
+		want projectAssistantPermissionDecision
+	}{
+		{name: "read tools auto allow", risk: projectAssistantToolRiskRead, want: projectAssistantPermissionAllow},
+		{name: "write tools ask", risk: projectAssistantToolRiskWrite, want: projectAssistantPermissionAsk},
+		{name: "commit tools ask", risk: projectAssistantToolRiskCommit, want: projectAssistantPermissionAsk},
+		{name: "unknown risk denies", risk: projectAssistantToolRisk("danger"), want: projectAssistantPermissionDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := projectAssistantPermissionForTool(projectAssistantToolSpec{
+				Name: "tool",
+				Risk: tt.risk,
+			})
+			if got != tt.want {
+				t.Fatalf("permission = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectAssistantPermissionDeniedToolMessageIsVisibleToModel(t *testing.T) {
+	msg := projectAssistantPermissionDeniedToolMessage(chatToolCall{
+		ID: "call-1",
+		Function: chatToolCallFunction{
+			Name: "dangerous_tool",
+		},
+	}, "unknown tool risk")
+	if msg.Role != "tool" || msg.ToolCallID != "call-1" || msg.Name != "dangerous_tool" {
+		t.Fatalf("tool message = %#v, want model-visible tool response", msg)
+	}
+	if !strings.Contains(msg.Content, "permission denied") || !strings.Contains(msg.Content, "unknown tool risk") {
+		t.Fatalf("tool content = %q, want permission denial reason", msg.Content)
+	}
+}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -172,9 +172,10 @@ type projectAssistantReply struct {
 }
 
 type projectAssistantStreamCallbacks struct {
-	OnChunk    func(string)
-	OnStatus   func(string)
-	OnToolCall func(projectToolCallStreamEvent)
+	OnChunk          func(string)
+	OnStatus         func(string)
+	OnToolCall       func(projectToolCallStreamEvent)
+	OnAssistantEvent func(projectAssistantEvent)
 }
 
 type projectNamingResult struct {
@@ -399,14 +400,14 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 					repeated = true
 				}
 				logger.V(2).Info("project assistant requested tool call",
-					"turn", i, "tool", tc.Function.Name, "args", tc.Function.Arguments)
+					"turn", i, "tool", tc.Function.Name, "args", summarizeProjectToolArguments(tc.Function.Name, tc.Function.Arguments))
 			}
 
 			messages = append(messages, chatMessage{
 				Role:      aiv1alpha1.ProjectMessageRoleAssistant,
 				ToolCalls: reply.ToolCalls,
 			})
-			nextMessages, callErr := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, reply.ToolCalls, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, callErr := s.resolveProjectToolCallsWithPermissions(ctx, req, projectRepositoryRef, reply.ToolCalls)
 			if callErr != nil {
 				return "", callErr
 			}
@@ -440,6 +441,97 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 	}
 
 	return "", errors.New("LLM tool loop exceeded safe turn limit")
+}
+
+func (s *Server) resolveProjectToolCallsWithPermissions(
+	ctx context.Context,
+	req projectAssistantRunRequest,
+	projectRepositoryRef string,
+	toolCalls []chatToolCall,
+) ([]chatMessage, error) {
+	if len(toolCalls) == 0 {
+		return nil, nil
+	}
+	registry := s.projectAssistantToolRegistry()
+	var toolMessages []chatMessage
+	for i, tc := range toolCalls {
+		tool, ok := registry.Get(tc.Function.Name)
+		if !ok {
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			if err != nil {
+				return nil, err
+			}
+			toolMessages = append(toolMessages, nextMessages...)
+			continue
+		}
+		args, err := projectAssistantToolCallArguments(tc)
+		if err != nil {
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			if err != nil {
+				return nil, err
+			}
+			toolMessages = append(toolMessages, nextMessages...)
+			continue
+		}
+		spec := tool.Spec()
+		switch projectAssistantPermissionForTool(spec) {
+		case projectAssistantPermissionAllow:
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			if err != nil {
+				return nil, err
+			}
+			toolMessages = append(toolMessages, nextMessages...)
+		case projectAssistantPermissionAsk:
+			if req.StreamCallbacks.OnToolCall != nil {
+				req.StreamCallbacks.OnToolCall(projectToolCallStreamEvent{
+					ID:        tc.ID,
+					Name:      tc.Function.Name,
+					Status:    "permission_required",
+					Arguments: summarizeProjectToolArgumentsMap(tc.Function.Name, args),
+					Summary:   projectAssistantPermissionReason(spec),
+				})
+			}
+			permissionErr, permission, checkpoint, err := s.saveProjectAssistantPermissionCheckpointForToolCalls(ctx, req, tool, toolCalls, i, projectRepositoryRef)
+			if err != nil {
+				return nil, err
+			}
+			if req.StreamCallbacks.OnAssistantEvent != nil {
+				req.StreamCallbacks.OnAssistantEvent(projectAssistantEvent{
+					Type:       projectAssistantEventPermissionNeeded,
+					Permission: &permission,
+				})
+				req.StreamCallbacks.OnAssistantEvent(projectAssistantEvent{
+					Type:       projectAssistantEventCheckpointSaved,
+					Checkpoint: &checkpoint,
+				})
+			}
+			return nil, permissionErr
+		case projectAssistantPermissionDeny:
+			reason := "unknown tool risk"
+			if req.StreamCallbacks.OnToolCall != nil {
+				req.StreamCallbacks.OnToolCall(projectToolCallStreamEvent{
+					ID:        tc.ID,
+					Name:      tc.Function.Name,
+					Status:    "rejected",
+					Arguments: summarizeProjectToolArgumentsMap(tc.Function.Name, args),
+					Error:     reason,
+				})
+			}
+			toolMessages = append(toolMessages, projectAssistantPermissionDeniedToolMessage(tc, reason))
+		}
+	}
+	return toolMessages, nil
+}
+
+func projectAssistantToolCallArguments(tc chatToolCall) (map[string]any, error) {
+	args := map[string]any{}
+	if strings.TrimSpace(tc.Function.Arguments) == "" {
+		return args, nil
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		return nil, err
+	}
+	return args, nil
 }
 
 func projectRepeatedToolLoopFallback(toolMessages []chatMessage) string {
@@ -990,7 +1082,7 @@ func (s *Server) resolveProjectToolCalls(
 		args := map[string]any{}
 		if strings.TrimSpace(tc.Function.Arguments) != "" {
 			if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
-				logger.Info("project assistant tool call rejected", "reason", "invalid arguments", "tool", tc.Function.Name, "args", tc.Function.Arguments, "err", err.Error())
+				logger.Info("project assistant tool call rejected", "reason", "invalid arguments", "tool", tc.Function.Name, "argsBytes", len(tc.Function.Arguments), "err", err.Error())
 				if onToolCall != nil {
 					onToolCall(projectToolCallStreamEvent{
 						ID:     tc.ID,

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -110,6 +110,8 @@ type projectMessageStreamEvent struct {
 	Error              string                      `json:"error,omitempty"`
 	Project            *ProjectView                `json:"project,omitempty"`
 	ToolCall           *projectToolCallStreamEvent `json:"toolCall,omitempty"`
+	Permission         *projectAssistantPermission `json:"permission,omitempty"`
+	Checkpoint         *projectAssistantCheckpoint `json:"checkpoint,omitempty"`
 }
 
 type projectToolCallStreamEvent struct {
@@ -473,6 +475,36 @@ func (s *Server) createProjectMessageStream(w http.ResponseWriter, r *http.Reque
 	s.streamProjectAssistant(w, flusher, r, c, id, p, msgStore)
 }
 
+func (s *Server) resumeProjectAssistant(w http.ResponseWriter, r *http.Request) {
+	_, id, p, ok := s.requireProjectWithClient(w, r)
+	if !ok {
+		return
+	}
+	var req projectAssistantResumeRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	resp, err := s.resumeProjectAssistantRun(r.Context(), r, id, p, mux.Vars(r)["run"], req)
+	if err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) abortProjectAssistant(w http.ResponseWriter, r *http.Request) {
+	_, id, p, ok := s.requireProjectWithClient(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.abortProjectAssistantRun(r.Context(), id, p, mux.Vars(r)["run"])
+	if err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func startProjectMessageStream(w http.ResponseWriter) (http.Flusher, bool) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -571,11 +603,19 @@ func (s *Server) streamProjectAssistant(
 	}
 
 	reply, err := s.generateProjectAssistantStream(r, id, c, p, projectAssistantStreamCallbacks{
-		OnChunk:    streamChunk,
-		OnStatus:   streamStatus,
-		OnToolCall: streamToolCall,
+		OnChunk:          streamChunk,
+		OnStatus:         streamStatus,
+		OnToolCall:       streamToolCall,
+		OnAssistantEvent: emitAssistantEvent,
 	})
 	if err != nil {
+		var permissionErr *projectAssistantPermissionRequiredError
+		if errors.As(err, &permissionErr) {
+			if streamErr != nil {
+				_ = appendInterruptedProjectAssistantMessage(r.Context(), msgStore, scope, assistantID, assistantContent.String())
+			}
+			return
+		}
 		if shouldPersistInterruptedProjectAssistant(r.Context(), err, streamErr, assistantContent.String()) {
 			persistErr := appendInterruptedProjectAssistantMessage(r.Context(), msgStore, scope, assistantID, assistantContent.String())
 			if persistErr != nil && streamErr == nil {

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -19,10 +19,12 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -483,15 +485,491 @@ func TestResolveProjectToolCallsRunsLocalWorkspaceMutationTools(t *testing.T) {
 	}
 }
 
+func TestGenerateProjectAssistantStreamRequestsPermissionForWriteTool(t *testing.T) {
+	var llmRequests []chatCompletionRequest
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode LLM request: %v", err)
+		}
+		llmRequests = append(llmRequests, req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"src/App.tsx","content":"hello\n"}`)
+	}))
+	defer llm.Close()
+
+	settings := projectLLMSettings{
+		Provider: defaultProjectLLMProvider,
+		BaseURL:  llm.URL,
+		Model:    "test-model",
+		APIKey:   "test-key",
+	}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	messageScope := store.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
+	if err := appendProjectUserMessage(context.Background(), messages, messageScope, "write a file"); err != nil {
+		t.Fatalf("appendProjectUserMessage returned error: %v", err)
+	}
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+
+	var events []projectAssistantEvent
+	_, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		client,
+		project,
+		projectAssistantStreamCallbacks{
+			OnAssistantEvent: func(event projectAssistantEvent) {
+				events = append(events, event)
+			},
+		},
+	)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("generateProjectAssistantStream error = %v, want permission required", err)
+	}
+	if permissionErr.RunID == "" || permissionErr.RequestID == "" {
+		t.Fatalf("permission error missing ids: %#v", permissionErr)
+	}
+	if len(llmRequests) != 1 {
+		t.Fatalf("LLM request count = %d, want 1", len(llmRequests))
+	}
+	if _, err := workspaces.ReadFile(context.Background(), workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}, workspace.ReadOptions{Path: "src/App.tsx"}); err == nil {
+		t.Fatal("write_file ran before permission was approved")
+	}
+
+	var sawPermission, sawCheckpoint bool
+	for _, event := range events {
+		switch event.Type {
+		case projectAssistantEventPermissionNeeded:
+			sawPermission = true
+			if event.Permission == nil || event.Permission.ID != permissionErr.RequestID || event.Permission.ToolName != "write_file" {
+				t.Fatalf("permission event = %#v, want write_file request %q", event, permissionErr.RequestID)
+			}
+		case projectAssistantEventCheckpointSaved:
+			sawCheckpoint = true
+			if event.Checkpoint == nil || event.Checkpoint.ID != permissionErr.RunID {
+				t.Fatalf("checkpoint event = %#v, want run %q", event, permissionErr.RunID)
+			}
+		}
+	}
+	if !sawPermission || !sawCheckpoint {
+		t.Fatalf("events = %#v, want permission and checkpoint events", events)
+	}
+	run, err := messages.GetAssistantRun(context.Background(), messageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if run.Status != store.AssistantRunStatusPendingPermission || run.RequestID != permissionErr.RequestID {
+		t.Fatalf("assistant run = %#v, want pending permission request", run)
+	}
+}
+
+func TestResumeProjectAssistantRunApprovesPendingTool(t *testing.T) {
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolWriteFile)
+	if !ok {
+		t.Fatal("write_file tool missing from registry")
+	}
+	tc := chatToolCall{
+		ID:   "call-write",
+		Type: "function",
+		Function: chatToolCallFunction{
+			Name:      projectToolWriteFile,
+			Arguments: `{"path":"src/App.tsx","content":"approved\n"}`,
+		},
+	}
+	permissionErr, _, _, err := server.saveProjectAssistantPermissionCheckpoint(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+			Project:        project,
+			WorkspaceScope: workspaceScope,
+			MessageScope:   messageScope,
+		},
+		tool,
+		tc,
+		map[string]any{"path": "src/App.tsx", "content": "approved\n"},
+		projectLinkedRepositoryRef(project),
+	)
+	if err != nil {
+		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
+	}
+
+	resp, err := server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{
+			RequestID: permissionErr.RequestID,
+			Decision:  string(projectAssistantPermissionAllow),
+		},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRun returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted || resp.ToolCall == nil || resp.ToolCall.Status != "succeeded" {
+		t.Fatalf("resume response = %#v, want completed succeeded tool call", resp)
+	}
+	read, err := workspaces.ReadFile(context.Background(), workspaceScope, workspace.ReadOptions{Path: "src/App.tsx"})
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if read.Content != "approved\n" {
+		t.Fatalf("content = %q, want approved write", read.Content)
+	}
+	run, err := messages.GetAssistantRun(context.Background(), messageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if run.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", run.Status)
+	}
+	audit := decodeProjectAssistantRunAudit(t, run.Audit)
+	if len(audit.Decisions) != 1 || audit.Decisions[0].Decision != projectAssistantPermissionAllow || audit.Decisions[0].Actor != id.user || audit.Decisions[0].Result == "" {
+		t.Fatalf("audit = %#v, want allow decision with actor and result", audit)
+	}
+}
+
+func TestAbortProjectAssistantRunMarksPendingRunAborted(t *testing.T) {
+	messages := store.NewMemoryStore()
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	run := store.AssistantRun{
+		ID:         "run-1",
+		Status:     store.AssistantRunStatusPendingPermission,
+		RequestID:  "perm-1",
+		Checkpoint: json.RawMessage(`{"toolCall":{"id":"call-1"}}`),
+	}
+	if err := messages.SaveAssistantRun(context.Background(), messageScope, run); err != nil {
+		t.Fatalf("SaveAssistantRun returned error: %v", err)
+	}
+
+	resp, err := server.abortProjectAssistantRun(context.Background(), id, project, "run-1")
+	if err != nil {
+		t.Fatalf("abortProjectAssistantRun returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusAborted {
+		t.Fatalf("abort response = %#v, want aborted", resp)
+	}
+	got, err := messages.GetAssistantRun(context.Background(), messageScope, "run-1")
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if got.Status != store.AssistantRunStatusAborted {
+		t.Fatalf("run status = %q, want aborted", got.Status)
+	}
+	audit := decodeProjectAssistantRunAudit(t, got.Audit)
+	if len(audit.Decisions) != 1 || audit.Decisions[0].Decision != projectAssistantPermissionDeny || audit.Decisions[0].Error != "aborted by user" {
+		t.Fatalf("audit = %#v, want abort decision", audit)
+	}
+}
+
+func TestResumeProjectAssistantRunClaimsBeforeCommitSideEffects(t *testing.T) {
+	var commitCalls atomic.Int32
+	commitEntered := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var envelope struct {
+			Method string `json:"method"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode MCP request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch envelope.Method {
+		case "tools/call":
+			if envelope.Params.Name != "code__commit_files" {
+				t.Fatalf("unexpected MCP tool call: %#v", envelope)
+			}
+			if commitCalls.Add(1) == 1 {
+				close(commitEntered)
+			}
+			<-releaseCommit
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":["src/App.tsx"],"commitSHA":"abcdef1234567890"}}}`)
+		default:
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"code__commit_files","description":"commit files"}]}}`)
+		}
+	}))
+	defer mcp.Close()
+	releasedCommit := false
+	defer func() {
+		if !releasedCommit {
+			close(releaseCommit)
+		}
+	}()
+
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, mcp.URL, false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	if err := workspaces.ApplyFiles(context.Background(), workspaceScope, []workspace.File{{Path: "src/App.tsx", Content: "approved\n"}}); err != nil {
+		t.Fatalf("ApplyFiles returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolCommitProjectFiles)
+	if !ok {
+		t.Fatal("commit_project_files tool missing from registry")
+	}
+	tc := chatToolCall{
+		ID:   "call-commit",
+		Type: "function",
+		Function: chatToolCallFunction{
+			Name:      projectToolCommitProjectFiles,
+			Arguments: `{"repositoryRef":"demo-repo","paths":["src/App.tsx"],"message":"Initial app"}`,
+		},
+	}
+	permissionErr, _, _, err := server.saveProjectAssistantPermissionCheckpoint(
+		context.Background(),
+		projectAssistantRunRequest{Identity: id, HTTPRequest: httptest.NewRequest(http.MethodPost, "/", nil), Project: project, WorkspaceScope: workspaceScope, MessageScope: messageScope},
+		tool,
+		tc,
+		map[string]any{"repositoryRef": "demo-repo", "paths": []any{"src/App.tsx"}, "message": "Initial app"},
+		projectLinkedRepositoryRef(project),
+	)
+	if err != nil {
+		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
+	}
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := server.resumeProjectAssistantRun(
+			context.Background(),
+			httptest.NewRequest(http.MethodPost, "/", nil),
+			id,
+			project,
+			permissionErr.RunID,
+			projectAssistantResumeRequest{RequestID: permissionErr.RequestID, Decision: string(projectAssistantPermissionAllow)},
+		)
+		firstErr <- err
+	}()
+	select {
+	case <-commitEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first resume did not reach commit call")
+	}
+
+	_, err = server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{RequestID: permissionErr.RequestID, Decision: string(projectAssistantPermissionAllow)},
+	)
+	if err == nil {
+		t.Fatal("second resume returned nil error")
+	}
+	close(releaseCommit)
+	releasedCommit = true
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first resume returned error: %v", err)
+	}
+	if got := commitCalls.Load(); got != 1 {
+		t.Fatalf("commit call count = %d, want 1", got)
+	}
+}
+
+func TestResumeProjectAssistantRunRejectsStaleRepositoryBinding(t *testing.T) {
+	var sawCommit bool
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var envelope struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode MCP request: %v", err)
+		}
+		if envelope.Method == "tools/call" {
+			sawCommit = true
+		}
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":["src/App.tsx"],"commitSHA":"abcdef1234567890"}}}`)
+	}))
+	defer mcp.Close()
+
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, mcp.URL, false)
+	project := projectWithRepository("old-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	if err := workspaces.ApplyFiles(context.Background(), workspaceScope, []workspace.File{{Path: "src/App.tsx", Content: "approved\n"}}); err != nil {
+		t.Fatalf("ApplyFiles returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolCommitProjectFiles)
+	if !ok {
+		t.Fatal("commit_project_files tool missing from registry")
+	}
+	tc := chatToolCall{
+		ID:   "call-commit",
+		Type: "function",
+		Function: chatToolCallFunction{
+			Name:      projectToolCommitProjectFiles,
+			Arguments: `{"repositoryRef":"old-repo","paths":["src/App.tsx"],"message":"Initial app"}`,
+		},
+	}
+	permissionErr, _, _, err := server.saveProjectAssistantPermissionCheckpoint(
+		context.Background(),
+		projectAssistantRunRequest{Identity: id, HTTPRequest: httptest.NewRequest(http.MethodPost, "/", nil), Project: project, WorkspaceScope: workspaceScope, MessageScope: messageScope},
+		tool,
+		tc,
+		map[string]any{"repositoryRef": "old-repo", "paths": []any{"src/App.tsx"}, "message": "Initial app"},
+		projectLinkedRepositoryRef(project),
+	)
+	if err != nil {
+		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
+	}
+	project.Spec.Repository.RepositoryRef = "new-repo"
+
+	_, err = server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{RequestID: permissionErr.RequestID, Decision: string(projectAssistantPermissionAllow)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "repository binding changed") {
+		t.Fatalf("resumeProjectAssistantRun error = %v, want stale repository binding", err)
+	}
+	if sawCommit {
+		t.Fatal("stale approval reached provider-code commit")
+	}
+	run, err := messages.GetAssistantRun(context.Background(), messageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if run.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("run status = %q, want completed stale checkpoint", run.Status)
+	}
+	audit := decodeProjectAssistantRunAudit(t, run.Audit)
+	if len(audit.Decisions) != 1 || !strings.Contains(audit.Decisions[0].Error, "repository binding changed") {
+		t.Fatalf("audit = %#v, want stale binding error", audit)
+	}
+}
+
+func TestResumeProjectAssistantRunContinuesToolBatchToNextPermission(t *testing.T) {
+	var llmRequests []chatCompletionRequest
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode LLM request: %v", err)
+		}
+		llmRequests = append(llmRequests, req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		callOne := chatStreamingCall{Index: 0, ID: "call-one", Type: "function"}
+		callOne.Function.Name = "write_file"
+		callOne.Function.Arguments = `{"path":"one.txt","content":"one\n"}`
+		callTwo := chatStreamingCall{Index: 1, ID: "call-two", Type: "function"}
+		callTwo.Function.Name = "write_file"
+		callTwo.Function.Arguments = `{"path":"two.txt","content":"two\n"}`
+		writeProjectTestToolCallChunks(t, w, callOne, callTwo)
+	}))
+	defer llm.Close()
+
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: llm.URL, Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, "demo")
+	if err := appendProjectUserMessage(context.Background(), messages, messageScope, "write files"); err != nil {
+		t.Fatalf("appendProjectUserMessage returned error: %v", err)
+	}
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+
+	_, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("generateProjectAssistantStream error = %v, want permission required", err)
+	}
+	first, err := server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{RequestID: permissionErr.RequestID, Decision: string(projectAssistantPermissionAllow)},
+	)
+	if err != nil {
+		t.Fatalf("first resumeProjectAssistantRun returned error: %v", err)
+	}
+	if first.Status != store.AssistantRunStatusPendingPermission || first.Permission == nil || first.Permission.ToolCallID != "call-two" {
+		t.Fatalf("first resume response = %#v, want next permission for call-two", first)
+	}
+	if _, err := workspaces.ReadFile(context.Background(), projectWorkspaceScope(id, project.Name), workspace.ReadOptions{Path: "one.txt"}); err != nil {
+		t.Fatalf("one.txt was not written after first approval: %v", err)
+	}
+	if _, err := workspaces.ReadFile(context.Background(), projectWorkspaceScope(id, project.Name), workspace.ReadOptions{Path: "two.txt"}); err == nil {
+		t.Fatal("two.txt was written before second approval")
+	}
+	second, err := server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{RequestID: first.RequestID, Decision: string(projectAssistantPermissionAllow)},
+	)
+	if err != nil {
+		t.Fatalf("second resumeProjectAssistantRun returned error: %v", err)
+	}
+	if second.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("second resume response = %#v, want completed", second)
+	}
+	if _, err := workspaces.ReadFile(context.Background(), projectWorkspaceScope(id, project.Name), workspace.ReadOptions{Path: "two.txt"}); err != nil {
+		t.Fatalf("two.txt was not written after second approval: %v", err)
+	}
+	run, err := messages.GetAssistantRun(context.Background(), messageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	audit := decodeProjectAssistantRunAudit(t, run.Audit)
+	if len(audit.Decisions) != 2 {
+		t.Fatalf("audit decisions = %#v, want two approvals", audit.Decisions)
+	}
+}
+
 func TestGenerateProjectAssistantStreamStopsOfferingToolsAfterRepeatedToolLoop(t *testing.T) {
-	reply, requests, err := runRepeatedWriteFileAssistantStream(t, func(w http.ResponseWriter) {
-		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"I updated src/App.tsx and stopped before repeating the same action.\"}}]}\n\n")
+	reply, requests, err := runRepeatedReadFileAssistantStream(t, func(w http.ResponseWriter) {
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"I inspected src/App.tsx and stopped before repeating the same action.\"}}]}\n\n")
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	})
 	if err != nil {
 		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
 	}
-	if !strings.Contains(reply, "I updated src/App.tsx") {
+	if !strings.Contains(reply, "I inspected src/App.tsx") {
 		t.Fatalf("reply = %q, want final text answer", reply)
 	}
 	if len(requests) != 3 {
@@ -503,14 +981,14 @@ func TestGenerateProjectAssistantStreamStopsOfferingToolsAfterRepeatedToolLoop(t
 }
 
 func TestGenerateProjectAssistantStreamFallsBackWhenFinalNoToolResponseIsEmpty(t *testing.T) {
-	reply, requests, err := runRepeatedWriteFileAssistantStream(t, func(w http.ResponseWriter) {
+	reply, requests, err := runRepeatedReadFileAssistantStream(t, func(w http.ResponseWriter) {
 		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{}}]}\n\n")
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	})
 	if err != nil {
 		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
 	}
-	if !strings.Contains(reply, "repeated the same action") || !strings.Contains(reply, "write_file") || !strings.Contains(reply, "src/App.tsx") {
+	if !strings.Contains(reply, "repeated the same action") || !strings.Contains(reply, "read_project_file") || !strings.Contains(reply, "src/App.tsx") {
 		t.Fatalf("reply = %q, want repeated action fallback", reply)
 	}
 	if len(requests) != 3 {
@@ -522,13 +1000,13 @@ func TestGenerateProjectAssistantStreamFallsBackWhenFinalNoToolResponseIsEmpty(t
 }
 
 func TestGenerateProjectAssistantStreamFallsBackWhenFinalToolLimitResponseHasOnlyToolCalls(t *testing.T) {
-	reply, requests, err := runUniqueWriteFileAssistantStream(t, func(w http.ResponseWriter) {
-		writeProjectTestToolCallChunk(t, w, "call-final", "write_file", `{"path":"src/final.tsx","content":"final\n"}`)
+	reply, requests, err := runUniqueReadFileAssistantStream(t, func(w http.ResponseWriter) {
+		writeProjectTestToolCallChunk(t, w, "call-final", "read_project_file", `{"path":"src/final.tsx"}`)
 	})
 	if err != nil {
 		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
 	}
-	if !strings.Contains(reply, "kept requesting actions") || !strings.Contains(reply, "write_file") || !strings.Contains(reply, "src/file-7.tsx") {
+	if !strings.Contains(reply, "kept requesting actions") || !strings.Contains(reply, "read_project_file") || !strings.Contains(reply, "src/file-7.tsx") {
 		t.Fatalf("reply = %q, want tool-limit fallback", reply)
 	}
 	if len(requests) != maxAssistantToolTurns {
@@ -567,7 +1045,7 @@ func TestProjectPromptMessagesCollapsesConsecutiveDuplicateUserMessages(t *testi
 	}
 }
 
-func TestGenerateProjectAssistantStreamReturnsCommitProjectFilesResult(t *testing.T) {
+func TestGenerateProjectAssistantStreamRequestsPermissionForCommitProjectFiles(t *testing.T) {
 	var llmRequests []chatCompletionRequest
 	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req chatCompletionRequest
@@ -578,8 +1056,6 @@ func TestGenerateProjectAssistantStreamReturnsCommitProjectFilesResult(t *testin
 		w.Header().Set("Content-Type", "text/event-stream")
 		switch len(llmRequests) {
 		case 1:
-			writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"index.html","content":"hello\n"}`)
-		case 2:
 			writeProjectTestToolCallChunk(t, w, "call-commit", "commit_project_files", `{"repositoryRef":"demo-repo","paths":["index.html"],"message":"Initial app"}`)
 		default:
 			t.Fatalf("unexpected LLM request after commit handoff: tools=%d tool_choice=%q", len(req.Tools), req.ToolChoice)
@@ -614,41 +1090,24 @@ func TestGenerateProjectAssistantStreamReturnsCommitProjectFilesResult(t *testin
 	}))
 	defer mcp.Close()
 
-	reply, requests, err := runProjectAssistantStreamWithLLMAndHub(t, llm.URL, mcp.URL, &llmRequests)
-	if err != nil {
-		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
+	_, requests, err := runProjectAssistantStreamWithLLMAndHub(t, llm.URL, mcp.URL, &llmRequests)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("generateProjectAssistantStream error = %v, want permission required", err)
 	}
-	if !strings.Contains(reply, "Committed the workspace files") || !strings.Contains(reply, "commit abcdef123456") {
-		t.Fatalf("reply = %q, want deterministic commit success", reply)
+	if permissionErr.ToolName != "commit_project_files" {
+		t.Fatalf("permission error = %#v, want commit_project_files", permissionErr)
 	}
-	if commitCalls != 1 {
-		t.Fatalf("commit call count = %d, want 1", commitCalls)
+	if commitCalls != 0 {
+		t.Fatalf("commit call count = %d, want no commit before approval", commitCalls)
 	}
-	if len(requests) != 2 {
-		t.Fatalf("LLM request count = %d, want 2", len(requests))
+	if len(requests) != 1 {
+		t.Fatalf("LLM request count = %d, want 1", len(requests))
 	}
 }
 
-func TestGenerateProjectAssistantStreamReportsCommitProjectFilesFailure(t *testing.T) {
+func TestResolveProjectToolCallsReportsCommitProjectFilesFailure(t *testing.T) {
 	var llmRequests []chatCompletionRequest
-	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req chatCompletionRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode LLM request: %v", err)
-		}
-		llmRequests = append(llmRequests, req)
-		w.Header().Set("Content-Type", "text/event-stream")
-		switch len(llmRequests) {
-		case 1:
-			writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"index.html","content":"hello\n"}`)
-		case 2:
-			writeProjectTestToolCallChunk(t, w, "call-commit", "commit_project_files", `{"repositoryRef":"demo-repo","paths":["index.html"],"message":"Initial app"}`)
-		default:
-			t.Fatalf("unexpected LLM request after failed commit handoff: tools=%d tool_choice=%q", len(req.Tools), req.ToolChoice)
-		}
-	}))
-	defer llm.Close()
-
 	var commitCalls int
 	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var envelope struct {
@@ -676,44 +1135,43 @@ func TestGenerateProjectAssistantStreamReportsCommitProjectFilesFailure(t *testi
 	}))
 	defer mcp.Close()
 
-	reply, requests, err := runProjectAssistantStreamWithLLMAndHub(t, llm.URL, mcp.URL, &llmRequests)
+	workspaces := workspace.NewFileStore(t.TempDir())
+	scope := workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
+	if err := workspaces.ApplyFiles(context.Background(), scope, []workspace.File{{Path: "index.html", Content: "hello\n"}}); err != nil {
+		t.Fatalf("ApplyFiles returned error: %v", err)
+	}
+	server := NewWithWorkspace(nil, nil, workspaces, mcp.URL, false)
+	messages, err := server.resolveProjectToolCalls(
+		context.Background(),
+		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		scope,
+		"demo-repo",
+		[]chatToolCall{{
+			ID:   "call-commit",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      "commit_project_files",
+				Arguments: `{"repositoryRef":"demo-repo","paths":["index.html"],"message":"Initial app"}`,
+			},
+		}},
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		nil,
+	)
 	if err != nil {
-		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
+		t.Fatalf("resolveProjectToolCalls returned error: %v", err)
 	}
-	if !strings.Contains(reply, "could not commit") || !strings.Contains(reply, "bundle not found") {
-		t.Fatalf("reply = %q, want deterministic commit failure", reply)
-	}
-	if strings.Contains(reply, "Committed the workspace files") {
-		t.Fatalf("reply = %q, should not claim commit success", reply)
+	if len(messages) != 1 || !strings.Contains(messages[0].Content, "bundle not found") {
+		t.Fatalf("tool messages = %#v, want commit failure", messages)
 	}
 	if commitCalls != 1 {
 		t.Fatalf("commit call count = %d, want 1", commitCalls)
 	}
-	if len(requests) != 2 {
-		t.Fatalf("LLM request count = %d, want 2", len(requests))
+	if len(llmRequests) != 0 {
+		t.Fatalf("LLM request count = %d, want none for executor test", len(llmRequests))
 	}
 }
 
-func TestGenerateProjectAssistantStreamRejectsCommitProjectFilesRepositoryMismatch(t *testing.T) {
-	var llmRequests []chatCompletionRequest
-	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req chatCompletionRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode LLM request: %v", err)
-		}
-		llmRequests = append(llmRequests, req)
-		w.Header().Set("Content-Type", "text/event-stream")
-		switch len(llmRequests) {
-		case 1:
-			writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"index.html","content":"hello\n"}`)
-		case 2:
-			writeProjectTestToolCallChunk(t, w, "call-commit", "commit_project_files", `{"repositoryRef":"other-repo","paths":["index.html"],"message":"Initial app"}`)
-		default:
-			t.Fatalf("unexpected LLM request after rejected commit handoff: tools=%d tool_choice=%q", len(req.Tools), req.ToolChoice)
-		}
-	}))
-	defer llm.Close()
-
+func TestResolveProjectToolCallsRejectsCommitProjectFilesRepositoryMismatch(t *testing.T) {
 	var sawCommit bool
 	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var envelope struct {
@@ -738,18 +1196,36 @@ func TestGenerateProjectAssistantStreamRejectsCommitProjectFilesRepositoryMismat
 	}))
 	defer mcp.Close()
 
-	reply, requests, err := runProjectAssistantStreamWithLLMAndHub(t, llm.URL, mcp.URL, &llmRequests)
+	workspaces := workspace.NewFileStore(t.TempDir())
+	scope := workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
+	if err := workspaces.ApplyFiles(context.Background(), scope, []workspace.File{{Path: "index.html", Content: "hello\n"}}); err != nil {
+		t.Fatalf("ApplyFiles returned error: %v", err)
+	}
+	server := NewWithWorkspace(nil, nil, workspaces, mcp.URL, false)
+	messages, err := server.resolveProjectToolCalls(
+		context.Background(),
+		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		scope,
+		"demo-repo",
+		[]chatToolCall{{
+			ID:   "call-commit",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      "commit_project_files",
+				Arguments: `{"repositoryRef":"other-repo","paths":["index.html"],"message":"Initial app"}`,
+			},
+		}},
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		nil,
+	)
 	if err != nil {
-		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
+		t.Fatalf("resolveProjectToolCalls returned error: %v", err)
 	}
 	if sawCommit {
 		t.Fatal("commit_project_files reached provider-code for a repository outside the Project binding")
 	}
-	if !strings.Contains(reply, "could not commit") || !strings.Contains(reply, "does not match this Project") {
-		t.Fatalf("reply = %q, want deterministic repository mismatch failure", reply)
-	}
-	if len(requests) != 2 {
-		t.Fatalf("LLM request count = %d, want 2", len(requests))
+	if len(messages) != 1 || !strings.Contains(messages[0].Content, "does not match this Project") {
+		t.Fatalf("tool messages = %#v, want deterministic repository mismatch failure", messages)
 	}
 }
 
@@ -787,7 +1263,7 @@ func TestProjectAssistantUnstreamedContentAppendsDistinctFinalReply(t *testing.T
 	}
 }
 
-func runRepeatedWriteFileAssistantStream(t *testing.T, finalNoToolResponse func(http.ResponseWriter)) (string, []chatCompletionRequest, error) {
+func runRepeatedReadFileAssistantStream(t *testing.T, finalNoToolResponse func(http.ResponseWriter)) (string, []chatCompletionRequest, error) {
 	t.Helper()
 
 	var requests []chatCompletionRequest
@@ -803,14 +1279,14 @@ func runRepeatedWriteFileAssistantStream(t *testing.T, finalNoToolResponse func(
 			return
 		}
 		callID := fmt.Sprintf("call-%d", len(requests))
-		writeProjectTestToolCallChunk(t, w, callID, "write_file", `{"path":"src/App.tsx","content":"hello world\n"}`)
+		writeProjectTestToolCallChunk(t, w, callID, "read_project_file", `{"path":"src/App.tsx"}`)
 	}))
 	defer llm.Close()
 
 	return runProjectAssistantStreamWithLLM(t, llm.URL, &requests)
 }
 
-func runUniqueWriteFileAssistantStream(t *testing.T, finalNoToolResponse func(http.ResponseWriter)) (string, []chatCompletionRequest, error) {
+func runUniqueReadFileAssistantStream(t *testing.T, finalNoToolResponse func(http.ResponseWriter)) (string, []chatCompletionRequest, error) {
 	t.Helper()
 
 	var requests []chatCompletionRequest
@@ -826,7 +1302,7 @@ func runUniqueWriteFileAssistantStream(t *testing.T, finalNoToolResponse func(ht
 			return
 		}
 		n := len(requests)
-		writeProjectTestToolCallChunk(t, w, fmt.Sprintf("call-%d", n), "write_file", fmt.Sprintf(`{"path":"src/file-%d.tsx","content":"hello %d\n"}`, n, n))
+		writeProjectTestToolCallChunk(t, w, fmt.Sprintf("call-%d", n), "read_project_file", fmt.Sprintf(`{"path":"src/file-%d.tsx"}`, n))
 	}))
 	defer llm.Close()
 
@@ -836,16 +1312,23 @@ func runUniqueWriteFileAssistantStream(t *testing.T, finalNoToolResponse func(ht
 func writeProjectTestToolCallChunk(t *testing.T, w http.ResponseWriter, id, name, arguments string) {
 	t.Helper()
 
-	chunk := chatCompletionStreamResponse{
-		Choices: []chatCompletionStreamChoice{{}},
-	}
-	chunk.Choices[0].Delta.ToolCalls = []chatStreamingCall{{
+	call := chatStreamingCall{
 		Index: 0,
 		ID:    id,
 		Type:  "function",
-	}}
-	chunk.Choices[0].Delta.ToolCalls[0].Function.Name = name
-	chunk.Choices[0].Delta.ToolCalls[0].Function.Arguments = arguments
+	}
+	call.Function.Name = name
+	call.Function.Arguments = arguments
+	writeProjectTestToolCallChunks(t, w, call)
+}
+
+func writeProjectTestToolCallChunks(t *testing.T, w http.ResponseWriter, calls ...chatStreamingCall) {
+	t.Helper()
+
+	chunk := chatCompletionStreamResponse{
+		Choices: []chatCompletionStreamChoice{{}},
+	}
+	chunk.Choices[0].Delta.ToolCalls = calls
 	raw, err := json.Marshal(chunk)
 	if err != nil {
 		t.Fatalf("marshal LLM stream chunk: %v", err)
@@ -887,6 +1370,15 @@ func runProjectAssistantStreamWithLLMAndHub(t *testing.T, llmURL string, hubBase
 		projectAssistantStreamCallbacks{},
 	)
 	return reply, *requests, err
+}
+
+func decodeProjectAssistantRunAudit(t *testing.T, raw []byte) projectAssistantRunAudit {
+	t.Helper()
+	var audit projectAssistantRunAudit
+	if err := json.Unmarshal(raw, &audit); err != nil {
+		t.Fatalf("decode assistant run audit: %v", err)
+	}
+	return audit
 }
 
 func TestProjectRepeatedToolLoopFallbackSummarizesLastToolResult(t *testing.T) {

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -87,6 +87,8 @@ func (s *Server) Register(r *mux.Router) {
 	r.HandleFunc("/api/projects/{project}", s.deleteProject).Methods(http.MethodDelete)
 	r.HandleFunc("/api/projects/{project}/messages", s.listProjectMessages).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/{project}/messages/stream", s.createProjectMessageStream).Methods(http.MethodPost)
+	r.HandleFunc("/api/projects/{project}/assistant/{run}/resume", s.resumeProjectAssistant).Methods(http.MethodPost)
+	r.HandleFunc("/api/projects/{project}/assistant/{run}/abort", s.abortProjectAssistant).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/{project}/memory", s.getProjectMemory).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/{project}/memory", s.patchProjectMemory).Methods(http.MethodPatch)
 }

--- a/providers/app-studio/store/assistant_run_test.go
+++ b/providers/app-studio/store/assistant_run_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreAssistantRunRoundTrip(t *testing.T) {
+	s := NewMemoryStore()
+	scope := Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
+	run := AssistantRun{
+		ID:         "run-1",
+		Status:     AssistantRunStatusPendingPermission,
+		RequestID:  "perm-1",
+		Checkpoint: json.RawMessage(`{"tool":"write_file"}`),
+		Audit:      json.RawMessage(`{"decisions":[{"decision":"allow"}]}`),
+	}
+	if err := s.SaveAssistantRun(context.Background(), scope, run); err != nil {
+		t.Fatalf("SaveAssistantRun returned error: %v", err)
+	}
+
+	got, err := s.GetAssistantRun(context.Background(), scope, "run-1")
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if got.ID != run.ID || got.Status != run.Status || got.RequestID != run.RequestID {
+		t.Fatalf("assistant run = %#v, want %#v", got, run)
+	}
+	if string(got.Checkpoint) != string(run.Checkpoint) {
+		t.Fatalf("checkpoint = %s, want %s", got.Checkpoint, run.Checkpoint)
+	}
+	if string(got.Audit) != string(run.Audit) {
+		t.Fatalf("audit = %s, want %s", got.Audit, run.Audit)
+	}
+
+	claimed, err := s.ClaimAssistantRun(context.Background(), scope, "run-1", "perm-1", got.CreatedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("ClaimAssistantRun returned error: %v", err)
+	}
+	if claimed.Status != AssistantRunStatusRunning {
+		t.Fatalf("claimed status = %q, want %q", claimed.Status, AssistantRunStatusRunning)
+	}
+	if _, err := s.ClaimAssistantRun(context.Background(), scope, "run-1", "perm-1", got.CreatedAt.Add(time.Minute)); err == nil {
+		t.Fatal("second ClaimAssistantRun returned nil error")
+	}
+
+	claimed.Status = AssistantRunStatusCompleted
+	if err := s.SaveAssistantRun(context.Background(), scope, claimed); err != nil {
+		t.Fatalf("SaveAssistantRun update returned error: %v", err)
+	}
+	updated, err := s.GetAssistantRun(context.Background(), scope, "run-1")
+	if err != nil {
+		t.Fatalf("GetAssistantRun update returned error: %v", err)
+	}
+	if updated.Status != AssistantRunStatusCompleted {
+		t.Fatalf("status = %q, want %q", updated.Status, AssistantRunStatusCompleted)
+	}
+}

--- a/providers/app-studio/store/encryption.go
+++ b/providers/app-studio/store/encryption.go
@@ -20,6 +20,7 @@ import (
 	"crypto/cipher"
 	cryptoRand "crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -185,6 +186,45 @@ func (s *encryptedStore) LoadRecentMessages(ctx context.Context, scope Scope, li
 	return items, nil
 }
 
+func (s *encryptedStore) SaveAssistantRun(ctx context.Context, scope Scope, run AssistantRun) error {
+	if err := scope.validate(); err != nil {
+		return err
+	}
+	checkpoint, err := s.encryptAssistantRunBlob(scope, run, "checkpoint", run.Checkpoint)
+	if err != nil {
+		return err
+	}
+	audit, err := s.encryptAssistantRunBlob(scope, run, "audit", run.Audit)
+	if err != nil {
+		return err
+	}
+	run.Checkpoint = checkpoint
+	run.Audit = audit
+	return s.inner.SaveAssistantRun(ctx, scope, run)
+}
+
+func (s *encryptedStore) ClaimAssistantRun(ctx context.Context, scope Scope, id string, requestID string, now time.Time) (AssistantRun, error) {
+	run, err := s.inner.ClaimAssistantRun(ctx, scope, id, requestID, now)
+	if err != nil {
+		return AssistantRun{}, err
+	}
+	if err := s.decryptAssistantRunBlobs(scope, &run); err != nil {
+		return AssistantRun{}, err
+	}
+	return run, nil
+}
+
+func (s *encryptedStore) GetAssistantRun(ctx context.Context, scope Scope, id string) (AssistantRun, error) {
+	run, err := s.inner.GetAssistantRun(ctx, scope, id)
+	if err != nil {
+		return AssistantRun{}, err
+	}
+	if err := s.decryptAssistantRunBlobs(scope, &run); err != nil {
+		return AssistantRun{}, err
+	}
+	return run, nil
+}
+
 func (s *encryptedStore) DeleteProjectMessages(ctx context.Context, scope Scope) error {
 	return s.inner.DeleteProjectMessages(ctx, scope)
 }
@@ -233,6 +273,85 @@ func messageAAD(scope Scope, msg Message) []byte {
 		scope.ProjectName,
 		msg.ID,
 		msg.Role,
+	}, "\x00"))
+}
+
+type encryptedAssistantRunCheckpoint struct {
+	Encrypted bool   `json:"encrypted"`
+	KeyID     string `json:"keyID"`
+	Payload   string `json:"payload"`
+}
+
+func (s *encryptedStore) encryptAssistantRunBlob(scope Scope, run AssistantRun, label string, plaintext []byte) ([]byte, error) {
+	if len(plaintext) == 0 {
+		return nil, nil
+	}
+	var existing encryptedAssistantRunCheckpoint
+	if json.Unmarshal(plaintext, &existing) == nil && existing.Encrypted && existing.KeyID != "" && existing.Payload != "" {
+		return cloneRawMessage(plaintext), nil
+	}
+	aead := s.keys[s.active]
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(cryptoRand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate assistant checkpoint nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, plaintext, assistantRunAAD(scope, run, label))
+	payload := append(nonce, ciphertext...)
+	envelope := encryptedAssistantRunCheckpoint{
+		Encrypted: true,
+		KeyID:     s.active,
+		Payload:   base64.RawStdEncoding.EncodeToString(payload),
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("encode encrypted assistant checkpoint: %w", err)
+	}
+	return raw, nil
+}
+
+func (s *encryptedStore) decryptAssistantRunBlobs(scope Scope, run *AssistantRun) error {
+	if err := s.decryptAssistantRunBlob(scope, run, "checkpoint", &run.Checkpoint); err != nil {
+		return err
+	}
+	return s.decryptAssistantRunBlob(scope, run, "audit", &run.Audit)
+}
+
+func (s *encryptedStore) decryptAssistantRunBlob(scope Scope, run *AssistantRun, label string, value *json.RawMessage) error {
+	if run == nil || value == nil || len(*value) == 0 {
+		return nil
+	}
+	var envelope encryptedAssistantRunCheckpoint
+	if err := json.Unmarshal(*value, &envelope); err != nil || !envelope.Encrypted {
+		return nil
+	}
+	aead := s.keys[envelope.KeyID]
+	if aead == nil {
+		return fmt.Errorf("assistant run %q uses unknown encryption key %q", run.ID, envelope.KeyID)
+	}
+	payload, err := base64.RawStdEncoding.DecodeString(envelope.Payload)
+	if err != nil {
+		return fmt.Errorf("decode encrypted assistant checkpoint %q: %w", run.ID, err)
+	}
+	if len(payload) < aead.NonceSize() {
+		return fmt.Errorf("encrypted assistant checkpoint %q is too short", run.ID)
+	}
+	nonce := payload[:aead.NonceSize()]
+	ciphertext := payload[aead.NonceSize():]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, assistantRunAAD(scope, *run, label))
+	if err != nil {
+		return fmt.Errorf("decrypt assistant checkpoint %q: %w", run.ID, err)
+	}
+	*value = plaintext
+	return nil
+}
+
+func assistantRunAAD(scope Scope, run AssistantRun, label string) []byte {
+	return []byte(strings.Join([]string{
+		scope.OrgUUID,
+		scope.WorkspaceUUID,
+		scope.ProjectName,
+		run.ID,
+		label,
 	}, "\x00"))
 }
 

--- a/providers/app-studio/store/memory.go
+++ b/providers/app-studio/store/memory.go
@@ -25,12 +25,16 @@ import (
 // MemoryStore is an in-memory implementation used for tests and explicit
 // local development. It must not be used as a silent production fallback.
 type MemoryStore struct {
-	mu       sync.RWMutex
-	messages map[Scope]map[string]Message
+	mu            sync.RWMutex
+	messages      map[Scope]map[string]Message
+	assistantRuns map[Scope]map[string]AssistantRun
 }
 
 func NewMemoryStore() *MemoryStore {
-	return &MemoryStore{messages: map[Scope]map[string]Message{}}
+	return &MemoryStore{
+		messages:      map[Scope]map[string]Message{},
+		assistantRuns: map[Scope]map[string]AssistantRun{},
+	}
 }
 
 func (s *MemoryStore) EnsureSchema(context.Context) error { return nil }
@@ -131,6 +135,86 @@ func (s *MemoryStore) LoadRecentMessages(_ context.Context, scope Scope, limit i
 	return all, nil
 }
 
+func (s *MemoryStore) SaveAssistantRun(_ context.Context, scope Scope, run AssistantRun) error {
+	if err := scope.validate(); err != nil {
+		return err
+	}
+	if run.ID == "" {
+		return fmt.Errorf("assistant run id is required")
+	}
+	if run.Status == "" {
+		return fmt.Errorf("assistant run status is required")
+	}
+	if run.CreatedAt.IsZero() {
+		run.CreatedAt = time.Now().UTC()
+	}
+	if run.UpdatedAt.IsZero() {
+		run.UpdatedAt = run.CreatedAt
+	}
+	run.ProjectName = scope.ProjectName
+	run.Checkpoint = cloneRawMessage(run.Checkpoint)
+	run.Audit = cloneRawMessage(run.Audit)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.assistantRuns[scope] == nil {
+		s.assistantRuns[scope] = map[string]AssistantRun{}
+	}
+	s.assistantRuns[scope][run.ID] = run
+	return nil
+}
+
+func (s *MemoryStore) ClaimAssistantRun(_ context.Context, scope Scope, id string, requestID string, now time.Time) (AssistantRun, error) {
+	if err := scope.validate(); err != nil {
+		return AssistantRun{}, err
+	}
+	if id == "" {
+		return AssistantRun{}, fmt.Errorf("assistant run id is required")
+	}
+	if requestID == "" {
+		return AssistantRun{}, fmt.Errorf("assistant run request id is required")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.assistantRuns[scope][id]
+	if !ok {
+		return AssistantRun{}, fmt.Errorf("assistant run %q not found", id)
+	}
+	if run.Status != AssistantRunStatusPendingPermission || run.RequestID != requestID {
+		return AssistantRun{}, fmt.Errorf("assistant run %q is not waiting for this permission request", id)
+	}
+	run.Status = AssistantRunStatusRunning
+	run.UpdatedAt = now.UTC()
+	run.ProjectName = scope.ProjectName
+	run.Checkpoint = cloneRawMessage(run.Checkpoint)
+	run.Audit = cloneRawMessage(run.Audit)
+	s.assistantRuns[scope][id] = run
+	return run, nil
+}
+
+func (s *MemoryStore) GetAssistantRun(_ context.Context, scope Scope, id string) (AssistantRun, error) {
+	if err := scope.validate(); err != nil {
+		return AssistantRun{}, err
+	}
+	if id == "" {
+		return AssistantRun{}, fmt.Errorf("assistant run id is required")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	run, ok := s.assistantRuns[scope][id]
+	if !ok {
+		return AssistantRun{}, fmt.Errorf("assistant run %q not found", id)
+	}
+	run.ProjectName = scope.ProjectName
+	run.Checkpoint = cloneRawMessage(run.Checkpoint)
+	run.Audit = cloneRawMessage(run.Audit)
+	return run, nil
+}
+
 func (s *MemoryStore) DeleteProjectMessages(_ context.Context, scope Scope) error {
 	if err := scope.validate(); err != nil {
 		return err
@@ -138,6 +222,7 @@ func (s *MemoryStore) DeleteProjectMessages(_ context.Context, scope Scope) erro
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.messages, scope)
+	delete(s.assistantRuns, scope)
 	return nil
 }
 
@@ -156,6 +241,17 @@ func (s *MemoryStore) DeleteMessagesOlderThan(_ context.Context, before time.Tim
 			delete(s.messages, scope)
 		}
 	}
+	for scope, runs := range s.assistantRuns {
+		for id, run := range runs {
+			if run.UpdatedAt.Before(before) {
+				delete(runs, id)
+				deleted++
+			}
+		}
+		if len(runs) == 0 {
+			delete(s.assistantRuns, scope)
+		}
+	}
 	return deleted, nil
 }
 
@@ -172,6 +268,15 @@ func cloneMetadata(src map[string]any) map[string]any {
 	for k, v := range src {
 		dst[k] = v
 	}
+	return dst
+}
+
+func cloneRawMessage(src []byte) []byte {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
 	return dst
 }
 

--- a/providers/app-studio/store/postgres.go
+++ b/providers/app-studio/store/postgres.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const messageSchemaVersion = "v1"
+const messageSchemaVersion = "v2"
 
 const createMessageSchemaMigrationsTable = `CREATE TABLE IF NOT EXISTS app_studio_message_schema_migrations (
 	version text PRIMARY KEY,
@@ -110,6 +110,21 @@ func (s *PostgresStore) EnsureSchema(ctx context.Context) error {
 			ON app_studio_messages (org_uuid, workspace_uuid, project_name, created_at, message_id)`,
 		`CREATE INDEX IF NOT EXISTS app_studio_messages_created_idx
 			ON app_studio_messages (created_at)`,
+		`CREATE TABLE IF NOT EXISTS app_studio_assistant_runs (
+			org_uuid text NOT NULL,
+			workspace_uuid text NOT NULL,
+			project_name text NOT NULL,
+			run_id text NOT NULL,
+			status text NOT NULL,
+			request_id text NOT NULL DEFAULT '',
+			checkpoint jsonb NOT NULL DEFAULT '{}'::jsonb,
+			audit jsonb NOT NULL DEFAULT '{}'::jsonb,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL,
+			PRIMARY KEY (org_uuid, workspace_uuid, project_name, run_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS app_studio_assistant_runs_scope_updated_idx
+			ON app_studio_assistant_runs (org_uuid, workspace_uuid, project_name, updated_at, run_id)`,
 	}
 	if err := ensureSchemaVersion(ctx, tx, messageSchemaVersion, stmts...); err != nil {
 		return err
@@ -291,6 +306,130 @@ func (s *PostgresStore) LoadRecentMessages(ctx context.Context, scope Scope, lim
 	return items, nil
 }
 
+func (s *PostgresStore) SaveAssistantRun(ctx context.Context, scope Scope, run AssistantRun) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("postgres store is nil")
+	}
+	if err := scope.validate(); err != nil {
+		return err
+	}
+	if run.ID == "" {
+		return fmt.Errorf("assistant run id is required")
+	}
+	if run.Status == "" {
+		return fmt.Errorf("assistant run status is required")
+	}
+	if run.CreatedAt.IsZero() {
+		run.CreatedAt = time.Now().UTC()
+	}
+	if run.UpdatedAt.IsZero() {
+		run.UpdatedAt = run.CreatedAt
+	}
+	run.ProjectName = scope.ProjectName
+	checkpoint := run.Checkpoint
+	if len(checkpoint) == 0 {
+		checkpoint = json.RawMessage(`{}`)
+	}
+	if !json.Valid(checkpoint) {
+		return fmt.Errorf("assistant run checkpoint is not valid json")
+	}
+	audit := run.Audit
+	if len(audit) == 0 {
+		audit = json.RawMessage(`{}`)
+	}
+	if !json.Valid(audit) {
+		return fmt.Errorf("assistant run audit is not valid json")
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO app_studio_assistant_runs (
+			org_uuid, workspace_uuid, project_name, run_id,
+			status, request_id, checkpoint, audit, created_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+		ON CONFLICT (org_uuid, workspace_uuid, project_name, run_id)
+		DO UPDATE SET
+			status = EXCLUDED.status,
+			request_id = EXCLUDED.request_id,
+			checkpoint = EXCLUDED.checkpoint,
+			audit = EXCLUDED.audit,
+			updated_at = EXCLUDED.updated_at
+	`,
+		scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName, run.ID,
+		run.Status, run.RequestID, []byte(checkpoint), []byte(audit), run.CreatedAt.UTC(), run.UpdatedAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert assistant run: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ClaimAssistantRun(ctx context.Context, scope Scope, id string, requestID string, now time.Time) (AssistantRun, error) {
+	if s == nil || s.db == nil {
+		return AssistantRun{}, fmt.Errorf("postgres store is nil")
+	}
+	if err := scope.validate(); err != nil {
+		return AssistantRun{}, err
+	}
+	if id == "" {
+		return AssistantRun{}, fmt.Errorf("assistant run id is required")
+	}
+	if requestID == "" {
+		return AssistantRun{}, fmt.Errorf("assistant run request id is required")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	row := s.db.QueryRowContext(ctx, `
+		UPDATE app_studio_assistant_runs
+		SET status = $1, updated_at = $2
+		WHERE org_uuid = $3
+		  AND workspace_uuid = $4
+		  AND project_name = $5
+		  AND run_id = $6
+		  AND request_id = $7
+		  AND status = $8
+		RETURNING run_id, status, request_id, checkpoint, audit, created_at, updated_at
+	`,
+		AssistantRunStatusRunning, now.UTC(),
+		scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName, id, requestID, AssistantRunStatusPendingPermission,
+	)
+
+	run, err := scanAssistantRun(row, scope.ProjectName)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return AssistantRun{}, fmt.Errorf("assistant run %q is not waiting for this permission request", id)
+		}
+		return AssistantRun{}, fmt.Errorf("claim assistant run: %w", err)
+	}
+	return run, nil
+}
+
+func (s *PostgresStore) GetAssistantRun(ctx context.Context, scope Scope, id string) (AssistantRun, error) {
+	if s == nil || s.db == nil {
+		return AssistantRun{}, fmt.Errorf("postgres store is nil")
+	}
+	if err := scope.validate(); err != nil {
+		return AssistantRun{}, err
+	}
+	if id == "" {
+		return AssistantRun{}, fmt.Errorf("assistant run id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT run_id, status, request_id, checkpoint, audit, created_at, updated_at
+		FROM app_studio_assistant_runs
+		WHERE org_uuid = $1 AND workspace_uuid = $2 AND project_name = $3 AND run_id = $4
+	`, scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName, id)
+
+	run, err := scanAssistantRun(row, scope.ProjectName)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return AssistantRun{}, fmt.Errorf("assistant run %q not found", id)
+		}
+		return AssistantRun{}, fmt.Errorf("get assistant run: %w", err)
+	}
+	return run, nil
+}
+
 func (s *PostgresStore) DeleteProjectMessages(ctx context.Context, scope Scope) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("postgres store is nil")
@@ -303,6 +442,12 @@ func (s *PostgresStore) DeleteProjectMessages(ctx context.Context, scope Scope) 
 		WHERE org_uuid = $1 AND workspace_uuid = $2 AND project_name = $3
 	`, scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName); err != nil {
 		return fmt.Errorf("delete project messages: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM app_studio_assistant_runs
+		WHERE org_uuid = $1 AND workspace_uuid = $2 AND project_name = $3
+	`, scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName); err != nil {
+		return fmt.Errorf("delete project assistant runs: %w", err)
 	}
 	return nil
 }
@@ -319,7 +464,15 @@ func (s *PostgresStore) DeleteMessagesOlderThan(ctx context.Context, before time
 	if err != nil {
 		return 0, fmt.Errorf("count deleted messages: %w", err)
 	}
-	return n, nil
+	runRes, err := s.db.ExecContext(ctx, `DELETE FROM app_studio_assistant_runs WHERE updated_at < $1`, before.UTC())
+	if err != nil {
+		return 0, fmt.Errorf("delete stale assistant runs: %w", err)
+	}
+	runN, err := runRes.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count deleted assistant runs: %w", err)
+	}
+	return n + runN, nil
 }
 
 func scanMessage(row interface {
@@ -353,6 +506,31 @@ func scanMessage(row interface {
 	msg.UpdatedAt = updatedAt.UTC()
 	msg.ProjectName = projectName
 	return msg, nil
+}
+
+func scanAssistantRun(row interface {
+	Scan(dest ...any) error
+}, projectName string) (AssistantRun, error) {
+	var run AssistantRun
+	var status string
+	if err := row.Scan(
+		&run.ID,
+		&status,
+		&run.RequestID,
+		&run.Checkpoint,
+		&run.Audit,
+		&run.CreatedAt,
+		&run.UpdatedAt,
+	); err != nil {
+		return AssistantRun{}, err
+	}
+	run.ProjectName = projectName
+	run.Status = AssistantRunStatus(status)
+	run.Checkpoint = cloneRawMessage(run.Checkpoint)
+	run.Audit = cloneRawMessage(run.Audit)
+	run.CreatedAt = run.CreatedAt.UTC()
+	run.UpdatedAt = run.UpdatedAt.UTC()
+	return run, nil
 }
 
 var _ Store = (*PostgresStore)(nil)

--- a/providers/app-studio/store/postgres_test.go
+++ b/providers/app-studio/store/postgres_test.go
@@ -17,6 +17,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"net/url"
 	"os"
 	"strings"
@@ -70,6 +71,59 @@ func TestPostgresStoreExternalDSN(t *testing.T) {
 	}
 	if len(page.Items) != 1 || page.Items[0].Content != msg.Content {
 		t.Fatalf("unexpected messages: %#v", page.Items)
+	}
+
+	run := AssistantRun{
+		ID:         "run-1",
+		Status:     AssistantRunStatusPendingPermission,
+		RequestID:  "perm-1",
+		Checkpoint: json.RawMessage(`{"tool":"write_file"}`),
+		Audit:      json.RawMessage(`{"decisions":[{"decision":"allow"}]}`),
+		CreatedAt:  time.Date(2026, 6, 14, 12, 1, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 14, 12, 1, 0, 0, time.UTC),
+	}
+	if err := s.SaveAssistantRun(ctx, scope, run); err != nil {
+		t.Fatalf("SaveAssistantRun: %v", err)
+	}
+	gotRun, err := s.GetAssistantRun(ctx, scope, run.ID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun: %v", err)
+	}
+	if gotRun.ID != run.ID || gotRun.Status != run.Status || gotRun.RequestID != run.RequestID || string(gotRun.Checkpoint) != string(run.Checkpoint) || string(gotRun.Audit) != string(run.Audit) {
+		t.Fatalf("assistant run = %#v, want %#v", gotRun, run)
+	}
+	claimed, err := s.ClaimAssistantRun(ctx, scope, run.ID, run.RequestID, run.UpdatedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("ClaimAssistantRun: %v", err)
+	}
+	if claimed.Status != AssistantRunStatusRunning || claimed.RequestID != run.RequestID {
+		t.Fatalf("claimed assistant run = %#v, want running request", claimed)
+	}
+	if _, err := s.ClaimAssistantRun(ctx, scope, run.ID, run.RequestID, run.UpdatedAt.Add(2*time.Minute)); err == nil {
+		t.Fatal("second ClaimAssistantRun returned nil error")
+	}
+	claimed.Status = AssistantRunStatusCompleted
+	claimed.UpdatedAt = run.UpdatedAt.Add(3 * time.Minute)
+	claimed.Audit = json.RawMessage(`{"decisions":[{"decision":"allow","result":"ok"}]}`)
+	if err := s.SaveAssistantRun(ctx, scope, claimed); err != nil {
+		t.Fatalf("SaveAssistantRun completed: %v", err)
+	}
+	completed, err := s.GetAssistantRun(ctx, scope, run.ID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun completed: %v", err)
+	}
+	if completed.Status != AssistantRunStatusCompleted || string(completed.Audit) != string(claimed.Audit) {
+		t.Fatalf("completed assistant run = %#v, want completed audit", completed)
+	}
+	deleted, err := s.DeleteMessagesOlderThan(ctx, run.UpdatedAt.Add(4*time.Minute))
+	if err != nil {
+		t.Fatalf("DeleteMessagesOlderThan: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted count = %d, want message and assistant run", deleted)
+	}
+	if _, err := s.GetAssistantRun(ctx, scope, run.ID); err == nil {
+		t.Fatal("GetAssistantRun after retention returned nil error")
 	}
 }
 

--- a/providers/app-studio/store/store.go
+++ b/providers/app-studio/store/store.go
@@ -52,6 +52,29 @@ type Message struct {
 	UpdatedAt        time.Time      `json:"updatedAt"`
 }
 
+type AssistantRunStatus string
+
+const (
+	AssistantRunStatusPendingPermission AssistantRunStatus = "pending_permission"
+	AssistantRunStatusRunning           AssistantRunStatus = "running"
+	AssistantRunStatusCompleted         AssistantRunStatus = "completed"
+	AssistantRunStatusAborted           AssistantRunStatus = "aborted"
+)
+
+// AssistantRun stores resumable assistant execution state. Checkpoint is an
+// App Studio API-owned JSON payload so store implementations do not need to
+// know private chat/tool types.
+type AssistantRun struct {
+	ID          string             `json:"id"`
+	ProjectName string             `json:"projectName,omitempty"`
+	Status      AssistantRunStatus `json:"status"`
+	RequestID   string             `json:"requestID,omitempty"`
+	Checkpoint  json.RawMessage    `json:"checkpoint,omitempty"`
+	Audit       json.RawMessage    `json:"audit,omitempty"`
+	CreatedAt   time.Time          `json:"createdAt"`
+	UpdatedAt   time.Time          `json:"updatedAt"`
+}
+
 // Page is an ordered slice of messages plus the next cursor for pagination.
 type Page struct {
 	Items      []Message `json:"items"`
@@ -64,6 +87,9 @@ type Store interface {
 	AppendMessage(ctx context.Context, scope Scope, msg Message) error
 	ListMessages(ctx context.Context, scope Scope, limit int, cursor string) (Page, error)
 	LoadRecentMessages(ctx context.Context, scope Scope, limit int) ([]Message, error)
+	SaveAssistantRun(ctx context.Context, scope Scope, run AssistantRun) error
+	ClaimAssistantRun(ctx context.Context, scope Scope, id string, requestID string, now time.Time) (AssistantRun, error)
+	GetAssistantRun(ctx context.Context, scope Scope, id string) (AssistantRun, error)
 	DeleteProjectMessages(ctx context.Context, scope Scope) error
 	DeleteMessagesOlderThan(ctx context.Context, before time.Time) (int64, error)
 }

--- a/providers/app-studio/store/store_test.go
+++ b/providers/app-studio/store/store_test.go
@@ -15,8 +15,10 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -36,6 +38,24 @@ func TestMemoryStorePaginationAndCleanup(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AppendMessage %d: %v", i, err)
 		}
+	}
+	if err := s.SaveAssistantRun(context.Background(), scope, AssistantRun{
+		ID:        "run-old",
+		Status:    AssistantRunStatusPendingPermission,
+		RequestID: "perm-old",
+		CreatedAt: base,
+		UpdatedAt: base,
+	}); err != nil {
+		t.Fatalf("SaveAssistantRun old: %v", err)
+	}
+	if err := s.SaveAssistantRun(context.Background(), scope, AssistantRun{
+		ID:        "run-new",
+		Status:    AssistantRunStatusPendingPermission,
+		RequestID: "perm-new",
+		CreatedAt: base.Add(2 * time.Minute),
+		UpdatedAt: base.Add(2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveAssistantRun new: %v", err)
 	}
 
 	page, err := s.ListMessages(context.Background(), scope, 2, "")
@@ -69,8 +89,8 @@ func TestMemoryStorePaginationAndCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteMessagesOlderThan: %v", err)
 	}
-	if deleted != 2 {
-		t.Fatalf("expected 2 deleted messages, got %d", deleted)
+	if deleted != 3 {
+		t.Fatalf("expected 2 deleted messages and 1 assistant run, got %d", deleted)
 	}
 	remaining, err := s.ListMessages(context.Background(), scope, 10, "")
 	if err != nil {
@@ -78,6 +98,12 @@ func TestMemoryStorePaginationAndCleanup(t *testing.T) {
 	}
 	if len(remaining.Items) != 1 || remaining.Items[0].ID != "c" {
 		t.Fatalf("unexpected remaining messages: %#v", remaining)
+	}
+	if _, err := s.GetAssistantRun(context.Background(), scope, "run-old"); err == nil {
+		t.Fatal("old assistant run still exists after cleanup")
+	}
+	if _, err := s.GetAssistantRun(context.Background(), scope, "run-new"); err != nil {
+		t.Fatalf("new assistant run missing after cleanup: %v", err)
 	}
 }
 
@@ -137,5 +163,50 @@ func TestEncryptedStoreEncryptsAtRestAndDecryptsOnRead(t *testing.T) {
 	}
 	if page.Items[0].Content != msg.Content || page.Items[0].ContentEncrypted {
 		t.Fatalf("message was not decrypted on read: %#v", page.Items[0])
+	}
+}
+
+func TestEncryptedStoreEncryptsAssistantRunCheckpointAtRest(t *testing.T) {
+	base := NewMemoryStore()
+	rawKey := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	keys, err := ParseEncryptionKeys("primary:" + rawKey)
+	if err != nil {
+		t.Fatalf("ParseEncryptionKeys: %v", err)
+	}
+	store, err := NewEncryptedStore(base, keys)
+	if err != nil {
+		t.Fatalf("NewEncryptedStore: %v", err)
+	}
+
+	scope := Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "customer-portal"}
+	run := AssistantRun{
+		ID:         "run-1",
+		Status:     AssistantRunStatusPendingPermission,
+		RequestID:  "perm-1",
+		Checkpoint: json.RawMessage(`{"tool":"write_file","content":"secret"}`),
+		Audit:      json.RawMessage(`{"decisions":[{"editedArguments":{"content":"secret"}}]}`),
+	}
+	if err := store.SaveAssistantRun(context.Background(), scope, run); err != nil {
+		t.Fatalf("SaveAssistantRun: %v", err)
+	}
+	rawRun, err := base.GetAssistantRun(context.Background(), scope, run.ID)
+	if err != nil {
+		t.Fatalf("raw GetAssistantRun: %v", err)
+	}
+	if string(rawRun.Checkpoint) == string(run.Checkpoint) || !bytes.Contains(rawRun.Checkpoint, []byte(`"encrypted":true`)) {
+		t.Fatalf("checkpoint was not encrypted at rest: %s", rawRun.Checkpoint)
+	}
+	if string(rawRun.Audit) == string(run.Audit) || !bytes.Contains(rawRun.Audit, []byte(`"encrypted":true`)) {
+		t.Fatalf("audit was not encrypted at rest: %s", rawRun.Audit)
+	}
+	got, err := store.GetAssistantRun(context.Background(), scope, run.ID)
+	if err != nil {
+		t.Fatalf("encrypted GetAssistantRun: %v", err)
+	}
+	if string(got.Checkpoint) != string(run.Checkpoint) {
+		t.Fatalf("checkpoint = %s, want %s", got.Checkpoint, run.Checkpoint)
+	}
+	if string(got.Audit) != string(run.Audit) {
+		t.Fatalf("audit = %s, want %s", got.Audit, run.Audit)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds assistant permission policy for App Studio project tools: read tools auto-allow, write/commit tools require approval, unknown risks deny as model-visible tool results.
- Persists resumable assistant runs with encrypted checkpoint and audit blobs, plus atomic claim semantics before approved tool side effects execute.
- Adds resume/abort endpoints for pending assistant runs and streams permission_required / checkpoint_saved events through the existing assistant SSE path.
- Preserves the current Eino assistant path as the only project-chat engine; no legacy switch or fallback mode is introduced.

Stacked on #303.

## Verification

- cd providers/app-studio && go test ./api -run TestProjectAssistantPermission\|TestGenerateProjectAssistantStream\|TestResolveProjectToolCalls -count=1
- cd providers/app-studio && go test ./store ./api -count=1
- cd providers/app-studio && go test ./...
- cd providers/app-studio && go mod tidy -diff
- git diff --check

## Review Notes

- Independent review identified duplicate-approval and audit concerns; fixed by claiming runs before side effects, persisting audit decisions/results, rejecting stale repository bindings, and carrying batched tool calls forward to the next permission request.
- External Postgres assistant-run coverage was added to TestPostgresStoreExternalDSN; it skips unless APP_STUDIO_TEST_POSTGRES_DSN is configured.