### PR TITLE
Add App Studio Eino workflow tools

### DIFF
--- a/providers/app-studio/README.md
+++ b/providers/app-studio/README.md
@@ -97,6 +97,9 @@ provider pod. Runtime commands are modeled behind an internal worker boundary so
 future implementations can use isolated tenant/project-scoped workers with their
 own resource limits, audit trail, and cancellation model.
 
-By default no runtime worker is configured, so `runtime_command` is not advertised
-to the assistant. If a future deployment injects a worker, runtime commands still
-require explicit user approval before the worker is started.
+By default no runtime worker is configured, so runtime tools are not advertised
+to the assistant. If a deployment injects a worker, both `verify_project_runtime`
+and `runtime_command` still require explicit user approval before the worker is
+started. `verify_project_runtime` uses fixed App Studio verification presets and
+routes them through the same worker boundary instead of running commands in the
+provider pod.

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -306,6 +306,15 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 	out projectAssistantResumeResponse,
 ) (projectAssistantResumeResponse, error) {
 	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name)
+	turn := newProjectAssistantTurnItem(projectAssistantTurnResume, id, p.Name)
+	turn.RunID = run.ID
+	turn.RequestID = run.RequestID
+	turn.AssistantMessageID = strings.TrimSpace(resumeReq.AssistantMessageID)
+	ctx, finishTurn := s.projectAssistantRunManager().Begin(ctx, turn)
+	defer finishTurn()
+	if r != nil {
+		r = r.WithContext(ctx)
+	}
 	if c == nil {
 		return s.completeClaimedProjectAssistantRunAfterResumeError(ctx, messageScope, run, state, resumeReq, decision, id.user, out, nil, fmt.Errorf("project client is required for assistant resume"))
 	}
@@ -394,7 +403,9 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		if !errors.As(err, &permissionErr) {
 			return s.completeClaimedProjectAssistantRunAfterResumeError(ctx, messageScope, run, state, resumeReq, decision, id.user, out, currentToolCall, err)
 		}
-		pendingRun, getErr := s.store.GetAssistantRun(ctx, messageScope, permissionErr.RunID)
+		persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+		defer cancelPersist()
+		pendingRun, getErr := s.store.GetAssistantRun(persistCtx, messageScope, permissionErr.RunID)
 		if getErr != nil {
 			return projectAssistantResumeResponse{}, getErr
 		}
@@ -412,18 +423,20 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		if err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
-		if err := s.store.SaveAssistantRun(ctx, messageScope, pendingRun); err != nil {
+		if err := s.store.SaveAssistantRun(persistCtx, messageScope, pendingRun); err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
 		out.RunID = pendingRun.ID
 		out.RequestID = pendingRun.RequestID
 		out.Status = pendingRun.Status
-		if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
+		if err := s.updateProjectAssistantPermissionMessage(persistCtx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
 		return out, nil
 	}
 
+	persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+	defer cancelPersist()
 	run.Status = store.AssistantRunStatusCompleted
 	run.UpdatedAt = time.Now().UTC()
 	run, err = appendProjectAssistantRunAudit(run, projectAssistantPermissionAudit{
@@ -440,11 +453,11 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 	if err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
-	if err := s.store.SaveAssistantRun(ctx, messageScope, run); err != nil {
+	if err := s.store.SaveAssistantRun(persistCtx, messageScope, run); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	out.Status = run.Status
-	if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
+	if err := s.updateProjectAssistantPermissionMessage(persistCtx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	assistantReply := projectAssistantStoredContent(result.Content, assistantContent.String())
@@ -452,7 +465,7 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		assistantContent.WriteString(pending)
 	}
 	if strings.TrimSpace(assistantReply) != "" {
-		assistantMessage, err := s.appendResumedProjectAssistantMessage(ctx, messageScope, assistantID, assistantReply, projectAssistantMessageMetadata("", streamedToolCalls))
+		assistantMessage, err := s.appendResumedProjectAssistantMessage(persistCtx, messageScope, assistantID, assistantReply, projectAssistantMessageMetadata("", streamedToolCalls))
 		if err != nil {
 			return projectAssistantResumeResponse{}, err
 		}
@@ -476,6 +489,8 @@ func (s *Server) completeClaimedProjectAssistantRunAfterResumeError(
 	if cause == nil {
 		cause = errors.New("assistant resume failed")
 	}
+	persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+	defer cancelPersist()
 	failure := strings.TrimSpace(cause.Error())
 	if failure == "" {
 		failure = "assistant resume failed"
@@ -522,11 +537,11 @@ func (s *Server) completeClaimedProjectAssistantRunAfterResumeError(
 		return projectAssistantResumeResponse{}, auditErr
 	}
 	run = updatedRun
-	if err := s.store.SaveAssistantRun(ctx, messageScope, run); err != nil {
+	if err := s.store.SaveAssistantRun(persistCtx, messageScope, run); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	out.Status = run.Status
-	if err := s.updateProjectAssistantPermissionMessage(ctx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
+	if err := s.updateProjectAssistantPermissionMessage(persistCtx, messageScope, strings.TrimSpace(resumeReq.AssistantMessageID), out); err != nil {
 		return projectAssistantResumeResponse{}, err
 	}
 	return out, cause

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -732,7 +732,7 @@ func appendProjectAssistantRunAudit(run store.AssistantRun, entry projectAssista
 }
 
 func cloneProjectAssistantToolArguments(src map[string]any) map[string]any {
-	if len(src) == 0 {
+	if src == nil {
 		return nil
 	}
 	dst := make(map[string]any, len(src))

--- a/providers/app-studio/api/assistant_eino_engine_test.go
+++ b/providers/app-studio/api/assistant_eino_engine_test.go
@@ -304,6 +304,77 @@ func TestEinoAssistantEngineResumesApprovedToolThroughRunner(t *testing.T) {
 	}
 }
 
+func TestEinoAssistantEngineValidatesEditedRuntimeVerificationArgsOnResume(t *testing.T) {
+	messages := store.NewMemoryStore()
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	worker := &recordingProjectRuntimeWorker{handles: []projectRuntimeHandle{{ID: "runtime-1"}}}
+	server.runtimeWorker = worker
+	runtimeTool, ok := server.projectAssistantToolRegistry().Get(projectToolVerifyProjectRuntime)
+	if !ok {
+		t.Fatal("verify_project_runtime tool missing")
+	}
+	chatModel := &resumeRuntimeVerificationEinoChatModel{}
+	engine := projectEinoAssistantEngine{
+		server: server,
+		newModel: func(context.Context, projectAssistantRunRequest, *projectEinoAssistantRunState) (einomodel.BaseChatModel, error) {
+			return chatModel, nil
+		},
+		newTools: func(_ context.Context, req projectAssistantRunRequest, state *projectEinoAssistantRunState) ([]einotool.BaseTool, error) {
+			return []einotool.BaseTool{newProjectEinoAssistantServerTool(server, runtimeTool, req, state)}, nil
+		},
+		newRunner: newProjectEinoAssistantRunner,
+	}
+	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", tenantPath: "root:org-a:ws-1"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+	req := projectAssistantRunRequest{
+		Identity:       id,
+		HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+		Project:        project,
+		WorkspaceScope: projectWorkspaceScope(id, project.Name),
+		MessageScope:   projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name),
+	}
+	_, err := engine.StreamProjectAssistant(context.Background(), req, nil)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("StreamProjectAssistant error = %v, want permission required", err)
+	}
+	if len(worker.requests) != 0 {
+		t.Fatalf("worker requests = %#v, want no start before approval", worker.requests)
+	}
+	run, err := messages.GetAssistantRun(context.Background(), req.MessageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	var checkpoint projectAssistantCheckpointState
+	if err := json.Unmarshal(run.Checkpoint, &checkpoint); err != nil {
+		t.Fatalf("decode checkpoint returned error: %v", err)
+	}
+
+	result, err := engine.ResumeProjectAssistant(
+		context.Background(),
+		req,
+		projectAssistantResumeRequest{
+			RequestID:       permissionErr.RequestID,
+			Decision:        string(projectAssistantPermissionAllow),
+			EditedArguments: map[string]any{},
+		},
+		checkpoint,
+	)
+	if err != nil {
+		t.Fatalf("ResumeProjectAssistant returned error: %v", err)
+	}
+	if result.Content != "runtime validation handled" {
+		t.Fatalf("content = %q, want resumed model response", result.Content)
+	}
+	if len(worker.requests) != 0 {
+		t.Fatalf("worker requests = %#v, want no start for invalid edited approval args", worker.requests)
+	}
+	if len(chatModel.inputs) != 2 || !einoMessagesContainToolResult(chatModel.inputs[1], "call-runtime", "requires at least one check") {
+		t.Fatalf("model inputs = %#v, want runtime validation tool result", chatModel.inputs)
+	}
+}
+
 func TestEinoAssistantEngineReturnsUnknownToolResultToModel(t *testing.T) {
 	chatModel := &unknownToolEinoChatModel{}
 	projectTool := &recordingProjectAssistantTool{
@@ -476,6 +547,36 @@ func (m *resumePermissionEinoChatModel) Generate(ctx context.Context, input []*s
 }
 
 func (m *resumePermissionEinoChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+type resumeRuntimeVerificationEinoChatModel struct {
+	inputs [][]*schema.Message
+}
+
+func (m *resumeRuntimeVerificationEinoChatModel) Generate(ctx context.Context, input []*schema.Message, _ ...einomodel.Option) (*schema.Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.inputs = append(m.inputs, cloneEinoMessagesForTest(input))
+	if len(m.inputs) == 1 {
+		return schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "call-runtime",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      projectToolVerifyProjectRuntime,
+				Arguments: `{"checks":["build"],"timeoutSeconds":30}`,
+			},
+		}}), nil
+	}
+	return schema.AssistantMessage("runtime validation handled", nil), nil
+}
+
+func (m *resumeRuntimeVerificationEinoChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
 	msg, err := m.Generate(ctx, input, opts...)
 	if err != nil {
 		return nil, err

--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -223,7 +223,7 @@ func (t projectEinoAssistantTool) resumePermission(ctx context.Context, callID s
 	}
 	switch data.Decision {
 	case projectAssistantPermissionAllow:
-		if len(data.EditedArguments) > 0 {
+		if data.EditedArguments != nil {
 			args = cloneProjectAssistantToolArguments(data.EditedArguments)
 		}
 		return t.invokeAllowedTool(ctx, callID, spec, args)

--- a/providers/app-studio/api/assistant_events.go
+++ b/providers/app-studio/api/assistant_events.go
@@ -36,7 +36,7 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 			return nil
 		}
 		return w.write(projectMessageStreamEvent{
-			Type:               "chunk",
+			Type:               string(projectAssistantEventMessageDelta),
 			AssistantMessageID: w.assistantID,
 			Content:            event.Delta,
 		})
@@ -54,7 +54,7 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 		}
 		toolCall := event.ToolCall.streamEvent()
 		return w.write(projectMessageStreamEvent{
-			Type:               "tool_call",
+			Type:               string(event.Type),
 			AssistantMessageID: w.assistantID,
 			ToolCall:           &toolCall,
 		})
@@ -81,12 +81,12 @@ func (w projectAssistantStreamWriter) EmitProjectAssistantEvent(
 			return nil
 		}
 		return w.write(projectMessageStreamEvent{
-			Type:  "error",
+			Type:  string(projectAssistantEventRunFailed),
 			Error: event.Error,
 		})
 	case projectAssistantEventRunFinished:
 		return w.write(projectMessageStreamEvent{
-			Type:               "done",
+			Type:               string(projectAssistantEventRunFinished),
 			AssistantMessageID: w.assistantID,
 		})
 	default:
@@ -102,5 +102,14 @@ func (tc projectAssistantToolCall) streamEvent() projectToolCallStreamEvent {
 		Arguments: tc.Arguments,
 		Summary:   tc.Summary,
 		Error:     tc.Error,
+	}
+}
+
+func projectAssistantEventTypeForToolCallStatus(status string) projectAssistantEventType {
+	switch status {
+	case "requested", "running":
+		return projectAssistantEventToolCallStarted
+	default:
+		return projectAssistantEventToolCallFinished
 	}
 }

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestProjectAssistantStreamWriterMapsDeltaToChunk(t *testing.T) {
+func TestProjectAssistantStreamWriterMapsDeltaToTypedEvent(t *testing.T) {
 	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
 		Type:  projectAssistantEventMessageDelta,
 		Delta: "hello",
@@ -30,8 +30,8 @@ func TestProjectAssistantStreamWriterMapsDeltaToChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
-	if len(got) != 1 || got[0].Type != "chunk" || got[0].Content != "hello" || got[0].AssistantMessageID != "assistant-1" {
-		t.Fatalf("events = %#v, want one assistant chunk event", got)
+	if len(got) != 1 || got[0].Type != string(projectAssistantEventMessageDelta) || got[0].Content != "hello" || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("events = %#v, want one assistant message_delta event", got)
 	}
 }
 
@@ -63,14 +63,36 @@ func TestProjectAssistantStreamWriterMapsToolCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
-	if len(got) != 1 || got[0].Type != "tool_call" || got[0].AssistantMessageID != "assistant-1" {
-		t.Fatalf("events = %#v, want one assistant tool_call event", got)
+	if len(got) != 1 || got[0].Type != string(projectAssistantEventToolCallFinished) || got[0].AssistantMessageID != "assistant-1" {
+		t.Fatalf("events = %#v, want one assistant tool_call_finished event", got)
 	}
 	if got[0].ToolCall == nil {
 		t.Fatalf("tool call event omitted payload: %#v", got[0])
 	}
 	if got[0].ToolCall.ID != "tool-1" || got[0].ToolCall.Name != "write_file" || got[0].ToolCall.Status != "succeeded" || got[0].ToolCall.Arguments != `{"path":"src/App.tsx"}` || got[0].ToolCall.Error != "warning only" {
 		t.Fatalf("tool call = %#v, want preserved current SSE payload", got[0].ToolCall)
+	}
+}
+
+func TestProjectAssistantEventTypeForToolCallStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   projectAssistantEventType
+	}{
+		{status: "requested", want: projectAssistantEventToolCallStarted},
+		{status: "running", want: projectAssistantEventToolCallStarted},
+		{status: "permission_required", want: projectAssistantEventToolCallFinished},
+		{status: "succeeded", want: projectAssistantEventToolCallFinished},
+		{status: "failed", want: projectAssistantEventToolCallFinished},
+		{status: "rejected", want: projectAssistantEventToolCallFinished},
+		{status: "", want: projectAssistantEventToolCallFinished},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := projectAssistantEventTypeForToolCallStatus(tt.status); got != tt.want {
+				t.Fatalf("event type = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -112,13 +134,13 @@ func TestProjectAssistantStreamWriterMapsTerminalEvents(t *testing.T) {
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
 	if len(got) != 2 {
-		t.Fatalf("events = %#v, want error and done", got)
+		t.Fatalf("events = %#v, want run_failed and run_finished", got)
 	}
-	if got[0].Type != "error" || got[0].Error != "boom" {
-		t.Fatalf("first event = %#v, want error", got[0])
+	if got[0].Type != string(projectAssistantEventRunFailed) || got[0].Error != "boom" {
+		t.Fatalf("first event = %#v, want run_failed", got[0])
 	}
-	if got[1].Type != "done" || got[1].AssistantMessageID != "assistant-1" {
-		t.Fatalf("second event = %#v, want assistant done", got[1])
+	if got[1].Type != string(projectAssistantEventRunFinished) || got[1].AssistantMessageID != "assistant-1" {
+		t.Fatalf("second event = %#v, want assistant run_finished", got[1])
 	}
 }
 

--- a/providers/app-studio/api/assistant_run_manager.go
+++ b/providers/app-studio/api/assistant_run_manager.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+type projectAssistantTurnKind string
+
+const (
+	projectAssistantTurnMessage projectAssistantTurnKind = "message"
+	projectAssistantTurnResume  projectAssistantTurnKind = "resume"
+	projectAssistantTurnAbort   projectAssistantTurnKind = "abort"
+)
+
+var errProjectAssistantTurnPreempted = errors.New("assistant turn preempted")
+
+// projectAssistantTurnItem is intentionally small and value-only so a later
+// Eino TurnLoop checkpoint can persist queued work without serializing request,
+// client, workspace, or tenant-authority handles.
+type projectAssistantTurnItem struct {
+	Kind               projectAssistantTurnKind `json:"kind"`
+	OrgUUID            string                   `json:"orgUUID"`
+	WorkspaceUUID      string                   `json:"workspaceUUID"`
+	ProjectName        string                   `json:"projectName"`
+	User               string                   `json:"user,omitempty"`
+	RunID              string                   `json:"runID,omitempty"`
+	RequestID          string                   `json:"requestID,omitempty"`
+	AssistantMessageID string                   `json:"assistantMessageID,omitempty"`
+	CreatedAt          time.Time                `json:"createdAt"`
+}
+
+func newProjectAssistantTurnItem(kind projectAssistantTurnKind, id identity, projectName string) projectAssistantTurnItem {
+	return projectAssistantTurnItem{
+		Kind:          kind,
+		OrgUUID:       strings.TrimSpace(id.orgUUID),
+		WorkspaceUUID: strings.TrimSpace(id.workspaceUUID),
+		ProjectName:   strings.TrimSpace(projectName),
+		User:          strings.TrimSpace(id.user),
+		CreatedAt:     time.Now().UTC(),
+	}
+}
+
+func (i projectAssistantTurnItem) key() projectAssistantRunKey {
+	return projectAssistantRunKey{
+		OrgUUID:       strings.TrimSpace(i.OrgUUID),
+		WorkspaceUUID: strings.TrimSpace(i.WorkspaceUUID),
+		ProjectName:   strings.TrimSpace(i.ProjectName),
+	}
+}
+
+type projectAssistantRunKey struct {
+	OrgUUID       string
+	WorkspaceUUID string
+	ProjectName   string
+}
+
+func (k projectAssistantRunKey) valid() bool {
+	return strings.TrimSpace(k.OrgUUID) != "" && strings.TrimSpace(k.WorkspaceUUID) != "" && strings.TrimSpace(k.ProjectName) != ""
+}
+
+type projectAssistantActiveTurn struct {
+	item   projectAssistantTurnItem
+	cancel context.CancelCauseFunc
+	done   chan struct{}
+}
+
+type projectAssistantRunManager struct {
+	mu     sync.Mutex
+	active map[projectAssistantRunKey]*projectAssistantActiveTurn
+}
+
+func newProjectAssistantRunManager() *projectAssistantRunManager {
+	return &projectAssistantRunManager{
+		active: map[projectAssistantRunKey]*projectAssistantActiveTurn{},
+	}
+}
+
+func (m *projectAssistantRunManager) Begin(ctx context.Context, item projectAssistantTurnItem) (context.Context, func()) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	key := item.key()
+	if m == nil || !key.valid() {
+		return ctx, func() {}
+	}
+	runCtx, cancel := context.WithCancelCause(ctx)
+	active := &projectAssistantActiveTurn{
+		item:   item,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	m.mu.Lock()
+	if previous := m.active[key]; previous != nil {
+		previous.cancel(errProjectAssistantTurnPreempted)
+	}
+	m.active[key] = active
+	m.mu.Unlock()
+
+	var once sync.Once
+	return runCtx, func() {
+		once.Do(func() {
+			m.mu.Lock()
+			if m.active[key] == active {
+				delete(m.active, key)
+			}
+			m.mu.Unlock()
+			cancel(nil)
+			close(active.done)
+		})
+	}
+}
+
+func (m *projectAssistantRunManager) activeCount() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.active)
+}

--- a/providers/app-studio/api/assistant_run_manager_test.go
+++ b/providers/app-studio/api/assistant_run_manager_test.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	asclient "github.com/faroshq/provider-app-studio/client"
+	"github.com/faroshq/provider-app-studio/store"
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+func TestProjectAssistantRunManagerPreemptsActiveTurnForSameProject(t *testing.T) {
+	manager := newProjectAssistantRunManager()
+	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	firstCtx, firstDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, id, "demo"))
+	secondCtx, secondDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, id, "demo"))
+	t.Cleanup(secondDone)
+
+	select {
+	case <-firstCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("first turn was not preempted")
+	}
+	if !errors.Is(context.Cause(firstCtx), errProjectAssistantTurnPreempted) {
+		t.Fatalf("first context cause = %v, want preempted", context.Cause(firstCtx))
+	}
+	if err := secondCtx.Err(); err != nil {
+		t.Fatalf("second turn context error = %v, want active", err)
+	}
+	firstDone()
+	if got := manager.activeCount(); got != 1 {
+		t.Fatalf("active count after stale finish = %d, want newer turn still active", got)
+	}
+	secondDone()
+	if got := manager.activeCount(); got != 0 {
+		t.Fatalf("active count after second finish = %d, want no active turns", got)
+	}
+}
+
+func TestProjectAssistantRunManagerScopesActiveTurnsByTenantProject(t *testing.T) {
+	manager := newProjectAssistantRunManager()
+	firstCtx, firstDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, identity{
+		orgUUID:       "org-a",
+		workspaceUUID: "ws-1",
+	}, "demo"))
+	defer firstDone()
+	secondCtx, secondDone := manager.Begin(context.Background(), newProjectAssistantTurnItem(projectAssistantTurnMessage, identity{
+		orgUUID:       "org-b",
+		workspaceUUID: "ws-1",
+	}, "demo"))
+	defer secondDone()
+
+	if err := firstCtx.Err(); err != nil {
+		t.Fatalf("first turn context error = %v, want active for different org", err)
+	}
+	if err := secondCtx.Err(); err != nil {
+		t.Fatalf("second turn context error = %v, want active", err)
+	}
+	if got := manager.activeCount(); got != 2 {
+		t.Fatalf("active count = %d, want separate tenant turns", got)
+	}
+}
+
+func TestProjectAssistantRunManagerIgnoresUnscopedTurns(t *testing.T) {
+	manager := newProjectAssistantRunManager()
+	ctx, done := manager.Begin(context.Background(), projectAssistantTurnItem{Kind: projectAssistantTurnMessage})
+	defer done()
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("unscoped turn context error = %v, want unchanged context", err)
+	}
+	if got := manager.activeCount(); got != 0 {
+		t.Fatalf("active count = %d, want unscoped turn ignored", got)
+	}
+}
+
+func TestGenerateProjectAssistantStreamPreemptsActiveProjectTurn(t *testing.T) {
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: "http://llm.example.test", Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	messages := store.NewMemoryStore()
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	engine := &preemptProbeProjectAssistantEngine{
+		entered:    make(chan struct{}),
+		firstCause: make(chan error, 1),
+	}
+	server.assistantEngine = engine
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := server.generateProjectAssistantStream(
+			httptest.NewRequest(http.MethodPost, "/", nil),
+			id,
+			client,
+			project,
+			projectAssistantStreamCallbacks{},
+		)
+		firstErr <- err
+	}()
+	select {
+	case <-engine.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first assistant turn did not start")
+	}
+
+	secondReply, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	if err != nil {
+		t.Fatalf("second generateProjectAssistantStream returned error: %v", err)
+	}
+	if secondReply != "second turn" {
+		t.Fatalf("second reply = %q, want second turn", secondReply)
+	}
+	select {
+	case err := <-firstErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first turn error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first assistant turn was not canceled")
+	}
+	select {
+	case cause := <-engine.firstCause:
+		if !errors.Is(cause, errProjectAssistantTurnPreempted) {
+			t.Fatalf("first turn cause = %v, want preempted", cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first assistant turn did not report cancellation cause")
+	}
+}
+
+func TestResumeProjectAssistantFinalizesClaimedRunAfterPreemption(t *testing.T) {
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: "http://llm.example.test", Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	baseStore := store.NewMemoryStore()
+	messages := cancelSensitiveAssistantRunStore{Store: baseStore}
+	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	engine := &preemptProbeResumeAssistantEngine{
+		resumeEntered: make(chan struct{}),
+		resumeCause:   make(chan error, 1),
+	}
+	server.assistantEngine = engine
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	state := projectAssistantCheckpointState{
+		ToolCalls: []chatToolCall{{
+			ID:   "call-write",
+			Type: "function",
+			Function: chatToolCallFunction{
+				Name:      projectToolWriteFile,
+				Arguments: `{"path":"src/App.tsx","content":"approved\n"}`,
+			},
+		}},
+		CurrentIndex: 0,
+		Eino: &projectAssistantEinoCheckpointState{
+			CheckpointID: "run-resume",
+			Checkpoint:   []byte("fake-checkpoint"),
+			InterruptID:  "interrupt-write",
+			ToolCallID:   "call-write",
+			ToolName:     projectToolWriteFile,
+		},
+	}
+	rawCheckpoint, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("encode checkpoint returned error: %v", err)
+	}
+	run := store.AssistantRun{
+		ID:         "run-resume",
+		Status:     store.AssistantRunStatusPendingPermission,
+		RequestID:  "perm-resume",
+		Checkpoint: rawCheckpoint,
+	}
+	if err := messages.SaveAssistantRun(context.Background(), messageScope, run); err != nil {
+		t.Fatalf("SaveAssistantRun returned error: %v", err)
+	}
+
+	resumeErr := make(chan error, 1)
+	go func() {
+		_, err := server.resumeProjectAssistantRunWithRepositoryAndClient(
+			context.Background(),
+			httptest.NewRequest(http.MethodPost, "/", nil),
+			id,
+			client,
+			project,
+			&ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+			run.ID,
+			projectAssistantResumeRequest{RequestID: run.RequestID, Decision: string(projectAssistantPermissionAllow)},
+		)
+		resumeErr <- err
+	}()
+	select {
+	case <-engine.resumeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("resume turn did not start")
+	}
+
+	reply, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	if err != nil {
+		t.Fatalf("generateProjectAssistantStream returned error: %v", err)
+	}
+	if reply != "new turn" {
+		t.Fatalf("reply = %q, want new turn", reply)
+	}
+	select {
+	case err := <-resumeErr:
+		if !errors.Is(err, errProjectAssistantTurnPreempted) {
+			t.Fatalf("resume error = %v, want preempted", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resume turn was not preempted")
+	}
+	got, err := messages.GetAssistantRun(context.Background(), messageScope, run.ID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	if got.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("run status = %q, want completed after preempted resume cleanup", got.Status)
+	}
+	audit := decodeProjectAssistantRunAudit(t, got.Audit)
+	if len(audit.Decisions) != 1 || audit.Decisions[0].Actor != id.user || !strings.Contains(audit.Decisions[0].Error, "preempted") {
+		t.Fatalf("audit = %#v, want preempted resume decision", audit)
+	}
+	select {
+	case cause := <-engine.resumeCause:
+		if !errors.Is(cause, errProjectAssistantTurnPreempted) {
+			t.Fatalf("resume cause = %v, want preempted", cause)
+		}
+	default:
+		t.Fatal("resume engine did not report cancellation cause")
+	}
+}
+
+type preemptProbeProjectAssistantEngine struct {
+	calls      atomic.Int32
+	entered    chan struct{}
+	firstCause chan error
+}
+
+func (e *preemptProbeProjectAssistantEngine) StreamProjectAssistant(
+	ctx context.Context,
+	_ projectAssistantRunRequest,
+	_ projectAssistantEventSink,
+) (projectAssistantRunResult, error) {
+	if e.calls.Add(1) == 1 {
+		close(e.entered)
+		<-ctx.Done()
+		e.firstCause <- context.Cause(ctx)
+		return projectAssistantRunResult{}, ctx.Err()
+	}
+	return projectAssistantRunResult{Content: "second turn"}, nil
+}
+
+func (e *preemptProbeProjectAssistantEngine) ResumeProjectAssistant(
+	context.Context,
+	projectAssistantRunRequest,
+	projectAssistantResumeRequest,
+	projectAssistantCheckpointState,
+) (projectAssistantRunResult, error) {
+	return projectAssistantRunResult{}, errors.New("unexpected resume")
+}
+
+type preemptProbeResumeAssistantEngine struct {
+	resumeEntered chan struct{}
+	resumeCause   chan error
+}
+
+func (e *preemptProbeResumeAssistantEngine) StreamProjectAssistant(
+	context.Context,
+	projectAssistantRunRequest,
+	projectAssistantEventSink,
+) (projectAssistantRunResult, error) {
+	return projectAssistantRunResult{Content: "new turn"}, nil
+}
+
+func (e *preemptProbeResumeAssistantEngine) ResumeProjectAssistant(
+	ctx context.Context,
+	_ projectAssistantRunRequest,
+	_ projectAssistantResumeRequest,
+	_ projectAssistantCheckpointState,
+) (projectAssistantRunResult, error) {
+	close(e.resumeEntered)
+	<-ctx.Done()
+	cause := context.Cause(ctx)
+	e.resumeCause <- cause
+	return projectAssistantRunResult{}, cause
+}
+
+type cancelSensitiveAssistantRunStore struct {
+	store.Store
+}
+
+func (s cancelSensitiveAssistantRunStore) SaveAssistantRun(ctx context.Context, scope store.Scope, run store.AssistantRun) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.Store.SaveAssistantRun(ctx, scope, run)
+}

--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -156,6 +156,7 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 			},
 		},
 		newProjectAssistantWorkflowTool(server),
+		newProjectAssistantReadinessWorkflowTool(server),
 		projectAssistantToolFunc{
 			spec: projectAssistantToolSpec{
 				Name:        projectToolWriteFile,
@@ -212,6 +213,7 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 				return projectAssistantToolJSONResult(s.workspaces.Mkdir(ctx, req.WorkspaceScope, workspace.MkdirOptions{Path: projectToolString(req.Arguments["path"])}))
 			},
 		},
+		newProjectRuntimeVerificationWorkflowToolForRegistry(server),
 		newProjectRuntimeCommandToolForRegistry(server),
 		projectAssistantToolFunc{
 			spec: projectAssistantToolSpec{

--- a/providers/app-studio/api/assistant_workflow.go
+++ b/providers/app-studio/api/assistant_workflow.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cloudwego/eino/compose"
 
@@ -28,7 +29,10 @@ import (
 	"github.com/faroshq/provider-app-studio/workspace"
 )
 
-const projectAssistantWorkflowMaxResultBytes = 4096
+const (
+	projectAssistantWorkflowMaxResultBytes   = 4096
+	projectAssistantWorkflowMaxRuntimeChecks = 3
+)
 
 type projectAssistantWorkflowInput struct {
 	Server         *Server
@@ -43,6 +47,7 @@ type projectAssistantWorkflowContext struct {
 	Project        *aiv1alpha1.Project
 	Repository     *ProjectRepositoryView
 	WorkspaceFiles []string
+	Trace          []projectAssistantWorkflowTraceEvent
 }
 
 type projectAssistantWorkflowPlan struct {
@@ -53,6 +58,50 @@ type projectAssistantWorkflowPlan struct {
 	Repository   *projectAssistantWorkflowRepo `json:"repository,omitempty"`
 	Files        []string                      `json:"files,omitempty"`
 	Steps        []string                      `json:"steps"`
+}
+
+type projectAssistantReadinessWorkflowResult struct {
+	Status            string                               `json:"status"`
+	Summary           string                               `json:"summary"`
+	RecommendedChecks []string                             `json:"recommendedChecks,omitempty"`
+	Repository        *projectAssistantWorkflowRepo        `json:"repository,omitempty"`
+	Files             []string                             `json:"files,omitempty"`
+	Trace             []projectAssistantWorkflowTraceEvent `json:"trace,omitempty"`
+}
+
+type projectAssistantRuntimeVerificationWorkflowInput struct {
+	Worker  projectRuntimeWorker
+	Request projectAssistantToolCallRequest
+}
+
+type projectAssistantRuntimeVerificationWorkflowState struct {
+	Worker         projectRuntimeWorker
+	Request        projectAssistantToolCallRequest
+	Checks         []projectAssistantRuntimeVerificationCheck
+	TimeoutSeconds int
+	Trace          []projectAssistantWorkflowTraceEvent
+}
+
+type projectAssistantRuntimeVerificationWorkflowResult struct {
+	Status  string                                     `json:"status"`
+	Summary string                                     `json:"summary,omitempty"`
+	Checks  []projectAssistantRuntimeVerificationCheck `json:"checks,omitempty"`
+	Trace   []projectAssistantWorkflowTraceEvent       `json:"trace,omitempty"`
+}
+
+type projectAssistantRuntimeVerificationCheck struct {
+	Name    string   `json:"name"`
+	Command []string `json:"command,omitempty"`
+	ID      string   `json:"id,omitempty"`
+	Status  string   `json:"status"`
+	Message string   `json:"message,omitempty"`
+}
+
+type projectAssistantWorkflowTraceEvent struct {
+	Node       string `json:"node"`
+	Status     string `json:"status"`
+	DurationMS int64  `json:"durationMs"`
+	Error      string `json:"error,omitempty"`
 }
 
 type projectAssistantWorkflowRepo struct {
@@ -83,6 +132,56 @@ func newProjectAssistantWorkflowTool(server *Server) projectAssistantTool {
 	}
 }
 
+func newProjectAssistantReadinessWorkflowTool(server *Server) projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolCheckProjectReadiness,
+			Description: "Check deterministic App Studio project readiness from memory, repository status, and workspace context before edits, verification, or commit.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"includeFiles":{"type":"boolean","description":"Whether to include a bounded current workspace file list."},"maxFiles":{"type":"integer","minimum":1,"maximum":50,"description":"Maximum workspace file paths to include when includeFiles is true."}}}`),
+			Risk:        projectAssistantToolRiskRead,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			includeFiles := true
+			if rawIncludeFiles, ok := req.Arguments["includeFiles"]; ok {
+				includeFiles = projectToolBool(rawIncludeFiles)
+			}
+			input := projectAssistantWorkflowInput{
+				Server:         server,
+				Project:        req.Project,
+				Repository:     req.Repository,
+				WorkspaceScope: req.WorkspaceScope,
+				IncludeFiles:   includeFiles,
+				MaxFiles:       boundedWorkflowFileLimit(projectToolInt(req.Arguments["maxFiles"])),
+			}
+			return runProjectAssistantReadinessWorkflow(ctx, input)
+		},
+	}
+}
+
+func newProjectRuntimeVerificationWorkflowToolForRegistry(server *Server) projectAssistantTool {
+	if server == nil || server.runtimeWorker == nil {
+		return nil
+	}
+	return newProjectRuntimeVerificationWorkflowTool(server.runtimeWorker)
+}
+
+func newProjectRuntimeVerificationWorkflowTool(worker projectRuntimeWorker) projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolVerifyProjectRuntime,
+			Description: "Start deterministic App Studio runtime verification checks by name through the sandboxed runtime worker.",
+			Parameters:  json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{"checks":{"type":"array","items":{"type":"string","enum":["build","test"]},"minItems":1,"maxItems":%d,"description":"Named verification checks to start through the runtime worker."},"timeoutSeconds":{"type":"integer","minimum":1,"maximum":%d,"description":"Maximum runtime per verification check in seconds."}},"required":["checks"]}`, projectAssistantWorkflowMaxRuntimeChecks, projectRuntimeCommandMaxTimeoutSeconds)),
+			Risk:        projectAssistantToolRiskRuntime,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			return runProjectAssistantRuntimeVerificationWorkflow(ctx, projectAssistantRuntimeVerificationWorkflowInput{
+				Worker:  worker,
+				Request: req,
+			})
+		},
+	}
+}
+
 func runProjectAssistantPlanningWorkflow(ctx context.Context, input projectAssistantWorkflowInput) (string, error) {
 	runner, err := newProjectAssistantPlanningWorkflow(ctx)
 	if err != nil {
@@ -95,6 +194,38 @@ func runProjectAssistantPlanningWorkflow(ctx context.Context, input projectAssis
 	raw, err := marshalProjectAssistantWorkflowPlan(plan)
 	if err != nil {
 		return "", fmt.Errorf("encode project planning workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func runProjectAssistantReadinessWorkflow(ctx context.Context, input projectAssistantWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantReadinessWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	readiness, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowJSON(readiness)
+	if err != nil {
+		return "", fmt.Errorf("encode project readiness workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func runProjectAssistantRuntimeVerificationWorkflow(ctx context.Context, input projectAssistantRuntimeVerificationWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantRuntimeVerificationWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	result, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowJSON(result)
+	if err != nil {
+		return "", fmt.Errorf("encode project runtime verification workflow result: %w", err)
 	}
 	return string(raw), nil
 }
@@ -133,6 +264,17 @@ func marshalProjectAssistantWorkflowPlan(plan projectAssistantWorkflowPlan) ([]b
 	minimal.Summary = "Project planning context was bounded for assistant context."
 	minimal.Repository = nil
 	return json.Marshal(minimal)
+}
+
+func marshalProjectAssistantWorkflowJSON(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil || len(raw) <= projectAssistantWorkflowMaxResultBytes {
+		return raw, err
+	}
+	return json.Marshal(map[string]any{
+		"status":  "bounded",
+		"summary": "Project assistant workflow result was bounded for assistant context.",
+	})
 }
 
 func boundedProjectAssistantWorkflowRepo(repo *projectAssistantWorkflowRepo) *projectAssistantWorkflowRepo {
@@ -190,6 +332,23 @@ func newProjectAssistantPlanningWorkflow(ctx context.Context) (compose.Runnable[
 	return chain.Compile(ctx, compose.WithGraphName("app-studio-plan-project-changes"), compose.WithMaxRunSteps(8))
 }
 
+func newProjectAssistantReadinessWorkflow(ctx context.Context) (compose.Runnable[projectAssistantWorkflowInput, projectAssistantReadinessWorkflowResult], error) {
+	chain := compose.NewChain[projectAssistantWorkflowInput, projectAssistantReadinessWorkflowResult]()
+	chain.
+		AppendLambda(compose.InvokableLambda(normalizeProjectAssistantWorkflowInput), compose.WithNodeKey("normalize")).
+		AppendLambda(compose.InvokableLambda(readProjectAssistantReadinessWorkflowContext), compose.WithNodeKey("read-context")).
+		AppendLambda(compose.InvokableLambda(formatProjectAssistantReadinessWorkflow), compose.WithNodeKey("format-readiness"))
+	return chain.Compile(ctx, compose.WithGraphName("app-studio-check-project-readiness"), compose.WithMaxRunSteps(8))
+}
+
+func newProjectAssistantRuntimeVerificationWorkflow(ctx context.Context) (compose.Runnable[projectAssistantRuntimeVerificationWorkflowInput, projectAssistantRuntimeVerificationWorkflowResult], error) {
+	chain := compose.NewChain[projectAssistantRuntimeVerificationWorkflowInput, projectAssistantRuntimeVerificationWorkflowResult]()
+	chain.
+		AppendLambda(compose.InvokableLambda(normalizeProjectAssistantRuntimeVerificationWorkflow), compose.WithNodeKey("normalize")).
+		AppendLambda(compose.InvokableLambda(startProjectAssistantRuntimeVerificationChecks), compose.WithNodeKey("start-runtime-checks"))
+	return chain.Compile(ctx, compose.WithGraphName("app-studio-verify-project-runtime"), compose.WithMaxRunSteps(6))
+}
+
 func normalizeProjectAssistantWorkflowInput(ctx context.Context, input projectAssistantWorkflowInput) (projectAssistantWorkflowInput, error) {
 	if err := ctx.Err(); err != nil {
 		return projectAssistantWorkflowInput{}, err
@@ -199,6 +358,13 @@ func normalizeProjectAssistantWorkflowInput(ctx context.Context, input projectAs
 		return projectAssistantWorkflowInput{}, fmt.Errorf("project is required")
 	}
 	return input, nil
+}
+
+func readProjectAssistantReadinessWorkflowContext(ctx context.Context, input projectAssistantWorkflowInput) (projectAssistantWorkflowContext, error) {
+	start := time.Now()
+	out, err := readProjectAssistantWorkflowContext(ctx, input)
+	out.Trace = appendProjectAssistantWorkflowTrace(out.Trace, "read-context", start, err)
+	return out, err
 }
 
 func readProjectAssistantWorkflowContext(ctx context.Context, input projectAssistantWorkflowInput) (projectAssistantWorkflowContext, error) {
@@ -229,6 +395,48 @@ func readProjectAssistantWorkflowContext(ctx context.Context, input projectAssis
 		out.WorkspaceFiles = append(out.WorkspaceFiles, fmt.Sprintf("+more (limit %d)", files.Limit))
 	}
 	return out, nil
+}
+
+func formatProjectAssistantReadinessWorkflow(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantReadinessWorkflowResult, error) {
+	start := time.Now()
+	result, err := formatProjectAssistantReadinessWorkflowResult(ctx, input)
+	result.Trace = appendProjectAssistantWorkflowTrace(result.Trace, "format-readiness", start, err)
+	return result, err
+}
+
+func formatProjectAssistantReadinessWorkflowResult(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantReadinessWorkflowResult, error) {
+	result := projectAssistantReadinessWorkflowResult{Trace: append([]projectAssistantWorkflowTraceEvent(nil), input.Trace...)}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	p := input.Project
+	if p == nil {
+		return result, fmt.Errorf("project is required")
+	}
+	displayName := strings.TrimSpace(p.Spec.DisplayName)
+	if displayName == "" {
+		displayName = p.Name
+	}
+	status := "ready_to_verify"
+	if len(p.Spec.Memory.Requirements) == 0 {
+		status = "needs_requirements"
+	} else if input.Repository == nil || input.Repository.Status != projectRepositoryStatusReady {
+		status = "needs_repository"
+	} else if len(input.WorkspaceFiles) == 0 {
+		status = "needs_workspace_context"
+	}
+	result.Status = status
+	result.Summary = fmt.Sprintf("Project %s is %s.", displayName, strings.ReplaceAll(status, "_", " "))
+	result.RecommendedChecks = projectAssistantRecommendedRuntimeChecks(input.WorkspaceFiles)
+	result.Files = append([]string(nil), input.WorkspaceFiles...)
+	if input.Repository != nil {
+		result.Repository = &projectAssistantWorkflowRepo{
+			Ref:    input.Repository.Ref,
+			Name:   input.Repository.Name,
+			Status: input.Repository.Status,
+		}
+	}
+	return result, nil
 }
 
 func formatProjectAssistantWorkflowPlan(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantWorkflowPlan, error) {
@@ -279,6 +487,147 @@ func projectAssistantWorkflowSteps(memory aiv1alpha1.ProjectMemory, repository *
 		steps = append(steps, "Defer commit handoff until the repository binding is ready.")
 	}
 	return steps
+}
+
+func normalizeProjectAssistantRuntimeVerificationWorkflow(ctx context.Context, input projectAssistantRuntimeVerificationWorkflowInput) (projectAssistantRuntimeVerificationWorkflowState, error) {
+	start := time.Now()
+	state, err := normalizeProjectAssistantRuntimeVerificationWorkflowInput(ctx, input)
+	state.Trace = appendProjectAssistantWorkflowTrace(state.Trace, "normalize", start, err)
+	return state, err
+}
+
+func normalizeProjectAssistantRuntimeVerificationWorkflowInput(ctx context.Context, input projectAssistantRuntimeVerificationWorkflowInput) (projectAssistantRuntimeVerificationWorkflowState, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantRuntimeVerificationWorkflowState{}, err
+	}
+	if input.Worker == nil {
+		return projectAssistantRuntimeVerificationWorkflowState{}, fmt.Errorf("runtime worker is not configured for this App Studio provider")
+	}
+	checks, err := projectAssistantRuntimeVerificationChecks(input.Request.Arguments["checks"])
+	if err != nil {
+		return projectAssistantRuntimeVerificationWorkflowState{}, err
+	}
+	timeout := projectToolInt(input.Request.Arguments["timeoutSeconds"])
+	if timeout <= 0 {
+		timeout = projectRuntimeCommandDefaultTimeoutSeconds
+	}
+	if timeout > projectRuntimeCommandMaxTimeoutSeconds {
+		timeout = projectRuntimeCommandMaxTimeoutSeconds
+	}
+	return projectAssistantRuntimeVerificationWorkflowState{
+		Worker:         input.Worker,
+		Request:        input.Request,
+		Checks:         checks,
+		TimeoutSeconds: timeout,
+	}, nil
+}
+
+func startProjectAssistantRuntimeVerificationChecks(ctx context.Context, input projectAssistantRuntimeVerificationWorkflowState) (projectAssistantRuntimeVerificationWorkflowResult, error) {
+	start := time.Now()
+	result, err := startProjectAssistantRuntimeVerificationChecksResult(ctx, input)
+	result.Trace = appendProjectAssistantWorkflowTrace(result.Trace, "start-runtime-checks", start, err)
+	return result, err
+}
+
+func startProjectAssistantRuntimeVerificationChecksResult(ctx context.Context, input projectAssistantRuntimeVerificationWorkflowState) (projectAssistantRuntimeVerificationWorkflowResult, error) {
+	result := projectAssistantRuntimeVerificationWorkflowResult{
+		Status: "started",
+		Checks: make([]projectAssistantRuntimeVerificationCheck, 0, len(input.Checks)),
+		Trace:  append([]projectAssistantWorkflowTraceEvent(nil), input.Trace...),
+	}
+	for _, check := range input.Checks {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		handle, err := input.Worker.Start(ctx, projectRuntimeRequest{
+			Identity:       input.Request.Identity,
+			WorkspaceScope: input.Request.WorkspaceScope,
+			Command:        append([]string(nil), check.Command...),
+			TimeoutSeconds: input.TimeoutSeconds,
+		})
+		started := check
+		if err != nil {
+			started.Status = "failed"
+			started.Message = trimProjectAssistantWorkflowString(err.Error(), 240)
+			result.Checks = append(result.Checks, started)
+			result.Status = "failed"
+			result.Summary = "One or more runtime verification checks failed to start."
+			return result, nil
+		}
+		started.ID = strings.TrimSpace(handle.ID)
+		started.Status = "started"
+		result.Checks = append(result.Checks, started)
+	}
+	result.Summary = fmt.Sprintf("Started %d runtime verification check(s).", len(result.Checks))
+	return result, nil
+}
+
+func projectAssistantRuntimeVerificationChecks(value any) ([]projectAssistantRuntimeVerificationCheck, error) {
+	if value == nil {
+		return nil, newValidationError("runtime verification requires at least one check")
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return nil, newValidationError("runtime verification checks must be an array")
+	}
+	if len(items) == 0 {
+		return nil, newValidationError("runtime verification requires at least one check")
+	}
+	if len(items) > projectAssistantWorkflowMaxRuntimeChecks {
+		return nil, newValidationError(fmt.Sprintf("runtime verification checks cannot exceed %d", projectAssistantWorkflowMaxRuntimeChecks))
+	}
+	out := make([]projectAssistantRuntimeVerificationCheck, 0, len(items))
+	for i, item := range items {
+		name, ok := item.(string)
+		if !ok {
+			return nil, newValidationError(fmt.Sprintf("runtime verification check %d must be a string", i))
+		}
+		if strings.TrimSpace(name) == "" {
+			return nil, newValidationError(fmt.Sprintf("runtime verification check %d cannot be empty", i))
+		}
+		check, ok := projectAssistantRuntimeVerificationCheckForName(name)
+		if !ok {
+			return nil, newValidationError(fmt.Sprintf("unsupported runtime verification check %q", name))
+		}
+		out = append(out, check)
+	}
+	return out, nil
+}
+
+func projectAssistantRuntimeVerificationCheckForName(name string) (projectAssistantRuntimeVerificationCheck, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "build":
+		return projectAssistantRuntimeVerificationCheck{Name: "build", Command: []string{"npm", "run", "build"}, Status: "pending"}, true
+	case "test":
+		return projectAssistantRuntimeVerificationCheck{Name: "test", Command: []string{"npm", "test"}, Status: "pending"}, true
+	default:
+		return projectAssistantRuntimeVerificationCheck{}, false
+	}
+}
+
+func projectAssistantRecommendedRuntimeChecks(files []string) []string {
+	for _, file := range files {
+		if strings.EqualFold(strings.TrimSpace(file), "package.json") {
+			return []string{"build", "test"}
+		}
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	return []string{"build"}
+}
+
+func appendProjectAssistantWorkflowTrace(trace []projectAssistantWorkflowTraceEvent, node string, start time.Time, err error) []projectAssistantWorkflowTraceEvent {
+	event := projectAssistantWorkflowTraceEvent{
+		Node:       node,
+		Status:     "ok",
+		DurationMS: time.Since(start).Milliseconds(),
+	}
+	if err != nil {
+		event.Status = "error"
+		event.Error = trimProjectAssistantWorkflowString(err.Error(), 240)
+	}
+	return append(trace, event)
 }
 
 func boundedWorkflowFileLimit(limit int) int {

--- a/providers/app-studio/api/assistant_workflow_test.go
+++ b/providers/app-studio/api/assistant_workflow_test.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -43,6 +44,25 @@ func TestProjectAssistantWorkflowRegisteredReadOnly(t *testing.T) {
 	}
 	if strings.TrimSpace(string(spec.Parameters)) == "" {
 		t.Fatal("workflow tool parameters are empty")
+	}
+}
+
+func TestProjectAssistantReadinessWorkflowRegisteredReadOnly(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	registry := server.projectAssistantToolRegistry()
+	tool, ok := registry.Get(projectToolCheckProjectReadiness)
+	if !ok {
+		t.Fatal("check_project_readiness tool missing from registry")
+	}
+	spec := tool.Spec()
+	if spec.Risk != projectAssistantToolRiskRead {
+		t.Fatalf("risk = %q, want read", spec.Risk)
+	}
+	if got := projectAssistantPermissionForTool(spec); got != projectAssistantPermissionAllow {
+		t.Fatalf("permission = %q, want allow", got)
+	}
+	if strings.TrimSpace(string(spec.Parameters)) == "" {
+		t.Fatal("readiness workflow tool parameters are empty")
 	}
 }
 
@@ -98,6 +118,62 @@ func TestProjectAssistantWorkflowPlansFromMemoryRepositoryAndWorkspace(t *testin
 	}
 	if len(plan.Steps) == 0 {
 		t.Fatalf("steps = %#v, want at least one deterministic next step", plan.Steps)
+	}
+}
+
+func TestProjectAssistantReadinessWorkflowReportsContextTraceAndChecks(t *testing.T) {
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = "Demo App"
+	project.Spec.Memory.Requirements = []string{"ship a tested build"}
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "package.json", Content: `{"scripts":{"build":"vite build","test":"vitest"}}`}); err != nil {
+		t.Fatalf("WriteFile package.json returned error: %v", err)
+	}
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "src/App.tsx", Content: "export function App() { return null }\n"}); err != nil {
+		t.Fatalf("WriteFile src/App.tsx returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolCheckProjectReadiness)
+	if !ok {
+		t.Fatal("check_project_readiness tool missing from registry")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		Repository:     &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		WorkspaceScope: scope,
+		Arguments:      map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(raw) > projectAssistantWorkflowMaxResultBytes {
+		t.Fatalf("workflow result length = %d, want <= %d", len(raw), projectAssistantWorkflowMaxResultBytes)
+	}
+	var readiness struct {
+		Status            string               `json:"status"`
+		Summary           string               `json:"summary"`
+		RecommendedChecks []string             `json:"recommendedChecks"`
+		Trace             []workflowTraceEntry `json:"trace"`
+	}
+	if err := json.Unmarshal([]byte(raw), &readiness); err != nil {
+		t.Fatalf("workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if readiness.Status != "ready_to_verify" {
+		t.Fatalf("status = %q, want ready_to_verify", readiness.Status)
+	}
+	if !strings.Contains(readiness.Summary, "Demo App") {
+		t.Fatalf("summary = %q, want project display name", readiness.Summary)
+	}
+	if !containsString(readiness.RecommendedChecks, "build") || !containsString(readiness.RecommendedChecks, "test") {
+		t.Fatalf("recommended checks = %#v, want build and test", readiness.RecommendedChecks)
+	}
+	if !workflowTraceContains(readiness.Trace, "read-context") || !workflowTraceContains(readiness.Trace, "format-readiness") {
+		t.Fatalf("trace = %#v, want read-context and format-readiness nodes", readiness.Trace)
 	}
 }
 
@@ -170,6 +246,222 @@ func TestProjectAssistantWorkflowBoundsLargeResultAsJSON(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantRuntimeVerificationWorkflowRegistersWithRuntimeWorker(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	worker := &fakeProjectRuntimeWorker{handle: projectRuntimeHandle{ID: "runtime-1"}}
+	server.runtimeWorker = worker
+	registry := server.projectAssistantToolRegistry()
+	tool, ok := registry.Get(projectToolVerifyProjectRuntime)
+	if !ok {
+		t.Fatal("verify_project_runtime tool missing with runtime worker")
+	}
+	spec := tool.Spec()
+	if spec.Risk != projectAssistantToolRiskRuntime {
+		t.Fatalf("risk = %q, want runtime", spec.Risk)
+	}
+	if got := projectAssistantPermissionForTool(spec); got != projectAssistantPermissionAsk {
+		t.Fatalf("permission = %q, want ask", got)
+	}
+	if strings.TrimSpace(string(spec.Parameters)) == "" {
+		t.Fatal("runtime verification workflow tool parameters are empty")
+	}
+}
+
+func TestProjectAssistantRuntimeVerificationWorkflowStartsPresetChecks(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	worker := &recordingProjectRuntimeWorker{
+		handles: []projectRuntimeHandle{{ID: "runtime-build"}, {ID: "runtime-test"}},
+	}
+	server.runtimeWorker = worker
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolVerifyProjectRuntime)
+	if !ok {
+		t.Fatal("verify_project_runtime tool missing with runtime worker")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		Repository:     &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		WorkspaceScope: scope,
+		Arguments: map[string]any{
+			"checks":         []any{"build", "test"},
+			"timeoutSeconds": 30,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(raw) > projectAssistantWorkflowMaxResultBytes {
+		t.Fatalf("workflow result length = %d, want <= %d", len(raw), projectAssistantWorkflowMaxResultBytes)
+	}
+	var verification struct {
+		Status string `json:"status"`
+		Checks []struct {
+			Name    string   `json:"name"`
+			Command []string `json:"command"`
+			ID      string   `json:"id"`
+			Status  string   `json:"status"`
+		} `json:"checks"`
+		Trace []workflowTraceEntry `json:"trace"`
+	}
+	if err := json.Unmarshal([]byte(raw), &verification); err != nil {
+		t.Fatalf("workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if verification.Status != "started" {
+		t.Fatalf("status = %q, want started", verification.Status)
+	}
+	if len(verification.Checks) != 2 {
+		t.Fatalf("checks = %#v, want build and test", verification.Checks)
+	}
+	if strings.Join(verification.Checks[0].Command, " ") != "npm run build" || strings.Join(verification.Checks[1].Command, " ") != "npm test" {
+		t.Fatalf("checks = %#v, want preset npm build/test commands", verification.Checks)
+	}
+	if len(worker.requests) != 2 {
+		t.Fatalf("worker requests = %#v, want 2", worker.requests)
+	}
+	if strings.Join(worker.requests[0].Command, " ") != "npm run build" || strings.Join(worker.requests[1].Command, " ") != "npm test" {
+		t.Fatalf("worker requests = %#v, want preset npm build/test commands", worker.requests)
+	}
+	if worker.requests[0].TimeoutSeconds != 30 || worker.requests[1].TimeoutSeconds != 30 {
+		t.Fatalf("worker requests = %#v, want requested timeout", worker.requests)
+	}
+	if !workflowTraceContains(verification.Trace, "start-runtime-checks") {
+		t.Fatalf("trace = %#v, want start-runtime-checks node", verification.Trace)
+	}
+}
+
+func TestProjectAssistantRuntimeVerificationWorkflowRejectsUnknownChecks(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	worker := &recordingProjectRuntimeWorker{handles: []projectRuntimeHandle{{ID: "runtime-1"}}}
+	server.runtimeWorker = worker
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolVerifyProjectRuntime)
+	if !ok {
+		t.Fatal("verify_project_runtime tool missing with runtime worker")
+	}
+
+	_, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Arguments: map[string]any{"checks": []any{"deploy"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported runtime verification check") {
+		t.Fatalf("Call error = %v, want unsupported check validation", err)
+	}
+	if len(worker.requests) != 0 {
+		t.Fatalf("worker requests = %#v, want no runtime starts", worker.requests)
+	}
+}
+
+func TestProjectAssistantRuntimeVerificationWorkflowRejectsMissingOrMalformedChecks(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "missing",
+			args: map[string]any{},
+			want: "requires at least one check",
+		},
+		{
+			name: "empty",
+			args: map[string]any{"checks": []any{}},
+			want: "requires at least one check",
+		},
+		{
+			name: "string",
+			args: map[string]any{"checks": "test"},
+			want: "checks must be an array",
+		},
+		{
+			name: "non string",
+			args: map[string]any{"checks": []any{"build", float64(1)}},
+			want: "check 1 must be a string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+			worker := &recordingProjectRuntimeWorker{handles: []projectRuntimeHandle{{ID: "runtime-1"}}}
+			server.runtimeWorker = worker
+			tool, ok := server.projectAssistantToolRegistry().Get(projectToolVerifyProjectRuntime)
+			if !ok {
+				t.Fatal("verify_project_runtime tool missing with runtime worker")
+			}
+
+			_, err := tool.Call(context.Background(), projectAssistantToolCallRequest{Arguments: tt.args})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Call error = %v, want %q", err, tt.want)
+			}
+			if len(worker.requests) != 0 {
+				t.Fatalf("worker requests = %#v, want no runtime starts", worker.requests)
+			}
+		})
+	}
+}
+
+func TestProjectAssistantRuntimeVerificationWorkflowReturnsPartialResultWhenStartFails(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	longWorkerError := "worker capacity exhausted " + strings.Repeat("x", projectAssistantWorkflowMaxResultBytes)
+	worker := &recordingProjectRuntimeWorker{
+		handles: []projectRuntimeHandle{{ID: "runtime-build"}},
+		errors:  []error{nil, errors.New(longWorkerError)},
+	}
+	server.runtimeWorker = worker
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolVerifyProjectRuntime)
+	if !ok {
+		t.Fatal("verify_project_runtime tool missing with runtime worker")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		WorkspaceScope: scope,
+		Arguments: map[string]any{
+			"checks": []any{"build", "test"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(raw) > projectAssistantWorkflowMaxResultBytes {
+		t.Fatalf("workflow result length = %d, want <= %d", len(raw), projectAssistantWorkflowMaxResultBytes)
+	}
+	var verification struct {
+		Status string `json:"status"`
+		Checks []struct {
+			Name    string `json:"name"`
+			ID      string `json:"id"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(raw), &verification); err != nil {
+		t.Fatalf("workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if verification.Status != "failed" {
+		t.Fatalf("status = %q, want failed", verification.Status)
+	}
+	if len(verification.Checks) != 2 {
+		t.Fatalf("checks = %#v, want started build and failed test", verification.Checks)
+	}
+	if verification.Checks[0].Name != "build" || verification.Checks[0].ID != "runtime-build" || verification.Checks[0].Status != "started" {
+		t.Fatalf("first check = %#v, want started build handle", verification.Checks[0])
+	}
+	if verification.Checks[1].Name != "test" || verification.Checks[1].Status != "failed" || !strings.Contains(verification.Checks[1].Message, "worker capacity exhausted") {
+		t.Fatalf("second check = %#v, want failed test with worker error", verification.Checks[1])
+	}
+	if len(verification.Checks[1].Message) > 260 {
+		t.Fatalf("worker error message length = %d, want bounded message", len(verification.Checks[1].Message))
+	}
+}
+
 func workflowTestFilePaths(files []workspace.FileInfo) []string {
 	out := make([]string, 0, len(files))
 	for _, file := range files {
@@ -185,4 +477,42 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+type workflowTraceEntry struct {
+	Node     string `json:"node"`
+	Status   string `json:"status"`
+	Duration int64  `json:"durationMs"`
+}
+
+func workflowTraceContains(values []workflowTraceEntry, node string) bool {
+	for _, value := range values {
+		if value.Node == node && value.Status == "ok" {
+			return true
+		}
+	}
+	return false
+}
+
+type recordingProjectRuntimeWorker struct {
+	handles  []projectRuntimeHandle
+	errors   []error
+	requests []projectRuntimeRequest
+}
+
+func (w *recordingProjectRuntimeWorker) Start(_ context.Context, req projectRuntimeRequest) (projectRuntimeHandle, error) {
+	w.requests = append(w.requests, req)
+	if len(w.errors) > 0 {
+		err := w.errors[0]
+		w.errors = w.errors[1:]
+		if err != nil {
+			return projectRuntimeHandle{}, err
+		}
+	}
+	if len(w.handles) == 0 {
+		return projectRuntimeHandle{}, nil
+	}
+	handle := w.handles[0]
+	w.handles = w.handles[1:]
+	return handle, nil
 }

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -68,17 +68,19 @@ const (
 )
 
 const (
-	projectToolListProjectFiles   = "list_project_files"
-	projectToolReadProjectFile    = "read_project_file"
-	projectToolSearchProjectFiles = "search_project_files"
-	projectToolPlanProjectChanges = "plan_project_changes"
-	projectToolWriteFile          = "write_file"
-	projectToolApplyPatch         = "apply_patch"
-	projectToolMkdir              = "mkdir"
-	projectToolRuntimeCommand     = "runtime_command"
-	projectToolCommitProjectFiles = "commit_project_files"
-	projectToolCommitFiles        = "commit_files"
-	projectToolCodeCommitFiles    = "code__commit_files"
+	projectToolListProjectFiles      = "list_project_files"
+	projectToolReadProjectFile       = "read_project_file"
+	projectToolSearchProjectFiles    = "search_project_files"
+	projectToolPlanProjectChanges    = "plan_project_changes"
+	projectToolCheckProjectReadiness = "check_project_readiness"
+	projectToolWriteFile             = "write_file"
+	projectToolApplyPatch            = "apply_patch"
+	projectToolMkdir                 = "mkdir"
+	projectToolVerifyProjectRuntime  = "verify_project_runtime"
+	projectToolRuntimeCommand        = "runtime_command"
+	projectToolCommitProjectFiles    = "commit_project_files"
+	projectToolCommitFiles           = "commit_files"
+	projectToolCodeCommitFiles       = "code__commit_files"
 )
 
 var (
@@ -1117,8 +1119,10 @@ func summarizeProjectToolArgumentsMap(name string, args map[string]any) string {
 		return summarizeProjectToolKeyValues(args, []string{"path", "maxBytes"})
 	case projectToolSearchProjectFiles:
 		return summarizeProjectToolKeyValues(args, []string{"query", "maxResults"})
-	case projectToolPlanProjectChanges:
+	case projectToolPlanProjectChanges, projectToolCheckProjectReadiness:
 		return summarizeProjectPlanningWorkflowArgs(args)
+	case projectToolVerifyProjectRuntime:
+		return summarizeProjectRuntimeVerificationArgs(args)
 	case projectToolWriteFile:
 		return summarizeProjectMutationArgs(args, []string{"path"}, true)
 	case projectToolApplyPatch:
@@ -1171,6 +1175,10 @@ func summarizeProjectToolResult(name, result string) string {
 			return summarizeWorkspaceSearchResult(decoded)
 		case projectToolPlanProjectChanges:
 			return summarizeProjectPlanningWorkflowResult(decoded)
+		case projectToolCheckProjectReadiness:
+			return summarizeProjectReadinessWorkflowResult(decoded)
+		case projectToolVerifyProjectRuntime:
+			return summarizeProjectRuntimeVerificationResult(decoded)
 		case projectToolWriteFile, projectToolApplyPatch, projectToolMkdir:
 			return summarizeWorkspaceMutationResult(decoded)
 		}
@@ -1226,6 +1234,17 @@ func summarizeProjectPlanningWorkflowArgs(args map[string]any) string {
 	return truncateProjectToolInfo(strings.Join(parts, "; "))
 }
 
+func summarizeProjectRuntimeVerificationArgs(args map[string]any) string {
+	parts := []string{}
+	if checks := projectToolStringList(args["checks"]); len(checks) > 0 {
+		parts = append(parts, "checks "+summarizeProjectToolList(checks, 4))
+	}
+	if n, ok := projectToolNumber(args["timeoutSeconds"]); ok {
+		parts = append(parts, fmt.Sprintf("timeoutSeconds %d", n))
+	}
+	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
 func summarizeWorkspaceMutationResult(decoded map[string]any) string {
 	parts := []string{}
 	if op := projectToolString(decoded["operation"]); op != "" {
@@ -1258,6 +1277,58 @@ func summarizeProjectPlanningWorkflowResult(decoded map[string]any) string {
 		return ""
 	}
 	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
+func summarizeProjectReadinessWorkflowResult(decoded map[string]any) string {
+	parts := []string{}
+	if status := projectToolString(decoded["status"]); status != "" {
+		parts = append(parts, "status "+status)
+	}
+	if checks := projectToolStringList(decoded["recommendedChecks"]); len(checks) > 0 {
+		parts = append(parts, "checks "+summarizeProjectToolList(checks, 4))
+	}
+	if files := projectToolStringList(decoded["files"]); len(files) > 0 {
+		parts = append(parts, fmt.Sprintf("%d file(s): %s", len(files), summarizeProjectToolList(files, 5)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
+func summarizeProjectRuntimeVerificationResult(decoded map[string]any) string {
+	parts := []string{}
+	if status := projectToolString(decoded["status"]); status != "" {
+		parts = append(parts, "status "+status)
+	}
+	if checks, ok := decoded["checks"].([]any); ok && len(checks) > 0 {
+		parts = append(parts, fmt.Sprintf("%d check(s): %s", len(checks), summarizeProjectRuntimeCheckNames(checks, 4)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
+func summarizeProjectRuntimeCheckNames(values []any, maxValues int) string {
+	if len(values) == 0 || maxValues <= 0 {
+		return ""
+	}
+	names := make([]string, 0, len(values))
+	for _, value := range values {
+		obj, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := projectToolString(obj["name"])
+		if status := projectToolString(obj["status"]); status != "" {
+			name = strings.TrimSpace(name + " " + status)
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return summarizeProjectToolList(names, maxValues)
 }
 
 func summarizeWorkspaceListResult(decoded map[string]any) string {
@@ -1310,6 +1381,19 @@ func summarizeWorkspaceSearchResult(decoded map[string]any) string {
 
 func projectToolCallResultStatus(name, result string) string {
 	baseName := projectToolBaseName(name)
+	if baseName == projectToolVerifyProjectRuntime {
+		decoded := map[string]any{}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(result)), &decoded); err == nil {
+			switch strings.ToLower(projectToolString(decoded["status"])) {
+			case "failed":
+				return "failed"
+			case "started":
+				return "running"
+			case "bounded":
+				return "failed"
+			}
+		}
+	}
 	if baseName != projectToolCommitFiles && baseName != projectToolCommitProjectFiles {
 		return "succeeded"
 	}
@@ -2016,6 +2100,7 @@ func projectSystemPrompt(p *aiv1alpha1.Project, repository *ProjectRepositoryVie
 			}
 			b.WriteString("Do not attempt to commit files until the user restores the missing Code repository or connection.\n")
 		} else {
+			b.WriteString("Use check_project_readiness before mutating or verifying existing work so repository, memory, workspace context, and recommended checks come from the App Studio graph workflow. ")
 			b.WriteString("For existing projects, inspect relevant files in the App Studio workspace before editing: use list_project_files to discover paths, read_project_file for targeted files, and search_project_files when you need to locate code. ")
 			b.WriteString("Prefer small App Studio workspace mutations with write_file, apply_patch, and mkdir instead of rewriting a whole project. ")
 			b.WriteString("After workspace mutations, commit the changed source/config files to the managed git source with commit_project_files using repositoryRef \"" + repoRef + "\". ")

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -307,6 +307,10 @@ func (s *Server) generateProjectAssistantStream(
 	if id.orgUUID == "" || id.workspaceUUID == "" {
 		return "", errors.New("tenant context missing")
 	}
+	turn := newProjectAssistantTurnItem(projectAssistantTurnMessage, id, p.Name)
+	ctx, finishTurn := s.projectAssistantRunManager().Begin(ctx, turn)
+	defer finishTurn()
+	r = r.WithContext(ctx)
 	recent, err := s.store.LoadRecentMessages(ctx, projectMessageScope(id.orgUUID, id.workspaceUUID, p.Name), 24)
 	if err != nil {
 		return "", err

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -399,7 +399,7 @@ func (s *Server) createProjectStartStream(w http.ResponseWriter, r *http.Request
 	}
 	writeStreamError := func(err error) {
 		_ = writeProjectMessageStreamEvent(w, flusher, projectMessageStreamEvent{
-			Type:  "error",
+			Type:  string(projectAssistantEventRunFailed),
 			Error: err.Error(),
 		})
 	}
@@ -617,7 +617,7 @@ func (s *Server) streamProjectAssistant(
 			return
 		}
 		emitAssistantEvent(projectAssistantEvent{
-			Type: projectAssistantEventToolCallFinished,
+			Type: projectAssistantEventTypeForToolCallStatus(toolCall.Status),
 			ToolCall: &projectAssistantToolCall{
 				ID:        toolCall.ID,
 				Name:      toolCall.Name,

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -95,6 +95,7 @@ func TestProjectToolAllowlistSeparatesWorkspaceAndGitTools(t *testing.T) {
 		"read_project_file",
 		"search_project_files",
 		"plan_project_changes",
+		"check_project_readiness",
 		"write_file",
 		"apply_patch",
 		"mkdir",
@@ -117,6 +118,7 @@ func TestProjectAssistantToolRegistryListsLocalToolsInOrder(t *testing.T) {
 		"read_project_file",
 		"search_project_files",
 		"plan_project_changes",
+		"check_project_readiness",
 		"write_file",
 		"apply_patch",
 		"mkdir",
@@ -198,7 +200,7 @@ func TestProjectSystemPromptRequiresWorkspaceInspectBeforeEdit(t *testing.T) {
 	}
 
 	prompt := projectSystemPrompt(project, repository)
-	for _, want := range []string{"list_project_files", "read_project_file", "search_project_files", "write_file", "apply_patch", "mkdir", "commit_project_files"} {
+	for _, want := range []string{"check_project_readiness", "list_project_files", "read_project_file", "search_project_files", "write_file", "apply_patch", "mkdir", "commit_project_files"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
@@ -280,6 +282,16 @@ func TestSummarizeProjectToolArgumentsWorkspaceReadTools(t *testing.T) {
 			want: []string{"includeFiles true", "maxFiles 12"},
 		},
 		{
+			name: "check_project_readiness",
+			args: `{"includeFiles":true,"maxFiles":12}`,
+			want: []string{"includeFiles true", "maxFiles 12"},
+		},
+		{
+			name: "verify_project_runtime",
+			args: `{"checks":["build","test"],"timeoutSeconds":30}`,
+			want: []string{"checks build, test", "timeoutSeconds 30"},
+		},
+		{
 			name: "write_file",
 			args: `{"path":"src/App.tsx","content":"secret-ish file body"}`,
 			want: []string{"path src/App.tsx", "20 bytes"},
@@ -353,6 +365,22 @@ func TestSummarizeProjectToolResultWorkspaceReadTools(t *testing.T) {
 			t.Fatalf("summary = %q, want %q", got, want)
 		}
 	}
+
+	readinessResult := `{"status":"ready_to_verify","recommendedChecks":["build","test"],"files":["package.json","src/App.tsx"],"trace":[{"node":"read-context","status":"ok"}]}`
+	got = summarizeProjectToolResult("check_project_readiness", readinessResult)
+	for _, want := range []string{"status ready_to_verify", "checks build, test", "2 file(s): package.json, src/App.tsx"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary = %q, want %q", got, want)
+		}
+	}
+
+	verificationResult := `{"status":"started","checks":[{"name":"build","status":"started","id":"runtime-build"},{"name":"test","status":"started","id":"runtime-test"}]}`
+	got = summarizeProjectToolResult("verify_project_runtime", verificationResult)
+	for _, want := range []string{"status started", "2 check(s): build started, test started"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary = %q, want %q", got, want)
+		}
+	}
 }
 
 func TestProjectAssistantMessageMetadataToolCalls(t *testing.T) {
@@ -381,6 +409,15 @@ func TestProjectToolCallResultStatusCommitFilesPending(t *testing.T) {
 	}
 	if got := projectToolCallResultStatus("code__commit_files", `{"phase":"Succeeded"}`); got != "succeeded" {
 		t.Fatalf("status = %q, want succeeded", got)
+	}
+	if got := projectToolCallResultStatus("verify_project_runtime", `{"status":"started"}`); got != "running" {
+		t.Fatalf("runtime verification started status = %q, want running", got)
+	}
+	if got := projectToolCallResultStatus("verify_project_runtime", `{"status":"failed"}`); got != "failed" {
+		t.Fatalf("runtime verification failed status = %q, want failed", got)
+	}
+	if got := projectToolCallResultStatus("verify_project_runtime", `{"status":"bounded"}`); got != "failed" {
+		t.Fatalf("runtime verification bounded status = %q, want failed", got)
 	}
 	if got := projectToolCallResultStatus("other_tool", result); got != "succeeded" {
 		t.Fatalf("non-commit status = %q, want succeeded", got)

--- a/providers/app-studio/api/runtime_worker_test.go
+++ b/providers/app-studio/api/runtime_worker_test.go
@@ -34,8 +34,14 @@ func TestProjectRuntimeWorkerToolsAbsentByDefault(t *testing.T) {
 	if registry.Has(projectToolRuntimeCommand) {
 		t.Fatal("runtime_command tool registered without a runtime worker")
 	}
+	if registry.Has(projectToolVerifyProjectRuntime) {
+		t.Fatal("verify_project_runtime tool registered without a runtime worker")
+	}
 	if projectLocalToolAllowed(projectToolRuntimeCommand) {
 		t.Fatal("runtime_command is globally local-allowed without a runtime worker")
+	}
+	if projectLocalToolAllowed(projectToolVerifyProjectRuntime) {
+		t.Fatal("verify_project_runtime is globally local-allowed without a runtime worker")
 	}
 	if tool := newProjectRuntimeCommandToolForRegistry(server); tool != nil {
 		t.Fatalf("runtime tool = %#v, want nil without worker", tool)

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -24,6 +24,7 @@ package api
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +49,9 @@ type Server struct {
 	hubBase                  string
 	mcpInsecureSkipTLSVerify bool
 	assistantEngine          projectAssistantEngine
+	assistantRunManager      *projectAssistantRunManager
 	runtimeWorker            projectRuntimeWorker
+	mu                       sync.Mutex
 }
 
 // New constructs a Server.
@@ -66,14 +69,26 @@ func NewWithWorkspace(clients *tenant.ClientFactory, msgStore store.Store, works
 		mcpInsecureSkipTLSVerify: mcpInsecureSkipTLSVerify,
 	}
 	s.assistantEngine = NewEinoAssistantEngine(s)
+	s.assistantRunManager = newProjectAssistantRunManager()
 	return s
 }
 
 func (s *Server) projectAssistantEngine() projectAssistantEngine {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.assistantEngine == nil {
 		s.assistantEngine = NewEinoAssistantEngine(s)
 	}
 	return s.assistantEngine
+}
+
+func (s *Server) projectAssistantRunManager() *projectAssistantRunManager {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.assistantRunManager == nil {
+		s.assistantRunManager = newProjectAssistantRunManager()
+	}
+	return s.assistantRunManager
 }
 
 // Register mounts the project routes onto r. The hub backend proxy strips the

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -937,7 +937,7 @@ async function createProjectAndStartConversation(content: string) {
         selected.value = event.project
         messages.value = messages.value.map((message) => ({ ...message, projectID: projectName }))
         props.navigate(encodeURIComponent(projectName))
-      } else if (event.type === 'chunk') {
+      } else if (event.type === 'message_delta') {
         conversationStatus.value = ''
         if (!projectName || !event.assistantMessageID) return
         if (!assistantMessageID) {
@@ -952,7 +952,7 @@ async function createProjectAndStartConversation(content: string) {
           content: `${existing.content}${event.content ?? ''}`,
         }
         messages.value = [...messages.value]
-      } else if (event.type === 'tool_call') {
+      } else if (event.type === 'tool_call_started' || event.type === 'tool_call_finished') {
         conversationStatus.value = ''
         if (!projectName || !event.assistantMessageID || !event.toolCall) return
         if (!assistantMessageID) {
@@ -973,12 +973,12 @@ async function createProjectAndStartConversation(content: string) {
           assistantMessageID = event.assistantMessageID
         }
         attachAssistantCheckpoint(projectName, event.assistantMessageID, event.checkpoint)
-      } else if (event.type === 'done') {
+      } else if (event.type === 'run_finished') {
         conversationStatus.value = ''
         if (!assistantMessageID) {
           assistantMessageID = event.assistantMessageID ?? ''
         }
-      } else if (event.type === 'error') {
+      } else if (event.type === 'run_failed') {
         throw new Error(event.error ?? 'Streaming error')
       }
     }, controller.signal)
@@ -1151,7 +1151,7 @@ async function sendMessage() {
     await api.createMessageStream(props.ctx, projectName, content, (event: ProjectMessageStreamEvent) => {
       if (event.type === 'status') {
         conversationStatus.value = event.status || 'Working'
-      } else if (event.type === 'chunk') {
+      } else if (event.type === 'message_delta') {
         conversationStatus.value = ''
         if (!event.assistantMessageID) return
         if (!assistantMessageID) {
@@ -1166,7 +1166,7 @@ async function sendMessage() {
           content: `${existing.content}${event.content ?? ''}`,
         }
         messages.value = [...messages.value]
-      } else if (event.type === 'tool_call') {
+      } else if (event.type === 'tool_call_started' || event.type === 'tool_call_finished') {
         conversationStatus.value = ''
         if (!event.assistantMessageID || !event.toolCall) return
         if (!assistantMessageID) {
@@ -1187,12 +1187,12 @@ async function sendMessage() {
           assistantMessageID = event.assistantMessageID
         }
         attachAssistantCheckpoint(projectName, event.assistantMessageID, event.checkpoint)
-      } else if (event.type === 'done') {
+      } else if (event.type === 'run_finished') {
         conversationStatus.value = ''
         if (!assistantMessageID) {
           assistantMessageID = event.assistantMessageID ?? ''
         }
-      } else if (event.type === 'error') {
+      } else if (event.type === 'run_failed') {
         throw new Error(event.error ?? 'Streaming error')
       }
     }, controller.signal)

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -178,10 +178,13 @@ async function requestStream(
     try {
       event = JSON.parse(data) as ProjectMessageStreamEvent
     } catch {
-      onEvent({ type: 'error', error: data })
+      onEvent({ type: 'run_failed', error: data })
       return
     }
-    if (!event.type) event.type = type === 'done' || type === 'error' ? type : 'chunk'
+    if (!event.type) {
+      onEvent({ type: 'run_failed', error: `stream event missing type${type ? ` (${type})` : ''}` })
+      return
+    }
     onEvent(event)
   }
 

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -62,7 +62,17 @@ export interface ProjectAssistantResumeResponse {
 }
 
 export interface ProjectMessageStreamEvent {
-  type: 'chunk' | 'tool_call' | 'permission_required' | 'checkpoint_saved' | 'done' | 'error' | 'status' | 'project'
+  type:
+    | 'run_started'
+    | 'message_delta'
+    | 'status'
+    | 'tool_call_started'
+    | 'tool_call_finished'
+    | 'permission_required'
+    | 'checkpoint_saved'
+    | 'run_failed'
+    | 'run_finished'
+    | 'project'
   assistantMessageID?: string
   content?: string
   status?: string


### PR DESCRIPTION
## Summary
- add Eino compose-backed `check_project_readiness` and runtime verification workflow tools
- route runtime verification through preset checks on the App Studio runtime worker with approval, bounded results, and trace metadata
- update assistant prompt/tool summaries and docs for workflow-first readiness and runtime verification

## Verification
- `go test -count=1 ./api -run 'TestProjectAssistantReadinessWorkflow|TestProjectAssistantRuntimeVerificationWorkflow|TestSummarizeProjectToolArgumentsWorkspaceReadTools|TestSummarizeProjectToolResultWorkspaceReadTools|TestProjectRuntimeWorkerToolsAbsentByDefault'` in `providers/app-studio`
- `go test -count=1 ./api -run 'TestProjectAssistantRuntimeVerificationWorkflowRejectsMissingOrMalformedChecks|TestProjectAssistantRuntimeVerificationWorkflowReturnsPartialResultWhenStartFails|TestEinoAssistantEngineValidatesEditedRuntimeVerificationArgsOnResume|TestProjectToolCallResultStatusCommitFilesPending'` in `providers/app-studio`
- `go test -count=1 ./...` in `providers/app-studio`
- `make test`
- `go build ./...`
- `git diff --check`

## Notes
- `go test -count=1 ./...` from the repo root still pulls in e2e suites and failed on local environment/setup assumptions (`bin/kedge` missing, provider/e2e provisioning/route failures); `make test` is the non-e2e Makefile gate and passed.