### PR TITLE
Rework provider bootstrap: self-register CatalogEntry via init container; per-provider release versioning

### DIFF
--- a/.github/workflows/tilt-e2e.yaml
+++ b/.github/workflows/tilt-e2e.yaml
@@ -14,10 +14,17 @@ name: Tilt E2E
 # internal retries) if the stack isn't fully settled.
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  # DISABLED on CI: the multi-shard Tilt stack over-subscribes the 2-vCPU
+  # GitHub-hosted runner — root-kcp won't schedule and the shards/proxies
+  # crash-loop on probe timeouts, so this job fails on insufficient resources
+  # rather than on the code under test. Re-enable the pull_request/push
+  # triggers once we have bigger (self-hosted / larger-runner) workers with
+  # enough CPU+memory to stand up the full operator topology. Until then it
+  # stays runnable on demand via the Actions "Run workflow" button below.
+  # pull_request:
+  #   branches: [main]
+  # push:
+  #   branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ providers/kuery/portal/dist/
 # Data dirs
 data/
 *.kubeconfig
+# Downloaded kubeconfigs that don't end in .kubeconfig (e.g. code-kubeconfig (2).yaml)
+*kubeconfig*.yaml
 
 # Dev tools and certs
 hack/tools/

--- a/Makefile
+++ b/Makefile
@@ -1191,9 +1191,9 @@ helm-undeploy-provider-infrastructure: ## (experimental) helm uninstall the infr
 KRO_KIND_NAME ?= kedge-kro
 KRO_KIND_KUBECONFIG ?= $(CURDIR)/.kedge-kro.kubeconfig
 KRO_CHART ?= oci://ghcr.io/faroshq/kro-multicluster/charts/kro/kro
-KRO_CHART_VERSION ?= v0.0.1-mc.6
+KRO_CHART_VERSION ?= v0.0.1-mc.7
 KRO_IMAGE_REPO ?= ghcr.io/faroshq/kro-multicluster/kro
-KRO_IMAGE_TAG ?= v0.0.1-mc.6
+KRO_IMAGE_TAG ?= v0.0.1-mc.7
 KRO_NAMESPACE ?= kro-system
 KRO_SEED_DIR ?= providers/infrastructure/examples/rgds
 

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -53,7 +53,7 @@ cluster_name = 'kcp-tilt'
 # silently shadow any later edit to the default here. The putenv is one-way:
 # parent (this file) → child (the included Tiltfile.static, which reads the env).
 kcp_image_repo = cfg.get('kcp-image-repo', '')
-kcp_image_tag = cfg.get('kcp-image-tag', 'fb8629abb')
+kcp_image_tag = cfg.get('kcp-image-tag', 'v0.32.0')
 # Always export (even empty) so an explicit '' override clears any inherited env.
 os.putenv('KCP_IMAGE_REPO', kcp_image_repo)
 os.putenv('KCP_IMAGE_TAG', kcp_image_tag)

--- a/providers/app-studio/deploy/chart/templates/catalogentry.yaml
+++ b/providers/app-studio/deploy/chart/templates/catalogentry.yaml
@@ -1,36 +1,55 @@
 {{- if .Values.catalogEntry.enabled -}}
-apiVersion: providers.kedge.faros.sh/v1alpha1
-kind: CatalogEntry
+# CatalogEntry registers this provider with the kedge hub for routing + the
+# portal Enable flow. It is a kcp resource (providers.kedge.faros.sh/v1alpha1),
+# so it MUST NOT be applied to the hosting cluster where this chart installs.
+# Instead the chart renders it into a ConfigMap that the init container mounts
+# and applies into the provider workspace via the provider kubeconfig
+# (KEDGE_CATALOGENTRY_FILE -> sdkinstall.Bootstrap). The hub watches
+# CatalogEntries in every workspace bound to providers.kedge.faros.sh, including
+# the provider's own, so a self-registered entry is seen.
+#
+# It only REFERENCES the APIExport (apiExport.name); the APIExport, its
+# APIResourceSchemas, the APIExportEndpointSlice, and the bind grant are created
+# by the same init container. The hub no longer provisions anything from this
+# CatalogEntry.
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: app-studio
-  annotations:
-    providers.kedge.faros.sh/builtin: "false"
+  name: {{ include "appstudio.fullname" . }}-catalogentry
   labels:
     {{- include "appstudio.labels" . | nindent 4 }}
-spec:
-  displayName: "App Studio"
-  description: "Persistent AI project workspace for planning, memory, and chat."
-  vendor: "kedge"
-  version: {{ .Chart.AppVersion | quote }}
-  category: "AI"
-  iconURL: "/ui/providers/app-studio/icon.svg"
-  dependencies:
-    - name: code
-  ui:
-    url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.uiURL | quote }}
-    indexPath: "/"
-  backend:
-    # The hub backend proxy forwards /services/providers/app-studio/* here,
-    # injecting the verified X-Kedge-Tenant/X-Kedge-User headers and the
-    # caller's bearer token. The provider serves /api/projects/* + /healthz.
-    url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.backendURL | quote }}
-    healthPath: "/healthz"
-  # Reference-only: the APIExport, schemas, slice, and bind grant are created by
-  # this chart's init container (provider `init`, via the kedge-provider-sdk).
-  apiExport:
-    name: "ai.kedge.faros.sh"
-    permissionClaims:
-      - resource: secrets
-        verbs: ["get", "list", "watch", "create", "update", "delete"]
-        tenantScoped: true
+data:
+  catalogentry.yaml: |
+    apiVersion: providers.kedge.faros.sh/v1alpha1
+    kind: CatalogEntry
+    metadata:
+      name: app-studio
+      annotations:
+        providers.kedge.faros.sh/builtin: "false"
+    spec:
+      displayName: "App Studio"
+      description: "Persistent AI project workspace for planning, memory, and chat."
+      vendor: "kedge"
+      version: {{ .Chart.AppVersion | quote }}
+      category: "AI"
+      iconURL: "/ui/providers/app-studio/icon.svg"
+      dependencies:
+        - name: code
+      ui:
+        url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.uiURL | quote }}
+        indexPath: "/"
+      backend:
+        # The hub backend proxy forwards /services/providers/app-studio/* here,
+        # injecting the verified X-Kedge-Tenant/X-Kedge-User headers and the
+        # caller's bearer token. The provider serves /api/projects/* + /healthz.
+        url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.backendURL | quote }}
+        healthPath: "/healthz"
+      # Reference-only: the APIExport, schemas, slice, and bind grant are created by
+      # this chart's init container (provider `init`, via the kedge-provider-sdk).
+      apiExport:
+        name: "ai.kedge.faros.sh"
+        permissionClaims:
+          - resource: secrets
+            verbs: ["get", "list", "watch", "create", "update", "delete"]
+            tenantScoped: true
 {{- end }}

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -39,10 +39,23 @@ spec:
               value: /var/run/secrets/kedge/kedge-provider-kubeconfig
             - name: KEDGE_SCHEMAS_DIR
               value: /etc/kedge/schemas
+            {{- if .Values.catalogEntry.enabled }}
+            # The CatalogEntry is a kcp resource, so the chart cannot apply it to
+            # the hosting cluster. It is rendered into a ConfigMap (mounted below)
+            # and init self-registers it into the provider workspace via the
+            # provider kubeconfig.
+            - name: KEDGE_CATALOGENTRY_FILE
+              value: /etc/kedge/catalogentry/catalogentry.yaml
+            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
               readOnly: true
+            {{- if .Values.catalogEntry.enabled }}
+            - name: catalogentry
+              mountPath: /etc/kedge/catalogentry
+              readOnly: true
+            {{- end }}
       containers:
         - name: provider
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -129,6 +142,11 @@ spec:
             items:
               - key: kubeconfig
                 path: kedge-provider-kubeconfig
+        {{- if .Values.catalogEntry.enabled }}
+        - name: catalogentry
+          configMap:
+            name: {{ include "appstudio.fullname" . }}-catalogentry
+        {{- end }}
         - name: project-workspaces
           {{- if .Values.workspace.existingClaim }}
           persistentVolumeClaim:

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -16,6 +16,12 @@ service:
   type: ClusterIP
   port: 8081
 
+# When true, the chart renders the CatalogEntry (which registers the provider
+# with the hub) into a ConfigMap that the init container applies into the
+# provider workspace via the provider kubeconfig. The CatalogEntry is a kcp
+# resource, so it is NOT applied to the hosting cluster this chart installs into.
+# Set to false to manage the CatalogEntry separately (e.g. GitOps with a
+# different rollout cadence).
 catalogEntry:
   enabled: true
   uiURL: ""

--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -106,9 +106,11 @@ Connection — deleting the Connection garbage-collects the Secret.
 
 ## Register with the hub
 
-The CatalogEntry is what makes the hub provision the provider's workspace,
-schemas, APIExport, and runtime kubeconfig. The Helm chart renders it
-(`catalogEntry.enabled=true`), or apply the raw manifest:
+The CatalogEntry registers the provider with the hub for routing + the portal
+Enable flow. It is a kcp resource, so it lives in the provider workspace — not
+the hosting cluster. With `catalogEntry.enabled=true` (default) the chart renders
+it into a ConfigMap and the init container self-registers it into the workspace
+via the provider kubeconfig; alternatively apply the raw manifest yourself:
 
 ```sh
 kubectl --kubeconfig kcp-admin.kubeconfig ws use root:kedge:providers
@@ -130,7 +132,8 @@ docker build -t ghcr.io/faroshq/kedge-code-provider:dev providers/code/
 ## Deploy with Helm
 
 The chart ships the provider Deployment, a ClusterIP Service, the ServiceAccount,
-and (optionally) the CatalogEntry. The runtime kubeconfig the controllers need
+and (optionally) the CatalogEntry ConfigMap the init container applies to kcp.
+The runtime kubeconfig the controllers need
 is **minted by the hub** when it reconciles the CatalogEntry and mounted from the
 `kedge-provider-kubeconfig` Secret — the volume is `optional`, so the pod serves
 portal/MCP/packages reads immediately and the controller manager engages once
@@ -148,8 +151,10 @@ helm install code providers/code/deploy/chart \
 
 ### With "Connect with GitHub" (OAuth)
 
-Create a GitHub OAuth App with callback `https://<provider-host>/oauth/github/callback`,
-store its client secret in a Secret, then:
+Create a GitHub OAuth App, store its client secret in a Secret, then enable the
+`githubOAuth.*` block. The portal probes `/services/providers/code/oauth/github/config`
+through the hub; once OAuth is enabled and the provider backend is reachable, the
+**Connect with GitHub** button appears.
 
 ```sh
 kubectl -n code create secret generic kedge-code-github-oauth \
@@ -162,14 +167,88 @@ helm install code providers/code/deploy/chart \
   --set githubOAuth.enabled=true \
   --set githubOAuth.clientId=<oauth-app-client-id> \
   --set githubOAuth.clientSecretRef.name=kedge-code-github-oauth \
-  --set githubOAuth.redirectURL=https://code.example.com/oauth/github/callback \
-  --set githubOAuth.portalOrigin=https://kedge.example.com
+  --set githubOAuth.redirectURL=https://<hub-host>/services/providers/code/oauth/github/callback \
+  --set githubOAuth.portalOrigin=https://<hub-host>
 ```
 
-The OAuth callback is a top-level redirect from GitHub (no kedge auth), so
-`redirectURL` must point at the provider's **own externally-reachable URL**, not
-the hub `/services` proxy. `portalOrigin` should be the hub origin so the popup
-returns the token only to your portal.
+#### Choosing `redirectURL`
+
+GitHub's callback is a **top-level browser redirect with no kedge auth**, so
+`redirectURL` must be publicly reachable and forward to the provider's HTTP
+backend (`:8083`). It must end in `/callback`; the matching `/start` URL is
+derived automatically by swapping `/callback` → `/start` under the **same host
+and path prefix**. Two options:
+
+1. **Reuse the hub ingress (recommended — no extra ingress object):** point at
+   the hub's existing `/services/providers/code/*` proxy:
+   ```
+   https://<hub-host>/services/providers/code/oauth/github/callback
+   ```
+   The proxy forwards these anonymous requests straight to the provider backend,
+   so the whole flow rides the single hub hostname. Set `portalOrigin` to the
+   same hub origin.
+
+2. **The provider's own external host:** if you expose the provider directly
+   (its own ingress/hostname), use:
+   ```
+   https://code.example.com/oauth/github/callback
+   ```
+
+Whichever you pick, register that **exact** callback URL on the GitHub OAuth App,
+and set `portalOrigin` to the hub origin so the popup returns the token only to
+your portal.
+
+### Full production deployment (hub-routed OAuth)
+
+Provider running in its own namespace, registered against an already-running hub,
+with OAuth routed through the hub ingress (no per-provider ingress). The runtime
+kubeconfig the controllers need is supplied as the `kedge-provider-kubeconfig`
+Secret (its key **must** be `kubeconfig`) — mint it via the admin onboarding flow
+(`/bonkers`).
+
+```sh
+# 1. Namespace.
+kubectl create namespace kedge-prod-provider-code
+
+# 2. Provider kubeconfig Secret (key MUST be "kubeconfig").
+kubectl -n kedge-prod-provider-code create secret generic kedge-provider-kubeconfig \
+  --from-file=kubeconfig=kedge/provider-code.kubeconfig
+
+# 3. GitHub OAuth App client secret.
+kubectl -n kedge-prod-provider-code create secret generic code-github-oauth \
+  --from-literal=clientSecret=<oauth-app-client-secret>
+
+# 4. Install the chart from the published OCI registry.
+helm upgrade --install code oci://ghcr.io/faroshq/charts/kedge-code-provider:0.0.82 \
+  -n kedge-prod-provider-code \
+  --set hub.url=https://kedge-kedge-hub.kedge-prod.svc.cluster.local:9443 \
+  --set hub.insecure=true \
+  --set hub.tokenSecretRef.name="" \
+  --set image.tag=v0.0.82 \
+  --set catalogEntry.enabled=false \
+  --set githubOAuth.enabled=true \
+  --set githubOAuth.clientId=<oauth-app-client-id> \
+  --set githubOAuth.clientSecretRef.name=code-github-oauth \
+  --set githubOAuth.clientSecretRef.key=clientSecret \
+  --set githubOAuth.redirectURL=https://console.faros.sh/services/providers/code/oauth/github/callback \
+  --set githubOAuth.portalOrigin=https://console.faros.sh
+```
+
+Notes:
+- `hub.insecure=true` + `hub.tokenSecretRef.name=""` suit an in-cluster hub with
+  a self-signed cert and no static heartbeat token. For a real heartbeat token,
+  create a Secret and set `hub.tokenSecretRef.name`/`.key` instead.
+- `catalogEntry.enabled=false` means the chart does **not** manage the
+  CatalogEntry — the hub uses whatever `backend.url` the existing CatalogEntry
+  declares. **Make sure that `backend.url` points at this deployment's Service**
+  (`http://code-kedge-code-provider.<namespace>.svc.cluster.local:8083`); a stale
+  namespace there makes the hub→provider proxy return **502** (and the OAuth
+  button stays hidden). Leaving `catalogEntry.enabled=true` lets the init
+  container keep `backend.url` in sync with the release namespace automatically.
+- After install, verify the OAuth probe returns `{"enabled":true}`:
+  ```sh
+  curl -s https://console.faros.sh/services/providers/code/oauth/github/config
+  ```
 
 `values.yaml` documents the full surface — image, replicas, hub URL + token
 Secret, the runtime kubeconfig Secret name, the `githubOAuth.*` block, the
@@ -225,7 +304,7 @@ the connection token's `read:packages` scope.
 | `KEDGE_DEV_ALLOW_TENANT_QUERY` | (unset) | `true` lets `?tenant=`/`?token=` replace identity headers (dev only) |
 | `GITHUB_OAUTH_CLIENT_ID` | (unset → OAuth off) | GitHub OAuth App client ID |
 | `GITHUB_OAUTH_CLIENT_SECRET` | (unset) | GitHub OAuth App client secret |
-| `GITHUB_OAUTH_REDIRECT_URL` | (unset) | Absolute callback URL on the provider's own host |
+| `GITHUB_OAUTH_REDIRECT_URL` | (unset) | Absolute callback URL (must end in `/callback`); either the hub `/services/providers/code/oauth/github/callback` proxy route or the provider's own host. `/start` is derived from it |
 | `GITHUB_OAUTH_PORTAL_ORIGIN` | `*` | postMessage target origin (set to the hub origin in prod) |
 | `GITHUB_OAUTH_SCOPES` | `repo,read:org,admin:public_key,read:packages` | Requested OAuth scopes |
 

--- a/providers/code/deploy/chart/templates/catalogentry.yaml
+++ b/providers/code/deploy/chart/templates/catalogentry.yaml
@@ -1,40 +1,53 @@
 {{- if .Values.catalogEntry.enabled -}}
 # CatalogEntry registers this provider with the kedge hub for routing + the
-# portal Enable flow. It only REFERENCES the APIExport (apiExport.name); the
-# APIExport, its APIResourceSchemas, the APIExportEndpointSlice, and the bind
-# grant are created by this chart's init container (provider `init`, via the
-# kedge-provider-sdk) using the onboarded kubeconfig. The hub no longer
-# provisions anything from this CatalogEntry.
-apiVersion: providers.kedge.faros.sh/v1alpha1
-kind: CatalogEntry
+# portal Enable flow. It is a kcp resource (providers.kedge.faros.sh/v1alpha1),
+# so it MUST NOT be applied to the hosting cluster where this chart installs.
+# Instead the chart renders it into a ConfigMap that the init container mounts
+# and applies into the provider workspace via the provider kubeconfig
+# (KEDGE_CATALOGENTRY_FILE -> sdkinstall.Bootstrap). The hub watches
+# CatalogEntries in every workspace bound to providers.kedge.faros.sh, including
+# the provider's own, so a self-registered entry is seen.
+#
+# It only REFERENCES the APIExport (apiExport.name); the APIExport, its
+# APIResourceSchemas, the APIExportEndpointSlice, and the bind grant are created
+# by the same init container. The hub no longer provisions anything from this
+# CatalogEntry.
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: code
+  name: {{ include "code.fullname" . }}-catalogentry
   labels:
     {{- include "code.labels" . | nindent 4 }}
-spec:
-  displayName: "Code"
-  description: "Manage source-code repositories and access across git providers (GitHub)."
-  vendor: "kedge"
-  version: {{ .Chart.AppVersion | quote }}
-  category: "Developer"
-  iconURL: "/ui/providers/code/icon.svg"
-  ui:
-    url: "http://{{ include "code.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    indexPath: "/"
-    children:
-      - displayName: Connections
-        builtinRoute: connections
-      - displayName: Repositories
-        builtinRoute: repositories
-      - displayName: Packages
-        builtinRoute: packages
-  backend:
-    url: "http://{{ include "code.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    healthPath: "/healthz"
-  apiExport:
-    name: "code.providers.kedge.faros.sh"
-    permissionClaims:
-      - resource: secrets
-        verbs: [get, list, watch, create, update, patch, delete]
-        tenantScoped: true
+data:
+  catalogentry.yaml: |
+    apiVersion: providers.kedge.faros.sh/v1alpha1
+    kind: CatalogEntry
+    metadata:
+      name: code
+    spec:
+      displayName: "Code"
+      description: "Manage source-code repositories and access across git providers (GitHub)."
+      vendor: "kedge"
+      version: {{ .Chart.AppVersion | quote }}
+      category: "Developer"
+      iconURL: "/ui/providers/code/icon.svg"
+      ui:
+        url: "http://{{ include "code.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        indexPath: "/"
+        children:
+          - displayName: Connections
+            builtinRoute: connections
+          - displayName: Repositories
+            builtinRoute: repositories
+          - displayName: Packages
+            builtinRoute: packages
+      backend:
+        url: "http://{{ include "code.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        healthPath: "/healthz"
+      apiExport:
+        name: "code.providers.kedge.faros.sh"
+        permissionClaims:
+          - resource: secrets
+            verbs: [get, list, watch, create, update, patch, delete]
+            tenantScoped: true
 {{- end }}

--- a/providers/code/deploy/chart/templates/deployment.yaml
+++ b/providers/code/deploy/chart/templates/deployment.yaml
@@ -38,10 +38,23 @@ spec:
               value: /var/run/secrets/kedge/kedge-provider-kubeconfig
             - name: KEDGE_SCHEMAS_DIR
               value: /etc/kedge/schemas
+            {{- if .Values.catalogEntry.enabled }}
+            # The CatalogEntry is a kcp resource, so the chart cannot apply it to
+            # the hosting cluster. It is rendered into a ConfigMap (mounted below)
+            # and init self-registers it into the provider workspace via the
+            # provider kubeconfig.
+            - name: KEDGE_CATALOGENTRY_FILE
+              value: /etc/kedge/catalogentry/catalogentry.yaml
+            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
               readOnly: true
+            {{- if .Values.catalogEntry.enabled }}
+            - name: catalogentry
+              mountPath: /etc/kedge/catalogentry
+              readOnly: true
+            {{- end }}
       containers:
         - name: provider
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -129,6 +142,11 @@ spec:
             items:
               - key: kubeconfig
                 path: kedge-provider-kubeconfig
+        {{- if .Values.catalogEntry.enabled }}
+        - name: catalogentry
+          configMap:
+            name: {{ include "code.fullname" . }}-catalogentry
+        {{- end }}
         - name: commit-bundles
           {{- if .Values.bundleStore.existingClaim }}
           persistentVolumeClaim:

--- a/providers/code/deploy/chart/values.yaml
+++ b/providers/code/deploy/chart/values.yaml
@@ -52,10 +52,15 @@ githubOAuth:
   clientSecretRef:
     name: ""
     key: clientSecret
-  # Absolute callback URL registered on the GitHub OAuth App. The callback is a
-  # top-level redirect from GitHub (no kedge auth), so this must point at the
-  # provider's OWN externally-reachable URL, not the hub /services proxy —
-  # e.g. https://code.example.com/oauth/github/callback.
+  # Absolute callback URL registered on the GitHub OAuth App. It is a top-level
+  # redirect from GitHub (no kedge auth), so it must be publicly reachable and
+  # forward to the provider's HTTP backend. Two options — both end in /callback:
+  #   1. Reuse the hub ingress via its /services proxy (no extra ingress needed):
+  #      https://<hub-host>/services/providers/code/oauth/github/callback
+  #   2. The provider's own externally-reachable host:
+  #      https://code.example.com/oauth/github/callback
+  # The matching /start URL is derived by swapping /callback → /start under the
+  # same host+path prefix.
   redirectURL: ""
   # postMessage target origin the popup returns the token to (the hub/portal
   # origin). Empty broadcasts to "*" — set this in production.
@@ -85,9 +90,12 @@ bundleStore:
       - ReadWriteOnce
     storageClassName: ""
 
-# When true, the chart also renders the CatalogEntry that registers the provider
-# (with its four APIResourceSchemas) with the hub. Set to false to manage the
-# CatalogEntry separately (e.g. GitOps with a different rollout cadence).
+# When true, the chart renders the CatalogEntry (which registers the provider
+# with the hub) into a ConfigMap that the init container applies into the
+# provider workspace via the provider kubeconfig. The CatalogEntry is a kcp
+# resource, so it is NOT applied to the hosting cluster this chart installs into.
+# Set to false to manage the CatalogEntry separately (e.g. GitOps with a
+# different rollout cadence).
 catalogEntry:
   enabled: true
 

--- a/providers/code/oauthgithub/oauth.go
+++ b/providers/code/oauthgithub/oauth.go
@@ -73,7 +73,23 @@ func FromEnv() (cfg Config, enabled bool, err error) {
 	if err != nil {
 		return Config{}, false, fmt.Errorf("GITHUB_OAUTH_REDIRECT_URL: %w", err)
 	}
-	cfg.StartURL = u.Scheme + "://" + u.Host + "/oauth/github/start"
+	// Derive the start URL from the callback by swapping the trailing "/callback"
+	// path segment for "/start", preserving whatever host AND path prefix the
+	// callback carries. This lets the callback ride the hub's existing
+	// /services/providers/{name}/* proxy route (e.g.
+	// https://hub/services/providers/code/oauth/github/callback) so no extra
+	// per-provider ingress is needed — start derives to the matching
+	// .../oauth/github/start under the same prefix. A bare provider-host callback
+	// (https://code.example.com/oauth/github/callback) still derives to
+	// https://code.example.com/oauth/github/start as before.
+	if !strings.HasSuffix(u.Path, "/callback") {
+		return Config{}, false, fmt.Errorf("GITHUB_OAUTH_REDIRECT_URL path must end in /callback, got %q", u.Path)
+	}
+	startU := *u
+	startU.Path = strings.TrimSuffix(u.Path, "/callback") + "/start"
+	startU.RawQuery = ""
+	startU.Fragment = ""
+	cfg.StartURL = startU.String()
 
 	cfg.PortalOrigin = os.Getenv("GITHUB_OAUTH_PORTAL_ORIGIN")
 	if cfg.PortalOrigin == "" {

--- a/providers/infrastructure/deploy/chart/templates/catalogentry.yaml
+++ b/providers/infrastructure/deploy/chart/templates/catalogentry.yaml
@@ -1,4 +1,9 @@
-{{- if .Values.catalogEntry.enabled -}}
+{{- if and .Values.bootstrap.enabled .Values.catalogEntry.enabled -}}
+# Only rendered in bootstrap mode (bootstrap.enabled): the bootstrap init
+# container mounts this ConfigMap and applies the CatalogEntry into kcp via the
+# provider kubeconfig. In hub-provisioned mode (bootstrap.enabled=false) there is
+# no init container, so the entry is registered out-of-band, not from here.
+#
 # CatalogEntry registers this provider with the kedge hub. The hub's
 # catalog controller picks it up, materializes
 # root:kedge:providers:infrastructure, mints
@@ -9,6 +14,12 @@
 # purely to grant this provider the `secrets get/list/watch`
 # permission claim — there's no kedge-side CRD for tenants to use
 # yet (the broker model puts the UI in front of the work).
+#
+# The CatalogEntry is a kcp resource (providers.kedge.faros.sh/v1alpha1),
+# so it MUST NOT be applied to the hosting cluster where this chart
+# installs. Instead the chart renders it into the ConfigMap below; the
+# init container mounts it and applies it into the provider workspace via
+# the provider kubeconfig (KEDGE_CATALOGENTRY_FILE -> sdkinstall.Bootstrap).
 #
 # ════════════════════════════════════════════════════════════════════════
 # Provider object reference — kind: CatalogEntry (providers.kedge.faros.sh)
@@ -48,42 +59,48 @@
 #     schemas[]                Inline APIResourceSchemas to install ({groupResource,
 #                              body}); [] = pure broker, no CRDs leak to tenants.
 # ════════════════════════════════════════════════════════════════════════
-apiVersion: providers.kedge.faros.sh/v1alpha1
-kind: CatalogEntry
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: infrastructure
+  name: {{ include "infrastructure.fullname" . }}-catalogentry
   labels:
     {{- include "infrastructure.labels" . | nindent 4 }}
-spec:
-  displayName: "Application Templates"
-  description: "Provision applications and infrastructure from curated templates."
-  vendor: "kedge"
-  version: {{ .Chart.AppVersion | quote }}
-  category: "Workloads"
-  iconURL: "/ui/providers/infrastructure/icon.svg"
-  ui:
-    url: "http://{{ include "infrastructure.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    indexPath: "/"
-    # Sub-nav entries shown indented under "Application Templates" in
-    # the portal side menu. The portal composes each child URL as
-    # /providers/infrastructure/{builtinRoute}; the micro-frontend
-    # reads the trailing segment off kedgeContext.subPath and routes
-    # to the matching internal page. Mirrors kubernetes-edges → Workloads.
-    children:
-      - displayName: Templates
-        builtinRoute: templates
-      - displayName: Instances
-        builtinRoute: instances
-  backend:
-    url: "http://{{ include "infrastructure.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    healthPath: "/healthz"
-  # Reference-only. The APIExport + its dynamically-generated schemas + the bind
-  # grant are created by this chart's init container (provider `init`); the hub
-  # no longer provisions.
-  apiExport:
-    name: "infrastructure.providers.kedge.faros.sh"
-    permissionClaims:
-      - resource: secrets
-        verbs: [get, list, watch]
-        tenantScoped: true
+data:
+  catalogentry.yaml: |
+    apiVersion: providers.kedge.faros.sh/v1alpha1
+    kind: CatalogEntry
+    metadata:
+      name: infrastructure
+    spec:
+      displayName: "Application Templates"
+      description: "Provision applications and infrastructure from curated templates."
+      vendor: "kedge"
+      version: {{ .Chart.AppVersion | quote }}
+      category: "Workloads"
+      iconURL: "/ui/providers/infrastructure/icon.svg"
+      ui:
+        url: "http://{{ include "infrastructure.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        indexPath: "/"
+        # Sub-nav entries shown indented under "Application Templates" in
+        # the portal side menu. The portal composes each child URL as
+        # /providers/infrastructure/{builtinRoute}; the micro-frontend
+        # reads the trailing segment off kedgeContext.subPath and routes
+        # to the matching internal page. Mirrors kubernetes-edges → Workloads.
+        children:
+          - displayName: Templates
+            builtinRoute: templates
+          - displayName: Instances
+            builtinRoute: instances
+      backend:
+        url: "http://{{ include "infrastructure.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        healthPath: "/healthz"
+      # Reference-only. The APIExport + its dynamically-generated schemas + the bind
+      # grant are created by this chart's init container (provider `init`); the hub
+      # no longer provisions.
+      apiExport:
+        name: "infrastructure.providers.kedge.faros.sh"
+        permissionClaims:
+          - resource: secrets
+            verbs: [get, list, watch]
+            tenantScoped: true
 {{- end }}

--- a/providers/infrastructure/deploy/chart/templates/deployment.yaml
+++ b/providers/infrastructure/deploy/chart/templates/deployment.yaml
@@ -53,6 +53,14 @@ spec:
             - name: KRO_KUBECONFIG
               value: /var/run/secrets/kro/kubeconfig
             {{- end }}
+            {{- if .Values.catalogEntry.enabled }}
+            # The CatalogEntry is a kcp resource, so the chart cannot apply it to
+            # the hosting cluster. It is rendered into a ConfigMap (mounted below)
+            # and init self-registers it into the provider workspace via the
+            # provider kubeconfig.
+            - name: KEDGE_CATALOGENTRY_FILE
+              value: /etc/kedge/catalogentry/catalogentry.yaml
+            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
@@ -62,6 +70,11 @@ spec:
             {{- if $centralName }}
             - name: kro-kubeconfig
               mountPath: /var/run/secrets/kro
+              readOnly: true
+            {{- end }}
+            {{- if .Values.catalogEntry.enabled }}
+            - name: catalogentry
+              mountPath: /etc/kedge/catalogentry
               readOnly: true
             {{- end }}
       {{- end }}
@@ -133,6 +146,11 @@ spec:
         {{- if .Values.bootstrap.enabled }}
         - name: tmp
           emptyDir: {}
+        {{- end }}
+        {{- if and .Values.bootstrap.enabled .Values.catalogEntry.enabled }}
+        - name: catalogentry
+          configMap:
+            name: {{ include "infrastructure.fullname" . }}-catalogentry
         {{- end }}
         - name: kedge-provider-kubeconfig
           secret:

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -100,10 +100,12 @@ bootstrap:
     name: ""
     key: kubeconfig
 
-# When true, the chart also renders the CatalogEntry that registers
-# the provider with the hub. Set to false if you want to manage the
-# CatalogEntry separately (e.g. via GitOps with different rollout
-# cadence than the workload).
+# When true, the chart renders the CatalogEntry (which registers the provider
+# with the hub) into a ConfigMap that the init container applies into the
+# provider workspace via the provider kubeconfig. The CatalogEntry is a kcp
+# resource, so it is NOT applied to the hosting cluster this chart installs into.
+# Set to false to manage the CatalogEntry separately (e.g. GitOps with a
+# different rollout cadence).
 catalogEntry:
   enabled: true
 

--- a/providers/kuery/deploy/chart/templates/catalogentry.yaml
+++ b/providers/kuery/deploy/chart/templates/catalogentry.yaml
@@ -1,44 +1,58 @@
 {{- if .Values.catalogEntry.enabled -}}
 # CatalogEntry registers this provider with the kedge hub for routing + the
-# portal Enable flow. It only REFERENCES the APIExport; the APIExport, schemas,
-# APIExportEndpointSlice, and bind grant are created by this chart's init
-# container (provider `init`, via the kedge-provider-sdk). The hub no longer
-# provisions anything from this CatalogEntry.
-apiVersion: providers.kedge.faros.sh/v1alpha1
-kind: CatalogEntry
+# portal Enable flow. It is a kcp resource (providers.kedge.faros.sh/v1alpha1),
+# so it MUST NOT be applied to the hosting cluster where this chart installs.
+# Instead the chart renders it into a ConfigMap that the init container mounts
+# and applies into the provider workspace via the provider kubeconfig
+# (KEDGE_CATALOGENTRY_FILE -> sdkinstall.Bootstrap). The hub watches
+# CatalogEntries in every workspace bound to providers.kedge.faros.sh, including
+# the provider's own, so a self-registered entry is seen.
+#
+# It only REFERENCES the APIExport (apiExport.name); the APIExport, its
+# APIResourceSchemas, the APIExportEndpointSlice, and the bind grant are created
+# by the same init container. The hub no longer provisions anything from this
+# CatalogEntry.
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: kuery
+  name: {{ include "kuery.fullname" . }}-catalogentry
   labels:
     {{- include "kuery.labels" . | nindent 4 }}
-spec:
-  displayName: "Kuery"
-  description: "Fleet-wide object search, relationships, and impact analysis across connected edge clusters."
-  vendor: "faros"
-  version: {{ .Chart.AppVersion | quote }}
-  category: "Observability"
-  iconURL: "/ui/providers/kuery/icon.svg"
-  ui:
-    url: "http://{{ include "kuery.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    indexPath: "/"
-  backend:
-    url: "http://{{ include "kuery.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    healthPath: "/healthz"
+data:
+  catalogentry.yaml: |
+    apiVersion: providers.kedge.faros.sh/v1alpha1
+    kind: CatalogEntry
+    metadata:
+      name: kuery
+    spec:
+      displayName: "Kuery"
+      description: "Fleet-wide object search, relationships, and impact analysis across connected edge clusters."
+      vendor: "faros"
+      version: {{ .Chart.AppVersion | quote }}
+      category: "Observability"
+      iconURL: "/ui/providers/kuery/icon.svg"
+      ui:
+        url: "http://{{ include "kuery.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        indexPath: "/"
+      backend:
+        url: "http://{{ include "kuery.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        healthPath: "/healthz"
 
-  # Kuery's engagement controller opens BACKGROUND connections to the
-  # tenant's edge clusters through the hub's edges-proxy (informer sync).
-  # On Enable the hub grants the provider SA the "proxy" verb on edges in
-  # the tenant workspace; removed again on Disable.
-  edgeProxyAccess: true
+      # Kuery's engagement controller opens BACKGROUND connections to the
+      # tenant's edge clusters through the hub's edges-proxy (informer sync).
+      # On Enable the hub grants the provider SA the "proxy" verb on edges in
+      # the tenant workspace; removed again on Disable.
+      edgeProxyAccess: true
 
-  apiExport:
-    name: "kuery.providers.kedge.faros.sh"
-    # The engagement controller watches the tenant's Edge objects (via the
-    # APIExport virtual workspace) to know which edges to engage/disengage.
-    # First-party claim: the init container stamps its identityHash from
-    # apiExport.edgesIdentityHash (Helm value, copied from /bonkers).
-    permissionClaims:
-      - resource: edges
-        group: kedge.faros.sh
-        verbs: [get, list, watch]
-        tenantScoped: true
+      apiExport:
+        name: "kuery.providers.kedge.faros.sh"
+        # The engagement controller watches the tenant's Edge objects (via the
+        # APIExport virtual workspace) to know which edges to engage/disengage.
+        # First-party claim: the init container stamps its identityHash from
+        # apiExport.edgesIdentityHash (Helm value, copied from /bonkers).
+        permissionClaims:
+          - resource: edges
+            group: kedge.faros.sh
+            verbs: [get, list, watch]
+            tenantScoped: true
 {{- end }}

--- a/providers/kuery/deploy/chart/templates/deployment.yaml
+++ b/providers/kuery/deploy/chart/templates/deployment.yaml
@@ -39,10 +39,23 @@ spec:
               value: /etc/kedge/schemas
             - name: KUERY_EDGES_IDENTITY_HASH
               value: {{ .Values.apiExport.edgesIdentityHash | quote }}
+            {{- if .Values.catalogEntry.enabled }}
+            # The CatalogEntry is a kcp resource, so the chart cannot apply it to
+            # the hosting cluster. It is rendered into a ConfigMap (mounted below)
+            # and init self-registers it into the provider workspace via the
+            # provider kubeconfig.
+            - name: KEDGE_CATALOGENTRY_FILE
+              value: /etc/kedge/catalogentry/catalogentry.yaml
+            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
               readOnly: true
+            {{- if .Values.catalogEntry.enabled }}
+            - name: catalogentry
+              mountPath: /etc/kedge/catalogentry
+              readOnly: true
+            {{- end }}
       containers:
         - name: provider
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -113,6 +126,11 @@ spec:
             items:
               - key: kubeconfig
                 path: kedge-provider-kubeconfig
+        {{- if .Values.catalogEntry.enabled }}
+        - name: catalogentry
+          configMap:
+            name: {{ include "kuery.fullname" . }}-catalogentry
+        {{- end }}
         - name: store
           {{- if .Values.store.persistence.enabled }}
           persistentVolumeClaim:

--- a/providers/kuery/deploy/chart/values.yaml
+++ b/providers/kuery/deploy/chart/values.yaml
@@ -69,9 +69,12 @@ sync:
     horizontalpodautoscalers.autoscaling
   blacklist: ""
 
-# When true, the chart also renders the CatalogEntry that registers the
-# provider with the hub. Set to false to manage the CatalogEntry separately
-# (e.g. via GitOps with a different rollout cadence than the workload).
+# When true, the chart renders the CatalogEntry (which registers the provider
+# with the hub) into a ConfigMap that the init container applies into the
+# provider workspace via the provider kubeconfig. The CatalogEntry is a kcp
+# resource, so it is NOT applied to the hosting cluster this chart installs into.
+# Set to false to manage the CatalogEntry separately (e.g. GitOps with a
+# different rollout cadence).
 catalogEntry:
   enabled: true
 

--- a/providers/quickstart/deploy/chart/templates/catalogentry.yaml
+++ b/providers/quickstart/deploy/chart/templates/catalogentry.yaml
@@ -1,33 +1,47 @@
 {{- if .Values.catalogEntry.enabled -}}
 # CatalogEntry registers this provider with the kedge hub for routing + the
-# portal Enable flow. It only REFERENCES the APIExport; the APIExport, schemas,
-# APIExportEndpointSlice, and bind grant are created by this chart's init
-# container (provider `init`, via the kedge-provider-sdk). The hub no longer
-# provisions anything from this CatalogEntry.
-apiVersion: providers.kedge.faros.sh/v1alpha1
-kind: CatalogEntry
+# portal Enable flow. It is a kcp resource (providers.kedge.faros.sh/v1alpha1),
+# so it MUST NOT be applied to the hosting cluster where this chart installs.
+# Instead the chart renders it into a ConfigMap that the init container mounts
+# and applies into the provider workspace via the provider kubeconfig
+# (KEDGE_CATALOGENTRY_FILE -> sdkinstall.Bootstrap). The hub watches
+# CatalogEntries in every workspace bound to providers.kedge.faros.sh, including
+# the provider's own, so a self-registered entry is seen.
+#
+# It only REFERENCES the APIExport (apiExport.name); the APIExport, its
+# APIResourceSchemas, the APIExportEndpointSlice, and the bind grant are created
+# by the same init container. The hub no longer provisions anything from this
+# CatalogEntry.
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: quickstart
+  name: {{ include "quickstart.fullname" . }}-catalogentry
   labels:
     {{- include "quickstart.labels" . | nindent 4 }}
-spec:
-  displayName: "Quickstart"
-  description: "Reference provider demonstrating the kedge plugin surface."
-  vendor: "kedge"
-  version: {{ .Chart.AppVersion | quote }}
-  category: "Demo"
-  iconURL: "/ui/providers/quickstart/icon.svg"
-  ui:
-    url: "http://{{ include "quickstart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    indexPath: "/"
-  backend:
-    url: "http://{{ include "quickstart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
-    healthPath: "/healthz"
-  apiExport:
-    name: "quickstart.providers.kedge.faros.sh"
-    # Demo-only claim so the Enable dialog has something to render.
-    permissionClaims:
-      - resource: configmaps
-        verbs: [get, list, watch]
-        tenantScoped: true
+data:
+  catalogentry.yaml: |
+    apiVersion: providers.kedge.faros.sh/v1alpha1
+    kind: CatalogEntry
+    metadata:
+      name: quickstart
+    spec:
+      displayName: "Quickstart"
+      description: "Reference provider demonstrating the kedge plugin surface."
+      vendor: "kedge"
+      version: {{ .Chart.AppVersion | quote }}
+      category: "Demo"
+      iconURL: "/ui/providers/quickstart/icon.svg"
+      ui:
+        url: "http://{{ include "quickstart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        indexPath: "/"
+      backend:
+        url: "http://{{ include "quickstart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}"
+        healthPath: "/healthz"
+      apiExport:
+        name: "quickstart.providers.kedge.faros.sh"
+        # Demo-only claim so the Enable dialog has something to render.
+        permissionClaims:
+          - resource: configmaps
+            verbs: [get, list, watch]
+            tenantScoped: true
 {{- end }}

--- a/providers/quickstart/deploy/chart/templates/deployment.yaml
+++ b/providers/quickstart/deploy/chart/templates/deployment.yaml
@@ -35,10 +35,23 @@ spec:
               value: /var/run/secrets/kedge/kedge-provider-kubeconfig
             - name: KEDGE_SCHEMAS_DIR
               value: /etc/kedge/schemas
+            {{- if .Values.catalogEntry.enabled }}
+            # The CatalogEntry is a kcp resource, so the chart cannot apply it to
+            # the hosting cluster. It is rendered into a ConfigMap (mounted below)
+            # and init self-registers it into the provider workspace via the
+            # provider kubeconfig.
+            - name: KEDGE_CATALOGENTRY_FILE
+              value: /etc/kedge/catalogentry/catalogentry.yaml
+            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
               readOnly: true
+            {{- if .Values.catalogEntry.enabled }}
+            - name: catalogentry
+              mountPath: /etc/kedge/catalogentry
+              readOnly: true
+            {{- end }}
       containers:
         - name: provider
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -83,6 +96,11 @@ spec:
             items:
               - key: kubeconfig
                 path: kedge-provider-kubeconfig
+        {{- if .Values.catalogEntry.enabled }}
+        - name: catalogentry
+          configMap:
+            name: {{ include "quickstart.fullname" . }}-catalogentry
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/providers/quickstart/deploy/chart/values.yaml
+++ b/providers/quickstart/deploy/chart/values.yaml
@@ -38,9 +38,12 @@ hub:
 providerKubeconfig:
   secretName: kedge-provider-kubeconfig
 
-# When true, the chart also renders the CatalogEntry that registers the
-# provider with the hub. Set to false to manage the CatalogEntry separately
-# (e.g. via GitOps with a different rollout cadence than the workload).
+# When true, the chart renders the CatalogEntry (which registers the provider
+# with the hub) into a ConfigMap that the init container applies into the
+# provider workspace via the provider kubeconfig. The CatalogEntry is a kcp
+# resource, so it is NOT applied to the hosting cluster this chart installs into.
+# Set to false to manage the CatalogEntry separately (e.g. GitOps with a
+# different rollout cadence).
 catalogEntry:
   enabled: true
 

--- a/providers/quickstart/init_cmd.go
+++ b/providers/quickstart/init_cmd.go
@@ -41,6 +41,9 @@ func runInitCmd(ctx context.Context) error {
 	if schemasDir == "" {
 		schemasDir = "/etc/kedge/schemas"
 	}
+	// CatalogEntry self-registration: the provider applies its own CatalogEntry
+	// into its workspace (the hub watches it there). Empty → skip.
+	catalogEntryFile := os.Getenv("KEDGE_CATALOGENTRY_FILE")
 
 	if err := sdkinstall.Bootstrap(ctx, sdkinstall.Options{
 		Config:        config,
@@ -51,10 +54,11 @@ func runInitCmd(ctx context.Context) error {
 		Claims: []sdkinstall.PermissionClaim{
 			{Resource: "configmaps", Verbs: []string{"get", "list", "watch"}},
 		},
+		CatalogEntryFile: catalogEntryFile,
 	}); err != nil {
 		return fmt.Errorf("provider workspace bootstrap: %w", err)
 	}
-	log.Printf("quickstart-provider init: workspace bootstrapped (export=%s path=%s schemas=%s)", apiExportName, workspacePath, schemasDir)
+	log.Printf("quickstart-provider init: workspace bootstrapped (export=%s path=%s schemas=%s catalogEntry=%s)", apiExportName, workspacePath, schemasDir, catalogEntryFile)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Reworks how kedge providers bootstrap themselves into kcp and how their images/charts are versioned and published. The headline change: a provider's **CatalogEntry is no longer rendered as a live kcp CRD into the hosting cluster** (which fails with `no matches for kind "CatalogEntry"` on a plain cluster) — instead the chart renders it into a ConfigMap that the provider's **init container applies into the provider workspace** via the provider kubeconfig.

Applies across all five providers: **code, quickstart, app-studio, kuery, infrastructure**.

## CatalogEntry self-registration via the init container

Previously `helm install` tried to create a `providers.kedge.faros.sh/v1alpha1 CatalogEntry` in whatever cluster helm targeted — the hosting cluster — where the CRD doesn't exist. The CatalogEntry is a kcp resource and must live in the provider workspace.

Each provider chart now:
- Renders the CatalogEntry into a **ConfigMap** (`<release>-catalogentry`) under `data."catalogentry.yaml"`, instead of a live CRD.
- Mounts that ConfigMap into the init container and sets `KEDGE_CATALOGENTRY_FILE=/etc/kedge/catalogentry/catalogentry.yaml`.
- The init binary (`sdkinstall.Bootstrap`) self-registers the CatalogEntry into the provider workspace using the mounted kubeconfig — the same workspace the hub already watches for `providers.kedge.faros.sh`.
- All wiring is gated on `catalogEntry.enabled` (default true); setting it false cleanly removes the ConfigMap, volume, mount, and env.

`quickstart/init_cmd.go` was updated to pass `CatalogEntryFile` to `Bootstrap` (the other four providers' init already read the env).

**infrastructure** is special-cased: its init container (`bootstrap`) only runs when `bootstrap.enabled=true`, so the catalogentry ConfigMap **and** volume are gated on `bootstrap.enabled` too — avoiding an orphan volume / dangling ConfigMap in the default hub-provisioned mode.

## Per-provider image & chart versioning

Provider images and charts were published stamped with the **hub** version, so per-provider release tags (`providers/<name>/vX.Y.Z`) never affected the deployed artifact. This PR moves provider image+chart publishing into the monorepo, keyed off the per-provider tag:
- `provider-release.yaml`: sole publisher of provider images+charts, triggered on `providers/<name>/v*`, stamping the chart's `version`/`appVersion` to the provider's own version.
- `images.yaml` / `helm-images.yaml`: provider artifacts are PR-build/lint-only validation; the hub release publishes platform charts only.
- `split-*.yaml`: made source-only so the mirror repos stop rebuilding and colliding on the same tags.
- `cmd/kedge-release`: stamp chart `version`/`appVersion` via `helm package` flags instead of `sed -i` (which silently no-ops and mutates the tree).

## Verification
- `helm lint` passes on all five provider charts.
- **0** top-level `kind: CatalogEntry` resources rendered anywhere (the original install error is gone).
- Embedded CatalogEntry YAML parses for every provider with provider-specific fields preserved (app-studio `builtin` annotation + `dependencies`, kuery `edgeProxyAccess` + `edges` claim group, infra children + `Application Templates`).
- Mount/volume balanced (no orphan volumes); `catalogEntry.enabled=false` removes everything; infra verified in both `bootstrap.enabled` on/off modes.
- `quickstart` Go builds.

