### PR TITLE
Add App Studio runtime worker boundary

### DIFF
--- a/providers/app-studio/README.md
+++ b/providers/app-studio/README.md
@@ -89,3 +89,14 @@ The assistant-facing workspace tools are App Studio local tools. Provider-code
 remains the git-source boundary: `commit_project_files` reads selected workspace
 files and delegates the actual commit to the Code provider's `code__commit_files`
 tool.
+
+## Runtime workers
+
+App Studio does not run build, test, preview, or log commands inside the
+provider pod. Runtime commands are modeled behind an internal worker boundary so
+future implementations can use isolated tenant/project-scoped workers with their
+own resource limits, audit trail, and cancellation model.
+
+By default no runtime worker is configured, so `runtime_command` is not advertised
+to the assistant. If a future deployment injects a worker, runtime commands still
+require explicit user approval before the worker is started.

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -148,6 +148,8 @@ func projectAssistantPermissionReason(spec projectAssistantToolSpec) string {
 		return "This action will modify files in the App Studio workspace."
 	case projectAssistantToolRiskCommit:
 		return "This action will commit App Studio workspace changes to the linked repository."
+	case projectAssistantToolRiskRuntime:
+		return "This action will start a sandboxed App Studio runtime command."
 	default:
 		return "This action requires approval."
 	}

--- a/providers/app-studio/api/assistant_permission.go
+++ b/providers/app-studio/api/assistant_permission.go
@@ -33,7 +33,7 @@ func projectAssistantPermissionForTool(spec projectAssistantToolSpec) projectAss
 	switch spec.Risk {
 	case projectAssistantToolRiskRead:
 		return projectAssistantPermissionAllow
-	case projectAssistantToolRiskWrite, projectAssistantToolRiskCommit:
+	case projectAssistantToolRiskWrite, projectAssistantToolRiskCommit, projectAssistantToolRiskRuntime:
 		return projectAssistantPermissionAsk
 	default:
 		return projectAssistantPermissionDeny

--- a/providers/app-studio/api/assistant_permission_test.go
+++ b/providers/app-studio/api/assistant_permission_test.go
@@ -30,6 +30,7 @@ func TestProjectAssistantPermissionPolicy(t *testing.T) {
 		{name: "read tools auto allow", risk: projectAssistantToolRiskRead, want: projectAssistantPermissionAllow},
 		{name: "write tools ask", risk: projectAssistantToolRiskWrite, want: projectAssistantPermissionAsk},
 		{name: "commit tools ask", risk: projectAssistantToolRiskCommit, want: projectAssistantPermissionAsk},
+		{name: "runtime tools ask", risk: projectAssistantToolRiskRuntime, want: projectAssistantPermissionAsk},
 		{name: "unknown risk denies", risk: projectAssistantToolRisk("danger"), want: projectAssistantPermissionDeny},
 	}
 	for _, tt := range tests {

--- a/providers/app-studio/api/assistant_tool.go
+++ b/providers/app-studio/api/assistant_tool.go
@@ -29,9 +29,10 @@ import (
 type projectAssistantToolRisk string
 
 const (
-	projectAssistantToolRiskRead   projectAssistantToolRisk = "read"
-	projectAssistantToolRiskWrite  projectAssistantToolRisk = "write"
-	projectAssistantToolRiskCommit projectAssistantToolRisk = "commit"
+	projectAssistantToolRiskRead    projectAssistantToolRisk = "read"
+	projectAssistantToolRiskWrite   projectAssistantToolRisk = "write"
+	projectAssistantToolRiskCommit  projectAssistantToolRisk = "commit"
+	projectAssistantToolRiskRuntime projectAssistantToolRisk = "runtime"
 )
 
 type projectAssistantToolSpec struct {

--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -200,6 +200,7 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 				return projectAssistantToolJSONResult(s.workspaces.Mkdir(ctx, req.WorkspaceScope, workspace.MkdirOptions{Path: projectToolString(req.Arguments["path"])}))
 			},
 		},
+		newProjectRuntimeCommandToolForRegistry(server),
 		projectAssistantToolFunc{
 			spec: projectAssistantToolSpec{
 				Name:        projectToolCommitProjectFiles,

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -75,6 +75,7 @@ const (
 	projectToolWriteFile          = "write_file"
 	projectToolApplyPatch         = "apply_patch"
 	projectToolMkdir              = "mkdir"
+	projectToolRuntimeCommand     = "runtime_command"
 	projectToolCommitProjectFiles = "commit_project_files"
 	projectToolCommitFiles        = "commit_files"
 	projectToolCodeCommitFiles    = "code__commit_files"
@@ -1017,6 +1018,7 @@ func (s *Server) resolveProjectToolCalls(
 	var toolMessages []chatMessage
 	mcpEndpoint := s.mcpEndpoint(id.tenantPath)
 	logger := klog.FromContext(ctx)
+	registry := s.projectAssistantToolRegistry()
 
 	for _, tc := range toolCalls {
 		if onToolCall != nil {
@@ -1043,7 +1045,9 @@ func (s *Server) resolveProjectToolCalls(
 			})
 			continue
 		}
-		if !projectToolAllowed(tc.Function.Name) {
+		localTool := registry.Has(tc.Function.Name)
+		runtimeTool := projectRuntimeToolAllowed(tc.Function.Name)
+		if !localTool && !runtimeTool && !projectMCPToolAllowed(tc.Function.Name) {
 			logger.Info("project assistant tool call rejected", "reason", "disallowed tool name", "tool", tc.Function.Name)
 			if onToolCall != nil {
 				onToolCall(projectToolCallStreamEvent{
@@ -1113,8 +1117,14 @@ func (s *Server) resolveProjectToolCalls(
 		}
 		var resp string
 		var err error
-		if projectLocalToolAllowed(tc.Function.Name) {
+		if localTool {
 			resp, err = s.callProjectLocalTool(ctx, id, project, repository, scope, projectRepositoryRef, mcpEndpoint, r, tc.Function.Name, args)
+		} else if runtimeTool {
+			resp, err = newProjectRuntimeCommandTool(nil).Call(ctx, projectAssistantToolCallRequest{
+				Identity:       id,
+				WorkspaceScope: scope,
+				Arguments:      args,
+			})
 		} else {
 			resp, err = callProjectMCPTool(ctx, mcpEndpoint, r, id.tenantPath, s.mcpInsecureSkipTLSVerify, tc.Function.Name, args)
 		}

--- a/providers/app-studio/api/runtime_worker.go
+++ b/providers/app-studio/api/runtime_worker.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+const (
+	projectRuntimeCommandDefaultTimeoutSeconds = 60
+	projectRuntimeCommandMaxTimeoutSeconds     = 600
+	projectRuntimeCommandMaxArgs               = 16
+	projectRuntimeCommandMaxArgBytes           = 256
+)
+
+type projectRuntimeWorker interface {
+	Start(context.Context, projectRuntimeRequest) (projectRuntimeHandle, error)
+}
+
+type projectRuntimeRequest struct {
+	Identity       identity
+	WorkspaceScope workspace.Scope
+	Command        []string
+	TimeoutSeconds int
+}
+
+type projectRuntimeHandle struct {
+	ID string
+}
+
+type projectRuntimeCommandResult struct {
+	Status  string `json:"status"`
+	ID      string `json:"id,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func newProjectRuntimeCommandToolForRegistry(server *Server) projectAssistantTool {
+	if server == nil || server.runtimeWorker == nil {
+		return nil
+	}
+	return newProjectRuntimeCommandTool(server.runtimeWorker)
+}
+
+func newProjectRuntimeCommandTool(worker projectRuntimeWorker) projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolRuntimeCommand,
+			Description: "Start an App Studio runtime worker command for checks, builds, previews, or logs. The provider never runs commands in-process.",
+			Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1,"maxItems":%d,"description":"Runtime worker command and arguments."},"timeoutSeconds":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum command runtime in seconds."}},"required":["command"]}`, projectRuntimeCommandMaxArgs, projectRuntimeCommandMaxTimeoutSeconds)),
+			Risk:        projectAssistantToolRiskRuntime,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			if worker == nil {
+				return projectAssistantToolJSONResult(projectRuntimeCommandResult{
+					Status:  "unavailable",
+					Message: "runtime worker is not configured for this App Studio provider",
+				}, nil)
+			}
+			runtimeReq, err := projectRuntimeRequestFromToolCall(req)
+			if err != nil {
+				return "", err
+			}
+			handle, err := worker.Start(ctx, runtimeReq)
+			if err != nil {
+				return "", err
+			}
+			return projectAssistantToolJSONResult(projectRuntimeCommandResult{
+				Status: "started",
+				ID:     strings.TrimSpace(handle.ID),
+			}, nil)
+		},
+	}
+}
+
+func projectRuntimeToolAllowed(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), projectToolRuntimeCommand)
+}
+
+func projectRuntimeRequestFromToolCall(req projectAssistantToolCallRequest) (projectRuntimeRequest, error) {
+	command, err := projectRuntimeCommandArgs(req.Arguments["command"])
+	if err != nil {
+		return projectRuntimeRequest{}, err
+	}
+	if len(command) > projectRuntimeCommandMaxArgs {
+		return projectRuntimeRequest{}, newValidationError(fmt.Sprintf("runtime command cannot exceed %d arguments", projectRuntimeCommandMaxArgs))
+	}
+	for _, arg := range command {
+		if len([]byte(arg)) > projectRuntimeCommandMaxArgBytes {
+			return projectRuntimeRequest{}, newValidationError(fmt.Sprintf("runtime command arguments cannot exceed %d bytes", projectRuntimeCommandMaxArgBytes))
+		}
+	}
+	timeout := projectToolInt(req.Arguments["timeoutSeconds"])
+	if timeout <= 0 {
+		timeout = projectRuntimeCommandDefaultTimeoutSeconds
+	}
+	if timeout > projectRuntimeCommandMaxTimeoutSeconds {
+		timeout = projectRuntimeCommandMaxTimeoutSeconds
+	}
+	return projectRuntimeRequest{
+		Identity:       req.Identity,
+		WorkspaceScope: req.WorkspaceScope,
+		Command:        command,
+		TimeoutSeconds: timeout,
+	}, nil
+}
+
+func projectRuntimeCommandArgs(value any) ([]string, error) {
+	items, ok := value.([]any)
+	if !ok || len(items) == 0 {
+		return nil, newValidationError("runtime command requires at least one command argument")
+	}
+	out := make([]string, 0, len(items))
+	for i, item := range items {
+		arg, ok := item.(string)
+		if !ok {
+			return nil, newValidationError(fmt.Sprintf("runtime command argument %d must be a string", i))
+		}
+		if strings.TrimSpace(arg) == "" {
+			return nil, newValidationError(fmt.Sprintf("runtime command argument %d cannot be empty", i))
+		}
+		out = append(out, arg)
+	}
+	return out, nil
+}

--- a/providers/app-studio/api/runtime_worker_test.go
+++ b/providers/app-studio/api/runtime_worker_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/faroshq/provider-app-studio/store"
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+func TestProjectRuntimeWorkerToolsAbsentByDefault(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	registry := server.projectAssistantToolRegistry()
+	if registry.Has(projectToolRuntimeCommand) {
+		t.Fatal("runtime_command tool registered without a runtime worker")
+	}
+	if projectLocalToolAllowed(projectToolRuntimeCommand) {
+		t.Fatal("runtime_command is globally local-allowed without a runtime worker")
+	}
+	if tool := newProjectRuntimeCommandToolForRegistry(server); tool != nil {
+		t.Fatalf("runtime tool = %#v, want nil without worker", tool)
+	}
+}
+
+func TestProjectRuntimeWorkerCommandUnavailableWithoutWorker(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, "demo")
+	messages, err := server.resolveProjectToolCalls(
+		context.Background(),
+		id,
+		nil,
+		nil,
+		scope,
+		"",
+		[]chatToolCall{{
+			ID:   "call-runtime",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      projectToolRuntimeCommand,
+				Arguments: `{"command":["npm","test"],"timeoutSeconds":30}`,
+			},
+		}},
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolveProjectToolCalls returned error: %v", err)
+	}
+	if len(messages) != 1 || !strings.Contains(messages[0].Content, `"status":"unavailable"`) || !strings.Contains(messages[0].Content, "runtime worker is not configured") {
+		t.Fatalf("tool messages = %#v, want unavailable runtime worker response", messages)
+	}
+}
+
+func TestProjectRuntimeWorkerRequiresApprovalWithWorker(t *testing.T) {
+	messages := store.NewMemoryStore()
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	worker := &fakeProjectRuntimeWorker{handle: projectRuntimeHandle{ID: "runtime-1"}}
+	server.runtimeWorker = worker
+	registry := server.projectAssistantToolRegistry()
+	tool, ok := registry.Get(projectToolRuntimeCommand)
+	if !ok {
+		t.Fatal("runtime_command tool missing with runtime worker")
+	}
+	if got := projectAssistantPermissionForTool(tool.Spec()); got != projectAssistantPermissionAsk {
+		t.Fatalf("permission = %q, want ask", got)
+	}
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	_, err := server.resolveProjectToolCallsWithPermissions(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+			WorkspaceScope: projectWorkspaceScope(id, "demo"),
+			MessageScope:   projectMessageScope(id.orgUUID, id.workspaceUUID, "demo"),
+		},
+		"",
+		[]chatToolCall{{
+			ID:   "call-runtime",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      projectToolRuntimeCommand,
+				Arguments: `{"command":["npm","test"],"timeoutSeconds":30}`,
+			},
+		}},
+	)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !strings.Contains(projectAssistantPermissionReason(tool.Spec()), "runtime command") {
+		t.Fatalf("permission reason = %q, want runtime command context", projectAssistantPermissionReason(tool.Spec()))
+	}
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("resolveProjectToolCallsWithPermissions error = %v, want permission required", err)
+	}
+	if worker.calls != 0 {
+		t.Fatalf("worker calls = %d, want no start before approval", worker.calls)
+	}
+}
+
+func TestProjectRuntimeWorkerStartsInjectedWorker(t *testing.T) {
+	worker := &fakeProjectRuntimeWorker{handle: projectRuntimeHandle{ID: "runtime-1"}}
+	tool := newProjectRuntimeCommandTool(worker)
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, "demo")
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		WorkspaceScope: scope,
+		Arguments: map[string]any{
+			"command":        []any{"npm", "test"},
+			"timeoutSeconds": 30,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	var result projectRuntimeCommandResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode runtime result: %v", err)
+	}
+	if result.Status != "started" || result.ID != "runtime-1" {
+		t.Fatalf("result = %#v, want started runtime-1", result)
+	}
+	if worker.calls != 1 {
+		t.Fatalf("worker calls = %d, want 1", worker.calls)
+	}
+	if strings.Join(worker.request.Command, " ") != "npm test" || worker.request.TimeoutSeconds != 30 || worker.request.WorkspaceScope != scope {
+		t.Fatalf("worker request = %#v, want mapped command, timeout, and scope", worker.request)
+	}
+}
+
+func TestProjectRuntimeWorkerPreservesCommandArgs(t *testing.T) {
+	worker := &fakeProjectRuntimeWorker{handle: projectRuntimeHandle{ID: "runtime-1"}}
+	tool := newProjectRuntimeCommandTool(worker)
+	_, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Arguments: map[string]any{"command": []any{"printf", " %s\n"}},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(worker.request.Command) != 2 || worker.request.Command[1] != " %s\n" {
+		t.Fatalf("command = %#v, want padded format string preserved exactly", worker.request.Command)
+	}
+}
+
+func TestProjectRuntimeWorkerRejectsMalformedCommandArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "non string",
+			args: map[string]any{"command": []any{"npm", float64(1), "test"}},
+			want: "argument 1 must be a string",
+		},
+		{
+			name: "empty string",
+			args: map[string]any{"command": []any{"npm", " ", "test"}},
+			want: "argument 1 cannot be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			worker := &fakeProjectRuntimeWorker{handle: projectRuntimeHandle{ID: "runtime-1"}}
+			tool := newProjectRuntimeCommandTool(worker)
+			_, err := tool.Call(context.Background(), projectAssistantToolCallRequest{Arguments: tt.args})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Call error = %v, want %q", err, tt.want)
+			}
+			if worker.calls != 0 {
+				t.Fatalf("worker calls = %d, want no start for malformed command", worker.calls)
+			}
+		})
+	}
+}
+
+type fakeProjectRuntimeWorker struct {
+	handle  projectRuntimeHandle
+	request projectRuntimeRequest
+	calls   int
+}
+
+func (w *fakeProjectRuntimeWorker) Start(_ context.Context, req projectRuntimeRequest) (projectRuntimeHandle, error) {
+	w.calls++
+	w.request = req
+	return w.handle, nil
+}

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -39,7 +39,8 @@ import (
 // per-(tenant, caller) dynamic client; store persists chat transcripts; hubBase
 // locates the hub's MCP virtual workspace; mcpInsecureSkipTLSVerify relaxes TLS
 // for dev MCP calls; workspaces stores project files owned by App Studio;
-// assistantEngine runs project assistant turns.
+// assistantEngine runs project assistant turns; runtimeWorker is an optional
+// boundary for future sandboxed checks and previews.
 type Server struct {
 	clients                  *tenant.ClientFactory
 	store                    store.Store
@@ -47,6 +48,7 @@ type Server struct {
 	hubBase                  string
 	mcpInsecureSkipTLSVerify bool
 	assistantEngine          projectAssistantEngine
+	runtimeWorker            projectRuntimeWorker
 }
 
 // New constructs a Server.


### PR DESCRIPTION
## Summary
- add an internal App Studio runtime worker interface for future checks, builds, previews, and logs
- keep runtime_command absent from the assistant tool registry unless a worker is injected
- return a safe unavailable result for accidental runtime_command calls when no worker exists
- require explicit assistant permission before an injected runtime worker can start
- validate runtime argv strictly and preserve approved string arguments exactly

## Verification
- cd providers/app-studio && go test ./api -run 'TestProjectRuntimeWorker|TestProjectAssistantPermission' -count=1
- cd providers/app-studio && go test ./...
- cd providers/app-studio && go mod tidy -diff
- git diff --check
- git diff --cached --check

## Review Notes
Independent review found runtime argv was initially normalized after approval. Fixed by rejecting malformed command arrays and preserving original string arguments exactly, with regression coverage. Follow-up review found no remaining actionable issues.