### PR TITLE
Fix App Studio approval continuation

### DIFF
--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/google/uuid"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	asclient "github.com/faroshq/provider-app-studio/client"
 	"github.com/faroshq/provider-app-studio/store"
 )
 
@@ -34,6 +36,12 @@ type projectAssistantCheckpointState struct {
 	ToolCalls            []chatToolCall `json:"toolCalls"`
 	CurrentIndex         int            `json:"currentIndex"`
 	ProjectRepositoryRef string         `json:"projectRepositoryRef,omitempty"`
+	Messages             []chatMessage  `json:"messages,omitempty"`
+	Turn                 int            `json:"turn,omitempty"`
+	SeenToolCalls        map[string]int `json:"seenToolCalls,omitempty"`
+	ForceTextAnswer      bool           `json:"forceTextAnswer,omitempty"`
+	RepeatedToolLoop     bool           `json:"repeatedToolLoop,omitempty"`
+	LastToolMessages     []chatMessage  `json:"lastToolMessages,omitempty"`
 }
 
 type projectAssistantResumeRequest struct {
@@ -44,14 +52,15 @@ type projectAssistantResumeRequest struct {
 }
 
 type projectAssistantResumeResponse struct {
-	RunID      string                             `json:"runID"`
-	RequestID  string                             `json:"requestID"`
-	Status     store.AssistantRunStatus           `json:"status"`
-	Decision   projectAssistantPermissionDecision `json:"decision"`
-	ToolCall   *projectToolCallStreamEvent        `json:"toolCall,omitempty"`
-	Permission *projectAssistantPermission        `json:"permission,omitempty"`
-	Checkpoint *projectAssistantCheckpoint        `json:"checkpoint,omitempty"`
-	Result     string                             `json:"result,omitempty"`
+	RunID            string                             `json:"runID"`
+	RequestID        string                             `json:"requestID"`
+	Status           store.AssistantRunStatus           `json:"status"`
+	Decision         projectAssistantPermissionDecision `json:"decision"`
+	ToolCall         *projectToolCallStreamEvent        `json:"toolCall,omitempty"`
+	Permission       *projectAssistantPermission        `json:"permission,omitempty"`
+	Checkpoint       *projectAssistantCheckpoint        `json:"checkpoint,omitempty"`
+	Result           string                             `json:"result,omitempty"`
+	AssistantMessage *aiv1alpha1.ProjectMessage         `json:"assistantMessage,omitempty"`
 }
 
 type projectAssistantRunAudit struct {
@@ -97,6 +106,22 @@ func (s *Server) saveProjectAssistantPermissionCheckpointForToolCalls(
 	currentIndex int,
 	projectRepositoryRef string,
 ) (*projectAssistantPermissionRequiredError, projectAssistantPermission, projectAssistantCheckpoint, error) {
+	state := projectAssistantCheckpointState{
+		ToolCalls:            cloneProjectAssistantToolCalls(toolCalls),
+		CurrentIndex:         currentIndex,
+		ProjectRepositoryRef: strings.TrimSpace(projectRepositoryRef),
+	}
+	return s.saveProjectAssistantPermissionCheckpointForState(ctx, req, tool, state, toolCalls, currentIndex)
+}
+
+func (s *Server) saveProjectAssistantPermissionCheckpointForState(
+	ctx context.Context,
+	req projectAssistantRunRequest,
+	tool projectAssistantTool,
+	state projectAssistantCheckpointState,
+	toolCalls []chatToolCall,
+	currentIndex int,
+) (*projectAssistantPermissionRequiredError, projectAssistantPermission, projectAssistantCheckpoint, error) {
 	if s.store == nil {
 		return nil, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("project message store not configured")
 	}
@@ -107,11 +132,12 @@ func (s *Server) saveProjectAssistantPermissionCheckpointForToolCalls(
 	runID := newProjectAssistantRunID()
 	requestID := newProjectAssistantPermissionRequestID()
 	now := time.Now().UTC()
-	state := projectAssistantCheckpointState{
-		ToolCalls:            cloneProjectAssistantToolCalls(toolCalls),
-		CurrentIndex:         currentIndex,
-		ProjectRepositoryRef: strings.TrimSpace(projectRepositoryRef),
-	}
+	state.ToolCalls = cloneProjectAssistantToolCalls(toolCalls)
+	state.CurrentIndex = currentIndex
+	state.ProjectRepositoryRef = strings.TrimSpace(state.ProjectRepositoryRef)
+	state.Messages = cloneChatMessages(state.Messages)
+	state.SeenToolCalls = cloneProjectAssistantSeenToolCalls(state.SeenToolCalls)
+	state.LastToolMessages = cloneChatMessages(state.LastToolMessages)
 	raw, err := json.Marshal(state)
 	if err != nil {
 		return nil, projectAssistantPermission{}, projectAssistantCheckpoint{}, fmt.Errorf("encode assistant checkpoint: %w", err)
@@ -189,6 +215,19 @@ func (s *Server) resumeProjectAssistantRunWithRepository(
 	runID string,
 	req projectAssistantResumeRequest,
 ) (projectAssistantResumeResponse, error) {
+	return s.resumeProjectAssistantRunWithRepositoryAndClient(ctx, r, id, nil, p, repository, runID, req)
+}
+
+func (s *Server) resumeProjectAssistantRunWithRepositoryAndClient(
+	ctx context.Context,
+	r *http.Request,
+	id identity,
+	c *asclient.Client,
+	p *aiv1alpha1.Project,
+	repository *ProjectRepositoryView,
+	runID string,
+	req projectAssistantResumeRequest,
+) (projectAssistantResumeResponse, error) {
 	if s.store == nil {
 		return projectAssistantResumeResponse{}, fmt.Errorf("project message store not configured")
 	}
@@ -255,7 +294,7 @@ func (s *Server) resumeProjectAssistantRunWithRepository(
 		return projectAssistantResumeResponse{}, newValidationError(staleBindingError)
 	}
 
-	run, out, err = s.resolveClaimedProjectAssistantRun(ctx, r, id, p, repository, run, state, req, decision, out)
+	run, out, state, err = s.resolveClaimedProjectAssistantRun(ctx, r, id, p, repository, run, state, req, decision, out)
 	if err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
@@ -265,6 +304,13 @@ func (s *Server) resumeProjectAssistantRunWithRepository(
 	out.Status = run.Status
 	if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(req.AssistantMessageID), out); err != nil {
 		return projectAssistantResumeResponse{}, err
+	}
+	if c != nil && decision == projectAssistantPermissionAllow && out.Status == store.AssistantRunStatusCompleted && len(state.Messages) > 0 {
+		assistantMessage, err := s.continueProjectAssistantRunAfterPermission(ctx, r, id, c, p, repository, state)
+		if err != nil {
+			return projectAssistantResumeResponse{}, err
+		}
+		out.AssistantMessage = assistantMessage
 	}
 	return out, nil
 }
@@ -331,7 +377,7 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 	req projectAssistantResumeRequest,
 	decision projectAssistantPermissionDecision,
 	out projectAssistantResumeResponse,
-) (store.AssistantRun, projectAssistantResumeResponse, error) {
+) (store.AssistantRun, projectAssistantResumeResponse, projectAssistantCheckpointState, error) {
 	index := state.CurrentIndex
 	for index < len(state.ToolCalls) {
 		tc := state.ToolCalls[index]
@@ -351,14 +397,16 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 			var err error
 			tc, err = projectAssistantToolCallWithEditedArguments(tc, editedArguments)
 			if err != nil {
-				return run, out, err
+				return run, out, state, err
 			}
-			result, toolCall, err := s.executeApprovedProjectAssistantToolCall(ctx, r, id, p, repository, state.ProjectRepositoryRef, tc)
+			messages, result, toolCall, err := s.executeApprovedProjectAssistantToolCall(ctx, r, id, p, repository, state.ProjectRepositoryRef, tc)
 			if err != nil {
-				return run, out, err
+				return run, out, state, err
 			}
 			out.Result = result
 			out.ToolCall = toolCall
+			state.Messages = append(state.Messages, messages...)
+			state.LastToolMessages = cloneChatMessages(messages)
 			now := time.Now().UTC()
 			run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
 				RequestID:       run.RequestID,
@@ -372,7 +420,7 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 				ResolvedAt:      now,
 			})
 			if err != nil {
-				return run, out, err
+				return run, out, state, err
 			}
 			index++
 		case projectAssistantPermissionDeny:
@@ -384,6 +432,8 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 				Status: "rejected",
 				Error:  msg.Content,
 			}
+			state.Messages = append(state.Messages, msg)
+			state.LastToolMessages = []chatMessage{msg}
 			now := time.Now().UTC()
 			var err error
 			run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
@@ -397,7 +447,7 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 				ResolvedAt:      now,
 			})
 			if err != nil {
-				return run, out, err
+				return run, out, state, err
 			}
 			index++
 		case projectAssistantPermissionAsk:
@@ -408,20 +458,20 @@ func (s *Server) resolveClaimedProjectAssistantRun(
 			}
 			nextRun, permission, checkpoint, err := prepareProjectAssistantNextPermission(run, state, index, tool)
 			if err != nil {
-				return run, out, err
+				return run, out, state, err
 			}
 			out.RequestID = nextRun.RequestID
 			out.Status = nextRun.Status
 			out.Permission = &permission
 			out.Checkpoint = &checkpoint
-			return nextRun, out, nil
+			return nextRun, out, state, nil
 		default:
-			return run, out, newValidationError("decision must be allow or deny")
+			return run, out, state, newValidationError("decision must be allow or deny")
 		}
 	}
 	run.Status = store.AssistantRunStatusCompleted
 	run.UpdatedAt = time.Now().UTC()
-	return run, out, nil
+	return run, out, state, nil
 }
 
 func (s *Server) executeApprovedProjectAssistantToolCall(
@@ -432,7 +482,7 @@ func (s *Server) executeApprovedProjectAssistantToolCall(
 	repository *ProjectRepositoryView,
 	projectRepositoryRef string,
 	tc chatToolCall,
-) (string, *projectToolCallStreamEvent, error) {
+) ([]chatMessage, string, *projectToolCallStreamEvent, error) {
 	var streamed []projectToolCallStreamEvent
 	messages, err := s.resolveProjectToolCalls(
 		ctx,
@@ -448,7 +498,7 @@ func (s *Server) executeApprovedProjectAssistantToolCall(
 		},
 	)
 	if err != nil {
-		return "", nil, err
+		return nil, "", nil, err
 	}
 	var toolCall *projectToolCallStreamEvent
 	if len(streamed) > 0 {
@@ -459,7 +509,123 @@ func (s *Server) executeApprovedProjectAssistantToolCall(
 	if len(messages) > 0 {
 		result = messages[len(messages)-1].Content
 	}
-	return result, toolCall, nil
+	return messages, result, toolCall, nil
+}
+
+func (s *Server) continueProjectAssistantRunAfterPermission(
+	ctx context.Context,
+	r *http.Request,
+	id identity,
+	c *asclient.Client,
+	p *aiv1alpha1.Project,
+	repository *ProjectRepositoryView,
+	state projectAssistantCheckpointState,
+) (*aiv1alpha1.ProjectMessage, error) {
+	settings, err := readProjectLLMSettings(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	if err := normalizeProjectLLMSettings(&settings); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(settings.APIKey) == "" {
+		return nil, errProjectLLMNotConfigured
+	}
+
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
+	assistantID := newMessageID()
+	assistantContent := &strings.Builder{}
+	var streamedToolCalls []projectToolCallStreamEvent
+	var pendingPermissionToolCallID string
+	emitAssistantEvent := func(event projectAssistantEvent) {
+		switch event.Type {
+		case projectAssistantEventPermissionNeeded:
+			if event.Permission != nil && event.Permission.ToolCallID != "" {
+				pendingPermissionToolCallID = event.Permission.ToolCallID
+				streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, projectToolCallStreamEvent{
+					ID:         event.Permission.ToolCallID,
+					Name:       event.Permission.ToolName,
+					Status:     "permission_required",
+					Summary:    event.Permission.Reason,
+					Permission: event.Permission,
+				})
+			}
+		case projectAssistantEventCheckpointSaved:
+			if event.Checkpoint != nil && pendingPermissionToolCallID != "" {
+				streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, projectToolCallStreamEvent{
+					ID:         pendingPermissionToolCallID,
+					Status:     "permission_required",
+					Checkpoint: event.Checkpoint,
+				})
+			}
+		}
+	}
+	streamToolCall := func(toolCall projectToolCallStreamEvent) {
+		if toolCall.ID == "" || toolCall.Status == "" {
+			return
+		}
+		streamedToolCalls = upsertProjectToolCallStreamEvent(streamedToolCalls, toolCall)
+	}
+	continuation := state
+	continuation.Messages = cloneChatMessages(state.Messages)
+	req := projectAssistantRunRequest{
+		Identity:                 id,
+		HTTPRequest:              r,
+		Client:                   c,
+		Project:                  p,
+		Repository:               repository,
+		WorkspaceScope:           projectWorkspaceScope(id, p.Name),
+		Workspace:                s.workspaces,
+		MessageScope:             messageScope,
+		LLM:                      settings,
+		MCPBaseURL:               s.hubBase,
+		MCPInsecureSkipTLSVerify: s.mcpInsecureSkipTLSVerify,
+		StreamCallbacks: projectAssistantStreamCallbacks{
+			OnChunk: func(chunk string) {
+				assistantContent.WriteString(chunk)
+			},
+			OnStatus: func(string) {},
+			OnToolCall: func(toolCall projectToolCallStreamEvent) {
+				streamToolCall(toolCall)
+			},
+			OnAssistantEvent: emitAssistantEvent,
+		},
+		Continuation: &continuation,
+	}
+	result, err := s.projectAssistantEngine().StreamProjectAssistant(ctx, req, nil)
+	if err != nil {
+		var permissionErr *projectAssistantPermissionRequiredError
+		if errors.As(err, &permissionErr) {
+			return s.appendResumedProjectAssistantMessage(ctx, messageScope, assistantID, assistantContent.String(), projectAssistantMessageMetadata(projectMessageStatusPendingPermission, streamedToolCalls))
+		}
+		return nil, err
+	}
+	assistantReply := projectAssistantStoredContent(result.Content, assistantContent.String())
+	if pending := projectAssistantUnstreamedContent(assistantReply, assistantContent.String()); pending != "" {
+		assistantContent.WriteString(pending)
+	}
+	if strings.TrimSpace(assistantReply) == "" {
+		return nil, errors.New("assistant generation returned an empty response")
+	}
+	return s.appendResumedProjectAssistantMessage(ctx, messageScope, assistantID, assistantReply, projectAssistantMessageMetadata("", streamedToolCalls))
+}
+
+func (s *Server) appendResumedProjectAssistantMessage(
+	ctx context.Context,
+	scope store.Scope,
+	id string,
+	content string,
+	metadata map[string]any,
+) (*aiv1alpha1.ProjectMessage, error) {
+	if err := appendProjectAssistantMessage(ctx, s.store, scope, id, content, metadata); err != nil {
+		return nil, err
+	}
+	msg, err := s.findProjectMessage(ctx, scope, id)
+	if err != nil {
+		return nil, err
+	}
+	apiMessage := projectMessageToAPI(msg)
+	return &apiMessage, nil
 }
 
 func prepareProjectAssistantNextPermission(
@@ -553,6 +719,42 @@ func cloneProjectAssistantToolCalls(src []chatToolCall) []chatToolCall {
 		return nil
 	}
 	dst := make([]chatToolCall, len(src))
-	copy(dst, src)
+	for i, tc := range src {
+		dst[i] = cloneChatToolCall(tc)
+	}
+	return dst
+}
+
+func cloneChatMessages(src []chatMessage) []chatMessage {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]chatMessage, len(src))
+	for i, msg := range src {
+		dst[i] = msg
+		dst[i].ToolCalls = cloneProjectAssistantToolCalls(msg.ToolCalls)
+	}
+	return dst
+}
+
+func cloneChatToolCall(src chatToolCall) chatToolCall {
+	out := src
+	if len(src.ExtraContent) > 0 {
+		out.ExtraContent = make(map[string]any, len(src.ExtraContent))
+		for k, v := range src.ExtraContent {
+			out.ExtraContent[k] = v
+		}
+	}
+	return out
+}
+
+func cloneProjectAssistantSeenToolCalls(src map[string]int) map[string]int {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]int, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
 	return dst
 }

--- a/providers/app-studio/api/assistant_contract.go
+++ b/providers/app-studio/api/assistant_contract.go
@@ -53,6 +53,7 @@ type projectAssistantRunRequest struct {
 	MCPBaseURL               string
 	MCPInsecureSkipTLSVerify bool
 	StreamCallbacks          projectAssistantStreamCallbacks
+	Continuation             *projectAssistantCheckpointState
 }
 
 type projectAssistantRunResult struct {

--- a/providers/app-studio/api/assistant_eino_engine.go
+++ b/providers/app-studio/api/assistant_eino_engine.go
@@ -60,7 +60,15 @@ func newProjectEinoAssistantBody(server *Server) projectEinoAssistantBody {
 		if err := ctx.Err(); err != nil {
 			return projectAssistantRunResult{}, err
 		}
-		reply, err := server.runProjectAssistantChatLoop(ctx, req)
+		var (
+			reply string
+			err   error
+		)
+		if req.Continuation != nil {
+			reply, err = server.runProjectAssistantChatLoopFromCheckpoint(ctx, req, *req.Continuation)
+		} else {
+			reply, err = server.runProjectAssistantChatLoop(ctx, req)
+		}
 		if err != nil {
 			return projectAssistantRunResult{}, err
 		}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -351,24 +351,48 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 			Content: projectMCPToolsFailurePrompt(toolsErr),
 		})
 	}
+	state := projectAssistantCheckpointState{
+		Messages:             messages,
+		ProjectRepositoryRef: strings.TrimSpace(projectRepositoryRef),
+		SeenToolCalls:        map[string]int{},
+	}
+	return s.runProjectAssistantChatLoopWithState(ctx, req, state, tools)
+}
 
+func (s *Server) runProjectAssistantChatLoopFromCheckpoint(ctx context.Context, req projectAssistantRunRequest, state projectAssistantCheckpointState) (string, error) {
+	if len(state.Messages) == 0 {
+		return s.runProjectAssistantChatLoop(ctx, req)
+	}
+	if strings.TrimSpace(state.ProjectRepositoryRef) == "" {
+		state.ProjectRepositoryRef = projectLinkedRepositoryRef(req.Project)
+	}
+	tools, err := s.loadProjectMCPTools(req.HTTPRequest, req.Identity, req.LLM)
+	if err != nil {
+		tools = nil
+	}
+	return s.runProjectAssistantChatLoopWithState(ctx, req, state, tools)
+}
+
+func (s *Server) runProjectAssistantChatLoopWithState(ctx context.Context, req projectAssistantRunRequest, state projectAssistantCheckpointState, tools []chatTool) (string, error) {
+	settings := req.LLM
 	logger := klog.FromContext(ctx)
 
 	// seenToolCalls tracks each (name, args) signature the model has already
 	// requested. A model that re-issues an identical call is looping rather
 	// than making progress, so we stop offering tools and force a text answer
 	// instead of grinding through every turn and dying with a generic error.
-	seenToolCalls := map[string]int{}
-	forceTextAnswer := false
-	repeatedToolLoop := false
-	var lastToolMessages []chatMessage
+	if state.SeenToolCalls == nil {
+		state.SeenToolCalls = map[string]int{}
+	}
+	messages := cloneChatMessages(state.Messages)
+	lastToolMessages := cloneChatMessages(state.LastToolMessages)
 
-	for i := 0; i < maxAssistantToolTurns; i++ {
+	for i := state.Turn; i < maxAssistantToolTurns; i++ {
 		// On the last allowed turn (or once we have detected a loop), stop
 		// offering tools so the model must produce a final text answer. This
 		// turns "exceeded safe turn limit" into a graceful explanation of why
 		// the assistant could not complete the request.
-		finalTurn := forceTextAnswer || i == maxAssistantToolTurns-1
+		finalTurn := state.ForceTextAnswer || i == maxAssistantToolTurns-1
 
 		reqBody := chatCompletionRequest{
 			Model:       settings.Model,
@@ -384,7 +408,7 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 
 		reply, err := callProjectChatCompletionStream(ctx, settings, reqBody, req.StreamCallbacks.OnChunk, req.StreamCallbacks.OnStatus)
 		if err != nil {
-			if repeatedToolLoop && errors.Is(err, errProjectLLMNoStreamedChoice) {
+			if state.RepeatedToolLoop && errors.Is(err, errProjectLLMNoStreamedChoice) {
 				return projectRepeatedToolLoopFallback(lastToolMessages), nil
 			}
 			if finalTurn && len(lastToolMessages) > 0 && errors.Is(err, errProjectLLMNoStreamedChoice) {
@@ -397,8 +421,8 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 			repeated := false
 			for _, tc := range reply.ToolCalls {
 				sig := tc.Function.Name + "\x00" + tc.Function.Arguments
-				seenToolCalls[sig]++
-				if seenToolCalls[sig] > 1 {
+				state.SeenToolCalls[sig]++
+				if state.SeenToolCalls[sig] > 1 {
 					repeated = true
 				}
 				logger.V(2).Info("project assistant requested tool call",
@@ -409,12 +433,20 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 				Role:      aiv1alpha1.ProjectMessageRoleAssistant,
 				ToolCalls: reply.ToolCalls,
 			})
-			nextMessages, callErr := s.resolveProjectToolCallsWithPermissions(ctx, req, projectRepositoryRef, reply.ToolCalls)
+			nextState := state
+			nextState.Messages = cloneChatMessages(messages)
+			nextState.SeenToolCalls = cloneProjectAssistantSeenToolCalls(state.SeenToolCalls)
+			nextState.LastToolMessages = cloneChatMessages(lastToolMessages)
+			nextState.Turn = i + 1
+			nextMessages, callErr := s.resolveProjectToolCallsWithPermissions(ctx, req, nextState, reply.ToolCalls)
 			if callErr != nil {
 				return "", callErr
 			}
 			lastToolMessages = nextMessages
 			messages = append(messages, nextMessages...)
+			state.Messages = cloneChatMessages(messages)
+			state.LastToolMessages = cloneChatMessages(lastToolMessages)
+			state.Turn = i + 1
 
 			if commitReply, ok := projectCommitToolReply(nextMessages); ok {
 				logger.Info("project assistant completed a project commit handoff attempt; forcing a final text answer",
@@ -424,14 +456,14 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 			if repeated {
 				logger.Info("project assistant repeated an identical tool call across turns; forcing a final text answer",
 					"turn", i, "project", req.Project.Name)
-				forceTextAnswer = true
-				repeatedToolLoop = true
+				state.ForceTextAnswer = true
+				state.RepeatedToolLoop = true
 			}
 			continue
 		}
 
 		if strings.TrimSpace(reply.Content) == "" {
-			if repeatedToolLoop {
+			if state.RepeatedToolLoop {
 				return projectRepeatedToolLoopFallback(lastToolMessages), nil
 			}
 			if finalTurn && len(lastToolMessages) > 0 {
@@ -448,7 +480,7 @@ func (s *Server) runProjectAssistantChatLoop(ctx context.Context, req projectAss
 func (s *Server) resolveProjectToolCallsWithPermissions(
 	ctx context.Context,
 	req projectAssistantRunRequest,
-	projectRepositoryRef string,
+	state projectAssistantCheckpointState,
 	toolCalls []chatToolCall,
 ) ([]chatMessage, error) {
 	if len(toolCalls) == 0 {
@@ -459,30 +491,36 @@ func (s *Server) resolveProjectToolCallsWithPermissions(
 	for i, tc := range toolCalls {
 		tool, ok := registry.Get(tc.Function.Name)
 		if !ok {
-			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, state.ProjectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if err != nil {
 				return nil, err
 			}
 			toolMessages = append(toolMessages, nextMessages...)
+			state.Messages = append(state.Messages, nextMessages...)
+			state.LastToolMessages = cloneChatMessages(nextMessages)
 			continue
 		}
 		args, err := projectAssistantToolCallArguments(tc)
 		if err != nil {
-			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, state.ProjectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if err != nil {
 				return nil, err
 			}
 			toolMessages = append(toolMessages, nextMessages...)
+			state.Messages = append(state.Messages, nextMessages...)
+			state.LastToolMessages = cloneChatMessages(nextMessages)
 			continue
 		}
 		spec := tool.Spec()
 		switch projectAssistantPermissionForTool(spec) {
 		case projectAssistantPermissionAllow:
-			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, projectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
+			nextMessages, err := s.resolveProjectToolCalls(ctx, req.Identity, req.Project, req.Repository, req.WorkspaceScope, state.ProjectRepositoryRef, []chatToolCall{tc}, req.HTTPRequest, req.StreamCallbacks.OnToolCall)
 			if err != nil {
 				return nil, err
 			}
 			toolMessages = append(toolMessages, nextMessages...)
+			state.Messages = append(state.Messages, nextMessages...)
+			state.LastToolMessages = cloneChatMessages(nextMessages)
 		case projectAssistantPermissionAsk:
 			if req.StreamCallbacks.OnToolCall != nil {
 				req.StreamCallbacks.OnToolCall(projectToolCallStreamEvent{
@@ -493,7 +531,7 @@ func (s *Server) resolveProjectToolCallsWithPermissions(
 					Summary:   projectAssistantPermissionReason(spec),
 				})
 			}
-			permissionErr, permission, checkpoint, err := s.saveProjectAssistantPermissionCheckpointForToolCalls(ctx, req, tool, toolCalls, i, projectRepositoryRef)
+			permissionErr, permission, checkpoint, err := s.saveProjectAssistantPermissionCheckpointForState(ctx, req, tool, state, toolCalls, i)
 			if err != nil {
 				return nil, err
 			}
@@ -519,7 +557,10 @@ func (s *Server) resolveProjectToolCallsWithPermissions(
 					Error:     reason,
 				})
 			}
-			toolMessages = append(toolMessages, projectAssistantPermissionDeniedToolMessage(tc, reason))
+			msg := projectAssistantPermissionDeniedToolMessage(tc, reason)
+			toolMessages = append(toolMessages, msg)
+			state.Messages = append(state.Messages, msg)
+			state.LastToolMessages = []chatMessage{msg}
 		}
 	}
 	return toolMessages, nil

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -489,7 +489,7 @@ func (s *Server) resumeProjectAssistant(w http.ResponseWriter, r *http.Request) 
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	resp, err := s.resumeProjectAssistantRunWithRepository(r.Context(), r, id, p, projectRepositoryView(r.Context(), c, p), mux.Vars(r)["run"], req)
+	resp, err := s.resumeProjectAssistantRunWithRepositoryAndClient(r.Context(), r, id, c, p, projectRepositoryView(r.Context(), c, p), mux.Vars(r)["run"], req)
 	if err != nil {
 		writeProjectError(w, err)
 		return

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -1408,6 +1408,108 @@ func TestResumeProjectAssistantRunContinuesToolBatchToNextPermission(t *testing.
 	}
 }
 
+func TestResumeProjectAssistantRunContinuesLLMAfterApprovedPermission(t *testing.T) {
+	var llmRequests []chatCompletionRequest
+	llm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode LLM request: %v", err)
+		}
+		llmRequests = append(llmRequests, req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch len(llmRequests) {
+		case 1:
+			writeProjectTestToolCallChunk(t, w, "call-write", "write_file", `{"path":"src/App.tsx","content":"approved\n"}`)
+		case 2:
+			var sawAssistantCall, sawToolResult bool
+			for _, msg := range req.Messages {
+				if msg.Role == aiv1alpha1.ProjectMessageRoleAssistant && len(msg.ToolCalls) == 1 && msg.ToolCalls[0].ID == "call-write" {
+					sawAssistantCall = true
+				}
+				if msg.Role == "tool" && msg.ToolCallID == "call-write" && strings.Contains(msg.Content, "src/App.tsx") {
+					sawToolResult = true
+				}
+			}
+			if !sawAssistantCall || !sawToolResult {
+				t.Fatalf("resume LLM messages = %#v, want approved tool call and result context", req.Messages)
+			}
+			fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"I wrote src/App.tsx after approval.\"}}]}\n\n")
+			fmt.Fprint(w, "data: [DONE]\n\n")
+		default:
+			t.Fatalf("unexpected LLM request count %d", len(llmRequests))
+		}
+	}))
+	defer llm.Close()
+
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: llm.URL, Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, "demo")
+	if err := appendProjectUserMessage(context.Background(), messages, messageScope, "write src/app"); err != nil {
+		t.Fatalf("appendProjectUserMessage returned error: %v", err)
+	}
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+
+	_, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("generateProjectAssistantStream error = %v, want permission required", err)
+	}
+
+	resp, err := server.resumeProjectAssistantRunWithRepositoryAndClient(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		&ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		permissionErr.RunID,
+		projectAssistantResumeRequest{RequestID: permissionErr.RequestID, Decision: string(projectAssistantPermissionAllow)},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRunWithRepositoryAndClient returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("resume response = %#v, want completed", resp)
+	}
+	if resp.AssistantMessage == nil || resp.AssistantMessage.Content != "I wrote src/App.tsx after approval." {
+		t.Fatalf("assistant message = %#v, want continuation response", resp.AssistantMessage)
+	}
+	if len(llmRequests) != 2 {
+		t.Fatalf("LLM request count = %d, want initial request plus resumed continuation", len(llmRequests))
+	}
+	read, err := workspaces.ReadFile(context.Background(), projectWorkspaceScope(id, project.Name), workspace.ReadOptions{Path: "src/App.tsx"})
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if read.Content != "approved\n" {
+		t.Fatalf("content = %q, want approved write", read.Content)
+	}
+	recent, err := messages.LoadRecentMessages(context.Background(), messageScope, 10)
+	if err != nil {
+		t.Fatalf("LoadRecentMessages returned error: %v", err)
+	}
+	var sawContinuation bool
+	for _, msg := range recent {
+		if msg.Role == aiv1alpha1.ProjectMessageRoleAssistant && msg.Content == "I wrote src/App.tsx after approval." {
+			sawContinuation = true
+		}
+	}
+	if !sawContinuation {
+		t.Fatalf("messages = %#v, want persisted resumed assistant continuation", recent)
+	}
+}
+
 func TestResumeProjectAssistantRunReplaysWorkflowWithRepositoryContext(t *testing.T) {
 	messages := store.NewMemoryStore()
 	workspaces := workspace.NewFileStore(t.TempDir())

--- a/providers/app-studio/api/runtime_worker_test.go
+++ b/providers/app-studio/api/runtime_worker_test.go
@@ -95,7 +95,7 @@ func TestProjectRuntimeWorkerRequiresApprovalWithWorker(t *testing.T) {
 			WorkspaceScope: projectWorkspaceScope(id, "demo"),
 			MessageScope:   projectMessageScope(id.orgUUID, id.workspaceUUID, "demo"),
 		},
-		"",
+		projectAssistantCheckpointState{},
 		[]chatToolCall{{
 			ID:   "call-runtime",
 			Type: "function",

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -75,6 +75,10 @@ type ProjectMessageView = ProjectMessage & {
   viewStatus?: ProjectMessageViewStatus
   toolCalls?: ProjectToolCallView[]
 }
+interface PendingApprovalView {
+  message: ProjectMessageView
+  toolCall: ProjectToolCallView
+}
 
 const SPLIT_WIDTH_KEY = 'kedge:projects:split-width'
 const OPENAI_COMPATIBLE_PROVIDER = 'openai-compatible'
@@ -186,6 +190,17 @@ const projects = ref<Project[]>([])
 const providers = ref<ProviderItem[]>([])
 const selected = ref<Project | null>(null)
 const messages = ref<ProjectMessageView[]>([])
+const pendingApproval = computed<PendingApprovalView | null>(() => {
+  for (let i = messages.value.length - 1; i >= 0; i--) {
+    const message = messages.value[i]
+    for (const toolCall of message.toolCalls ?? []) {
+      if (toolCall.status === 'permission_required' && toolCall.permission) {
+        return { message, toolCall }
+      }
+    }
+  }
+  return null
+})
 const loading = ref(true)
 const projectsLoaded = ref(false)
 const providersLoading = ref(false)
@@ -1346,6 +1361,9 @@ async function resolveToolPermission(message: ProjectMessageView, toolCall: Proj
   }
 
   permissionBusy.value = { ...permissionBusy.value, [key]: decision }
+  if (decision === 'allow') {
+    conversationStatus.value = 'Working'
+  }
   try {
     const response = await api.resumeAssistantRun(props.ctx, projectName, runID, {
       requestID,
@@ -1363,6 +1381,7 @@ async function resolveToolPermission(message: ProjectMessageView, toolCall: Proj
     const next = { ...permissionBusy.value }
     delete next[key]
     permissionBusy.value = next
+    conversationStatus.value = ''
   }
 }
 
@@ -1397,6 +1416,21 @@ function applyPermissionResponse(
       attachAssistantCheckpoint(projectName, assistantMessageID, response.checkpoint)
     }
   }
+  if (response.assistantMessage) {
+    upsertProjectMessage(response.assistantMessage)
+  }
+}
+
+function upsertProjectMessage(message: ProjectMessage) {
+  const view = toProjectMessageView(message)
+  const idx = messages.value.findIndex((item) => item.id === view.id)
+  if (idx >= 0) {
+    messages.value[idx] = view
+  } else {
+    messages.value = [...messages.value, view]
+    return
+  }
+  messages.value = [...messages.value]
 }
 
 function toProjectMessageView(message: ProjectMessage): ProjectMessageView {
@@ -2158,6 +2192,75 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
       </div>
 
       <template v-if="selected">
+        <div
+          v-if="pendingApproval"
+          class="mx-4 mt-3 rounded-lg border border-accent/30 bg-accent-subtle p-3 shadow-sm"
+        >
+          <div class="flex min-w-0 items-start gap-3">
+            <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-accent/30 bg-accent/10 text-accent">
+              <ClipboardList class="h-4 w-4" :stroke-width="1.75" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="flex min-w-0 items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-[13px] font-semibold text-text-primary">Approval required</div>
+                  <div class="mt-0.5 text-[12px] leading-5 text-text-secondary">
+                    {{ pendingApproval.toolCall.permission?.reason || 'Review this action before it runs.' }}
+                  </div>
+                </div>
+                <div class="shrink-0 rounded-md border border-border-subtle bg-surface px-2 py-1 font-mono text-[11px] text-text-muted">
+                  {{ pendingApproval.toolCall.checkpoint?.id || 'Saving' }}
+                </div>
+              </div>
+              <div class="mt-2 flex min-w-0 flex-wrap items-center gap-2 text-[11px] text-text-muted">
+                <span class="rounded-md border border-border-subtle bg-surface px-2 py-1 font-mono text-text-primary">
+                  {{ displayToolName(pendingApproval.toolCall.permission?.toolName || pendingApproval.toolCall.name) }}
+                </span>
+                <span class="min-w-0 truncate">{{ actionSummary(pendingApproval.toolCall) }}</span>
+              </div>
+              <textarea
+                v-if="canEditPermission(pendingApproval.toolCall)"
+                v-model="permissionEdits[permissionKey(pendingApproval.toolCall)]"
+                rows="4"
+                class="mt-3 min-h-[92px] w-full resize-y rounded-md border border-border-subtle bg-surface px-2 py-1.5 font-mono text-[11px] leading-4 text-text-secondary outline-none transition focus:border-accent/50"
+                spellcheck="false"
+              />
+              <div v-if="permissionError(pendingApproval.toolCall)" class="mt-2 text-[11px] leading-4 text-danger">
+                {{ permissionError(pendingApproval.toolCall) }}
+              </div>
+              <div class="mt-3 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  class="inline-flex h-8 items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-3 text-[12px] font-medium text-accent transition hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  :disabled="!pendingApproval.toolCall.checkpoint || !!permissionBusyState(pendingApproval.toolCall)"
+                  @click="resolveToolPermission(pendingApproval.message, pendingApproval.toolCall, 'allow')"
+                >
+                  <Loader2
+                    v-if="permissionBusyState(pendingApproval.toolCall) === 'allow'"
+                    class="h-3.5 w-3.5 animate-spin"
+                    :stroke-width="1.75"
+                  />
+                  <Check v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+                  Allow
+                </button>
+                <button
+                  type="button"
+                  class="inline-flex h-8 items-center gap-1.5 rounded-md border border-border-subtle bg-surface px-3 text-[12px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  :disabled="!pendingApproval.toolCall.checkpoint || !!permissionBusyState(pendingApproval.toolCall)"
+                  @click="resolveToolPermission(pendingApproval.message, pendingApproval.toolCall, 'deny')"
+                >
+                  <Loader2
+                    v-if="permissionBusyState(pendingApproval.toolCall) === 'deny'"
+                    class="h-3.5 w-3.5 animate-spin"
+                    :stroke-width="1.75"
+                  />
+                  <X v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+                  Deny
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
         <div
           ref="messagesRef"
           class="min-h-0 flex-1 overflow-auto px-4 py-3"

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -58,6 +58,7 @@ export interface ProjectAssistantResumeResponse {
   permission?: ProjectAssistantPermission
   checkpoint?: ProjectAssistantCheckpoint
   result?: string
+  assistantMessage?: ProjectMessage
 }
 
 export interface ProjectMessageStreamEvent {

--- a/providers/app-studio/store/postgres.go
+++ b/providers/app-studio/store/postgres.go
@@ -330,18 +330,20 @@ func (s *PostgresStore) SaveAssistantRun(ctx context.Context, scope Scope, run A
 	if len(checkpoint) == 0 {
 		checkpoint = json.RawMessage(`{}`)
 	}
-	if !json.Valid(checkpoint) {
-		return fmt.Errorf("assistant run checkpoint is not valid json")
+	normalizedCheckpoint, err := normalizePostgresJSONB(checkpoint)
+	if err != nil {
+		return fmt.Errorf("assistant run checkpoint is not valid json: %w", err)
 	}
 	audit := run.Audit
 	if len(audit) == 0 {
 		audit = json.RawMessage(`{}`)
 	}
-	if !json.Valid(audit) {
-		return fmt.Errorf("assistant run audit is not valid json")
+	normalizedAudit, err := normalizePostgresJSONB(audit)
+	if err != nil {
+		return fmt.Errorf("assistant run audit is not valid json: %w", err)
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO app_studio_assistant_runs (
 			org_uuid, workspace_uuid, project_name, run_id,
 			status, request_id, checkpoint, audit, created_at, updated_at
@@ -355,12 +357,27 @@ func (s *PostgresStore) SaveAssistantRun(ctx context.Context, scope Scope, run A
 			updated_at = EXCLUDED.updated_at
 	`,
 		scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName, run.ID,
-		run.Status, run.RequestID, []byte(checkpoint), []byte(audit), run.CreatedAt.UTC(), run.UpdatedAt.UTC(),
+		run.Status, run.RequestID, string(normalizedCheckpoint), string(normalizedAudit), run.CreatedAt.UTC(), run.UpdatedAt.UTC(),
 	)
 	if err != nil {
 		return fmt.Errorf("upsert assistant run: %w", err)
 	}
 	return nil
+}
+
+func normalizePostgresJSONB(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var parsed any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, err
+	}
+	normalized, err := json.Marshal(parsed)
+	if err != nil {
+		return nil, err
+	}
+	return normalized, nil
 }
 
 func (s *PostgresStore) ClaimAssistantRun(ctx context.Context, scope Scope, id string, requestID string, now time.Time) (AssistantRun, error) {


### PR DESCRIPTION
## Summary
- Persist safe assistant chat-loop continuation state when App Studio pauses for tool approval.
- Resume approved tool calls back through the Eino assistant engine and return the persisted follow-up assistant message.
- Surface pending approvals in a prominent conversation-level panel while preserving the existing action details row.

## Verification
- `go test -count=1 ./api -run TestResumeProjectAssistantRunContinuesLLMAfterApprovedPermission` from `providers/app-studio`
- `go test -count=1 ./...` from `providers/app-studio`
- `npm run typecheck` from `providers/app-studio/portal`
- `npm run build` from `providers/app-studio/portal`
- `git diff --check`