### PR TITLE
Bump kuery to 3fbe9b2 (jsonb UNION fix + clusters-root e2e)

### DIFF
--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -3,7 +3,7 @@ module github.com/faroshq/provider-kuery
 go 1.26.3
 
 require (
-	github.com/faroshq/kuery v0.0.0-20260620061119-7fcd75d5dcc3
+	github.com/faroshq/kuery v0.0.0-20260620133059-3fbe9b2ef4c4
 	github.com/faroshq/provider-sdk v0.0.1
 	github.com/kcp-dev/multicluster-provider v0.8.0
 	github.com/kcp-dev/sdk v0.32.0

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -22,8 +22,8 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/kuery v0.0.0-20260620061119-7fcd75d5dcc3 h1:UMBBoROdCvdJBNselQqEsI8Ikl02Qf2ucl0bo0R3cGg=
-github.com/faroshq/kuery v0.0.0-20260620061119-7fcd75d5dcc3/go.mod h1:TfZU4DmN/ir3/3XSkVoLhXXoIed8cu8jaQMBYWigJmY=
+github.com/faroshq/kuery v0.0.0-20260620133059-3fbe9b2ef4c4 h1:RfrWoyFSq9LEAdJ4mXdCySv4dg8s2lNwuhiqiheaSoE=
+github.com/faroshq/kuery v0.0.0-20260620133059-3fbe9b2ef4c4/go.mod h1:TfZU4DmN/ir3/3XSkVoLhXXoIed8cu8jaQMBYWigJmY=
 github.com/faroshq/provider-sdk v0.0.1 h1:nJeNHfYfuUf+nyd6/iSC6xWAJuSjiSZYtnDW6yAMWys=
 github.com/faroshq/provider-sdk v0.0.1/go.mod h1:0nSxc6lF9tux2DHDc7mPx3z3x98xZUduNjStTgdqG/E=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
## What

Bumps `github.com/faroshq/kuery` in the kuery provider to [`3fbe9b2`](https://github.com/faroshq/kuery/commit/3fbe9b2ef4c4) (`v0.0.0-20260620133059-3fbe9b2ef4c4`).

## Why

Follow-up to #323. That PR pinned kuery at `7fcd75d`, which fixed only the first half of the clusters-rooted UNION bug (the `id` uuid/varchar mismatch). A second `42804` then surfaced in the provider logs:

```
ERROR: UNION types text and jsonb cannot be matched (SQLSTATE 42804)
```

`3fbe9b2` fixes it: the synthesized `annotations`/`owner_refs`/`conditions` columns in the clusters-rooted branch are now typed `jsonb` on Postgres (`'{}'::jsonb` / `'[]'::jsonb`) so they match the `objects` table's jsonb columns in the `UNION ALL`.

## Catching this earlier

`3fbe9b2` also adds a `Root: clusters` Postgres e2e test (`TestPostgres_ClusterRoot`) — the only path that builds the failing union. It was verified to reproduce **both** `42804` variants against the real-Postgres testcontainer (SQLite is dynamically typed and never caught them):

- fix in place → PASS
- fix reverted → FAIL with the exact production error

go.mod/go.sum only; provider builds clean (`go build ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)