### PR TITLE
Bump kuery to 7fcd75d (UNION id type fix)

### DIFF
--- a/providers/kuery/engagement/controller.go
+++ b/providers/kuery/engagement/controller.go
@@ -44,6 +44,7 @@ import (
 	apiskcpv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	kuerystore "github.com/faroshq/kuery/pkg/store"
@@ -300,7 +301,7 @@ func (c *Controller) engage(ctx context.Context, key, tenantCluster, edgeName, t
 		return fmt.Errorf("cache sync failed for edge %s", storeName)
 	}
 
-	if err := c.cfg.Sync.Engage(clusterCtx, storeName, cl); err != nil {
+	if err := c.cfg.Sync.Engage(clusterCtx, multicluster.ClusterName(storeName), cl); err != nil {
 		cancel()
 		return fmt.Errorf("kuery engage: %w", err)
 	}

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -3,7 +3,7 @@ module github.com/faroshq/provider-kuery
 go 1.26.3
 
 require (
-	github.com/faroshq/kuery v0.0.0-20260614065711-08329d47d344
+	github.com/faroshq/kuery v0.0.0-20260620061119-7fcd75d5dcc3
 	github.com/faroshq/provider-sdk v0.0.1
 	github.com/kcp-dev/multicluster-provider v0.8.0
 	github.com/kcp-dev/sdk v0.32.0

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -22,8 +22,8 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/kuery v0.0.0-20260614065711-08329d47d344 h1:Magn//NZd+GAeX3X1U8+kFJAwUiy/WkrzOU5lXoiB+c=
-github.com/faroshq/kuery v0.0.0-20260614065711-08329d47d344/go.mod h1:xfFaDclu0sX98zyI1N9C63Hwuhvg5g2oIs93dqzl3kk=
+github.com/faroshq/kuery v0.0.0-20260620061119-7fcd75d5dcc3 h1:UMBBoROdCvdJBNselQqEsI8Ikl02Qf2ucl0bo0R3cGg=
+github.com/faroshq/kuery v0.0.0-20260620061119-7fcd75d5dcc3/go.mod h1:TfZU4DmN/ir3/3XSkVoLhXXoIed8cu8jaQMBYWigJmY=
 github.com/faroshq/provider-sdk v0.0.1 h1:nJeNHfYfuUf+nyd6/iSC6xWAJuSjiSZYtnDW6yAMWys=
 github.com/faroshq/provider-sdk v0.0.1/go.mod h1:0nSxc6lF9tux2DHDc7mPx3z3x98xZUduNjStTgdqG/E=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
## What

Bumps `github.com/faroshq/kuery` in the kuery provider to [`7fcd75d`](https://github.com/faroshq/kuery/commit/7fcd75d5dcc35ec94688f656e8b5ab08631467fc) (`v0.0.0-20260620061119-7fcd75d5dcc3`).

## Why

That commit fixes the Postgres `UNION types character varying and uuid cannot be matched` error (SQLSTATE **42804**) seen in the kuery provider logs. It occurred on **clusters-rooted queries with relations** (the Topology / cluster-graph view): the `UNION ALL` paired a root branch whose `id` is `clusters.name` (varchar) with relation branches whose `id` is `objects.id` (uuid). The fix casts `id` to text across all union branches so the types match.

## Provider-side change

The same kuery commit retyped `SyncController.Engage` to take a `multicluster.ClusterName` instead of a `string`, so `storeName` is converted at the engagement call site (`Disengage` still takes a string and is unchanged).

- `providers/kuery/go.mod` / `go.sum` — version bump
- `providers/kuery/engagement/controller.go` — import `multicluster`, wrap `storeName` in `multicluster.ClusterName(...)`

Builds clean (`go build ./...`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)