### PR TITLE
Build provider images & charts at their own version, not the hub version

### DIFF
--- a/.github/workflows/helm-images.yaml
+++ b/.github/workflows/helm-images.yaml
@@ -75,14 +75,18 @@ jobs:
             APP_VERSION="${CHART_VERSION}"
           fi
 
-          # Package (and on non-PR events push) each platform chart in
-          # deploy/charts/ plus every per-provider chart in
-          # providers/*/deploy/chart/. The provider chart dirs are all named
-          # "chart", so the chart name is read from the Chart.yaml name: field
-          # rather than the directory basename. Provider charts are built here
-          # in the monorepo (not their synced-out mirrors) so a broken chart is
-          # caught in the PR that changes it.
-          for chart_dir in deploy/charts/*/ providers/*/deploy/chart/; do
+          # Platform charts (deploy/charts/*) are versioned + published here with
+          # the hub version. Provider charts (providers/*/deploy/chart/) are only
+          # LINTED/PACKAGED here on PRs for validation — they are published, with
+          # each provider's OWN version, by provider-release.yaml on a
+          # `providers/<name>/v*` tag. Publishing them here would stamp them with
+          # the hub version. The provider chart dirs are all named "chart", so the
+          # chart name is read from the Chart.yaml name: field.
+          chart_dirs=(deploy/charts/*/)
+          if [ "${PUSH}" != "true" ]; then
+            chart_dirs+=(providers/*/deploy/chart/)
+          fi
+          for chart_dir in "${chart_dirs[@]}"; do
             if [ -f "${chart_dir}Chart.yaml" ]; then
               chart_name=$(grep -E '^name:' "${chart_dir}Chart.yaml" | head -1 | awk '{print $2}')
               echo "Processing chart: $chart_name ($chart_dir)"

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -63,13 +63,14 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.release.created_at }}
 
-  # Per-provider images are built here in the monorepo (not in the synced-out
-  # mirror repos) so a broken provider Dockerfile is caught in the PR that
-  # changes it — before the split sync ever reaches a mirror. Each provider is
-  # a self-contained module/build context (providers/<name>/), so the build is
-  # identical to what the mirror would run. The image name matches the
-  # provider chart's values.yaml image.repository so deployments resolve it.
+  # PR-only validation that every provider Dockerfile + build context still
+  # builds, before the split sync ever reaches a mirror. Each provider is a
+  # self-contained build context (providers/<name>/). These builds are NEVER
+  # pushed here — provider images are published per-provider, stamped with the
+  # provider's own version, by provider-release.yaml on a `providers/<name>/v*`
+  # tag. (Publishing here would tag provider images with the hub version.)
   build-and-push-provider-images:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -98,12 +98,12 @@ jobs:
           # the 'vX.Y.Z' image tag pushed above.
           CHART_VERSION="${{ steps.tag.outputs.semver }}"
           APP_VERSION="${{ steps.tag.outputs.version }}"
-          sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}Chart.yaml"
-          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}Chart.yaml"
 
           # lint renders templates against default values (package only tars), so
           # a broken template fails here rather than shipping.
           helm lint "$chart_dir"
-          helm package "$chart_dir" --version "${CHART_VERSION}"
+          # Stamp version + appVersion at package time via flags rather than
+          # rewriting Chart.yaml, so the checked-out source is never mutated.
+          helm package "$chart_dir" --version "${CHART_VERSION}" --app-version "${APP_VERSION}"
           helm push "${chart_name}-${CHART_VERSION}.tgz" "oci://${REGISTRY}/${{ github.repository_owner }}/charts"
           echo "Pushed oci://${REGISTRY}/${{ github.repository_owner }}/charts/${chart_name}:${CHART_VERSION} (appVersion ${APP_VERSION})"

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -1,0 +1,109 @@
+name: Provider release (image + chart)
+
+# Builds and publishes a single provider's container image and Helm chart from
+# the monorepo, stamped with that provider's OWN version — not the hub version.
+#
+# Triggered by a per-provider release tag `providers/<name>/v<X.Y.Z>` (cut by
+# `cmd/kedge-release`). The provider name and version are parsed from the tag;
+# the image is tagged `vX.Y.Z` and `X.Y.Z`, and the chart's version/appVersion
+# are set to that version. Because every provider chart leaves `image.tag` empty
+# (→ defaults to `.Chart.AppVersion`), the deployed chart resolves to the
+# matching provider-versioned image built here.
+#
+# This is the sole publisher of provider images/charts. The hub `v*` release
+# (images.yaml / helm-images.yaml) builds providers in build-only PR validation
+# mode and no longer publishes them, and the split-*.yaml mirrors publish source
+# only (no version tag → no mirror image build), so there is no double-build.
+
+on:
+  push:
+    tags:
+      - 'providers/*/v*'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse provider + version from tag
+        id: tag
+        run: |
+          set -euo pipefail
+          # refs/tags/providers/<name>/vX.Y.Z
+          FULL="${GITHUB_REF#refs/tags/}"      # providers/code/v0.0.9
+          REST="${FULL#providers/}"            # code/v0.0.9
+          PROVIDER="${REST%%/*}"               # code
+          VERSION="${FULL##*/}"                # v0.0.9
+          [ -d "providers/${PROVIDER}" ] || { echo "unknown provider ${PROVIDER}"; exit 1; }
+          [ -f "providers/${PROVIDER}/Dockerfile" ] || { echo "no Dockerfile for ${PROVIDER}"; exit 1; }
+          # Image repo matches the provider chart's values.yaml image.repository.
+          # app-studio is published under a nested path; the rest are flat.
+          case "${PROVIDER}" in
+            app-studio) IMAGE="${{ github.repository_owner }}/kedge/app-studio-provider" ;;
+            *)          IMAGE="${{ github.repository_owner }}/kedge-${PROVIDER}-provider" ;;
+          esac
+          echo "provider=${PROVIDER}"   >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}"     >> "$GITHUB_OUTPUT"   # v0.0.9 (chart appVersion + image tag)
+          echo "semver=${VERSION#v}"    >> "$GITHUB_OUTPUT"   # 0.0.9  (chart version, OCI convention)
+          echo "image=${IMAGE}"         >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./providers/${{ steps.tag.outputs.provider }}
+          file: ./providers/${{ steps.tag.outputs.provider }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.semver }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.0'
+
+      - name: Package and push chart
+        env:
+          HELM_EXPERIMENTAL_OCI: 1
+        run: |
+          set -euo pipefail
+          echo "${{ github.token }}" | helm registry login "${REGISTRY}" --username ${{ github.actor }} --password-stdin
+
+          chart_dir="providers/${{ steps.tag.outputs.provider }}/deploy/chart/"
+          chart_name=$(grep -E '^name:' "${chart_dir}Chart.yaml" | head -1 | awk '{print $2}')
+
+          # Chart version follows OCI/semver convention (no 'v'); appVersion keeps
+          # the 'v' so the chart's image.tag default (.Chart.AppVersion) matches
+          # the 'vX.Y.Z' image tag pushed above.
+          CHART_VERSION="${{ steps.tag.outputs.semver }}"
+          APP_VERSION="${{ steps.tag.outputs.version }}"
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" "${chart_dir}Chart.yaml"
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" "${chart_dir}Chart.yaml"
+
+          # lint renders templates against default values (package only tars), so
+          # a broken template fails here rather than shipping.
+          helm lint "$chart_dir"
+          helm package "$chart_dir" --version "${CHART_VERSION}"
+          helm push "${chart_name}-${CHART_VERSION}.tgz" "oci://${REGISTRY}/${{ github.repository_owner }}/charts"
+          echo "Pushed oci://${REGISTRY}/${{ github.repository_owner }}/charts/${chart_name}:${CHART_VERSION} (appVersion ${APP_VERSION})"

--- a/.github/workflows/split-app-studio.yaml
+++ b/.github/workflows/split-app-studio.yaml
@@ -5,16 +5,16 @@ name: Split app-studio provider
 #
 # Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
 # the same source always splits to the same commit sha1s, so pushes normally
-# fast-forward. Runs on every push to main (mirrors the branch) and on
-# per-provider release tags (see below). workflow_dispatch is provided for the
-# initial seed / manual re-sync. It also runs on PRs that touch the split
+# fast-forward. Runs on every push to main (mirrors the branch); workflow_dispatch
+# is provided for the initial seed / manual re-sync. It also runs on PRs that touch the split
 # surface, but those only validate (install + split) — the deploy-key and push
 # steps are gated to non-PR events, so a PR never writes to the mirror.
 #
-# Releases are tagged per-provider in the monorepo as
-# `providers/app-studio/vX.Y.Z`; the prefix is stripped on the way out, so the
-# mirror receives a plain `vX.Y.Z` tag (which then triggers its own image/chart
-# release workflows). A repo-wide `vX.Y.Z` tag does NOT release the mirror.
+# This mirror is SOURCE ONLY: it tracks `main`, and does NOT receive release
+# tags. Provider images and charts are built+published from the monorepo by
+# provider-release.yaml (on a `providers/app-studio/vX.Y.Z` tag), stamped with
+# the provider's own version. Pushing the tag here too would make the mirror
+# rebuild the same image/chart and collide on the published tag.
 #
 # Required secret: APP_STUDIO_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -24,7 +24,6 @@ name: Split app-studio provider
 on:
   push:
     branches: [main]
-    tags: ['providers/app-studio/v*']
   pull_request:
     branches: [main]
     paths:
@@ -114,19 +113,8 @@ jobs:
 
           git remote add mirror "${TARGET_REPO}"
 
-          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            # Per-provider tag: refs/tags/providers/app-studio/vX.Y.Z. Strip the
-            # path prefix (everything up to the last '/') so the mirror gets a
-            # plain vX.Y.Z tag.
-            FULL_TAG="${GITHUB_REF#refs/tags/}"
-            TAG="${FULL_TAG##*/}"
-            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
-            # Tags are immutable; push without force so an accidental re-tag fails loudly.
-            git push mirror "${SHA}:refs/tags/${TAG}"
-          else
-            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
-            # --force keeps the mirror a faithful reflection even if monorepo
-            # history is ever rewritten. The mirror is read-only, so there are
-            # no downstream commits to clobber.
-            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
-          fi
+          echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+          # --force keeps the mirror a faithful reflection even if monorepo
+          # history is ever rewritten. The mirror is read-only, so there are
+          # no downstream commits to clobber.
+          git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"

--- a/.github/workflows/split-code.yaml
+++ b/.github/workflows/split-code.yaml
@@ -5,16 +5,16 @@ name: Split code provider
 #
 # Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
 # the same source always splits to the same commit sha1s, so pushes normally
-# fast-forward. Runs on every push to main (mirrors the branch) and on
-# per-provider release tags (see below). workflow_dispatch is provided for the
-# initial seed / manual re-sync. It also runs on PRs that touch the split
+# fast-forward. Runs on every push to main (mirrors the branch); workflow_dispatch
+# is provided for the initial seed / manual re-sync. It also runs on PRs that touch the split
 # surface, but those only validate (install + split) — the deploy-key and push
 # steps are gated to non-PR events, so a PR never writes to the mirror.
 #
-# Releases are tagged per-provider in the monorepo as
-# `providers/code/vX.Y.Z`; the prefix is stripped on the way out, so the
-# mirror receives a plain `vX.Y.Z` tag (which then triggers its own image/chart
-# release workflows). A repo-wide `vX.Y.Z` tag does NOT release the mirror.
+# This mirror is SOURCE ONLY: it tracks `main`, and does NOT receive release
+# tags. Provider images and charts are built+published from the monorepo by
+# provider-release.yaml (on a `providers/code/vX.Y.Z` tag), stamped with the
+# provider's own version. Pushing the tag here too would make the mirror
+# rebuild the same image/chart and collide on the published tag.
 #
 # Required secret: CODE_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -24,7 +24,6 @@ name: Split code provider
 on:
   push:
     branches: [main]
-    tags: ['providers/code/v*']
   pull_request:
     branches: [main]
     paths:
@@ -114,19 +113,8 @@ jobs:
 
           git remote add mirror "${TARGET_REPO}"
 
-          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            # Per-provider tag: refs/tags/providers/code/vX.Y.Z. Strip the
-            # path prefix (everything up to the last '/') so the mirror gets a
-            # plain vX.Y.Z tag.
-            FULL_TAG="${GITHUB_REF#refs/tags/}"
-            TAG="${FULL_TAG##*/}"
-            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
-            # Tags are immutable; push without force so an accidental re-tag fails loudly.
-            git push mirror "${SHA}:refs/tags/${TAG}"
-          else
-            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
-            # --force keeps the mirror a faithful reflection even if monorepo
-            # history is ever rewritten. The mirror is read-only, so there are
-            # no downstream commits to clobber.
-            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
-          fi
+          echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+          # --force keeps the mirror a faithful reflection even if monorepo
+          # history is ever rewritten. The mirror is read-only, so there are
+          # no downstream commits to clobber.
+          git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"

--- a/.github/workflows/split-infrastructure.yaml
+++ b/.github/workflows/split-infrastructure.yaml
@@ -5,17 +5,16 @@ name: Split infrastructure provider
 #
 # Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
 # the same source always splits to the same commit sha1s, so pushes normally
-# fast-forward. Runs on every push to main (mirrors the branch) and on
-# per-provider release tags (see below). workflow_dispatch is provided for the
-# initial seed / manual re-sync. It also runs on PRs that touch the split
+# fast-forward. Runs on every push to main (mirrors the branch); workflow_dispatch
+# is provided for the initial seed / manual re-sync. It also runs on PRs that touch the split
 # surface, but those only validate (install + split) — the deploy-key and push
 # steps are gated to non-PR events, so a PR never writes to the mirror.
 #
-# Releases are tagged per-provider in the monorepo as
-# `providers/infrastructure/vX.Y.Z`; the prefix is stripped on the way out, so
-# the mirror receives a plain `vX.Y.Z` tag (which then triggers its own
-# image/chart release workflows). A repo-wide `vX.Y.Z` tag does NOT release the
-# mirror.
+# This mirror is SOURCE ONLY: it tracks `main`, and does NOT receive release
+# tags. Provider images and charts are built+published from the monorepo by
+# provider-release.yaml (on a `providers/infrastructure/vX.Y.Z` tag), stamped
+# with the provider's own version. Pushing the tag here too would make the
+# mirror rebuild the same image/chart and collide on the published tag.
 #
 # Required secret: INFRA_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -25,7 +24,6 @@ name: Split infrastructure provider
 on:
   push:
     branches: [main]
-    tags: ['providers/infrastructure/v*']
   pull_request:
     branches: [main]
     paths:
@@ -115,19 +113,8 @@ jobs:
 
           git remote add mirror "${TARGET_REPO}"
 
-          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            # Per-provider tag: refs/tags/providers/infrastructure/vX.Y.Z. Strip
-            # the path prefix (everything up to the last '/') so the mirror gets
-            # a plain vX.Y.Z tag.
-            FULL_TAG="${GITHUB_REF#refs/tags/}"
-            TAG="${FULL_TAG##*/}"
-            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
-            # Tags are immutable; push without force so an accidental re-tag fails loudly.
-            git push mirror "${SHA}:refs/tags/${TAG}"
-          else
-            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
-            # --force keeps the mirror a faithful reflection even if monorepo
-            # history is ever rewritten. The mirror is read-only, so there are
-            # no downstream commits to clobber.
-            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
-          fi
+          echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+          # --force keeps the mirror a faithful reflection even if monorepo
+          # history is ever rewritten. The mirror is read-only, so there are
+          # no downstream commits to clobber.
+          git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"

--- a/.github/workflows/split-kuery.yaml
+++ b/.github/workflows/split-kuery.yaml
@@ -5,16 +5,16 @@ name: Split kuery provider
 #
 # Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
 # the same source always splits to the same commit sha1s, so pushes normally
-# fast-forward. Runs on every push to main (mirrors the branch) and on
-# per-provider release tags (see below). workflow_dispatch is provided for the
-# initial seed / manual re-sync. It also runs on PRs that touch the split
+# fast-forward. Runs on every push to main (mirrors the branch); workflow_dispatch
+# is provided for the initial seed / manual re-sync. It also runs on PRs that touch the split
 # surface, but those only validate (install + split) — the deploy-key and push
 # steps are gated to non-PR events, so a PR never writes to the mirror.
 #
-# Releases are tagged per-provider in the monorepo as
-# `providers/kuery/vX.Y.Z`; the prefix is stripped on the way out, so the
-# mirror receives a plain `vX.Y.Z` tag (which then triggers its own image/chart
-# release workflows). A repo-wide `vX.Y.Z` tag does NOT release the mirror.
+# This mirror is SOURCE ONLY: it tracks `main`, and does NOT receive release
+# tags. Provider images and charts are built+published from the monorepo by
+# provider-release.yaml (on a `providers/kuery/vX.Y.Z` tag), stamped with the
+# provider's own version. Pushing the tag here too would make the mirror
+# rebuild the same image/chart and collide on the published tag.
 #
 # Required secret: KUERY_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -24,7 +24,6 @@ name: Split kuery provider
 on:
   push:
     branches: [main]
-    tags: ['providers/kuery/v*']
   pull_request:
     branches: [main]
     paths:
@@ -114,19 +113,8 @@ jobs:
 
           git remote add mirror "${TARGET_REPO}"
 
-          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            # Per-provider tag: refs/tags/providers/kuery/vX.Y.Z. Strip the
-            # path prefix (everything up to the last '/') so the mirror gets a
-            # plain vX.Y.Z tag.
-            FULL_TAG="${GITHUB_REF#refs/tags/}"
-            TAG="${FULL_TAG##*/}"
-            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
-            # Tags are immutable; push without force so an accidental re-tag fails loudly.
-            git push mirror "${SHA}:refs/tags/${TAG}"
-          else
-            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
-            # --force keeps the mirror a faithful reflection even if monorepo
-            # history is ever rewritten. The mirror is read-only, so there are
-            # no downstream commits to clobber.
-            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
-          fi
+          echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+          # --force keeps the mirror a faithful reflection even if monorepo
+          # history is ever rewritten. The mirror is read-only, so there are
+          # no downstream commits to clobber.
+          git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"

--- a/.github/workflows/split-quickstart.yaml
+++ b/.github/workflows/split-quickstart.yaml
@@ -5,16 +5,16 @@ name: Split quickstart provider
 #
 # Uses splitsh-lite (https://github.com/splitsh/lite) which is deterministic:
 # the same source always splits to the same commit sha1s, so pushes normally
-# fast-forward. Runs on every push to main (mirrors the branch) and on
-# per-provider release tags (see below). workflow_dispatch is provided for the
-# initial seed / manual re-sync. It also runs on PRs that touch the split
+# fast-forward. Runs on every push to main (mirrors the branch); workflow_dispatch
+# is provided for the initial seed / manual re-sync. It also runs on PRs that touch the split
 # surface, but those only validate (install + split) — the deploy-key and push
 # steps are gated to non-PR events, so a PR never writes to the mirror.
 #
-# Releases are tagged per-provider in the monorepo as
-# `providers/quickstart/vX.Y.Z`; the prefix is stripped on the way out, so the
-# mirror receives a plain `vX.Y.Z` tag (which then triggers its own image/chart
-# release workflows). A repo-wide `vX.Y.Z` tag does NOT release the mirror.
+# This mirror is SOURCE ONLY: it tracks `main`, and does NOT receive release
+# tags. Provider images and charts are built+published from the monorepo by
+# provider-release.yaml (on a `providers/quickstart/vX.Y.Z` tag), stamped with
+# the provider's own version. Pushing the tag here too would make the mirror
+# rebuild the same image/chart and collide on the published tag.
 #
 # Required secret: QUICKSTART_DEPLOY_KEY
 #   An SSH private key whose public half is added as a *write* deploy key on
@@ -23,7 +23,6 @@ name: Split quickstart provider
 on:
   push:
     branches: [main]
-    tags: ['providers/quickstart/v*']
   pull_request:
     branches: [main]
     paths:
@@ -113,19 +112,8 @@ jobs:
 
           git remote add mirror "${TARGET_REPO}"
 
-          if [ "${GITHUB_REF}" != "${GITHUB_REF#refs/tags/}" ]; then
-            # Per-provider tag: refs/tags/providers/quickstart/vX.Y.Z. Strip the
-            # path prefix (everything up to the last '/') so the mirror gets a
-            # plain vX.Y.Z tag.
-            FULL_TAG="${GITHUB_REF#refs/tags/}"
-            TAG="${FULL_TAG##*/}"
-            echo "Publishing tag ${FULL_TAG} -> ${TARGET_REPO} as ${TAG}"
-            # Tags are immutable; push without force so an accidental re-tag fails loudly.
-            git push mirror "${SHA}:refs/tags/${TAG}"
-          else
-            echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
-            # --force keeps the mirror a faithful reflection even if monorepo
-            # history is ever rewritten. The mirror is read-only, so there are
-            # no downstream commits to clobber.
-            git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"
-          fi
+          echo "Publishing branch ${TARGET_BRANCH} -> ${TARGET_REPO}"
+          # --force keeps the mirror a faithful reflection even if monorepo
+          # history is ever rewritten. The mirror is read-only, so there are
+          # no downstream commits to clobber.
+          git push --force mirror "${SHA}:refs/heads/${TARGET_BRANCH}"

--- a/cmd/kedge-release/main.go
+++ b/cmd/kedge-release/main.go
@@ -11,11 +11,14 @@
 // Each component has its own tag namespace and independent version line:
 //
 //	hub             v<X.Y.Z>                          repo-wide release: goreleaser
-//	                                                  CLI + hub/agent images + all
-//	                                                  in-tree provider images & charts
-//	quickstart      providers/quickstart/v<X.Y.Z>     split → faroshq/provider-quickstart
-//	                                                  mirror, which builds its own
-//	                                                  image + chart
+//	                                                  CLI + hub/agent images +
+//	                                                  platform charts (kedge-hub,
+//	                                                  kedge-agent)
+//	quickstart      providers/quickstart/v<X.Y.Z>     provider-release.yaml builds
+//	                                                  the image + chart stamped with
+//	                                                  this version; the source is
+//	                                                  also mirrored to faroshq/
+//	                                                  provider-<name> (source only)
 //	infrastructure  providers/infrastructure/v<X.Y.Z>
 //	code            providers/code/v<X.Y.Z>
 //
@@ -67,12 +70,12 @@ var componentOrder = []string{"provider-sdk", "hub", "quickstart", "kuery", "app
 
 var components = map[string]component{
 	"provider-sdk":   {"provider-sdk/v", "split → faroshq/provider-sdk; publishes the go-gettable SDK module (providers require this version once the replace is dropped)"},
-	"hub":            {"v", "goreleaser CLI release + hub/agent/provider images + Helm charts (ghcr.io/faroshq)"},
-	"quickstart":     {"providers/quickstart/v", "split → faroshq/provider-quickstart; the mirror builds its image + chart"},
-	"kuery":          {"providers/kuery/v", "split → faroshq/provider-kuery; the mirror builds its image + chart"},
-	"app-studio":     {"providers/app-studio/v", "split → faroshq/provider-app-studio; the mirror builds its image + chart"},
-	"infrastructure": {"providers/infrastructure/v", "tag only — no split/release workflow wired up yet"},
-	"code":           {"providers/code/v", "tag only — no split/release workflow wired up yet"},
+	"hub":            {"v", "goreleaser CLI release + hub/agent images + platform Helm charts (ghcr.io/faroshq)"},
+	"quickstart":     {"providers/quickstart/v", "provider-release.yaml builds the image + chart at this version; source mirror → faroshq/provider-quickstart"},
+	"kuery":          {"providers/kuery/v", "provider-release.yaml builds the image + chart at this version; source mirror → faroshq/provider-kuery"},
+	"app-studio":     {"providers/app-studio/v", "provider-release.yaml builds the image + chart at this version; source mirror → faroshq/provider-app-studio"},
+	"infrastructure": {"providers/infrastructure/v", "provider-release.yaml builds the image + chart at this version; source mirror → faroshq/provider-infrastructure"},
+	"code":           {"providers/code/v", "provider-release.yaml builds the image + chart at this version; source mirror → faroshq/provider-code"},
 }
 
 func main() {


### PR DESCRIPTION
## Problem

Provider images and charts were published stamped with the **hub** version (e.g. `v0.0.83`) instead of each provider's own release version.

Every provider chart leaves `image.tag` empty (→ `.Chart.AppVersion`), and both `images.yaml` and `helm-images.yaml` stamped provider artifacts with the hub tag. So the per-provider release tags (`providers/<name>/vX.Y.Z`) never affected the deployed artifact:

| Provider | before: monorepo build | before: mirror build |
|---|---|---|
| quickstart / kuery / app-studio | image+chart `0.0.83` (hub) | image+chart `0.0.x` (provider) — duplicate/colliding |
| code / infrastructure | image+chart `0.0.83` (hub) | none |

## Fix — monorepo, per-provider tag

Provider image+chart publishing moves into the monorepo, keyed off the per-provider tag and stamped with the provider's own version.

- **`provider-release.yaml` (new):** sole publisher of provider images+charts. Triggers on `providers/<name>/v*`, parses name+version from the tag, builds the image (`vX.Y.Z` / `X.Y.Z`) + chart (`version X.Y.Z`, `appVersion vX.Y.Z`) so the chart resolves to the matching provider-versioned image.
- **`images.yaml`:** provider matrix job is now PR build-only validation; no longer publishes hub-versioned provider images.
- **`helm-images.yaml`:** provider charts only linted/packaged on PRs; the hub release publishes platform charts (`kedge-hub`, `kedge-agent`) only.
- **`split-*.yaml` (×5):** made source-only (dropped the per-provider tag trigger and tag-push). Prevents the mirror repos from rebuilding and colliding on the same image/chart tag the monorepo now produces.
- **`cmd/kedge-release`:** plan descriptions + doc comment updated to match.

`CatalogEntry.spec.version` is chart-declared, so the catalog will now show each provider's real version instead of the hub version. Nothing references provider artifacts by the hub version (verified: no umbrella chart dependency, no hub-side chart pull, goreleaser builds CLI/hub/agent only).

## Follow-up (out of this repo)

The mirror repos (`faroshq/provider-quickstart`, `-kuery`, `-app-studio`) still contain their own image/chart build workflows. They're now dormant (no tag ever arrives, so no collision), but can be deleted there for tidiness.

## Test

- `go build ./cmd/kedge-release` + `--dry-run` reflect the new model
- All 8 changed/new workflow YAMLs parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)