### PR TITLE
Add App Studio assistant run manager

### DIFF
--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -306,6 +306,15 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 	out projectAssistantResumeResponse,
 ) (projectAssistantResumeResponse, error) {
 	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
+	turn := newProjectAssistantTurnItem(projectAssistantTurnResume, id, p.Name)
+	turn.RunID = run.ID
+	turn.RequestID = run.RequestID
+	turn.AssistantMessageID = strings.TrimSpace(resumeReq.AssistantMessageID)
+	ctx, finishTurn := s.projectAssistantRunManager().Begin(ctx, turn)
+	defer finishTurn()
+	if r != nil {
+		r = r.WithContext(ctx)
+	}
 	if c == nil {
 		return s.completeClaimedProjectAssistantRunAfterResumeError(ctx, messageScope, run, state, resumeReq, decision, id.user, out, nil, fmt.Errorf("project client is required for assistant resume"))
 	}
@@ -394,7 +403,9 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		if !errors.As(err, &permissionErr) {
 			return s.completeClaimedProjectAssistantRunAfterResumeError(ctx, messageScope, run, state, resumeReq, decision, id.user, out, currentToolCall, err)
 		}
-		pendingRun, getErr := s.store.GetAssistantRun(ctx, messageScope, permissionErr.RunID)
+		persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+		defer cancelPersist()
+		pendingRun, getErr := s.store.GetAssistantRun(persistCtx, messageScope, permissionErr.RunID)
 		if getErr != nil {
 			return projectAssistantResumeResponse{}, getErr
 		}
@@ -412,18 +423,20 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		if err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
-		if err := s.store.SaveAssistantRun(ctx, messageScope, pendingRun); err != nil {
+		if err := s.store.SaveAssistantRun(persistCtx, messageScope, pendingRun); err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
 		out.RunID = pendingRun.ID
 		out.RequestID = pendingRun.RequestID
 		out.Status = pendingRun.Status
-		if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
+		if err := s.updateProjectAssistantPermissionMessage(persistCtx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
 		return out, nil
 	}
 
+	persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+	defer cancelPersist()
 	run.Status = store.AssistantRunStatusCompleted
 	run.UpdatedAt = time.Now().UTC()
 	run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
@@ -440,11 +453,11 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 	if err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
-	if err := s.store.SaveAssistantRun(ctx, messageScope, run); err != nil {
+	if err := s.store.SaveAssistantRun(persistCtx, messageScope, run); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	out.Status = run.Status
-	if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
+	if err := s.updateProjectAssistantPermissionMessage(persistCtx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	assistantReply := projectAssistantStoredContent(result.Content, assistantContent.String())
@@ -452,7 +465,7 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		assistantContent.WriteString(pending)
 	}
 	if strings.TrimSpace(assistantReply) != "" {
-		assistantMessage, err := s.appendResumedProjectAssistantMessage(ctx, messageScope, assistantID, assistantReply, projectAssistantMessageMetadata("", streamedToolCalls))
+		assistantMessage, err := s.appendResumedProjectAssistantMessage(persistCtx, messageScope, assistantID, assistantReply, projectAssistantMessageMetadata("", streamedToolCalls))
 		if err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
@@ -476,6 +489,8 @@ func (s *Server) completeClaimedProjectAssistantRunAfterResumeError(
 	if cause == nil {
 		cause = errors.New("assistant resume failed")
 	}
+	persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+	defer cancelPersist()
 	failure := strings.TrimSpace(cause.Error())
 	if failure == "" {
 		failure = "assistant resume failed"
@@ -522,11 +537,11 @@ func (s *Server) completeClaimedProjectAssistantRunAfterResumeError(
 		return projectAssistantResumeResponse{}, auditErr
 	}
 	run = updatedRun
-	if err := s.store.SaveAssistantRun(ctx, messageScope, run); err != nil {
+	if err := s.store.SaveAssistantRun(persistCtx, messageScope, run); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	out.Status = run.Status
-	if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
+	if err := s.updateProjectAssistantPermissionMessage(persistCtx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	return out, cause

--- a/providers/app-studio/api/assistant_run_manager.go
+++ b/providers/app-studio/api/assistant_run_manager.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+type projectAssistantTurnKind string
+
+const (
+	projectAssistantTurnMessage projectAssistantTurnKind = "message"
+	projectAssistantTurnResume  projectAssistantTurnKind = "resume"
+	projectAssistantTurnAbort   projectAssistantTurnKind = "abort"
+)
+
+var errProjectAssistantTurnPreempted = errors.New("assistant turn preempted")
+
+// projectAssistantTurnItem is intentionally small and value-only so a later
+// Eino TurnLoop checkpoint can persist queued work without serializing request,
+// client, workspace, or tenant-authority handles.
+type projectAssistantTurnItem struct {
+	Kind               projectAssistantTurnKind `json:"kind"`
+	OrgUUID            string                   `json:"orgUUID"`
+	WorkspaceUUID      string                   `json:"workspaceUUID"`
+	ProjectName        string                   `json:"projectName"`
+	User               string                   `json:"user,omitempty"`
+	RunID              string                   `json:"runID,omitempty"`
+	RequestID          string                   `json:"requestID,omitempty"`
+	AssistantMessageID string                   `json:"assistantMessageID,omitempty"`
+	CreatedAt          time.Time                `json:"createdAt"`
+}
+
+func newProjectAssistantTurnItem(kind projectAssistantTurnKind, id identity, projectName string) projectAssistantTurnItem {
+	return projectAssistantTurnItem{
+		Kind:          kind,
+		OrgUUID:       strings.TrimSpace(id.orgUUID),
+		WorkspaceUUID: strings.TrimSpace(id.workspaceUUID),
+		ProjectName:   strings.TrimSpace(projectName),
+		User:          strings.TrimSpace(id.user),
+		CreatedAt:     time.Now().UTC(),
+	}
+}
+
+func (i projectAssistantTurnItem) key() projectAssistantRunKey {
+	return projectAssistantRunKey{
+		OrgUUID:       strings.TrimSpace(i.OrgUUID),
+		WorkspaceUUID: strings.TrimSpace(i.WorkspaceUUID),
+		ProjectName:   strings.TrimSpace(i.ProjectName),
+	}
+}
+
+type projectAssistantRunKey struct {
+	OrgUUID       string
+	WorkspaceUUID string
+	ProjectName   string
+}
+
+func (k projectAssistantRunKey) valid() bool {
+	return strings.TrimSpace(k.OrgUUID) != "" && strings.TrimSpace(k.WorkspaceUUID) != "" && strings.TrimSpace(k.ProjectName) != ""
+}
+
+type projectAssistantActiveTurn struct {
+	item   projectAssistantTurnItem
+	cancel context.CancelCauseFunc
+	done   chan struct{}
+}
+
+type projectAssistantRunManager struct {
+	mu     sync.Mutex
+	active map[projectAssistantRunKey]*projectAssistantActiveTurn
+}
+
+func newProjectAssistantRunManager() *projectAssistantRunManager {
+	return &projectAssistantRunManager{
+		active: map[projectAssistantRunKey]*projectAssistantActiveTurn{},
+	}
+}
+
+func (m *projectAssistantRunManager) Begin(ctx context.Context, item projectAssistantTurnItem) (context.Context, func()) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	key := item.key()
+	if m == nil || !key.valid() {
+		return ctx, func() {}
+	}
+	runCtx, cancel := context.WithCancelCause(ctx)
+	active := &projectAssistantActiveTurn{
+		item:   item,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	m.mu.Lock()
+	if previous := m.active[key]; previous != nil {
+		previous.cancel(errProjectAssistantTurnPreempted)
+	}
+	m.active[key] = active
+	m.mu.Unlock()
+
+	var once sync.Once
+	return runCtx, func() {
+		once.Do(func() {
+			m.mu.Lock()
+			if m.active[key] == active {
+				delete(m.active, key)
+			}
+			m.mu.Unlock()
+			cancel(nil)
+			close(active.done)
+		})
+	}
+}
+
+func (m *projectAssistantRunManager) activeCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.active)
+}

--- a/providers/app-studio/api/assistant_run_manager_test.go
+++ b/providers/app-studio/api/assistant_run_manager_test.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	asclient "github.com/faroshq/provider-app-studio/client"
+	"github.com/faroshq/provider-app-studio/store"
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+func TestProjectAssistantRunManagerPreemptsActiveTurnForSameProject(t *testing.T) {
+	manager := newProjectAssistantRunManager()
+	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	firstCtx, firstDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, id, "demo"))
+	secondCtx, secondDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, id, "demo"))
+	t.Cleanup(secondDone)
+
+	select {
+	case <-firstCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("first turn was not preempted")
+	}
+	if !errors.Is(context.Cause(firstCtx), errProjectAssistantTurnPreempted) {
+		t.Fatalf("first context cause = %v, want preempted", context.Cause(firstCtx))
+	}
+	if err := secondCtx.Err(); err != nil {
+		t.Fatalf("second turn context error = %v, want active", err)
+	}
+	firstDone()
+	if got := manager.activeCount(); got != 1 {
+		t.Fatalf("active count after stale finish = %d, want newer turn still active", got)
+	}
+	secondDone()
+	if got := manager.activeCount(); got != 0 {
+		t.Fatalf("active count after second finish = %d, want no active turns", got)
+	}
+}
+
+func TestProjectAssistantRunManagerScopesActiveTurnsByTenantProject(t *testing.T) {
+	manager := newProjectAssistantRunManager()
+	firstCtx, firstDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, identity{
+		orgUUID:       "org-a",
+		workspaceUUID: "ws-1",
+	}, "demo"))
+	defer firstDone()
+	secondCtx, secondDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, identity{
+		orgUUID:       "org-b",
+		workspaceUUID: "ws-1",
+	}, "demo"))
+	defer secondDone()
+
+	if err := firstCtx.Err(); err != nil {
+		t.Fatalf("first turn context error = %v, want active for different org", err)
+	}
+	if err := secondCtx.Err(); err != nil {
+		t.Fatalf("second turn context error = %v, want active", err)
+	}
+	if got := manager.activeCount(); got != 2 {
+		t.Fatalf("active count = %d, want separate tenant turns", got)
+	}
+}
+
+func TestProjectAssistantRunManagerIgnoresUnscopedTurns(t *testing.T) {
+	manager := newProjectAssistantRunManager()
+	ctx, done := manager.Begin(context.Background(), projectAssistantTurnItem{Kind: projectAssistantTurnMessage})
+	defer done()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("unscoped turn context error = %v, want unchanged context", err)
+	}
+	if got := manager.activeCount(); got != 0 {
+		t.Fatalf("active count = %d, want unscoped turn ignored", got)
+	}
+}
+
+func TestGenerateProjectAssistantStreamPreemptsActiveProjectTurn(t *testing.T) {
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: "http://llm.example.test", Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	engine := &preemptProbeProjectAssistantEngine{
+		entered:    make(chan struct{}),
+		firstCause: make(chan error, 1),
+	}
+	server.assistantEngine = engine
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := server.generateProjectAssistantStream(
+			httptest.NewRequest(http.MethodPost, "/", nil),
+			id,
+			client,
+			project,
+			projectAssistantStreamCallbacks{},
+		)
+		firstErr <- err
+	}()
+	select {
+	case <-engine.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first assistant turn did not start")
+	}
+
+	secondReply, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	if err != nil {
+		t.Fatalf("second generateProjectAssistantStream returned error: %v", err)
+	}
+	if secondReply != "second turn" {
+		t.Fatalf("second reply = %q, want second turn", secondReply)
+	}
+	select {
+	case err := <-firstErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first turn error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first assistant turn was not canceled")
+	}
+	select {
+	case cause := <-engine.firstCause:
+		if !errors.Is(cause, errProjectAssistantTurnPreempted) {
+			t.Fatalf("first turn cause = %v, want preempted", cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first assistant turn did not report cancellation cause")
+	}
+}
+
+func TestResumeProjectAssistantFinalizesClaimedRunAfterPreemption(t *testing.T) {
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: "http://llm.example.test", Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	baseStore := store.NewMemoryStore()
+	messages := cancelSensitiveAssistantRunStore{Store: baseStore}
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	engine := &preemptProbeResumeAssistantEngine{
+		resumeEntered: make(chan struct{}),
+		resumeCause:   make(chan error, 1),
+	}
+	server.assistantEngine = engine
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	state := projectAssistantCheckpointState{
+		ToolCalls: []chatToolCall{{
+			ID:   "call-write",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      projectToolWriteFile,
+				Arguments: `{"path":"src/App.tsx","content":"approved\n"}`,
+			},
+		}},
+		CurrentIndex: 0,
+		Eino: &projectAssistantEinoCheckpointState{
+			CheckpointID: "run-resume",
+			Checkpoint:   []byte("fake-checkpoint"),
+			InterruptID:  "interrupt-write",
+			ToolCallID:   "call-write",
+			ToolName:     projectToolWriteFile,
+		},
+	}
+	rawCheckpoint, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("encode checkpoint returned error: %v", err)
+	}
+	run := store.AssistantRun{
+		ID:         "run-resume",
+		Status:     store.AssistantRunStatusPendingPermission,
+		RequestID:  "perm-resume",
+		Checkpoint: rawCheckpoint,
+	}
+	if err := messages.SaveAssistantRun(context.Background(), messageScope, run); err != nil {
+		t.Fatalf("SaveAssistantRun returned error: %v", err)
+	}
+
+	resumeErr := make(chan error, 1)
+	go func() {
+		_, err := server.resumeProjectAssistantRunWithRepositoryAndClient(
+			context.Background(),
+			httptest.NewRequest(http.MethodPost, "/", nil),
+			id,
+			client,
+			project,
+			&ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+			run.ID,
+			projectAssistantResumeRequest{RequestID: run.RequestID, Decision: string(projectAssistantPermissionAllow)},
+		)
+		resumeErr <- err
+	}()
+	select {
+	case <-engine.resumeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("resume turn did not start")
+	}
+
+	reply, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	if err != nil {
+		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
+	}
+	if reply != "new turn" {
+		t.Fatalf("reply = %q, want new turn", reply)
+	}
+	select {
+	case err := <-resumeErr:
+		if !errors.Is(err, errProjectAssistantTurnPreempted) {
+			t.Fatalf("resume error = %v, want preempted", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resume turn was not preempted")
+	}
+	got, err := messages.GetAssistantRun(context.Background(), messageScope, run.ID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if got.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("run status = %q, want completed after preempted resume cleanup", got.Status)
+	}
+	audit := decodeProjectAssistantRunAudit(t, got.Audit)
+	if len(audit.Decisions) != 1 || audit.Decisions[0].Actor != id.user || !strings.Contains(audit.Decisions[0].Error, "preempted") {
+		t.Fatalf("audit = %#v, want preempted resume decision", audit)
+	}
+	select {
+	case cause := <-engine.resumeCause:
+		if !errors.Is(cause, errProjectAssistantTurnPreempted) {
+			t.Fatalf("resume cause = %v, want preempted", cause)
+		}
+	default:
+		t.Fatal("resume engine did not report cancellation cause")
+	}
+}
+
+type preemptProbeProjectAssistantEngine struct {
+	calls      atomic.Int32
+	entered    chan struct{}
+	firstCause chan error
+}
+
+func (e *preemptProbeProjectAssistantEngine) StreamProjectAssistant(
+	ctx context.Context,
+	_ projectAssistantRunRequest,
+	_ projectAssistantEventSink,
+) (projectAssistantRunResult, error) {
+	if e.calls.Add(1) == 1 {
+		close(e.entered)
+		<-ctx.Done()
+		e.firstCause <- context.Cause(ctx)
+		return projectAssistantRunResult{}, ctx.Err()
+	}
+	return projectAssistantRunResult{Content: "second turn"}, nil
+}
+
+func (e *preemptProbeProjectAssistantEngine) ResumeProjectAssistant(
+	context.Context,
+	projectAssistantRunRequest,
+	projectAssistantResumeRequest,
+	projectAssistantCheckpointState,
+) (projectAssistantRunResult, error) {
+	return projectAssistantRunResult{}, errors.New("unexpected resume")
+}
+
+type preemptProbeResumeAssistantEngine struct {
+	resumeEntered chan struct{}
+	resumeCause   chan error
+}
+
+func (e *preemptProbeResumeAssistantEngine) StreamProjectAssistant(
+	context.Context,
+	projectAssistantRunRequest,
+	projectAssistantEventSink,
+) (projectAssistantRunResult, error) {
+	return projectAssistantRunResult{Content: "new turn"}, nil
+}
+
+func (e *preemptProbeResumeAssistantEngine) ResumeProjectAssistant(
+	ctx context.Context,
+	_ projectAssistantRunRequest,
+	_ projectAssistantResumeRequest,
+	_ projectAssistantCheckpointState,
+) (projectAssistantRunResult, error) {
+	close(e.resumeEntered)
+	<-ctx.Done()
+	cause := context.Cause(ctx)
+	e.resumeCause <- cause
+	return projectAssistantRunResult{}, cause
+}
+
+type cancelSensitiveAssistantRunStore struct {
+	store.Store
+}
+
+func (s cancelSensitiveAssistantRunStore) SaveAssistantRun(ctx context.Context, scope store.Scope, run store.AssistantRun) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.Store.SaveAssistantRun(ctx, scope, run)
+}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -307,6 +307,10 @@ func (s *Server) generateProjectAssistantStream(
 	if id.orgUUID == "" || id.workspaceUUID == "" {
 		return "", errors.New("tenant context missing")
 	}
+	turn := newProjectAssistantTurnItem(projectAssistantTurnMessage, id, p.Name)
+	ctx, finishTurn := s.projectAssistantRunManager().Begin(ctx, turn)
+	defer finishTurn()
+	r = r.WithContext(ctx)
 	recent, err := s.store.LoadRecentMessages(ctx, projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name), 24)
 	if err != nil {
 		return "", err

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -24,6 +24,7 @@ package api
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +49,9 @@ type Server struct {
 	hubBase                  string
 	mcpInsecureSkipTLSVerify bool
 	assistantEngine          projectAssistantEngine
+	assistantRunManager      *projectAssistantRunManager
 	runtimeWorker            projectRuntimeWorker
+	mu                       sync.Mutex
 }
 
 // New constructs a Server.
@@ -66,14 +69,26 @@ func NewWithWorkspace(clients *tenant.ClientFactory, msgStore store.Store, works
 		mcpInsecureSkipTLSVerify: mcpInsecureSkipTLSVerify,
 	}
 	s.assistantEngine = NewEinoAssistantEngine(s)
+	s.assistantRunManager = newProjectAssistantRunManager()
 	return s
 }
 
 func (s *Server) projectAssistantEngine() projectAssistantEngine {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.assistantEngine == nil {
 		s.assistantEngine = NewEinoAssistantEngine(s)
 	}
 	return s.assistantEngine
+}
+
+func (s *Server) projectAssistantRunManager() *projectAssistantRunManager {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.assistantRunManager == nil {
+		s.assistantRunManager = newProjectAssistantRunManager()
+	}
+	return s.assistantRunManager
 }
 
 // Register mounts the project routes onto r. The hub backend proxy strips the


### PR DESCRIPTION
## Summary
- add an App Studio assistant run manager with Eino-compatible turn item shapes and project-scoped active turn tracking
- route new assistant messages and Eino approval resumes through managed contexts so newer turns preempt stale active work
- harden claimed-resume finalization with detached persistence contexts so preempted/canceled resumes do not strand AssistantRun rows

## Verification
- go test -count=1 ./api -run 'TestProjectAssistantRunManager|TestGenerateProjectAssistantStreamPreemptsActiveProjectTurn|TestResumeProjectAssistantFinalizesClaimedRunAfterPreemption'
- go test -count=1 ./api
- go test -count=1 ./...
- go build ./...
- git diff --check
- independent targeted reviews of preempted-resume cleanup passed