### PR TITLE
Use typed App Studio assistant stream events

### DIFF
--- a/providers/app-studio/api/assistant_events.go
+++ b/providers/app-studio/api/assistant_events.go
@@ -36,7 +36,7 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 			return nil
 		}
 		return w.write(projectMessageStreamEvent{
-			Type:               "chunk",
+			Type:               string(projectAssistantEventMessageDelta),
 			AssistantMessageID: w.assistantID,
 			Content:            event.Delta,
 		})
@@ -54,7 +54,7 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 		}
 		toolCall := event.ToolCall.streamEvent()
 		return w.write(projectMessageStreamEvent{
-			Type:               "tool_call",
+			Type:               string(event.Type),
 			AssistantMessageID: w.assistantID,
 			ToolCall:           &toolCall,
 		})
@@ -81,12 +81,12 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 			return nil
 		}
 		return w.write(projectMessageStreamEvent{
-			Type:  "error",
+			Type:  string(projectAssistantEventRunFailed),
 			Error: event.Error,
 		})
 	case projectAssistantEventRunFinished:
 		return w.write(projectMessageStreamEvent{
-			Type:               "done",
+			Type:               string(projectAssistantEventRunFinished),
 			AssistantMessageID: w.assistantID,
 		})
 	default:
@@ -102,5 +102,14 @@ func (tc projectAssistantToolCall) streamEvent() projectToolCallStreamEvent {
 		Arguments: tc.Arguments,
 		Summary:   tc.Summary,
 		Error:     tc.Error,
+	}
+}
+
+func projectAssistantEventTypeForToolCallStatus(status string) projectAssistantEventType {
+	switch status {
+	case "requested", "running":
+		return projectAssistantEventToolCallStarted
+	default:
+		return projectAssistantEventToolCallFinished
 	}
 }

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestProjectAssistantStreamWriterMapsDeltaToChunk(t *testing.T) {
+func TestProjectAssistantStreamWriterMapsDeltaToTypedEvent(t *testing.T) {
 	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
 		Type:  projectAssistantEventMessageDelta,
 		Delta: "hello",
@@ -30,8 +30,8 @@ func TestProjectAssistantStreamWriterMapsDeltaToChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
-	if len(got) != 1 || got[0].Type != "chunk" || got[0].Content != "hello" || got[0].AssistantMessageID != "assistant-1" {
-		t.Fatalf("events = %#v, want one assistant chunk event", got)
+	if len(got) != 1 || got[0].Type != string(projectAssistantEventMessageDelta) || got[0].Content != "hello" || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("events = %#v, want one assistant message_delta event", got)
 	}
 }
 
@@ -63,14 +63,36 @@ func TestProjectAssistantStreamWriterMapsToolCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
-	if len(got) != 1 || got[0].Type != "tool_call" || got[0].AssistantMessageID != "assistant-1" {
-		t.Fatalf("events = %#v, want one assistant tool_call event", got)
+	if len(got) != 1 || got[0].Type != string(projectAssistantEventToolCallFinished) || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("events = %#v, want one assistant tool_call_finished event", got)
 	}
 	if got[0].ToolCall == nil {
 		t.Fatalf("tool call event omitted payload: %#v", got[0])
 	}
 	if got[0].ToolCall.ID != "tool-1" || got[0].ToolCall.Name != "write_file" || got[0].ToolCall.Status != "succeeded" || got[0].ToolCall.Arguments != `{"path":"src/App.tsx"}` || got[0].ToolCall.Error != "warning only" {
 		t.Fatalf("tool call = %#v, want preserved current SSE payload", got[0].ToolCall)
+	}
+}
+
+func TestProjectAssistantEventTypeForToolCallStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   projectAssistantEventType
+	}{
+		{status: "requested", want: projectAssistantEventToolCallStarted},
+		{status: "running", want: projectAssistantEventToolCallStarted},
+		{status: "permission_required", want: projectAssistantEventToolCallFinished},
+		{status: "succeeded", want: projectAssistantEventToolCallFinished},
+		{status: "failed", want: projectAssistantEventToolCallFinished},
+		{status: "rejected", want: projectAssistantEventToolCallFinished},
+		{status: "", want: projectAssistantEventToolCallFinished},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := projectAssistantEventTypeForToolCallStatus(tt.status); got != tt.want {
+				t.Fatalf("event type = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -112,13 +134,13 @@ func TestProjectAssistantStreamWriterMapsTerminalEvents(t *testing.T) {
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
 	if len(got) != 2 {
-		t.Fatalf("events = %#v, want error and done", got)
+		t.Fatalf("events = %#v, want run_failed and run_finished", got)
 	}
-	if got[0].Type != "error" || got[0].Error != "boom" {
-		t.Fatalf("first event = %#v, want error", got[0])
+	if got[0].Type != string(projectAssistantEventRunFailed) || got[0].Error != "boom" {
+		t.Fatalf("first event = %#v, want run_failed", got[0])
 	}
-	if got[1].Type != "done" || got[1].AssistantMessageID != "assistant-1" {
-		t.Fatalf("second event = %#v, want assistant done", got[1])
+	if got[1].Type != string(projectAssistantEventRunFinished) || got[1].AssistantMessageID != "assistant-1" {
+		t.Fatalf("second event = %#v, want assistant run_finished", got[1])
 	}
 }
 

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -399,7 +399,7 @@ func (s *Server) createProjectStartStream(w http.ResponseWriter, r *http.Request
 	}
 	writeStreamError := func(err error) {
 		_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:  "error",
+			Type:  string(projectAssistantEventRunFailed),
 			Error: err.Error(),
 		})
 	}
@@ -617,7 +617,7 @@ func (s *Server) streamProjectAssistant(
 			return
 		}
 		emitAssistantEvent(projectAssistantEvent{
-			Type: projectAssistantEventToolCallFinished,
+			Type: projectAssistantEventTypeForToolCallStatus(toolCall.Status),
 			ToolCall: &projectAssistantToolCall{
 				ID:        toolCall.ID,
 				Name:      toolCall.Name,

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -937,7 +937,7 @@ async function createProjectAndStartConversation(content: string) {
         selected.value = event.project
         messages.value = messages.value.map((message) => ({ ...message, projectID: projectName }))
         props.navigate(encodeURIComponent(projectName))
-      } else if (event.type === 'chunk') {
+      } else if (event.type === 'message_delta') {
         conversationStatus.value = ''
         if (!projectName || !event.assistantMessageID) return
         if (!assistantMessageID) {
@@ -952,7 +952,7 @@ async function createProjectAndStartConversation(content: string) {
           content: `${existing.content}${event.content ?? ''}`,
         }
         messages.value = [...messages.value]
-      } else if (event.type === 'tool_call') {
+      } else if (event.type === 'tool_call_started' || event.type === 'tool_call_finished') {
         conversationStatus.value = ''
         if (!projectName || !event.assistantMessageID || !event.toolCall) return
         if (!assistantMessageID) {
@@ -973,12 +973,12 @@ async function createProjectAndStartConversation(content: string) {
           assistantMessageID = event.assistantMessageID
         }
         attachAssistantCheckpoint(projectName, event.assistantMessageID, event.checkpoint)
-      } else if (event.type === 'done') {
+      } else if (event.type === 'run_finished') {
         conversationStatus.value = ''
         if (!assistantMessageID) {
           assistantMessageID = event.assistantMessageID ?? ''
         }
-      } else if (event.type === 'error') {
+      } else if (event.type === 'run_failed') {
         throw new Error(event.error ?? 'Streaming error')
       }
     }, controller.signal)
@@ -1151,7 +1151,7 @@ async function sendMessage() {
     await api.createMessageStream(props.ctx, projectName, content, (event: ProjectMessageStreamEvent) => {
       if (event.type === 'status') {
         conversationStatus.value = event.status || 'Working'
-      } else if (event.type === 'chunk') {
+      } else if (event.type === 'message_delta') {
         conversationStatus.value = ''
         if (!event.assistantMessageID) return
         if (!assistantMessageID) {
@@ -1166,7 +1166,7 @@ async function sendMessage() {
           content: `${existing.content}${event.content ?? ''}`,
         }
         messages.value = [...messages.value]
-      } else if (event.type === 'tool_call') {
+      } else if (event.type === 'tool_call_started' || event.type === 'tool_call_finished') {
         conversationStatus.value = ''
         if (!event.assistantMessageID || !event.toolCall) return
         if (!assistantMessageID) {
@@ -1187,12 +1187,12 @@ async function sendMessage() {
           assistantMessageID = event.assistantMessageID
         }
         attachAssistantCheckpoint(projectName, event.assistantMessageID, event.checkpoint)
-      } else if (event.type === 'done') {
+      } else if (event.type === 'run_finished') {
         conversationStatus.value = ''
         if (!assistantMessageID) {
           assistantMessageID = event.assistantMessageID ?? ''
         }
-      } else if (event.type === 'error') {
+      } else if (event.type === 'run_failed') {
         throw new Error(event.error ?? 'Streaming error')
       }
     }, controller.signal)

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -178,10 +178,13 @@ async function requestStream(
     try {
       event = JSON.parse(data) as ProjectMessageStreamEvent
     } catch {
-      onEvent({ type: 'error', error: data })
+      onEvent({ type: 'run_failed', error: data })
       return
     }
-    if (!event.type) event.type = type === 'done' || type === 'error' ? type : 'chunk'
+    if (!event.type) {
+      onEvent({ type: 'run_failed', error: `stream event missing type${type ? ` (${type})` : ''}` })
+      return
+    }
     onEvent(event)
   }
 

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -62,7 +62,17 @@ export interface ProjectAssistantResumeResponse {
 }
 
 export interface ProjectMessageStreamEvent {
-  type: 'chunk' | 'tool_call' | 'permission_required' | 'checkpoint_saved' | 'done' | 'error' | 'status' | 'project'
+  type:
+    | 'run_started'
+    | 'message_delta'
+    | 'status'
+    | 'tool_call_started'
+    | 'tool_call_finished'
+    | 'permission_required'
+    | 'checkpoint_saved'
+    | 'run_failed'
+    | 'run_finished'
+    | 'project'
   assistantMessageID?: string
   content?: string
   status?: string


### PR DESCRIPTION
## Summary
- make typed App Studio assistant events the canonical SSE protocol for assistant message deltas, tool lifecycle, failures, and completion
- update the App Studio portal stream parser and handlers to consume typed event names instead of legacy chunk/tool_call/done/error aliases
- preserve project creation stream support while switching assistant failures to run_failed

## Verification
- go test -count=1 ./api -run 'TestProjectAssistantEventTypeForToolCallStatus|TestProjectAssistantStreamWriter'
- go test -count=1 ./api
- go test -count=1 ./...
- go build ./...
- npm run typecheck
- npm run build
- git diff --check
- legacy assistant SSE event-name scan clean
- independent typed event contract review passed