### PR TITLE
Add App Studio assistant planning workflow

### DIFF
--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -175,6 +175,18 @@ func (s *Server) resumeProjectAssistantRun(
 	runID string,
 	req projectAssistantResumeRequest,
 ) (projectAssistantResumeResponse, error) {
+	return s.resumeProjectAssistantRunWithRepository(ctx, r, id, p, nil, runID, req)
+}
+
+func (s *Server) resumeProjectAssistantRunWithRepository(
+	ctx context.Context,
+	r *http.Request,
+	id identity,
+	p *aiv1alpha1.Project,
+	repository *ProjectRepositoryView,
+	runID string,
+	req projectAssistantResumeRequest,
+) (projectAssistantResumeResponse, error) {
 	if s.store == nil {
 		return projectAssistantResumeResponse{}, fmt.Errorf("project message store not configured")
 	}
@@ -241,7 +253,7 @@ func (s *Server) resumeProjectAssistantRun(
 		return projectAssistantResumeResponse{}, newValidationError(staleBindingError)
 	}
 
-	run, out, err = s.resolveClaimedProjectAssistantRun(ctx, r, id, p, run, state, req, decision, out)
+	run, out, err = s.resolveClaimedProjectAssistantRun(ctx, r, id, p, repository, run, state, req, decision, out)
 	if err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
@@ -311,6 +323,7 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 	r *http.Request,
 	id identity,
 	p *aiv1alpha1.Project,
+	repository *ProjectRepositoryView,
 	run store.AssistantRun,
 	state projectAssistantCheckpointState,
 	req projectAssistantResumeRequest,
@@ -338,7 +351,7 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 			if err != nil {
 				return run, out, err
 			}
-			result, toolCall, err := s.executeApprovedProjectAssistantToolCall(ctx, r, id, p, state.ProjectRepositoryRef, tc)
+			result, toolCall, err := s.executeApprovedProjectAssistantToolCall(ctx, r, id, p, repository, state.ProjectRepositoryRef, tc)
 			if err != nil {
 				return run, out, err
 			}
@@ -414,6 +427,7 @@ func (s *Server) executeApprovedProjectAssistantToolCall(
 	r *http.Request,
 	id identity,
 	p *aiv1alpha1.Project,
+	repository *ProjectRepositoryView,
 	projectRepositoryRef string,
 	tc chatToolCall,
 ) (string, *projectToolCallStreamEvent, error) {
@@ -421,6 +435,8 @@ func (s *Server) executeApprovedProjectAssistantToolCall(
 	messages, err := s.resolveProjectToolCalls(
 		ctx,
 		id,
+		p,
+		repository,
 		projectWorkspaceScope(id, p.Name),
 		projectRepositoryRef,
 		[]chatToolCall{tc},

--- a/providers/app-studio/api/assistant_tool.go
+++ b/providers/app-studio/api/assistant_tool.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 	"github.com/faroshq/provider-app-studio/workspace"
 )
 
@@ -53,6 +54,8 @@ func (s projectAssistantToolSpec) chatTool() chatTool {
 
 type projectAssistantToolCallRequest struct {
 	Identity             identity
+	Project              *aiv1alpha1.Project
+	Repository           *ProjectRepositoryView
 	WorkspaceScope       workspace.Scope
 	ProjectRepositoryRef string
 	MCPEndpoint          string

--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -143,6 +143,7 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 				}))
 			},
 		},
+		newProjectAssistantWorkflowTool(server),
 		projectAssistantToolFunc{
 			spec: projectAssistantToolSpec{
 				Name:        projectToolWriteFile,

--- a/providers/app-studio/api/assistant_workflow.go
+++ b/providers/app-studio/api/assistant_workflow.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cloudwego/eino/compose"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+const projectAssistantWorkflowMaxResultBytes = 4096
+
+type projectAssistantWorkflowInput struct {
+	Server         *Server
+	Project        *aiv1alpha1.Project
+	Repository     *ProjectRepositoryView
+	WorkspaceScope workspace.Scope
+	IncludeFiles   bool
+	MaxFiles       int
+}
+
+type projectAssistantWorkflowContext struct {
+	Project        *aiv1alpha1.Project
+	Repository     *ProjectRepositoryView
+	WorkspaceFiles []string
+}
+
+type projectAssistantWorkflowPlan struct {
+	Summary      string                        `json:"summary"`
+	Goals        []string                      `json:"goals,omitempty"`
+	Requirements []string                      `json:"requirements,omitempty"`
+	Constraints  []string                      `json:"constraints,omitempty"`
+	Repository   *projectAssistantWorkflowRepo `json:"repository,omitempty"`
+	Files        []string                      `json:"files,omitempty"`
+	Steps        []string                      `json:"steps"`
+}
+
+type projectAssistantWorkflowRepo struct {
+	Ref    string `json:"ref,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+func newProjectAssistantWorkflowTool(server *Server) projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolPlanProjectChanges,
+			Description: "Create a deterministic read-only plan for project changes from project memory, repository status, and the current workspace file list.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"includeFiles":{"type":"boolean","description":"Whether to include a bounded current workspace file list."},"maxFiles":{"type":"integer","minimum":1,"maximum":50,"description":"Maximum workspace file paths to include when includeFiles is true."}}}`),
+			Risk:        projectAssistantToolRiskRead,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			input := projectAssistantWorkflowInput{
+				Server:         server,
+				Project:        req.Project,
+				Repository:     req.Repository,
+				WorkspaceScope: req.WorkspaceScope,
+				IncludeFiles:   projectToolBool(req.Arguments["includeFiles"]),
+				MaxFiles:       boundedWorkflowFileLimit(projectToolInt(req.Arguments["maxFiles"])),
+			}
+			return runProjectAssistantPlanningWorkflow(ctx, input)
+		},
+	}
+}
+
+func runProjectAssistantPlanningWorkflow(ctx context.Context, input projectAssistantWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantPlanningWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	plan, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowPlan(plan)
+	if err != nil {
+		return "", fmt.Errorf("encode project planning workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func marshalProjectAssistantWorkflowPlan(plan projectAssistantWorkflowPlan) ([]byte, error) {
+	raw, err := json.Marshal(plan)
+	if err != nil || len(raw) <= projectAssistantWorkflowMaxResultBytes {
+		return raw, err
+	}
+
+	bounded := plan
+	bounded.Summary = trimProjectAssistantWorkflowString(bounded.Summary, 240)
+	bounded.Goals = boundedProjectAssistantWorkflowStrings(bounded.Goals, 5, 160)
+	bounded.Requirements = boundedProjectAssistantWorkflowStrings(bounded.Requirements, 5, 160)
+	bounded.Constraints = boundedProjectAssistantWorkflowStrings(bounded.Constraints, 5, 160)
+	bounded.Repository = boundedProjectAssistantWorkflowRepo(bounded.Repository)
+	bounded.Files = nil
+	steps := append([]string(nil), bounded.Steps...)
+	steps = append(steps, "Review detailed workspace file lists separately; the planning result was bounded for assistant context.")
+	bounded.Steps = boundedProjectAssistantWorkflowStrings(steps, 5, 180)
+	raw, err = json.Marshal(bounded)
+	if err != nil || len(raw) <= projectAssistantWorkflowMaxResultBytes {
+		return raw, err
+	}
+
+	minimal := projectAssistantWorkflowPlan{
+		Summary:    trimProjectAssistantWorkflowString(plan.Summary, 160),
+		Repository: boundedProjectAssistantWorkflowRepo(plan.Repository),
+		Steps:      []string{"Review detailed project context separately; workflow result was bounded for assistant context."},
+	}
+	raw, err = json.Marshal(minimal)
+	if err != nil || len(raw) <= projectAssistantWorkflowMaxResultBytes {
+		return raw, err
+	}
+
+	minimal.Summary = "Project planning context was bounded for assistant context."
+	minimal.Repository = nil
+	return json.Marshal(minimal)
+}
+
+func boundedProjectAssistantWorkflowRepo(repo *projectAssistantWorkflowRepo) *projectAssistantWorkflowRepo {
+	if repo == nil {
+		return nil
+	}
+	return &projectAssistantWorkflowRepo{
+		Ref:    trimProjectAssistantWorkflowString(repo.Ref, 80),
+		Name:   trimProjectAssistantWorkflowString(repo.Name, 80),
+		Status: trimProjectAssistantWorkflowString(repo.Status, 80),
+	}
+}
+
+func boundedProjectAssistantWorkflowStrings(values []string, maxValues int, maxChars int) []string {
+	if len(values) == 0 || maxValues <= 0 {
+		return nil
+	}
+	limit := len(values)
+	if limit > maxValues {
+		limit = maxValues
+	}
+	out := make([]string, 0, limit+1)
+	for _, value := range values[:limit] {
+		if trimmed := trimProjectAssistantWorkflowString(value, maxChars); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(values) > limit {
+		out = append(out, fmt.Sprintf("+%d more", len(values)-limit))
+	}
+	return out
+}
+
+func trimProjectAssistantWorkflowString(value string, maxChars int) string {
+	value = strings.TrimSpace(value)
+	if maxChars <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxChars {
+		return value
+	}
+	if maxChars <= 3 {
+		return string(runes[:maxChars])
+	}
+	return strings.TrimSpace(string(runes[:maxChars-3])) + "..."
+}
+
+func newProjectAssistantPlanningWorkflow(ctx context.Context) (compose.Runnable[projectAssistantWorkflowInput, projectAssistantWorkflowPlan], error) {
+	chain := compose.NewChain[projectAssistantWorkflowInput, projectAssistantWorkflowPlan]()
+	chain.
+		AppendLambda(compose.InvokableLambda(normalizeProjectAssistantWorkflowInput), compose.WithNodeKey("normalize")).
+		AppendLambda(compose.InvokableLambda(readProjectAssistantWorkflowContext), compose.WithNodeKey("read-context")).
+		AppendLambda(compose.InvokableLambda(formatProjectAssistantWorkflowPlan), compose.WithNodeKey("format-plan"))
+	return chain.Compile(ctx, compose.WithGraphName("app-studio-plan-project-changes"), compose.WithMaxRunSteps(8))
+}
+
+func normalizeProjectAssistantWorkflowInput(ctx context.Context, input projectAssistantWorkflowInput) (projectAssistantWorkflowInput, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantWorkflowInput{}, err
+	}
+	input.MaxFiles = boundedWorkflowFileLimit(input.MaxFiles)
+	if input.Project == nil {
+		return projectAssistantWorkflowInput{}, fmt.Errorf("project is required")
+	}
+	return input, nil
+}
+
+func readProjectAssistantWorkflowContext(ctx context.Context, input projectAssistantWorkflowInput) (projectAssistantWorkflowContext, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantWorkflowContext{}, err
+	}
+	out := projectAssistantWorkflowContext{
+		Project:    input.Project,
+		Repository: input.Repository,
+	}
+	if !input.IncludeFiles {
+		return out, nil
+	}
+	if input.Server == nil || input.Server.workspaces == nil {
+		return out, nil
+	}
+	files, err := input.Server.workspaces.ListFiles(ctx, input.WorkspaceScope, workspace.ListOptions{Limit: input.MaxFiles})
+	if err != nil {
+		return projectAssistantWorkflowContext{}, err
+	}
+	out.WorkspaceFiles = make([]string, 0, len(files.Files))
+	for _, file := range files.Files {
+		if strings.TrimSpace(file.Path) != "" {
+			out.WorkspaceFiles = append(out.WorkspaceFiles, file.Path)
+		}
+	}
+	if files.Truncated {
+		out.WorkspaceFiles = append(out.WorkspaceFiles, fmt.Sprintf("+more (limit %d)", files.Limit))
+	}
+	return out, nil
+}
+
+func formatProjectAssistantWorkflowPlan(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantWorkflowPlan, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantWorkflowPlan{}, err
+	}
+	p := input.Project
+	if p == nil {
+		return projectAssistantWorkflowPlan{}, fmt.Errorf("project is required")
+	}
+	displayName := strings.TrimSpace(p.Spec.DisplayName)
+	if displayName == "" {
+		displayName = p.Name
+	}
+	plan := projectAssistantWorkflowPlan{
+		Summary:      fmt.Sprintf("Plan project changes for %s.", displayName),
+		Goals:        append([]string(nil), p.Spec.Memory.Goals...),
+		Requirements: append([]string(nil), p.Spec.Memory.Requirements...),
+		Constraints:  append([]string(nil), p.Spec.Memory.Constraints...),
+		Files:        append([]string(nil), input.WorkspaceFiles...),
+		Steps:        projectAssistantWorkflowSteps(p.Spec.Memory, input.Repository, input.WorkspaceFiles),
+	}
+	if input.Repository != nil {
+		plan.Repository = &projectAssistantWorkflowRepo{
+			Ref:    input.Repository.Ref,
+			Name:   input.Repository.Name,
+			Status: input.Repository.Status,
+		}
+	}
+	return plan, nil
+}
+
+func projectAssistantWorkflowSteps(memory aiv1alpha1.ProjectMemory, repository *ProjectRepositoryView, files []string) []string {
+	steps := []string{}
+	if len(memory.Requirements) > 0 {
+		steps = append(steps, "Review the project requirements and identify the smallest file changes needed.")
+	} else {
+		steps = append(steps, "Clarify the project requirements before mutating workspace files.")
+	}
+	if len(files) > 0 {
+		steps = append(steps, "Inspect the listed workspace files before writing or patching source.")
+	} else {
+		steps = append(steps, "List the workspace files before editing an existing project.")
+	}
+	if repository != nil && repository.Status == projectRepositoryStatusReady {
+		steps = append(steps, "After approved workspace edits, commit changed source files through commit_project_files.")
+	} else {
+		steps = append(steps, "Defer commit handoff until the repository binding is ready.")
+	}
+	return steps
+}
+
+func boundedWorkflowFileLimit(limit int) int {
+	if limit <= 0 {
+		return 20
+	}
+	if limit > 50 {
+		return 50
+	}
+	return limit
+}

--- a/providers/app-studio/api/assistant_workflow_test.go
+++ b/providers/app-studio/api/assistant_workflow_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	"github.com/faroshq/provider-app-studio/store"
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+func TestProjectAssistantWorkflowRegisteredReadOnly(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	registry := server.projectAssistantToolRegistry()
+	tool, ok := registry.Get(projectToolPlanProjectChanges)
+	if !ok {
+		t.Fatal("plan_project_changes tool missing from registry")
+	}
+	spec := tool.Spec()
+	if spec.Risk != projectAssistantToolRiskRead {
+		t.Fatalf("risk = %q, want read", spec.Risk)
+	}
+	if got := projectAssistantPermissionForTool(spec); got != projectAssistantPermissionAllow {
+		t.Fatalf("permission = %q, want allow", got)
+	}
+	if strings.TrimSpace(string(spec.Parameters)) == "" {
+		t.Fatal("workflow tool parameters are empty")
+	}
+}
+
+func TestProjectAssistantWorkflowPlansFromMemoryRepositoryAndWorkspace(t *testing.T) {
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = "Demo App"
+	project.Spec.Memory = aiv1alpha1.ProjectMemory{
+		Goals:        []string{"ship a task tracker"},
+		Requirements: []string{"persist tasks"},
+		Constraints:  []string{"avoid external queues"},
+	}
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "src/App.tsx", Content: "export function App() { return null }\n"}); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolPlanProjectChanges)
+	if !ok {
+		t.Fatal("plan_project_changes tool missing from registry")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		Repository:     &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		WorkspaceScope: scope,
+		Arguments:      map[string]any{"includeFiles": true},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(raw) > projectAssistantWorkflowMaxResultBytes {
+		t.Fatalf("workflow result length = %d, want <= %d", len(raw), projectAssistantWorkflowMaxResultBytes)
+	}
+	var plan projectAssistantWorkflowPlan
+	if err := json.Unmarshal([]byte(raw), &plan); err != nil {
+		t.Fatalf("workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if !strings.Contains(plan.Summary, "Demo App") {
+		t.Fatalf("summary = %q, want project display name", plan.Summary)
+	}
+	if !containsString(plan.Goals, "ship a task tracker") || !containsString(plan.Requirements, "persist tasks") || !containsString(plan.Constraints, "avoid external queues") {
+		t.Fatalf("plan memory = %#v, want project memory copied", plan)
+	}
+	if plan.Repository == nil || plan.Repository.Ref != "demo-repo" || plan.Repository.Status != projectRepositoryStatusReady {
+		t.Fatalf("repository = %#v, want ready demo-repo", plan.Repository)
+	}
+	if !containsString(plan.Files, "src/App.tsx") {
+		t.Fatalf("files = %#v, want workspace file", plan.Files)
+	}
+	if len(plan.Steps) == 0 {
+		t.Fatalf("steps = %#v, want at least one deterministic next step", plan.Steps)
+	}
+}
+
+func TestProjectAssistantWorkflowDoesNotMutateWorkspace(t *testing.T) {
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "README.md", Content: "# Demo\n"}); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	before, err := workspaces.ListFiles(context.Background(), scope, workspace.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListFiles before returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolPlanProjectChanges)
+	if !ok {
+		t.Fatal("plan_project_changes tool missing from registry")
+	}
+	if _, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		WorkspaceScope: scope,
+		Arguments:      map[string]any{"includeFiles": true},
+	}); err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	after, err := workspaces.ListFiles(context.Background(), scope, workspace.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListFiles after returned error: %v", err)
+	}
+	if strings.Join(workflowTestFilePaths(before.Files), "\n") != strings.Join(workflowTestFilePaths(after.Files), "\n") {
+		t.Fatalf("files changed from %#v to %#v", before.Files, after.Files)
+	}
+}
+
+func TestProjectAssistantWorkflowBoundsLargeResultAsJSON(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = strings.Repeat("Demo App ", 80)
+	for i := 0; i < 80; i++ {
+		project.Spec.Memory.Goals = append(project.Spec.Memory.Goals, strings.Repeat("goal ", 80))
+		project.Spec.Memory.Requirements = append(project.Spec.Memory.Requirements, strings.Repeat("requirement ", 80))
+		project.Spec.Memory.Constraints = append(project.Spec.Memory.Constraints, strings.Repeat("constraint ", 80))
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolPlanProjectChanges)
+	if !ok {
+		t.Fatal("plan_project_changes tool missing from registry")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Project:   project,
+		Arguments: map[string]any{"includeFiles": false},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(raw) > projectAssistantWorkflowMaxResultBytes {
+		t.Fatalf("workflow result length = %d, want <= %d", len(raw), projectAssistantWorkflowMaxResultBytes)
+	}
+	var plan projectAssistantWorkflowPlan
+	if err := json.Unmarshal([]byte(raw), &plan); err != nil {
+		t.Fatalf("bounded workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if len(plan.Steps) == 0 {
+		t.Fatalf("steps = %#v, want bounded guidance", plan.Steps)
+	}
+}
+
+func workflowTestFilePaths(files []workspace.FileInfo) []string {
+	out := make([]string, 0, len(files))
+	for _, file := range files {
+		out = append(out, file.Path)
+	}
+	return out
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -71,6 +71,7 @@ const (
 	projectToolListProjectFiles   = "list_project_files"
 	projectToolReadProjectFile    = "read_project_file"
 	projectToolSearchProjectFiles = "search_project_files"
+	projectToolPlanProjectChanges = "plan_project_changes"
 	projectToolWriteFile          = "write_file"
 	projectToolApplyPatch         = "apply_patch"
 	projectToolMkdir              = "mkdir"
@@ -457,7 +458,7 @@ func (s *Server) resolveProjectToolCallsWithPermissions(
 	for i, tc := range toolCalls {
 		tool, ok := registry.Get(tc.Function.Name)
 		if !ok {
-			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if err != nil {
 				return nil, err
 			}
@@ -466,7 +467,7 @@ func (s *Server) resolveProjectToolCallsWithPermissions(
 		}
 		args, err := projectAssistantToolCallArguments(tc)
 		if err != nil {
-			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if err != nil {
 				return nil, err
 			}
@@ -476,7 +477,7 @@ func (s *Server) resolveProjectToolCallsWithPermissions(
 		spec := tool.Spec()
 		switch projectAssistantPermissionForTool(spec) {
 		case projectAssistantPermissionAllow:
-			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if err != nil {
 				return nil, err
 			}
@@ -1001,6 +1002,8 @@ func projectLLMAuthToken(ctx context.Context, settings projectLLMSettings) (stri
 func (s *Server) resolveProjectToolCalls(
 	ctx context.Context,
 	id identity,
+	project *aiv1alpha1.Project,
+	repository *ProjectRepositoryView,
 	scope workspace.Scope,
 	projectRepositoryRef string,
 	toolCalls []chatToolCall,
@@ -1111,7 +1114,7 @@ func (s *Server) resolveProjectToolCalls(
 		var resp string
 		var err error
 		if projectLocalToolAllowed(tc.Function.Name) {
-			resp, err = s.callProjectLocalTool(ctx, id, scope, projectRepositoryRef, mcpEndpoint, r, tc.Function.Name, args)
+			resp, err = s.callProjectLocalTool(ctx, id, project, repository, scope, projectRepositoryRef, mcpEndpoint, r, tc.Function.Name, args)
 		} else {
 			resp, err = callProjectMCPTool(ctx, mcpEndpoint, r, id.tenantPath, s.mcpInsecureSkipTLSVerify, tc.Function.Name, args)
 		}
@@ -1170,13 +1173,15 @@ func projectLinkedRepositoryRef(p *aiv1alpha1.Project) string {
 	return strings.TrimSpace(p.Spec.Repository.RepositoryRef)
 }
 
-func (s *Server) callProjectLocalTool(ctx context.Context, id identity, scope workspace.Scope, projectRepositoryRef, mcpEndpoint string, r *http.Request, name string, args map[string]any) (string, error) {
+func (s *Server) callProjectLocalTool(ctx context.Context, id identity, project *aiv1alpha1.Project, repository *ProjectRepositoryView, scope workspace.Scope, projectRepositoryRef, mcpEndpoint string, r *http.Request, name string, args map[string]any) (string, error) {
 	tool, ok := s.projectAssistantToolRegistry().Get(name)
 	if !ok {
 		return "", fmt.Errorf("unknown local project tool %q", name)
 	}
 	return tool.Call(ctx, projectAssistantToolCallRequest{
 		Identity:             id,
+		Project:              project,
+		Repository:           repository,
 		WorkspaceScope:       scope,
 		ProjectRepositoryRef: projectRepositoryRef,
 		MCPEndpoint:          mcpEndpoint,
@@ -1301,6 +1306,8 @@ func summarizeProjectToolArgumentsMap(name string, args map[string]any) string {
 		return summarizeProjectToolKeyValues(args, []string{"path", "maxBytes"})
 	case projectToolSearchProjectFiles:
 		return summarizeProjectToolKeyValues(args, []string{"query", "maxResults"})
+	case projectToolPlanProjectChanges:
+		return summarizeProjectPlanningWorkflowArgs(args)
 	case projectToolWriteFile:
 		return summarizeProjectMutationArgs(args, []string{"path"}, true)
 	case projectToolApplyPatch:
@@ -1351,6 +1358,8 @@ func summarizeProjectToolResult(name, result string) string {
 			return summarizeWorkspaceReadResult(decoded)
 		case projectToolSearchProjectFiles:
 			return summarizeWorkspaceSearchResult(decoded)
+		case projectToolPlanProjectChanges:
+			return summarizeProjectPlanningWorkflowResult(decoded)
 		case projectToolWriteFile, projectToolApplyPatch, projectToolMkdir:
 			return summarizeWorkspaceMutationResult(decoded)
 		}
@@ -1395,6 +1404,17 @@ func summarizeProjectToolKeyValues(args map[string]any, keys []string) string {
 	return truncateProjectToolInfo(strings.Join(parts, "; "))
 }
 
+func summarizeProjectPlanningWorkflowArgs(args map[string]any) string {
+	parts := []string{}
+	if includeFiles, ok := args["includeFiles"].(bool); ok {
+		parts = append(parts, fmt.Sprintf("includeFiles %t", includeFiles))
+	}
+	if n, ok := projectToolNumber(args["maxFiles"]); ok {
+		parts = append(parts, fmt.Sprintf("maxFiles %d", n))
+	}
+	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
 func summarizeWorkspaceMutationResult(decoded map[string]any) string {
 	parts := []string{}
 	if op := projectToolString(decoded["operation"]); op != "" {
@@ -1408,6 +1428,23 @@ func summarizeWorkspaceMutationResult(decoded map[string]any) string {
 	}
 	if replacements, ok := projectToolNumber(decoded["replacements"]); ok {
 		parts = append(parts, fmt.Sprintf("%d replacement(s)", replacements))
+	}
+	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
+func summarizeProjectPlanningWorkflowResult(decoded map[string]any) string {
+	parts := []string{}
+	if summary := projectToolString(decoded["summary"]); summary != "" {
+		parts = append(parts, summary)
+	}
+	if steps, ok := decoded["steps"].([]any); ok && len(steps) > 0 {
+		parts = append(parts, fmt.Sprintf("%d step(s)", len(steps)))
+	}
+	if files := projectToolStringList(decoded["files"]); len(files) > 0 {
+		parts = append(parts, fmt.Sprintf("%d file(s): %s", len(files), summarizeProjectToolList(files, 5)))
+	}
+	if len(parts) == 0 {
+		return ""
 	}
 	return truncateProjectToolInfo(strings.Join(parts, "; "))
 }

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -481,7 +481,7 @@ func (s *Server) createProjectMessageStream(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) resumeProjectAssistant(w http.ResponseWriter, r *http.Request) {
-	_, id, p, ok := s.requireProjectWithClient(w, r)
+	c, id, p, ok := s.requireProjectWithClient(w, r)
 	if !ok {
 		return
 	}
@@ -489,7 +489,7 @@ func (s *Server) resumeProjectAssistant(w http.ResponseWriter, r *http.Request) 
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	resp, err := s.resumeProjectAssistantRun(r.Context(), r, id, p, mux.Vars(r)["run"], req)
+	resp, err := s.resumeProjectAssistantRunWithRepository(r.Context(), r, id, p, projectRepositoryView(r.Context(), c, p), mux.Vars(r)["run"], req)
 	if err != nil {
 		writeProjectError(w, err)
 		return

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -94,6 +94,7 @@ func TestProjectToolAllowlistSeparatesWorkspaceAndGitTools(t *testing.T) {
 		"list_project_files",
 		"read_project_file",
 		"search_project_files",
+		"plan_project_changes",
 		"write_file",
 		"apply_patch",
 		"mkdir",
@@ -115,6 +116,7 @@ func TestProjectAssistantToolRegistryListsLocalToolsInOrder(t *testing.T) {
 		"list_project_files",
 		"read_project_file",
 		"search_project_files",
+		"plan_project_changes",
 		"write_file",
 		"apply_patch",
 		"mkdir",
@@ -273,6 +275,11 @@ func TestSummarizeProjectToolArgumentsWorkspaceReadTools(t *testing.T) {
 			want: []string{"query secret-ish user query", "maxResults 10"},
 		},
 		{
+			name: "plan_project_changes",
+			args: `{"includeFiles":true,"maxFiles":12}`,
+			want: []string{"includeFiles true", "maxFiles 12"},
+		},
+		{
 			name: "write_file",
 			args: `{"path":"src/App.tsx","content":"secret-ish file body"}`,
 			want: []string{"path src/App.tsx", "20 bytes"},
@@ -337,6 +344,14 @@ func TestSummarizeProjectToolResultWorkspaceReadTools(t *testing.T) {
 	}
 	if strings.Contains(got, "secret-ish") {
 		t.Fatalf("summary leaked content: %q", got)
+	}
+
+	workflowResult := `{"summary":"Plan project changes for Demo App.","files":["src/App.tsx"],"steps":["Inspect files","Commit after approval"]}`
+	got = summarizeProjectToolResult("plan_project_changes", workflowResult)
+	for _, want := range []string{"Plan project changes for Demo App.", "2 step(s)", "1 file(s): src/App.tsx"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary = %q, want %q", got, want)
+		}
 	}
 }
 
@@ -410,6 +425,8 @@ func TestResolveProjectToolCallsRunsLocalWorkspaceTools(t *testing.T) {
 	messages, err := server.resolveProjectToolCalls(
 		context.Background(),
 		identity{},
+		nil,
+		nil,
 		scope,
 		"",
 		[]chatToolCall{{
@@ -439,6 +456,8 @@ func TestResolveProjectToolCallsRunsLocalWorkspaceMutationTools(t *testing.T) {
 	messages, err := server.resolveProjectToolCalls(
 		context.Background(),
 		identity{},
+		nil,
+		nil,
 		scope,
 		"",
 		[]chatToolCall{
@@ -1389,6 +1408,88 @@ func TestResumeProjectAssistantRunContinuesToolBatchToNextPermission(t *testing.
 	}
 }
 
+func TestResumeProjectAssistantRunReplaysWorkflowWithRepositoryContext(t *testing.T) {
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = "Demo"
+	project.Spec.Memory.Requirements = []string{"Keep the implementation small."}
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolWriteFile)
+	if !ok {
+		t.Fatal("write_file tool missing from registry")
+	}
+	toolCalls := []chatToolCall{
+		{
+			ID:   "call-write",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      projectToolWriteFile,
+				Arguments: `{"path":"src/App.tsx","content":"approved\n"}`,
+			},
+		},
+		{
+			ID:   "call-plan",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      projectToolPlanProjectChanges,
+				Arguments: `{"includeFiles":false}`,
+			},
+		},
+	}
+	permissionErr, _, _, err := server.saveProjectAssistantPermissionCheckpointForToolCalls(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+			Project:        project,
+			WorkspaceScope: workspaceScope,
+			MessageScope:   messageScope,
+		},
+		tool,
+		toolCalls,
+		0,
+		projectLinkedRepositoryRef(project),
+	)
+	if err != nil {
+		t.Fatalf("saveProjectAssistantPermissionCheckpointForToolCalls returned error: %v", err)
+	}
+
+	resp, err := server.resumeProjectAssistantRunWithRepository(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		project,
+		&ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		permissionErr.RunID,
+		projectAssistantResumeRequest{
+			RequestID: permissionErr.RequestID,
+			Decision:  string(projectAssistantPermissionAllow),
+		},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRunWithRepository returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted || resp.ToolCall == nil || resp.ToolCall.Name != projectToolPlanProjectChanges || resp.ToolCall.Status != "succeeded" {
+		t.Fatalf("resume response = %#v, want completed planning workflow", resp)
+	}
+	var plan projectAssistantWorkflowPlan
+	if err := json.Unmarshal([]byte(resp.Result), &plan); err != nil {
+		t.Fatalf("decode planning workflow result: %v", err)
+	}
+	if plan.Repository == nil || plan.Repository.Ref != "demo-repo" || plan.Repository.Status != projectRepositoryStatusReady {
+		t.Fatalf("repository = %#v, want ready demo-repo", plan.Repository)
+	}
+	steps := strings.Join(plan.Steps, "\n")
+	if !strings.Contains(steps, "commit_project_files") || strings.Contains(steps, "Defer commit handoff") {
+		t.Fatalf("steps = %#v, want ready repository commit guidance", plan.Steps)
+	}
+}
+
 func TestGenerateProjectAssistantStreamStopsOfferingToolsAfterRepeatedToolLoop(t *testing.T) {
 	reply, requests, err := runRepeatedReadFileAssistantStream(t, func(w http.ResponseWriter) {
 		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"I inspected src/App.tsx and stopped before repeating the same action.\"}}]}\n\n")
@@ -1572,6 +1673,8 @@ func TestResolveProjectToolCallsReportsCommitProjectFilesFailure(t *testing.T) {
 	messages, err := server.resolveProjectToolCalls(
 		context.Background(),
 		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		nil,
+		nil,
 		scope,
 		"demo-repo",
 		[]chatToolCall{{
@@ -1633,6 +1736,8 @@ func TestResolveProjectToolCallsRejectsCommitProjectFilesRepositoryMismatch(t *t
 	messages, err := server.resolveProjectToolCalls(
 		context.Background(),
 		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		nil,
+		nil,
 		scope,
 		"demo-repo",
 		[]chatToolCall{{
@@ -1899,6 +2004,8 @@ func TestResolveProjectToolCallsCommitsWorkspaceFilesThroughCodeProvider(t *test
 	messages, err := server.resolveProjectToolCalls(
 		context.Background(),
 		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		nil,
+		nil,
 		scope,
 		"demo-repo",
 		[]chatToolCall{{
@@ -1937,6 +2044,8 @@ func TestResolveProjectToolCallsRejectsDirectCodeCommitFiles(t *testing.T) {
 	messages, err := server.resolveProjectToolCalls(
 		context.Background(),
 		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		nil,
+		nil,
 		scope,
 		"demo",
 		[]chatToolCall{{


### PR DESCRIPTION
## Summary
- add a read-only plan_project_changes assistant tool backed by an Eino compose workflow
- include project memory, repository status, and an optionally bounded workspace file list in the planning result
- thread project/repository context through local tool execution and permission-resume replay
- add workflow tests plus resume replay coverage for an approved write followed by planning

## Verification
- cd providers/app-studio && go test ./api -run TestResumeProjectAssistantRunReplaysWorkflowWithRepositoryContext -count=1
- cd providers/app-studio && go test ./...
- cd providers/app-studio && go mod tidy -diff
- git diff --check
- git diff --cached --check
- cd providers/app-studio/portal && npm run typecheck
- cd providers/app-studio/portal && npm run build

## Review Notes
Independent review initially found that resume replay dropped repository context for plan_project_changes after a permission gate. Fixed by passing the caller-scoped repository view from the resume handler into replay execution and adding a regression test. Follow-up independent review found no remaining actionable issues.