### PR TITLE
Render App Studio assistant tool timeline

### DIFF
--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -37,9 +37,10 @@ type projectAssistantCheckpointState struct {
 }
 
 type projectAssistantResumeRequest struct {
-	RequestID       string         `json:"requestID"`
-	Decision        string         `json:"decision"`
-	EditedArguments map[string]any `json:"editedArguments,omitempty"`
+	RequestID          string         `json:"requestID"`
+	Decision           string         `json:"decision"`
+	AssistantMessageID string         `json:"assistantMessageID,omitempty"`
+	EditedArguments    map[string]any `json:"editedArguments,omitempty"`
 }
 
 type projectAssistantResumeResponse struct {
@@ -206,6 +207,8 @@ func (s *Server) resumeProjectAssistantRun(
 		Decision:  decision,
 	}
 	if projectAssistantCheckpointHasStaleRepositoryBinding(state, p) {
+		staleBindingError := "Project repository binding changed after permission was requested"
+		tc := state.ToolCalls[state.CurrentIndex]
 		now := time.Now().UTC()
 		run.Status = store.AssistantRunStatusCompleted
 		run.UpdatedAt = now
@@ -213,9 +216,9 @@ func (s *Server) resumeProjectAssistantRun(
 			RequestID:  run.RequestID,
 			Decision:   decision,
 			Actor:      id.user,
-			ToolCallID: state.ToolCalls[state.CurrentIndex].ID,
-			ToolName:   state.ToolCalls[state.CurrentIndex].Function.Name,
-			Error:      "Project repository binding changed after permission was requested",
+			ToolCallID: tc.ID,
+			ToolName:   tc.Function.Name,
+			Error:      staleBindingError,
 			ResolvedAt: now,
 		})
 		if err != nil {
@@ -224,7 +227,18 @@ func (s *Server) resumeProjectAssistantRun(
 		if saveErr := s.store.SaveAssistantRun(ctx, messageScope, run); saveErr != nil {
 			return projectAssistantResumeResponse{}, saveErr
 		}
-		return projectAssistantResumeResponse{}, newValidationError("Project repository binding changed after permission was requested")
+		out.Status = run.Status
+		out.Result = staleBindingError
+		out.ToolCall = &projectToolCallStreamEvent{
+			ID:     tc.ID,
+			Name:   tc.Function.Name,
+			Status: "failed",
+			Error:  staleBindingError,
+		}
+		if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(req.AssistantMessageID), out); err != nil {
+			return projectAssistantResumeResponse{}, err
+		}
+		return projectAssistantResumeResponse{}, newValidationError(staleBindingError)
 	}
 
 	run, out, err = s.resolveClaimedProjectAssistantRun(ctx, r, id, p, run, state, req, decision, out)
@@ -235,6 +249,9 @@ func (s *Server) resumeProjectAssistantRun(
 		return projectAssistantResumeResponse{}, err
 	}
 	out.Status = run.Status
+	if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(req.AssistantMessageID), out); err != nil {
+		return projectAssistantResumeResponse{}, err
+	}
 	return out, nil
 }
 
@@ -346,6 +363,12 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 		case projectAssistantPermissionDeny:
 			msg := projectAssistantPermissionDeniedToolMessage(tc, "denied by user")
 			out.Result = msg.Content
+			out.ToolCall = &projectToolCallStreamEvent{
+				ID:     tc.ID,
+				Name:   tc.Function.Name,
+				Status: "rejected",
+				Error:  msg.Content,
+			}
 			now := time.Now().UTC()
 			var err error
 			run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -115,19 +115,24 @@ type projectMessageStreamEvent struct {
 }
 
 type projectToolCallStreamEvent struct {
-	ID        string `json:"id"`
-	Name      string `json:"name,omitempty"`
-	Status    string `json:"status"`
-	Arguments string `json:"arguments,omitempty"`
-	Summary   string `json:"summary,omitempty"`
-	Error     string `json:"error,omitempty"`
+	ID         string                      `json:"id"`
+	Name       string                      `json:"name,omitempty"`
+	Status     string                      `json:"status"`
+	Arguments  string                      `json:"arguments,omitempty"`
+	Summary    string                      `json:"summary,omitempty"`
+	Error      string                      `json:"error,omitempty"`
+	Permission *projectAssistantPermission `json:"permission,omitempty"`
+	Checkpoint *projectAssistantCheckpoint `json:"checkpoint,omitempty"`
 }
 
 const projectAPIInitializingMessage = "App Studio is still initializing for this workspace. Try again shortly."
 const projectMessageMetadataStatus = "status"
 const projectMessageMetadataToolCalls = "toolCalls"
 const projectMessageStatusInterrupted = "interrupted"
+const projectMessageStatusPendingPermission = "pending_permission"
 const projectMessagePersistTimeout = 5 * time.Second
+
+var errProjectAssistantMessageNotFound = errors.New("project assistant message not found")
 
 type projectCreationStatusFunc func(string) error
 
@@ -542,6 +547,7 @@ func (s *Server) streamProjectAssistant(
 	assistantContent := &strings.Builder{}
 	var streamErr error
 	var streamedToolCalls []projectToolCallStreamEvent
+	var pendingPermissionToolCallID string
 	scope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
 	streamWriter := projectAssistantStreamWriter{
 		assistantID: assistantID,
@@ -550,6 +556,27 @@ func (s *Server) streamProjectAssistant(
 		},
 	}
 	emitAssistantEvent := func(event projectAssistantEvent) {
+		switch event.Type {
+		case projectAssistantEventPermissionNeeded:
+			if event.Permission != nil && event.Permission.ToolCallID != "" {
+				pendingPermissionToolCallID = event.Permission.ToolCallID
+				streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, projectToolCallStreamEvent{
+					ID:         event.Permission.ToolCallID,
+					Name:       event.Permission.ToolName,
+					Status:     "permission_required",
+					Summary:    event.Permission.Reason,
+					Permission: event.Permission,
+				})
+			}
+		case projectAssistantEventCheckpointSaved:
+			if event.Checkpoint != nil && pendingPermissionToolCallID != "" {
+				streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, projectToolCallStreamEvent{
+					ID:         pendingPermissionToolCallID,
+					Status:     "permission_required",
+					Checkpoint: event.Checkpoint,
+				})
+			}
+		}
 		if streamErr != nil {
 			return
 		}
@@ -582,13 +609,13 @@ func (s *Server) streamProjectAssistant(
 		})
 	}
 	streamToolCall := func(toolCall projectToolCallStreamEvent) {
-		if streamErr != nil {
-			return
-		}
 		if toolCall.ID == "" || toolCall.Status == "" {
 			return
 		}
 		streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, toolCall)
+		if streamErr != nil {
+			return
+		}
 		emitAssistantEvent(projectAssistantEvent{
 			Type: projectAssistantEventToolCallFinished,
 			ToolCall: &projectAssistantToolCall{
@@ -611,8 +638,15 @@ func (s *Server) streamProjectAssistant(
 	if err != nil {
 		var permissionErr *projectAssistantPermissionRequiredError
 		if errors.As(err, &permissionErr) {
-			if streamErr != nil {
-				_ = appendInterruptedProjectAssistantMessage(r.Context(), msgStore, scope, assistantID, assistantContent.String())
+			persistCtx, cancel := detachedProjectPersistenceContext(r.Context())
+			defer cancel()
+			if err := appendProjectAssistantMessage(persistCtx, msgStore, scope, assistantID, assistantContent.String(), projectAssistantMessageMetadata(projectMessageStatusPendingPermission, streamedToolCalls)); err != nil {
+				if streamErr == nil {
+					_ = streamWriter.EmitProjectAssistantEvent(r.Context(), projectAssistantEvent{
+						Type:  projectAssistantEventRunFailed,
+						Error: "assistant persistence failed: " + err.Error(),
+					})
+				}
 			}
 			return
 		}
@@ -726,18 +760,165 @@ func appendProjectAssistantMessage(ctx context.Context, msgStore store.Store, sc
 	})
 }
 
+func (s *Server) updateProjectAssistantPermissionMessage(
+	ctx context.Context,
+	scope store.Scope,
+	assistantMessageID string,
+	response projectAssistantResumeResponse,
+) error {
+	if s == nil || s.store == nil || assistantMessageID == "" {
+		return nil
+	}
+	msg, err := s.findProjectMessage(ctx, scope, assistantMessageID)
+	if err != nil {
+		if errors.Is(err, errProjectAssistantMessageNotFound) {
+			return nil
+		}
+		return err
+	}
+	if msg.Role != aiv1alpha1.ProjectMessageRoleAssistant {
+		return nil
+	}
+	metadata := cloneAnyMap(msg.Metadata)
+	toolCalls := projectToolCallStreamEventsFromMetadata(metadata[projectMessageMetadataToolCalls])
+	if !projectAssistantPermissionMessageMatchesResume(metadata, toolCalls, response) {
+		return nil
+	}
+	if response.ToolCall != nil {
+		toolCalls = upsertProjectToolCallStreamEvent(toolCalls, *response.ToolCall)
+	}
+	if response.Permission != nil {
+		toolCalls = upsertProjectToolCallStreamEvent(toolCalls, projectToolCallStreamEvent{
+			ID:         response.Permission.ToolCallID,
+			Name:       response.Permission.ToolName,
+			Status:     "permission_required",
+			Summary:    response.Permission.Reason,
+			Permission: response.Permission,
+		})
+	}
+	if response.Checkpoint != nil && response.Permission != nil {
+		toolCalls = upsertProjectToolCallStreamEvent(toolCalls, projectToolCallStreamEvent{
+			ID:         response.Permission.ToolCallID,
+			Status:     "permission_required",
+			Checkpoint: response.Checkpoint,
+		})
+	}
+	if response.Status == store.AssistantRunStatusPendingPermission {
+		metadata[projectMessageMetadataStatus] = projectMessageStatusPendingPermission
+	} else {
+		delete(metadata, projectMessageMetadataStatus)
+	}
+	metadata[projectMessageMetadataToolCalls] = sanitizeProjectToolCallStreamEventsForMetadata(toolCalls)
+	now := time.Now().UTC()
+	return s.store.AppendMessage(ctx, scope, store.Message{
+		ID:        msg.ID,
+		Role:      msg.Role,
+		Content:   msg.Content,
+		Metadata:  metadata,
+		CreatedAt: msg.CreatedAt,
+		UpdatedAt: now,
+	})
+}
+
+func projectAssistantPermissionMessageMatchesResume(metadata map[string]any, toolCalls []projectToolCallStreamEvent, response projectAssistantResumeResponse) bool {
+	if metadata[projectMessageMetadataStatus] != projectMessageStatusPendingPermission {
+		return false
+	}
+	if response.RunID == "" || len(toolCalls) == 0 {
+		return false
+	}
+	toolIDs := map[string]struct{}{}
+	if response.ToolCall != nil && response.ToolCall.ID != "" {
+		toolIDs[response.ToolCall.ID] = struct{}{}
+	}
+	if response.Permission != nil && response.Permission.ToolCallID != "" {
+		toolIDs[response.Permission.ToolCallID] = struct{}{}
+	}
+	for _, event := range toolCalls {
+		if event.Checkpoint == nil || event.Checkpoint.ID != response.RunID {
+			continue
+		}
+		if len(toolIDs) == 0 {
+			return true
+		}
+		if _, ok := toolIDs[event.ID]; ok {
+			return true
+		}
+		if event.Permission != nil {
+			if _, ok := toolIDs[event.Permission.ToolCallID]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *Server) findProjectMessage(ctx context.Context, scope store.Scope, id string) (store.Message, error) {
+	cursor := ""
+	for {
+		page, err := s.store.ListMessages(ctx, scope, 250, cursor)
+		if err != nil {
+			return store.Message{}, err
+		}
+		for _, msg := range page.Items {
+			if msg.ID == id {
+				return msg, nil
+			}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	return store.Message{}, fmt.Errorf("%w: %q", errProjectAssistantMessageNotFound, id)
+}
+
 func projectAssistantMessageMetadata(status string, toolCalls []projectToolCallStreamEvent) map[string]any {
 	metadata := map[string]any{}
 	if status != "" {
 		metadata[projectMessageMetadataStatus] = status
 	}
 	if len(toolCalls) > 0 {
-		metadata[projectMessageMetadataToolCalls] = toolCalls
+		metadata[projectMessageMetadataToolCalls] = sanitizeProjectToolCallStreamEventsForMetadata(toolCalls)
 	}
 	if len(metadata) == 0 {
 		return nil
 	}
 	return metadata
+}
+
+func sanitizeProjectToolCallStreamEventsForMetadata(events []projectToolCallStreamEvent) []projectToolCallStreamEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]projectToolCallStreamEvent, 0, len(events))
+	for _, event := range events {
+		if event.Permission != nil {
+			permission := *event.Permission
+			permission.Input = nil
+			event.Permission = &permission
+		}
+		out = append(out, event)
+	}
+	return out
+}
+
+func projectToolCallStreamEventsFromMetadata(raw any) []projectToolCallStreamEvent {
+	if raw == nil {
+		return nil
+	}
+	if typed, ok := raw.([]projectToolCallStreamEvent); ok {
+		return append([]projectToolCallStreamEvent(nil), typed...)
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var out []projectToolCallStreamEvent
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return out
 }
 
 func upsertProjectToolCallStreamEvent(events []projectToolCallStreamEvent, event projectToolCallStreamEvent) []projectToolCallStreamEvent {
@@ -762,6 +943,12 @@ func mergeProjectToolCallStreamEvent(existing, next projectToolCallStreamEvent) 
 	}
 	if next.Error == "" {
 		next.Error = existing.Error
+	}
+	if next.Permission == nil {
+		next.Permission = existing.Permission
+	}
+	if next.Checkpoint == nil {
+		next.Checkpoint = existing.Checkpoint
 	}
 	return next
 }

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -568,7 +568,243 @@ func TestGenerateProjectAssistantStreamRequestsPermissionForWriteTool(t *testing
 	}
 }
 
+func TestStreamProjectAssistantPersistsPermissionTimelineMessage(t *testing.T) {
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"src/App.tsx","content":"hello\n"}`)
+	}))
+	defer llm.Close()
+
+	settings := projectLLMSettings{
+		Provider: defaultProjectLLMProvider,
+		BaseURL:  llm.URL,
+		Model:    "test-model",
+		APIKey:   "test-key",
+	}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, "demo")
+	if err := appendProjectUserMessage(context.Background(), messages, messageScope, "write a file"); err != nil {
+		t.Fatalf("appendProjectUserMessage returned error: %v", err)
+	}
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	rr := httptest.NewRecorder()
+	flusher, ok := startProjectMessageStream(rr)
+	if !ok {
+		t.Fatal("response recorder did not support streaming")
+	}
+
+	server.streamProjectAssistant(
+		rr,
+		flusher,
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		client,
+		id,
+		project,
+		messages,
+	)
+
+	recent, err := messages.LoadRecentMessages(context.Background(), messageScope, 10)
+	if err != nil {
+		t.Fatalf("LoadRecentMessages returned error: %v", err)
+	}
+	var assistant store.Message
+	for _, msg := range recent {
+		if msg.Role == aiv1alpha1.ProjectMessageRoleAssistant {
+			assistant = msg
+		}
+	}
+	if assistant.ID == "" {
+		t.Fatalf("messages = %#v, want persisted assistant permission message", recent)
+	}
+	if assistant.Metadata[projectMessageMetadataStatus] != projectMessageStatusPendingPermission {
+		t.Fatalf("assistant metadata = %#v, want pending permission status", assistant.Metadata)
+	}
+	rawToolCalls, ok := assistant.Metadata[projectMessageMetadataToolCalls].([]projectToolCallStreamEvent)
+	if !ok || len(rawToolCalls) != 1 {
+		t.Fatalf("tool call metadata = %#v, want one typed tool call", assistant.Metadata[projectMessageMetadataToolCalls])
+	}
+	if rawToolCalls[0].Status != "permission_required" || rawToolCalls[0].Permission == nil || rawToolCalls[0].Checkpoint == nil {
+		t.Fatalf("tool call metadata = %#v, want permission and checkpoint", rawToolCalls[0])
+	}
+	if rawToolCalls[0].Permission.Input != nil {
+		t.Fatalf("persisted permission input = %#v, want redacted", rawToolCalls[0].Permission.Input)
+	}
+	if !strings.Contains(rawToolCalls[0].Arguments, "path src/App.tsx") || !strings.Contains(rawToolCalls[0].Arguments, "6 bytes") {
+		t.Fatalf("arguments summary = %q, want redacted path and byte count", rawToolCalls[0].Arguments)
+	}
+	if strings.Contains(rawToolCalls[0].Arguments, "hello") {
+		t.Fatalf("arguments summary leaked file content: %q", rawToolCalls[0].Arguments)
+	}
+}
+
+func TestStreamProjectAssistantPersistsPermissionTimelineAfterStreamWriteFailure(t *testing.T) {
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"src/App.tsx","content":"hello\n"}`)
+	}))
+	defer llm.Close()
+
+	settings := projectLLMSettings{
+		Provider: defaultProjectLLMProvider,
+		BaseURL:  llm.URL,
+		Model:    "test-model",
+		APIKey:   "test-key",
+	}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, "demo")
+	if err := appendProjectUserMessage(context.Background(), messages, messageScope, "write a file"); err != nil {
+		t.Fatalf("appendProjectUserMessage returned error: %v", err)
+	}
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	stream := &failingProjectStreamResponseWriter{header: http.Header{}}
+
+	server.streamProjectAssistant(
+		stream,
+		stream,
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		client,
+		id,
+		project,
+		messages,
+	)
+
+	recent, err := messages.LoadRecentMessages(context.Background(), messageScope, 10)
+	if err != nil {
+		t.Fatalf("LoadRecentMessages returned error: %v", err)
+	}
+	var assistant store.Message
+	for _, msg := range recent {
+		if msg.Role == aiv1alpha1.ProjectMessageRoleAssistant {
+			assistant = msg
+		}
+	}
+	if assistant.ID == "" {
+		t.Fatalf("messages = %#v, want persisted assistant permission message", recent)
+	}
+	rawToolCalls, ok := assistant.Metadata[projectMessageMetadataToolCalls].([]projectToolCallStreamEvent)
+	if !ok || len(rawToolCalls) != 1 {
+		t.Fatalf("tool call metadata = %#v, want one typed tool call", assistant.Metadata[projectMessageMetadataToolCalls])
+	}
+	if assistant.Metadata[projectMessageMetadataStatus] != projectMessageStatusPendingPermission || rawToolCalls[0].Status != "permission_required" || rawToolCalls[0].Permission == nil || rawToolCalls[0].Checkpoint == nil {
+		t.Fatalf("assistant metadata = %#v, want pending permission with checkpoint after stream write failure", assistant.Metadata)
+	}
+	if rawToolCalls[0].Permission.Input != nil {
+		t.Fatalf("persisted permission input = %#v, want redacted", rawToolCalls[0].Permission.Input)
+	}
+}
+
 func TestResumeProjectAssistantRunApprovesPendingTool(t *testing.T) {
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolWriteFile)
+	if !ok {
+		t.Fatal("write_file tool missing from registry")
+	}
+	tc := chatToolCall{
+		ID:   "call-write",
+		Type: "function",
+		Function: chatToolCallFunction{
+			Name:      projectToolWriteFile,
+			Arguments: `{"path":"src/App.tsx","content":"approved\n"}`,
+		},
+	}
+	permissionErr, permission, checkpoint, err := server.saveProjectAssistantPermissionCheckpoint(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+			Project:        project,
+			WorkspaceScope: workspaceScope,
+			MessageScope:   messageScope,
+		},
+		tool,
+		tc,
+		map[string]any{"path": "src/App.tsx", "content": "approved\n"},
+		projectLinkedRepositoryRef(project),
+	)
+	if err != nil {
+		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
+	}
+	assistantMessageID := "msg-assistant"
+	if err := appendProjectAssistantMessage(context.Background(), messages, messageScope, assistantMessageID, "", projectAssistantMessageMetadata(projectMessageStatusPendingPermission, []projectToolCallStreamEvent{{
+		ID:         tc.ID,
+		Name:       tc.Function.Name,
+		Status:     "permission_required",
+		Arguments:  "path src/App.tsx, 9 bytes",
+		Summary:    permission.Reason,
+		Permission: &permission,
+		Checkpoint: &checkpoint,
+	}})); err != nil {
+		t.Fatalf("appendProjectAssistantMessage returned error: %v", err)
+	}
+
+	resp, err := server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{
+			RequestID:          permissionErr.RequestID,
+			Decision:           string(projectAssistantPermissionAllow),
+			AssistantMessageID: assistantMessageID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRun returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted || resp.ToolCall == nil || resp.ToolCall.Status != "succeeded" {
+		t.Fatalf("resume response = %#v, want completed succeeded tool call", resp)
+	}
+	read, err := workspaces.ReadFile(context.Background(), workspaceScope, workspace.ReadOptions{Path: "src/App.tsx"})
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if read.Content != "approved\n" {
+		t.Fatalf("content = %q, want approved write", read.Content)
+	}
+	run, err := messages.GetAssistantRun(context.Background(), messageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if run.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", run.Status)
+	}
+	audit := decodeProjectAssistantRunAudit(t, run.Audit)
+	if len(audit.Decisions) != 1 || audit.Decisions[0].Decision != projectAssistantPermissionAllow || audit.Decisions[0].Actor != id.user || audit.Decisions[0].Result == "" {
+		t.Fatalf("audit = %#v, want allow decision with actor and result", audit)
+	}
+	updatedMessage, err := server.findProjectMessage(context.Background(), messageScope, assistantMessageID)
+	if err != nil {
+		t.Fatalf("findProjectMessage returned error: %v", err)
+	}
+	if _, ok := updatedMessage.Metadata[projectMessageMetadataStatus]; ok {
+		t.Fatalf("assistant metadata = %#v, want pending status cleared", updatedMessage.Metadata)
+	}
+	updatedToolCalls := projectToolCallStreamEventsFromMetadata(updatedMessage.Metadata[projectMessageMetadataToolCalls])
+	if len(updatedToolCalls) != 1 || updatedToolCalls[0].Status != "succeeded" {
+		t.Fatalf("updated tool calls = %#v, want persisted succeeded action", updatedToolCalls)
+	}
+	if updatedToolCalls[0].Permission != nil && updatedToolCalls[0].Permission.Input != nil {
+		t.Fatalf("persisted permission input = %#v, want redacted", updatedToolCalls[0].Permission.Input)
+	}
+}
+
+func TestResumeProjectAssistantRunIgnoresStaleAssistantMessageID(t *testing.T) {
 	messages := store.NewMemoryStore()
 	workspaces := workspace.NewFileStore(t.TempDir())
 	server := NewWithWorkspace(nil, messages, workspaces, "", false)
@@ -614,8 +850,9 @@ func TestResumeProjectAssistantRunApprovesPendingTool(t *testing.T) {
 		project,
 		permissionErr.RunID,
 		projectAssistantResumeRequest{
-			RequestID: permissionErr.RequestID,
-			Decision:  string(projectAssistantPermissionAllow),
+			RequestID:          permissionErr.RequestID,
+			Decision:           string(projectAssistantPermissionAllow),
+			AssistantMessageID: "missing-assistant-message",
 		},
 	)
 	if err != nil {
@@ -631,16 +868,180 @@ func TestResumeProjectAssistantRunApprovesPendingTool(t *testing.T) {
 	if read.Content != "approved\n" {
 		t.Fatalf("content = %q, want approved write", read.Content)
 	}
-	run, err := messages.GetAssistantRun(context.Background(), messageScope, permissionErr.RunID)
+}
+
+func TestResumeProjectAssistantRunIgnoresMismatchedAssistantMessageID(t *testing.T) {
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolWriteFile)
+	if !ok {
+		t.Fatal("write_file tool missing from registry")
+	}
+	tc := chatToolCall{
+		ID:   "call-write",
+		Type: "function",
+		Function: chatToolCallFunction{
+			Name:      projectToolWriteFile,
+			Arguments: `{"path":"src/App.tsx","content":"approved\n"}`,
+		},
+	}
+	permissionErr, _, _, err := server.saveProjectAssistantPermissionCheckpoint(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+			Project:        project,
+			WorkspaceScope: workspaceScope,
+			MessageScope:   messageScope,
+		},
+		tool,
+		tc,
+		map[string]any{"path": "src/App.tsx", "content": "approved\n"},
+		projectLinkedRepositoryRef(project),
+	)
 	if err != nil {
-		t.Fatalf("GetAssistantRun returned error: %v", err)
+		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
 	}
-	if run.Status != store.AssistantRunStatusCompleted {
-		t.Fatalf("run status = %q, want completed", run.Status)
+	otherMessageID := "msg-other-assistant"
+	otherPermission := projectAssistantPermission{ID: "perm-other", ToolCallID: "call-other", ToolName: projectToolWriteFile, Reason: "other permission"}
+	otherCheckpoint := projectAssistantCheckpoint{ID: "run-other", Reason: "waiting_for_permission"}
+	otherMetadata := projectAssistantMessageMetadata(projectMessageStatusPendingPermission, []projectToolCallStreamEvent{{
+		ID:         "call-other",
+		Name:       projectToolWriteFile,
+		Status:     "permission_required",
+		Summary:    otherPermission.Reason,
+		Permission: &otherPermission,
+		Checkpoint: &otherCheckpoint,
+	}})
+	if err := appendProjectAssistantMessage(context.Background(), messages, messageScope, otherMessageID, "other pending message", otherMetadata); err != nil {
+		t.Fatalf("appendProjectAssistantMessage returned error: %v", err)
 	}
-	audit := decodeProjectAssistantRunAudit(t, run.Audit)
-	if len(audit.Decisions) != 1 || audit.Decisions[0].Decision != projectAssistantPermissionAllow || audit.Decisions[0].Actor != id.user || audit.Decisions[0].Result == "" {
-		t.Fatalf("audit = %#v, want allow decision with actor and result", audit)
+
+	resp, err := server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{
+			RequestID:          permissionErr.RequestID,
+			Decision:           string(projectAssistantPermissionAllow),
+			AssistantMessageID: otherMessageID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRun returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted || resp.ToolCall == nil || resp.ToolCall.Status != "succeeded" {
+		t.Fatalf("resume response = %#v, want completed succeeded tool call", resp)
+	}
+	read, err := workspaces.ReadFile(context.Background(), workspaceScope, workspace.ReadOptions{Path: "src/App.tsx"})
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if read.Content != "approved\n" {
+		t.Fatalf("content = %q, want approved write", read.Content)
+	}
+	otherMessage, err := server.findProjectMessage(context.Background(), messageScope, otherMessageID)
+	if err != nil {
+		t.Fatalf("findProjectMessage returned error: %v", err)
+	}
+	if otherMessage.Metadata[projectMessageMetadataStatus] != projectMessageStatusPendingPermission {
+		t.Fatalf("other message metadata = %#v, want pending status unchanged", otherMessage.Metadata)
+	}
+	toolCalls := projectToolCallStreamEventsFromMetadata(otherMessage.Metadata[projectMessageMetadataToolCalls])
+	if len(toolCalls) != 1 || toolCalls[0].ID != "call-other" || toolCalls[0].Status != "permission_required" {
+		t.Fatalf("other message tool calls = %#v, want unrelated pending call unchanged", toolCalls)
+	}
+}
+
+func TestResumeProjectAssistantRunDeniesPendingToolAndUpdatesMessage(t *testing.T) {
+	messages := store.NewMemoryStore()
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolWriteFile)
+	if !ok {
+		t.Fatal("write_file tool missing from registry")
+	}
+	tc := chatToolCall{
+		ID:   "call-write",
+		Type: "function",
+		Function: chatToolCallFunction{
+			Name:      projectToolWriteFile,
+			Arguments: `{"path":"src/App.tsx","content":"denied\n"}`,
+		},
+	}
+	permissionErr, permission, checkpoint, err := server.saveProjectAssistantPermissionCheckpoint(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+			Project:        project,
+			WorkspaceScope: workspaceScope,
+			MessageScope:   messageScope,
+		},
+		tool,
+		tc,
+		map[string]any{"path": "src/App.tsx", "content": "denied\n"},
+		projectLinkedRepositoryRef(project),
+	)
+	if err != nil {
+		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
+	}
+	assistantMessageID := "msg-assistant-denied"
+	if err := appendProjectAssistantMessage(context.Background(), messages, messageScope, assistantMessageID, "", projectAssistantMessageMetadata(projectMessageStatusPendingPermission, []projectToolCallStreamEvent{{
+		ID:         tc.ID,
+		Name:       tc.Function.Name,
+		Status:     "permission_required",
+		Arguments:  "path src/App.tsx, 7 bytes",
+		Summary:    permission.Reason,
+		Permission: &permission,
+		Checkpoint: &checkpoint,
+	}})); err != nil {
+		t.Fatalf("appendProjectAssistantMessage returned error: %v", err)
+	}
+
+	resp, err := server.resumeProjectAssistantRun(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		permissionErr.RunID,
+		projectAssistantResumeRequest{
+			RequestID:          permissionErr.RequestID,
+			Decision:           string(projectAssistantPermissionDeny),
+			AssistantMessageID: assistantMessageID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRun returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted || resp.ToolCall == nil || resp.ToolCall.Status != "rejected" {
+		t.Fatalf("resume response = %#v, want completed rejected tool call", resp)
+	}
+	updatedMessage, err := server.findProjectMessage(context.Background(), messageScope, assistantMessageID)
+	if err != nil {
+		t.Fatalf("findProjectMessage returned error: %v", err)
+	}
+	if _, ok := updatedMessage.Metadata[projectMessageMetadataStatus]; ok {
+		t.Fatalf("assistant metadata = %#v, want pending status cleared", updatedMessage.Metadata)
+	}
+	updatedToolCalls := projectToolCallStreamEventsFromMetadata(updatedMessage.Metadata[projectMessageMetadataToolCalls])
+	if len(updatedToolCalls) != 1 || updatedToolCalls[0].Status != "rejected" {
+		t.Fatalf("updated tool calls = %#v, want persisted rejected action", updatedToolCalls)
+	}
+	if updatedToolCalls[0].Permission != nil && updatedToolCalls[0].Permission.Input != nil {
+		t.Fatalf("persisted permission input = %#v, want redacted", updatedToolCalls[0].Permission.Input)
 	}
 }
 
@@ -831,7 +1232,7 @@ func TestResumeProjectAssistantRunRejectsStaleRepositoryBinding(t *testing.T) {
 			Arguments: `{"repositoryRef":"old-repo","paths":["src/App.tsx"],"message":"Initial app"}`,
 		},
 	}
-	permissionErr, _, _, err := server.saveProjectAssistantPermissionCheckpoint(
+	permissionErr, permission, checkpoint, err := server.saveProjectAssistantPermissionCheckpoint(
 		context.Background(),
 		projectAssistantRunRequest{Identity: id, HTTPRequest: httptest.NewRequest(http.MethodPost, "/", nil), Project: project, WorkspaceScope: workspaceScope, MessageScope: messageScope},
 		tool,
@@ -842,6 +1243,18 @@ func TestResumeProjectAssistantRunRejectsStaleRepositoryBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("saveProjectAssistantPermissionCheckpoint returned error: %v", err)
 	}
+	assistantMessageID := "msg-assistant-stale"
+	if err := appendProjectAssistantMessage(context.Background(), messages, messageScope, assistantMessageID, "", projectAssistantMessageMetadata(projectMessageStatusPendingPermission, []projectToolCallStreamEvent{{
+		ID:         tc.ID,
+		Name:       tc.Function.Name,
+		Status:     "permission_required",
+		Arguments:  "repositoryRef old-repo, 1 file(s): src/App.tsx",
+		Summary:    permission.Reason,
+		Permission: &permission,
+		Checkpoint: &checkpoint,
+	}})); err != nil {
+		t.Fatalf("appendProjectAssistantMessage returned error: %v", err)
+	}
 	project.Spec.Repository.RepositoryRef = "new-repo"
 
 	_, err = server.resumeProjectAssistantRun(
@@ -850,7 +1263,11 @@ func TestResumeProjectAssistantRunRejectsStaleRepositoryBinding(t *testing.T) {
 		id,
 		project,
 		permissionErr.RunID,
-		projectAssistantResumeRequest{RequestID: permissionErr.RequestID, Decision: string(projectAssistantPermissionAllow)},
+		projectAssistantResumeRequest{
+			RequestID:          permissionErr.RequestID,
+			Decision:           string(projectAssistantPermissionAllow),
+			AssistantMessageID: assistantMessageID,
+		},
 	)
 	if err == nil || !strings.Contains(err.Error(), "repository binding changed") {
 		t.Fatalf("resumeProjectAssistantRun error = %v, want stale repository binding", err)
@@ -868,6 +1285,17 @@ func TestResumeProjectAssistantRunRejectsStaleRepositoryBinding(t *testing.T) {
 	audit := decodeProjectAssistantRunAudit(t, run.Audit)
 	if len(audit.Decisions) != 1 || !strings.Contains(audit.Decisions[0].Error, "repository binding changed") {
 		t.Fatalf("audit = %#v, want stale binding error", audit)
+	}
+	updatedMessage, err := server.findProjectMessage(context.Background(), messageScope, assistantMessageID)
+	if err != nil {
+		t.Fatalf("findProjectMessage returned error: %v", err)
+	}
+	if _, ok := updatedMessage.Metadata[projectMessageMetadataStatus]; ok {
+		t.Fatalf("assistant metadata = %#v, want pending status cleared", updatedMessage.Metadata)
+	}
+	updatedToolCalls := projectToolCallStreamEventsFromMetadata(updatedMessage.Metadata[projectMessageMetadataToolCalls])
+	if len(updatedToolCalls) != 1 || updatedToolCalls[0].Status != "failed" || !strings.Contains(updatedToolCalls[0].Error, "repository binding changed") {
+		t.Fatalf("updated tool calls = %#v, want failed stale binding action", updatedToolCalls)
 	}
 }
 
@@ -1706,6 +2134,22 @@ func codeObjectGetter(objects ...*unstructured.Unstructured) codeResourceGetter 
 		return nil, apierrors.NewNotFound(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, name)
 	}
 }
+
+type failingProjectStreamResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingProjectStreamResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingProjectStreamResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("stream write failed")
+}
+
+func (w *failingProjectStreamResponseWriter) WriteHeader(int) {}
+
+func (w *failingProjectStreamResponseWriter) Flush() {}
 
 func codeObjectLister(objects ...*unstructured.Unstructured) codeResourceLister {
 	return func(_ context.Context, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -33,6 +33,9 @@ import { useEscapeKey } from '@/composables/useEscapeKey'
 import type {
   KedgeContext,
   Project,
+  ProjectAssistantCheckpoint,
+  ProjectAssistantPermission,
+  ProjectAssistantResumeResponse,
   ProjectLLMSettings,
   ProjectMessage,
   ProjectRepositoryCommit,
@@ -204,6 +207,9 @@ const prompt = ref('')
 const projectQuery = ref('')
 const providerQuery = ref('')
 const conversationStatus = ref('')
+const permissionBusy = ref<Record<string, 'allow' | 'deny'>>({})
+const permissionEdits = ref<Record<string, string>>({})
+const permissionErrors = ref<Record<string, string>>({})
 const selectedTool = ref<ProviderTool | null>(null)
 const toolState = ref<'idle' | 'loading' | 'ready' | 'error'>('idle')
 const llmSettings = ref<ProjectLLMSettings | null>(null)
@@ -938,6 +944,20 @@ async function createProjectAndStartConversation(content: string) {
           assistantMessageID = event.assistantMessageID
         }
         upsertAssistantToolCall(projectName, event.assistantMessageID, event.toolCall)
+      } else if (event.type === 'permission_required') {
+        conversationStatus.value = ''
+        if (!projectName || !event.assistantMessageID || !event.permission) return
+        if (!assistantMessageID) {
+          assistantMessageID = event.assistantMessageID
+        }
+        upsertAssistantPermission(projectName, event.assistantMessageID, event.permission)
+      } else if (event.type === 'checkpoint_saved') {
+        conversationStatus.value = ''
+        if (!projectName || !event.assistantMessageID || !event.checkpoint) return
+        if (!assistantMessageID) {
+          assistantMessageID = event.assistantMessageID
+        }
+        attachAssistantCheckpoint(projectName, event.assistantMessageID, event.checkpoint)
       } else if (event.type === 'done') {
         conversationStatus.value = ''
         if (!assistantMessageID) {
@@ -1138,6 +1158,20 @@ async function sendMessage() {
           assistantMessageID = event.assistantMessageID
         }
         upsertAssistantToolCall(projectName, event.assistantMessageID, event.toolCall)
+      } else if (event.type === 'permission_required') {
+        conversationStatus.value = ''
+        if (!event.assistantMessageID || !event.permission) return
+        if (!assistantMessageID) {
+          assistantMessageID = event.assistantMessageID
+        }
+        upsertAssistantPermission(projectName, event.assistantMessageID, event.permission)
+      } else if (event.type === 'checkpoint_saved') {
+        conversationStatus.value = ''
+        if (!event.assistantMessageID || !event.checkpoint) return
+        if (!assistantMessageID) {
+          assistantMessageID = event.assistantMessageID
+        }
+        attachAssistantCheckpoint(projectName, event.assistantMessageID, event.checkpoint)
       } else if (event.type === 'done') {
         conversationStatus.value = ''
         if (!assistantMessageID) {
@@ -1210,6 +1244,44 @@ function upsertAssistantToolCall(projectName: string, assistantMessageID: string
   messages.value = [...messages.value]
 }
 
+function upsertAssistantPermission(projectName: string, assistantMessageID: string, permission: ProjectAssistantPermission) {
+  const id = permission.toolCallID || permission.id
+  const toolCall: ProjectToolCallEvent = {
+    id,
+    name: permission.toolName,
+    status: 'permission_required',
+    arguments: permissionInputLabel(permission),
+    summary: permission.reason,
+    permission,
+  }
+  upsertAssistantToolCall(projectName, assistantMessageID, toolCall)
+  const key = permissionKey(toolCall)
+  if (key && permissionEdits.value[key] === undefined) {
+    permissionEdits.value = {
+      ...permissionEdits.value,
+      [key]: prettyPermissionInput(permission.input),
+    }
+  }
+}
+
+function attachAssistantCheckpoint(projectName: string, assistantMessageID: string, checkpoint: ProjectAssistantCheckpoint) {
+  const idx = ensureAssistantMessage(projectName, assistantMessageID)
+  const message = messages.value[idx]
+  const toolCalls = [...(message.toolCalls ?? [])]
+  const targetIdx = [...toolCalls].reverse().findIndex((item) => item.status === 'permission_required' && !item.checkpoint)
+  if (targetIdx === -1) return
+  const idxFromStart = toolCalls.length - 1 - targetIdx
+  toolCalls[idxFromStart] = {
+    ...toolCalls[idxFromStart],
+    checkpoint,
+  }
+  messages.value[idx] = {
+    ...message,
+    toolCalls,
+  }
+  messages.value = [...messages.value]
+}
+
 function mergeToolCall(existing: ProjectToolCallView, next: ProjectToolCallEvent): ProjectToolCallView {
   return {
     ...existing,
@@ -1218,6 +1290,8 @@ function mergeToolCall(existing: ProjectToolCallView, next: ProjectToolCallEvent
     arguments: next.arguments || existing.arguments,
     summary: next.summary || existing.summary,
     error: next.error || existing.error,
+    permission: next.permission || existing.permission,
+    checkpoint: next.checkpoint || existing.checkpoint,
   }
 }
 
@@ -1245,6 +1319,84 @@ function markAssistantMessageInterrupted(projectName: string, assistantMessageID
       createdAt: new Date().toISOString(),
     },
   ]
+}
+
+async function resolveToolPermission(message: ProjectMessageView, toolCall: ProjectToolCallView, decision: 'allow' | 'deny') {
+  const projectName = selected.value?.name || message.projectID
+  const runID = toolCall.checkpoint?.id
+  const requestID = toolCall.permission?.id
+  const key = permissionKey(toolCall)
+  if (!projectName || !runID || !requestID || !key || permissionBusy.value[key]) return
+
+  permissionErrors.value = { ...permissionErrors.value, [key]: '' }
+  let editedArguments: Record<string, unknown> | undefined
+  if (decision === 'allow' && canEditPermission(toolCall)) {
+    const raw = (permissionEdits.value[key] ?? '').trim()
+    if (raw) {
+      try {
+        editedArguments = JSON.parse(raw) as Record<string, unknown>
+      } catch (e) {
+        permissionErrors.value = {
+          ...permissionErrors.value,
+          [key]: e instanceof Error ? e.message : 'Invalid JSON input',
+        }
+        return
+      }
+    }
+  }
+
+  permissionBusy.value = { ...permissionBusy.value, [key]: decision }
+  try {
+    const response = await api.resumeAssistantRun(props.ctx, projectName, runID, {
+      requestID,
+      decision,
+      assistantMessageID: message.id,
+      ...(editedArguments ? { editedArguments } : {}),
+    })
+    applyPermissionResponse(projectName, message.id, toolCall, response)
+  } catch (e) {
+    permissionErrors.value = {
+      ...permissionErrors.value,
+      [key]: e instanceof Error ? e.message : String(e),
+    }
+  } finally {
+    const next = { ...permissionBusy.value }
+    delete next[key]
+    permissionBusy.value = next
+  }
+}
+
+function applyPermissionResponse(
+  projectName: string,
+  assistantMessageID: string,
+  toolCall: ProjectToolCallView,
+  response: ProjectAssistantResumeResponse,
+) {
+  const key = permissionKey(toolCall)
+  if (response.toolCall) {
+    upsertAssistantToolCall(projectName, assistantMessageID, response.toolCall)
+  } else {
+    upsertAssistantToolCall(projectName, assistantMessageID, {
+      id: toolCall.id,
+      name: toolCall.name,
+      status: response.decision === 'allow' ? 'succeeded' : 'rejected',
+      summary: response.result,
+      error: response.decision === 'deny' ? response.result || 'Permission denied' : undefined,
+      permission: toolCall.permission,
+      checkpoint: toolCall.checkpoint,
+    })
+  }
+  if (key) {
+    const edits = { ...permissionEdits.value }
+    delete edits[key]
+    permissionEdits.value = edits
+  }
+  if (response.permission) {
+    upsertAssistantPermission(projectName, assistantMessageID, response.permission)
+    if (response.checkpoint) {
+      attachAssistantCheckpoint(projectName, assistantMessageID, response.checkpoint)
+    }
+  }
 }
 
 function toProjectMessageView(message: ProjectMessage): ProjectMessageView {
@@ -1496,6 +1648,8 @@ function toolCallStatusLabel(toolCall: ProjectToolCallView): string {
       return 'Preparing'
     case 'running':
       return 'Running'
+    case 'permission_required':
+      return 'Needs approval'
     case 'succeeded':
       return 'Ran'
     case 'failed':
@@ -1508,7 +1662,7 @@ function toolCallStatusLabel(toolCall: ProjectToolCallView): string {
 }
 
 function toolCallHasDetails(toolCall: ProjectToolCallView): boolean {
-  return Boolean(toolCall.arguments || toolCall.summary || toolCall.error)
+  return Boolean(toolCall.arguments || toolCall.summary || toolCall.error || toolCall.permission || toolCall.checkpoint)
 }
 
 function actionBundleLabel(toolCalls?: ProjectToolCallView[]): string {
@@ -1525,6 +1679,8 @@ function actionSummary(toolCall: ProjectToolCallView): string {
       return 'Preparing tool input'
     case 'running':
       return 'Waiting for result'
+    case 'permission_required':
+      return toolCall.permission?.reason || 'Waiting for approval'
     case 'succeeded':
       return 'Completed'
     case 'failed':
@@ -1547,11 +1703,68 @@ function toolCallStatusClass(toolCall: ProjectToolCallView): string {
     case 'failed':
     case 'rejected':
       return 'text-danger'
+    case 'permission_required':
+      return 'text-accent'
     case 'requested':
     case 'running':
     default:
       return 'text-warning'
   }
+}
+
+function permissionKey(toolCall: ProjectToolCallView): string {
+  return toolCall.permission?.id || toolCall.id
+}
+
+function permissionBusyState(toolCall: ProjectToolCallView): 'allow' | 'deny' | undefined {
+  return permissionBusy.value[permissionKey(toolCall)]
+}
+
+function permissionError(toolCall: ProjectToolCallView): string {
+  return permissionErrors.value[permissionKey(toolCall)] || ''
+}
+
+function permissionInputLabel(permission?: ProjectAssistantPermission): string {
+  if (!permission || permission.input === undefined || permission.input === null) return ''
+  if (typeof permission.input !== 'object' || Array.isArray(permission.input)) return ''
+  const input = permission.input as Record<string, unknown>
+  const parts: string[] = []
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null) continue
+    if (['content', 'oldText', 'newText'].includes(key)) {
+      const text = typeof value === 'string' ? value : JSON.stringify(value)
+      parts.push(`${key} ${new TextEncoder().encode(text).length} bytes`)
+      continue
+    }
+    if (key === 'paths' && Array.isArray(value)) {
+      parts.push(`${value.length} file(s): ${value.map((item) => String(item)).slice(0, 3).join(', ')}`)
+      continue
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      parts.push(`${key} ${value}`)
+      continue
+    }
+    if (Array.isArray(value)) {
+      parts.push(`${key} ${value.length} item(s)`)
+    }
+  }
+  return parts.join(', ')
+}
+
+function prettyPermissionInput(input: unknown): string {
+  if (input === undefined || input === null) return ''
+  if (typeof input === 'string') return input
+  try {
+    return JSON.stringify(input, null, 2)
+  } catch {
+    return ''
+  }
+}
+
+function canEditPermission(toolCall: ProjectToolCallView): boolean {
+  if (toolCall.permission?.input === undefined || toolCall.permission.input === null) return false
+  const name = displayToolName(toolCall.permission?.toolName || toolCall.name).toLowerCase()
+  return ['write_file', 'apply_patch', 'mkdir', 'commit_project_files'].includes(name)
 }
 
 function isMissingCodeConnectionError(value: string | null): boolean {
@@ -2126,6 +2339,62 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
                             </div>
                           </summary>
                           <div class="grid gap-2 border-t border-border-subtle px-3 py-2.5">
+                            <div
+                              v-if="toolCall.status === 'permission_required' && toolCall.permission"
+                              class="grid gap-2 rounded-md border border-accent/20 bg-accent-subtle px-2.5 py-2"
+                            >
+                              <div class="flex min-w-0 items-start justify-between gap-3">
+                                <div class="min-w-0">
+                                  <div class="text-[11px] font-semibold text-text-primary">Approval required</div>
+                                  <div class="mt-0.5 text-[11px] leading-4 text-text-secondary">
+                                    {{ toolCall.permission.reason || 'Review this action before it runs.' }}
+                                  </div>
+                                </div>
+                                <div class="shrink-0 font-mono text-[11px] text-text-muted">
+                                  {{ toolCall.checkpoint?.id || 'Saving' }}
+                                </div>
+                              </div>
+                              <textarea
+                                v-if="canEditPermission(toolCall)"
+                                v-model="permissionEdits[permissionKey(toolCall)]"
+                                rows="4"
+                                class="min-h-[84px] resize-y rounded-md border border-border-subtle bg-surface px-2 py-1.5 font-mono text-[11px] leading-4 text-text-secondary outline-none transition focus:border-accent/50"
+                                spellcheck="false"
+                              />
+                              <div v-if="permissionError(toolCall)" class="text-[11px] leading-4 text-danger">
+                                {{ permissionError(toolCall) }}
+                              </div>
+                              <div class="flex flex-wrap items-center gap-2">
+                                <button
+                                  type="button"
+                                  class="inline-flex h-7 items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2.5 text-[11px] font-medium text-accent transition hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-60"
+                                  :disabled="!toolCall.checkpoint || !!permissionBusyState(toolCall)"
+                                  @click="resolveToolPermission(message, toolCall, 'allow')"
+                                >
+                                  <Loader2
+                                    v-if="permissionBusyState(toolCall) === 'allow'"
+                                    class="h-3.5 w-3.5 animate-spin"
+                                    :stroke-width="1.75"
+                                  />
+                                  <Check v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+                                  Allow
+                                </button>
+                                <button
+                                  type="button"
+                                  class="inline-flex h-7 items-center gap-1.5 rounded-md border border-border-subtle bg-surface px-2.5 text-[11px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                                  :disabled="!toolCall.checkpoint || !!permissionBusyState(toolCall)"
+                                  @click="resolveToolPermission(message, toolCall, 'deny')"
+                                >
+                                  <Loader2
+                                    v-if="permissionBusyState(toolCall) === 'deny'"
+                                    class="h-3.5 w-3.5 animate-spin"
+                                    :stroke-width="1.75"
+                                  />
+                                  <X v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+                                  Deny
+                                </button>
+                              </div>
+                            </div>
                             <div v-if="toolCall.arguments" class="grid gap-1">
                               <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Input</div>
                               <pre class="overflow-x-auto whitespace-pre-wrap rounded-md border border-border-subtle bg-surface px-2 py-1.5 font-mono text-[11px] leading-4 text-text-secondary">{{ toolCall.arguments }}</pre>

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -2,6 +2,7 @@ import type {
   KedgeContext,
   ListResponse,
   Project,
+  ProjectAssistantResumeResponse,
   ProjectLLMSettings,
   ProjectMemory,
   ProjectMessage,
@@ -298,6 +299,28 @@ export const api = {
       { role: 'user', content },
       onEvent,
       signal,
+    )
+  },
+
+  async resumeAssistantRun(
+    ctx: KedgeContext | null,
+    name: string,
+    runID: string,
+    body: { requestID: string; decision: 'allow' | 'deny'; assistantMessageID?: string; editedArguments?: Record<string, unknown> },
+  ): Promise<ProjectAssistantResumeResponse> {
+    return request<ProjectAssistantResumeResponse>(
+      ctx,
+      'POST',
+      `${baseURL(ctx)}/${encodeURIComponent(name)}/assistant/${encodeURIComponent(runID)}/resume`,
+      body,
+    )
+  },
+
+  async abortAssistantRun(ctx: KedgeContext | null, name: string, runID: string): Promise<ProjectAssistantResumeResponse> {
+    return request<ProjectAssistantResumeResponse>(
+      ctx,
+      'POST',
+      `${baseURL(ctx)}/${encodeURIComponent(name)}/assistant/${encodeURIComponent(runID)}/abort`,
     )
   },
 

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -27,20 +27,49 @@ export interface ProjectMessage {
 export interface ProjectToolCallEvent {
   id: string
   name?: string
-  status: 'requested' | 'running' | 'succeeded' | 'failed' | 'rejected'
+  status: 'requested' | 'running' | 'permission_required' | 'succeeded' | 'failed' | 'rejected'
   arguments?: string
   summary?: string
   error?: string
+  permission?: ProjectAssistantPermission
+  checkpoint?: ProjectAssistantCheckpoint
+}
+
+export interface ProjectAssistantPermission {
+  id: string
+  toolCallID?: string
+  toolName?: string
+  reason?: string
+  input?: unknown
+}
+
+export interface ProjectAssistantCheckpoint {
+  id: string
+  reason?: string
+  createdAt?: string
+}
+
+export interface ProjectAssistantResumeResponse {
+  runID: string
+  requestID: string
+  status: 'pending_permission' | 'running' | 'completed' | 'aborted'
+  decision: 'allow' | 'deny'
+  toolCall?: ProjectToolCallEvent
+  permission?: ProjectAssistantPermission
+  checkpoint?: ProjectAssistantCheckpoint
+  result?: string
 }
 
 export interface ProjectMessageStreamEvent {
-  type: 'chunk' | 'tool_call' | 'done' | 'error' | 'status' | 'project'
+  type: 'chunk' | 'tool_call' | 'permission_required' | 'checkpoint_saved' | 'done' | 'error' | 'status' | 'project'
   assistantMessageID?: string
   content?: string
   status?: string
   error?: string
   project?: Project
   toolCall?: ProjectToolCallEvent
+  permission?: ProjectAssistantPermission
+  checkpoint?: ProjectAssistantCheckpoint
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary
- render App Studio assistant tool timeline rows for tool calls, permission requests, and checkpoints
- add allow/deny controls that resume pending assistant tool runs from the timeline
- persist pending permission rows and update them after approve, deny, stale repository binding, or stream write failure paths without storing plaintext permission input in message metadata

## Stack
- Base: #304 / codex/app-studio-eino-07-permissions-resume
- This PR: phase 8 portal timeline and permission UX

## Verification
- cd providers/app-studio && go test ./api -run 'TestStreamProjectAssistantPersistsPermissionTimelineAfterStreamWriteFailure|TestResumeProjectAssistantRunRejectsStaleRepositoryBinding|TestResumeProjectAssistantRunApprovesPendingTool|TestResumeProjectAssistantRunIgnoresStaleAssistantMessageID|TestResumeProjectAssistantRunDeniesPendingToolAndUpdatesMessage' -count=1
- cd providers/app-studio && go test ./...
- cd providers/app-studio/portal && npm run typecheck
- cd providers/app-studio/portal && npm run build
- cd providers/app-studio && go mod tidy -diff
- git diff --check

## Review
- Independent review found no P0/P1/P2 findings after fixes.