### PR TITLE
[codex] Move App Studio workflows into Eino

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -777,9 +777,9 @@ KROMC_MANIFEST ?= providers/infrastructure/manifest.yaml
 KROMC_PROVIDER_MANIFEST ?= providers/infrastructure/provider.yaml
 
 # --- App Studio provider (local dev) ---
-# Same pattern as quickstart/infrastructure, but the CatalogEntry template
-# defaults to the cluster Service DNS and the helper target below overrides
-# only the UI URL for local host access.
+# Same pattern as quickstart/infrastructure/code: local dev applies the
+# checked-in manifest.yaml; the Helm chart's CatalogEntry is for in-cluster
+# self-registration via ConfigMap.
 APP_STUDIO_PORT ?= 8085
 APP_STUDIO_HUB_URL ?= https://localhost:9443
 APP_STUDIO_TOKEN ?= $(STATIC_AUTH_TOKEN)
@@ -788,19 +788,8 @@ APP_STUDIO_KCP_SERVER ?= https://localhost:6443
 APP_STUDIO_WORKSPACE_PATH ?= root:kedge:providers:app-studio
 APP_STUDIO_RUNTIME_KUBECONFIG ?= $(KCP_DATA_DIR)/app-studio-runtime.kubeconfig
 APP_STUDIO_SCHEMAS_DIR ?= providers/app-studio/deploy/chart/files/schemas
-APP_STUDIO_HELM_RELEASE ?= app-studio
-APP_STUDIO_HELM_NAMESPACE ?= app-studio
-APP_STUDIO_CHART ?= providers/app-studio/deploy/chart
+APP_STUDIO_MANIFEST ?= providers/app-studio/manifest.yaml
 APP_STUDIO_PROVIDER_MANIFEST ?= providers/app-studio/provider.yaml
-APP_STUDIO_CATALOGENTRY_UI_URL ?= http://localhost:$(APP_STUDIO_PORT)
-# The backend (REST/LLM API) is reverse-proxied by the hub too, to the SAME
-# host:port as the UI (one provider process serves both). It must point at the
-# running provider — loopback for the all-host flow, host.docker.internal for
-# the in-cluster hub flow — not the chart's Service DNS, or
-# /services/providers/app-studio/* returns 502. Tracking UI_URL makes both
-# Tiltfiles work without a separate override.
-APP_STUDIO_CATALOGENTRY_BACKEND_URL ?= $(APP_STUDIO_CATALOGENTRY_UI_URL)
-APP_STUDIO_CATALOGENTRY_RENDERED ?= /tmp/kedge-app-studio-catalogentry.yaml
 APP_STUDIO_DATABASE_URL ?=
 APP_STUDIO_IN_MEMORY_MESSAGE_STORE ?=
 APP_STUDIO_AUTO_APPROVE_ACTIONS ?= true
@@ -934,28 +923,16 @@ run-provider-app-studio: build-app-studio-provider app-studio-db-up ## Run the A
 	fi
 
 ## Apply the App Studio CatalogEntry into root:kedge:providers. Idempotent.
-## Renders only the CatalogEntry from the Helm chart so host-cluster objects
-## from the full chart never touch the KCP workspace. The chart normally renders
-## the CatalogEntry into a ConfigMap for in-cluster init self-registration; dev
-## registration renders the CatalogEntry directly for kcp.
-install-provider-app-studio: ## Apply App Studio CatalogEntry into root:kedge:providers
+install-provider-app-studio: ## Apply App Studio Provider + CatalogEntry into root:kedge:providers
 	@test -f $(APP_STUDIO_KCP_KUBECONFIG) || { \
 		echo "kubeconfig not found at $(APP_STUDIO_KCP_KUBECONFIG)"; \
 		echo "start the hub first with: make run-hub-embedded-static"; \
 		exit 1; \
 	}
-	helm template $(APP_STUDIO_HELM_RELEASE) $(APP_STUDIO_CHART) \
-		--namespace $(APP_STUDIO_HELM_NAMESPACE) \
-		--set-string catalogEntry.uiURL=$(APP_STUDIO_CATALOGENTRY_UI_URL) \
-		--set-string catalogEntry.backendURL=$(APP_STUDIO_CATALOGENTRY_BACKEND_URL) \
-		--set catalogEntry.renderAsConfigMap=false \
-		--set catalogEntry.renderDirect=true \
-		--show-only templates/catalogentry.yaml \
-		> $(APP_STUDIO_CATALOGENTRY_RENDERED)
 	kubectl --kubeconfig=$(APP_STUDIO_KCP_KUBECONFIG) \
 		--server=$(APP_STUDIO_KCP_SERVER)/clusters/root:kedge:system:providers \
 		--insecure-skip-tls-verify \
-		apply -f $(APP_STUDIO_PROVIDER_MANIFEST) -f $(APP_STUDIO_CATALOGENTRY_RENDERED)
+		apply -f $(APP_STUDIO_PROVIDER_MANIFEST) -f $(APP_STUDIO_MANIFEST)
 
 ## Create App Studio's APIExport (+ schemas + endpoint slice + bind grant) in
 ## its provider workspace so tenants can Enable it. Reads the provider-token the
@@ -992,18 +969,10 @@ uninstall-provider-app-studio: ## Delete App Studio CatalogEntry
 		echo "start the hub first with: make run-hub-embedded-static"; \
 		exit 1; \
 	}
-	helm template $(APP_STUDIO_HELM_RELEASE) $(APP_STUDIO_CHART) \
-		--namespace $(APP_STUDIO_HELM_NAMESPACE) \
-		--set-string catalogEntry.uiURL=$(APP_STUDIO_CATALOGENTRY_UI_URL) \
-		--set-string catalogEntry.backendURL=$(APP_STUDIO_CATALOGENTRY_BACKEND_URL) \
-		--set catalogEntry.renderAsConfigMap=false \
-		--set catalogEntry.renderDirect=true \
-		--show-only templates/catalogentry.yaml \
-		> $(APP_STUDIO_CATALOGENTRY_RENDERED)
 	-kubectl --kubeconfig=$(APP_STUDIO_KCP_KUBECONFIG) \
 		--server=$(APP_STUDIO_KCP_SERVER)/clusters/root:kedge:system:providers \
 		--insecure-skip-tls-verify \
-		delete -f $(APP_STUDIO_CATALOGENTRY_RENDERED) -f $(APP_STUDIO_PROVIDER_MANIFEST)
+		delete -f $(APP_STUDIO_MANIFEST) -f $(APP_STUDIO_PROVIDER_MANIFEST)
 
 ## Apply the infrastructure CatalogEntry into root:kedge:providers. Idempotent.
 ## Requires the hub to be running so the admin kubeconfig exists.

--- a/Makefile
+++ b/Makefile
@@ -935,7 +935,9 @@ run-provider-app-studio: build-app-studio-provider app-studio-db-up ## Run the A
 
 ## Apply the App Studio CatalogEntry into root:kedge:providers. Idempotent.
 ## Renders only the CatalogEntry from the Helm chart so host-cluster objects
-## from the full chart never touch the KCP workspace.
+## from the full chart never touch the KCP workspace. The chart normally renders
+## the CatalogEntry into a ConfigMap for in-cluster init self-registration; dev
+## registration renders the CatalogEntry directly for kcp.
 install-provider-app-studio: ## Apply App Studio CatalogEntry into root:kedge:providers
 	@test -f $(APP_STUDIO_KCP_KUBECONFIG) || { \
 		echo "kubeconfig not found at $(APP_STUDIO_KCP_KUBECONFIG)"; \
@@ -946,6 +948,7 @@ install-provider-app-studio: ## Apply App Studio CatalogEntry into root:kedge:pr
 		--namespace $(APP_STUDIO_HELM_NAMESPACE) \
 		--set-string catalogEntry.uiURL=$(APP_STUDIO_CATALOGENTRY_UI_URL) \
 		--set-string catalogEntry.backendURL=$(APP_STUDIO_CATALOGENTRY_BACKEND_URL) \
+		--set catalogEntry.renderAsConfigMap=false \
 		--show-only templates/catalogentry.yaml \
 		> $(APP_STUDIO_CATALOGENTRY_RENDERED)
 	kubectl --kubeconfig=$(APP_STUDIO_KCP_KUBECONFIG) \
@@ -992,6 +995,7 @@ uninstall-provider-app-studio: ## Delete App Studio CatalogEntry
 		--namespace $(APP_STUDIO_HELM_NAMESPACE) \
 		--set-string catalogEntry.uiURL=$(APP_STUDIO_CATALOGENTRY_UI_URL) \
 		--set-string catalogEntry.backendURL=$(APP_STUDIO_CATALOGENTRY_BACKEND_URL) \
+		--set catalogEntry.renderAsConfigMap=false \
 		--show-only templates/catalogentry.yaml \
 		> $(APP_STUDIO_CATALOGENTRY_RENDERED)
 	-kubectl --kubeconfig=$(APP_STUDIO_KCP_KUBECONFIG) \

--- a/Makefile
+++ b/Makefile
@@ -949,6 +949,7 @@ install-provider-app-studio: ## Apply App Studio CatalogEntry into root:kedge:pr
 		--set-string catalogEntry.uiURL=$(APP_STUDIO_CATALOGENTRY_UI_URL) \
 		--set-string catalogEntry.backendURL=$(APP_STUDIO_CATALOGENTRY_BACKEND_URL) \
 		--set catalogEntry.renderAsConfigMap=false \
+		--set catalogEntry.renderDirect=true \
 		--show-only templates/catalogentry.yaml \
 		> $(APP_STUDIO_CATALOGENTRY_RENDERED)
 	kubectl --kubeconfig=$(APP_STUDIO_KCP_KUBECONFIG) \
@@ -996,6 +997,7 @@ uninstall-provider-app-studio: ## Delete App Studio CatalogEntry
 		--set-string catalogEntry.uiURL=$(APP_STUDIO_CATALOGENTRY_UI_URL) \
 		--set-string catalogEntry.backendURL=$(APP_STUDIO_CATALOGENTRY_BACKEND_URL) \
 		--set catalogEntry.renderAsConfigMap=false \
+		--set catalogEntry.renderDirect=true \
 		--show-only templates/catalogentry.yaml \
 		> $(APP_STUDIO_CATALOGENTRY_RENDERED)
 	-kubectl --kubeconfig=$(APP_STUDIO_KCP_KUBECONFIG) \

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -416,11 +416,7 @@ def rewrite_manifest_cmd(src):
 
 QUICKSTART_REWRITE_CMD, QUICKSTART_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/quickstart/manifest.yaml')
 INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/infrastructure/manifest.yaml')
-# App Studio runs on the host like the other external providers, but the
-# hub lives inside the kind cluster, so the rendered CatalogEntry must point
-# at host.docker.internal rather than localhost.
-APP_STUDIO_CATALOGENTRY_UI_URL = 'http://host.docker.internal:8085'
-APP_STUDIO_CATALOGENTRY_BACKEND_URL = APP_STUDIO_CATALOGENTRY_UI_URL
+APP_STUDIO_REWRITE_CMD, APP_STUDIO_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/app-studio/manifest.yaml')
 CODE_REWRITE_CMD, CODE_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/code/manifest.yaml')
 KUERY_REWRITE_CMD, KUERY_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/kuery/manifest.yaml')
 
@@ -516,8 +512,7 @@ local_resource(
         'providers/app-studio/portal/src',
         'providers/app-studio/portal/package.json',
         'providers/app-studio/portal/vite.config.ts',
-        'providers/app-studio/deploy/chart/templates/catalogentry.yaml',
-        'providers/app-studio/deploy/chart/values.yaml',
+        'providers/app-studio/manifest.yaml',
         'providers/app-studio/.env',
     ],
     resource_deps=['kedge-hub', 'app-studio-db'],
@@ -538,13 +533,11 @@ local_resource(
 
 local_resource(
     'app-studio-register',
-    cmd=('APP_STUDIO_KCP_KUBECONFIG={kc} APP_STUDIO_KCP_SERVER={sv} ' +
-         'APP_STUDIO_CATALOGENTRY_UI_URL={ui} ' +
-         'APP_STUDIO_CATALOGENTRY_BACKEND_URL={backend} ' +
+    cmd=('{rewrite} && APP_STUDIO_KCP_KUBECONFIG={kc} ' +
+         'APP_STUDIO_KCP_SERVER={sv} APP_STUDIO_MANIFEST={mf} ' +
          'make install-provider-app-studio').format(
-             kc=KCP_ADMIN_KUBECONFIG, sv=KCP_ADMIN_SERVER,
-             ui=APP_STUDIO_CATALOGENTRY_UI_URL,
-             backend=APP_STUDIO_CATALOGENTRY_BACKEND_URL),
+             rewrite=APP_STUDIO_REWRITE_CMD, kc=KCP_ADMIN_KUBECONFIG,
+             sv=KCP_ADMIN_SERVER, mf=APP_STUDIO_MANIFEST_REWRITTEN),
     trigger_mode=TRIGGER_MODE_MANUAL,
     auto_init=False,
     resource_deps=['kedge-hub'],
@@ -564,13 +557,11 @@ local_resource(
 
 local_resource(
     'app-studio-unregister',
-    cmd=('APP_STUDIO_KCP_KUBECONFIG={kc} APP_STUDIO_KCP_SERVER={sv} ' +
-         'APP_STUDIO_CATALOGENTRY_UI_URL={ui} ' +
-         'APP_STUDIO_CATALOGENTRY_BACKEND_URL={backend} ' +
+    cmd=('{rewrite} && APP_STUDIO_KCP_KUBECONFIG={kc} ' +
+         'APP_STUDIO_KCP_SERVER={sv} APP_STUDIO_MANIFEST={mf} ' +
          'make uninstall-provider-app-studio').format(
-             kc=KCP_ADMIN_KUBECONFIG, sv=KCP_ADMIN_SERVER,
-             ui=APP_STUDIO_CATALOGENTRY_UI_URL,
-             backend=APP_STUDIO_CATALOGENTRY_BACKEND_URL),
+             rewrite=APP_STUDIO_REWRITE_CMD, kc=KCP_ADMIN_KUBECONFIG,
+             sv=KCP_ADMIN_SERVER, mf=APP_STUDIO_MANIFEST_REWRITTEN),
     trigger_mode=TRIGGER_MODE_MANUAL,
     auto_init=False,
     resource_deps=['kedge-hub'],

--- a/providers/app-studio/README.md
+++ b/providers/app-studio/README.md
@@ -94,5 +94,8 @@ tool.
 
 App Studio does not run build, test, preview, or log commands inside the
 provider pod. The assistant can recommend build and test checks from project
-context, but App Studio no longer advertises runtime execution tools until a
-tenant-isolated worker implementation is productized.
+context. Runtime deployment, status, and preview URL requests are exposed as
+App Studio graph workflow tools so the model gets structured handoff results and
+blockers. Until a tenant-isolated `RuntimeTarget` implementation is productized,
+those workflows return a clear not-configured result instead of executing
+provider-pod commands.

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -43,6 +43,7 @@ type projectAssistantCheckpointState struct {
 	RepeatedToolLoop     bool                                 `json:"repeatedToolLoop,omitempty"`
 	LastToolMessages     []chatMessage                        `json:"lastToolMessages,omitempty"`
 	ApprovedPlan         *projectAssistantApprovedPlan        `json:"approvedPlan,omitempty"`
+	SessionSnapshot      *projectEinoAssistantSessionSnapshot `json:"sessionSnapshot,omitempty"`
 	Eino                 *projectAssistantEinoCheckpointState `json:"eino,omitempty"`
 }
 
@@ -300,7 +301,7 @@ func projectAssistantPermissionReason(spec projectAssistantToolSpec) string {
 	case projectAssistantToolRiskCommit:
 		return "This action will commit App Studio workspace changes to the linked repository."
 	case projectAssistantToolRiskRuntime:
-		return "This action will start a sandboxed App Studio runtime command."
+		return "This action will request an App Studio runtime deployment handoff."
 	default:
 		return "This action requires approval."
 	}

--- a/providers/app-studio/api/assistant_eino_callbacks.go
+++ b/providers/app-studio/api/assistant_eino_callbacks.go
@@ -32,10 +32,16 @@ import (
 
 func projectEinoAssistantRunOptions(req projectAssistantRunRequest, runState *projectEinoAssistantRunState) []adk.AgentRunOption {
 	handler := newProjectEinoAssistantModelCallbackHandler(req.StreamCallbacks, runState)
-	if handler == nil {
-		return nil
+	opts := []adk.AgentRunOption{}
+	if handler != nil {
+		opts = append(opts, adk.WithCallbacks(handler))
 	}
-	return []adk.AgentRunOption{adk.WithCallbacks(handler)}
+	if snapshot := runState.SessionSnapshot(); snapshot != nil {
+		opts = append(opts, adk.WithSessionValues(map[string]any{
+			projectEinoAssistantSessionSnapshotKey: *snapshot,
+		}))
+	}
+	return opts
 }
 
 func newProjectEinoAssistantModelCallbackHandler(streamCallbacks projectAssistantStreamCallbacks, runState *projectEinoAssistantRunState) callbacks.Handler {
@@ -110,9 +116,6 @@ func (r *projectEinoAssistantModelCallbackRecorder) recordModelStream(output *sc
 		msg := modelOutput.Message
 		if msg.Content != "" {
 			content.WriteString(msg.Content)
-			if r.streamCallbacks.OnChunk != nil {
-				r.streamCallbacks.OnChunk(msg.Content)
-			}
 		}
 		if len(msg.ToolCalls) > 0 {
 			r.reportToolPreparation()

--- a/providers/app-studio/api/assistant_eino_callbacks_test.go
+++ b/providers/app-studio/api/assistant_eino_callbacks_test.go
@@ -73,8 +73,8 @@ func TestProjectEinoAssistantModelCallbackRecordsStreamedToolCalls(t *testing.T)
 	handler.OnEndWithStreamOutput(ctx, nil, stream)
 
 	state := runState.CheckpointState()
-	if len(chunks) != 1 || chunks[0] != "Working " {
-		t.Fatalf("chunks = %#v, want streamed content chunk", chunks)
+	if len(chunks) != 0 {
+		t.Fatalf("chunks = %#v, want model callback to avoid publishing public content chunks", chunks)
 	}
 	if len(statuses) != 1 || statuses[0] != "Preparing action" {
 		t.Fatalf("statuses = %#v, want one preparation status", statuses)
@@ -88,5 +88,29 @@ func TestProjectEinoAssistantModelCallbackRecordsStreamedToolCalls(t *testing.T)
 	call := state.ToolCalls[0]
 	if call.ID != "call-write" || call.Function.Name != projectToolWriteFile || call.Function.Arguments != `{"path":"src/App.tsx","content":"hi"}` {
 		t.Fatalf("tool call = %#v, want merged streamed function call", call)
+	}
+}
+
+func TestProjectEinoAssistantModelCallbackDoesNotPublishPublicContentChunks(t *testing.T) {
+	runState := newProjectEinoAssistantRunState()
+	var chunks []string
+	handler := newProjectEinoAssistantModelCallbackHandler(projectAssistantStreamCallbacks{
+		OnChunk: func(chunk string) { chunks = append(chunks, chunk) },
+	}, runState)
+
+	ctx := handler.OnStart(context.Background(), nil, &einomodel.CallbackInput{
+		Messages: []*schema.Message{schema.UserMessage("say thanks")},
+	})
+	stream := schema.StreamReaderFromArray([]callbacks.CallbackOutput{
+		&einomodel.CallbackOutput{Message: schema.AssistantMessage("You are welcome.", nil)},
+	})
+	handler.OnEndWithStreamOutput(ctx, nil, stream)
+
+	if len(chunks) != 0 {
+		t.Fatalf("chunks = %#v, want model callback to avoid publishing public content chunks", chunks)
+	}
+	state := runState.CheckpointState()
+	if len(state.Messages) != 2 || state.Messages[1].Content != "You are welcome." {
+		t.Fatalf("checkpoint messages = %#v, want streamed assistant reply recorded", state.Messages)
 	}
 }

--- a/providers/app-studio/api/assistant_eino_engine.go
+++ b/providers/app-studio/api/assistant_eino_engine.go
@@ -462,17 +462,13 @@ func projectEinoAssistantMessageOutput(
 			continue
 		}
 		chunks = append(chunks, msg)
+		if output.Role == schema.Assistant && streamCallbacks.OnChunk != nil && msg.Content != "" {
+			streamCallbacks.OnChunk(msg.Content)
+		}
 	}
 	msg, err := schema.ConcatMessages(chunks)
 	if err != nil {
 		return nil, err
-	}
-	if output.Role == schema.Assistant && streamCallbacks.OnChunk != nil {
-		for _, chunk := range chunks {
-			if chunk != nil && chunk.Content != "" {
-				streamCallbacks.OnChunk(chunk.Content)
-			}
-		}
 	}
 	return msg, nil
 }

--- a/providers/app-studio/api/assistant_eino_engine.go
+++ b/providers/app-studio/api/assistant_eino_engine.go
@@ -419,7 +419,7 @@ func (e projectEinoAssistantEngine) collectProjectAssistantTurnEvents(
 		if role == "" && msg != nil {
 			role = msg.Role
 		}
-		if msg != nil && role == schema.Assistant && strings.TrimSpace(msg.Content) != "" && !projectEinoAssistantMessageSuppressesPublicContent(msg) {
+		if msg != nil && role == schema.Assistant && strings.TrimSpace(msg.Content) != "" {
 			outcome.result.Content = msg.Content
 			outcome.receivedOutput = true
 		}
@@ -467,7 +467,7 @@ func projectEinoAssistantMessageOutput(
 	if err != nil {
 		return nil, err
 	}
-	if output.Role == schema.Assistant && !projectEinoAssistantMessageSuppressesPublicContent(msg) && streamCallbacks.OnChunk != nil {
+	if output.Role == schema.Assistant && streamCallbacks.OnChunk != nil {
 		for _, chunk := range chunks {
 			if chunk != nil && chunk.Content != "" {
 				streamCallbacks.OnChunk(chunk.Content)
@@ -475,33 +475,6 @@ func projectEinoAssistantMessageOutput(
 		}
 	}
 	return msg, nil
-}
-
-func projectEinoAssistantMessageHasToolCalls(msg *schema.Message) bool {
-	return msg != nil && len(msg.ToolCalls) > 0
-}
-
-func projectEinoAssistantMessageSuppressesPublicContent(msg *schema.Message) bool {
-	return projectEinoAssistantMessageHasToolCalls(msg) && projectEinoAssistantToolNarration(msg.Content)
-}
-
-func projectEinoAssistantToolNarration(content string) bool {
-	content = strings.TrimSpace(strings.ToLower(content))
-	if content == "" {
-		return false
-	}
-	for _, prefix := range []string{
-		"i will ",
-		"i'll ",
-		"i am going to ",
-		"i'm going to ",
-		"let me ",
-	} {
-		if strings.HasPrefix(content, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func (e projectEinoAssistantEngine) projectAssistantToolLoopFinalAnswer(

--- a/providers/app-studio/api/assistant_eino_engine.go
+++ b/providers/app-studio/api/assistant_eino_engine.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/cloudwego/eino/adk"
@@ -35,6 +36,10 @@ const (
 	projectEinoAssistantSummaryContextMessages = 128
 	projectEinoAssistantSummaryContextTokens   = 24000
 	projectEinoAssistantSummaryInstruction     = "Summarize this App Studio project session for the next builder turn. Preserve user requirements, accepted plans, files touched or inspected, unresolved questions, repository/runtime state, and any constraints. Keep it concise and operational."
+
+	// Bundle search is for App Studio's full product toolbox. Smaller injected
+	// tool sets stay direct so focused permission/resume flows keep their shape.
+	projectEinoAssistantBundleSearchMinTools = 4
 )
 
 type projectEinoAssistantEngine struct {
@@ -181,6 +186,8 @@ func (e projectEinoAssistantEngine) newAgent(ctx context.Context, req projectAss
 }
 
 func projectEinoAssistantToolSearchSets(ctx context.Context, tools []einotool.BaseTool) ([]einotool.BaseTool, []einotool.BaseTool, error) {
+	infos := make([]*schema.ToolInfo, 0, len(tools))
+	searchCandidateCount := 0
 	staticTools := make([]einotool.BaseTool, 0, len(tools))
 	dynamicTools := make([]einotool.BaseTool, 0, len(tools))
 	for _, tool := range tools {
@@ -191,7 +198,20 @@ func projectEinoAssistantToolSearchSets(ctx context.Context, tools []einotool.Ba
 		if err != nil {
 			return nil, nil, err
 		}
-		if projectEinoAssistantToolUsesSearch(info) {
+		infos = append(infos, info)
+		if projectEinoAssistantToolCanUseSearch(info) {
+			searchCandidateCount++
+		}
+	}
+	useBundleSearch := searchCandidateCount >= projectEinoAssistantBundleSearchMinTools
+	infoIndex := 0
+	for _, tool := range tools {
+		if tool == nil {
+			continue
+		}
+		info := infos[infoIndex]
+		infoIndex++
+		if projectEinoAssistantToolUsesSearch(info, useBundleSearch) {
 			dynamicTools = append(dynamicTools, tool)
 			continue
 		}
@@ -200,9 +220,20 @@ func projectEinoAssistantToolSearchSets(ctx context.Context, tools []einotool.Ba
 	return staticTools, dynamicTools, nil
 }
 
-func projectEinoAssistantToolUsesSearch(info *schema.ToolInfo) bool {
+func projectEinoAssistantToolCanUseSearch(info *schema.ToolInfo) bool {
 	if info == nil || info.Extra == nil {
 		return false
+	}
+	bundle, _ := info.Extra["bundle"].(string)
+	return projectAssistantToolBundle(bundle) != projectAssistantToolBundleCollaboration
+}
+
+func projectEinoAssistantToolUsesSearch(info *schema.ToolInfo, useBundleSearch bool) bool {
+	if info == nil || info.Extra == nil {
+		return false
+	}
+	if useBundleSearch && projectEinoAssistantToolCanUseSearch(info) {
+		return true
 	}
 	risk, _ := info.Extra["risk"].(string)
 	return projectAssistantToolRisk(risk) == projectAssistantToolRiskRead
@@ -231,7 +262,7 @@ func (e projectEinoAssistantEngine) runProjectAssistantTurnLoop(
 			if len(items) == 0 {
 				return nil, errors.New("eino turn loop received no work")
 			}
-			input, err := projectEinoAssistantInputMessages(req, runState)
+			input, err := projectEinoAssistantInputMessages(loopCtx, req, runState)
 			if err != nil {
 				return nil, err
 			}
@@ -376,14 +407,19 @@ func (e projectEinoAssistantEngine) collectProjectAssistantTurnEvents(
 			outcome.receivedOutput = true
 			continue
 		}
-		if event.Output.MessageOutput == nil {
+		messageOutput := event.Output.MessageOutput
+		if messageOutput == nil {
 			continue
 		}
-		msg, err := event.Output.MessageOutput.GetMessage()
+		msg, err := projectEinoAssistantMessageOutput(eventCtx, messageOutput, req.StreamCallbacks)
 		if err != nil {
 			return err
 		}
-		if msg != nil && msg.Role == schema.Assistant && strings.TrimSpace(msg.Content) != "" {
+		role := messageOutput.Role
+		if role == "" && msg != nil {
+			role = msg.Role
+		}
+		if msg != nil && role == schema.Assistant && strings.TrimSpace(msg.Content) != "" && !projectEinoAssistantMessageSuppressesPublicContent(msg) {
 			outcome.result.Content = msg.Content
 			outcome.receivedOutput = true
 		}
@@ -392,6 +428,80 @@ func (e projectEinoAssistantEngine) collectProjectAssistantTurnEvents(
 		tc.Loop.Stop()
 	}
 	return nil
+}
+
+func projectEinoAssistantMessageOutput(
+	ctx context.Context,
+	output *adk.TypedMessageVariant[*schema.Message],
+	streamCallbacks projectAssistantStreamCallbacks,
+) (*schema.Message, error) {
+	if output == nil {
+		return nil, nil
+	}
+	if !output.IsStreaming {
+		return output.Message, nil
+	}
+	if output.MessageStream == nil {
+		return nil, errors.New("eino assistant stream event missing message stream")
+	}
+	defer output.MessageStream.Close()
+
+	var chunks []*schema.Message
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		msg, err := output.MessageStream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if msg == nil {
+			continue
+		}
+		chunks = append(chunks, msg)
+	}
+	msg, err := schema.ConcatMessages(chunks)
+	if err != nil {
+		return nil, err
+	}
+	if output.Role == schema.Assistant && !projectEinoAssistantMessageSuppressesPublicContent(msg) && streamCallbacks.OnChunk != nil {
+		for _, chunk := range chunks {
+			if chunk != nil && chunk.Content != "" {
+				streamCallbacks.OnChunk(chunk.Content)
+			}
+		}
+	}
+	return msg, nil
+}
+
+func projectEinoAssistantMessageHasToolCalls(msg *schema.Message) bool {
+	return msg != nil && len(msg.ToolCalls) > 0
+}
+
+func projectEinoAssistantMessageSuppressesPublicContent(msg *schema.Message) bool {
+	return projectEinoAssistantMessageHasToolCalls(msg) && projectEinoAssistantToolNarration(msg.Content)
+}
+
+func projectEinoAssistantToolNarration(content string) bool {
+	content = strings.TrimSpace(strings.ToLower(content))
+	if content == "" {
+		return false
+	}
+	for _, prefix := range []string{
+		"i will ",
+		"i'll ",
+		"i am going to ",
+		"i'm going to ",
+		"let me ",
+	} {
+		if strings.HasPrefix(content, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (e projectEinoAssistantEngine) projectAssistantToolLoopFinalAnswer(
@@ -571,12 +681,15 @@ func projectEinoFollowUpInterruptInfoFromEvent(interrupted *adk.InterruptInfo) (
 	return nil, "", false
 }
 
-func projectEinoAssistantInputMessages(req projectAssistantRunRequest, runState *projectEinoAssistantRunState) ([]adk.Message, error) {
+func projectEinoAssistantInputMessages(ctx context.Context, req projectAssistantRunRequest, runState *projectEinoAssistantRunState) ([]adk.Message, error) {
 	var chatMessages []chatMessage
 	if req.Continuation != nil && len(req.Continuation.Messages) > 0 {
 		chatMessages = cloneChatMessages(req.Continuation.Messages)
 	} else {
 		chatMessages = projectPromptMessages(req.Project, req.Repository, req.History)
+		if snapshot, ok := projectEinoAssistantSessionContextMessage(ctx, req, runState); ok {
+			chatMessages = append(chatMessages, snapshot)
+		}
 		if prompt := runState.ToolPrompt(); prompt != "" {
 			chatMessages = append(chatMessages, chatMessage{Role: "system", Content: prompt})
 		}

--- a/providers/app-studio/api/assistant_eino_engine_test.go
+++ b/providers/app-studio/api/assistant_eino_engine_test.go
@@ -73,7 +73,7 @@ func TestProjectEinoAssistantMessageOutputPublishesAssistantStreamChunks(t *test
 	}
 }
 
-func TestProjectEinoAssistantMessageOutputSuppressesToolCallNarration(t *testing.T) {
+func TestProjectEinoAssistantMessageOutputStreamsToolCallContent(t *testing.T) {
 	var chunks []string
 	output := &adk.TypedMessageVariant[*schema.Message]{
 		IsStreaming: true,
@@ -100,8 +100,8 @@ func TestProjectEinoAssistantMessageOutputSuppressesToolCallNarration(t *testing
 	if msg == nil || len(msg.ToolCalls) != 1 || msg.ToolCalls[0].Function.Name != projectToolCheckProjectReadiness {
 		t.Fatalf("message = %#v, want preserved tool call for existing tool summary UX", msg)
 	}
-	if len(chunks) != 0 {
-		t.Fatalf("chunks = %#v, want tool-call narration suppressed from public assistant content", chunks)
+	if strings.Join(chunks, "") != "I will inspect the project." {
+		t.Fatalf("chunks = %#v, want assistant content streamed even when a tool call follows", chunks)
 	}
 }
 

--- a/providers/app-studio/api/assistant_eino_engine_test.go
+++ b/providers/app-studio/api/assistant_eino_engine_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cloudwego/eino/adk"
 	einomodel "github.com/cloudwego/eino/components/model"
@@ -70,6 +71,63 @@ func TestProjectEinoAssistantMessageOutputPublishesAssistantStreamChunks(t *test
 	}
 	if strings.Join(chunks, "") != "Hello world" || len(chunks) != 2 {
 		t.Fatalf("chunks = %#v, want two public assistant chunks", chunks)
+	}
+}
+
+func TestProjectEinoAssistantMessageOutputPublishesAssistantStreamChunksBeforeEOF(t *testing.T) {
+	stream, writer := schema.Pipe[*schema.Message](0)
+	output := &adk.TypedMessageVariant[*schema.Message]{
+		IsStreaming:   true,
+		MessageStream: stream,
+		Role:          schema.Assistant,
+	}
+	chunks := make(chan string, 2)
+	result := make(chan struct {
+		msg *schema.Message
+		err error
+	}, 1)
+	go func() {
+		msg, err := projectEinoAssistantMessageOutput(context.Background(), output, projectAssistantStreamCallbacks{
+			OnChunk: func(chunk string) { chunks <- chunk },
+		})
+		result <- struct {
+			msg *schema.Message
+			err error
+		}{msg: msg, err: err}
+	}()
+
+	if closed := writer.Send(schema.AssistantMessage("Hello ", nil), nil); closed {
+		t.Fatal("stream closed before first chunk was sent")
+	}
+	select {
+	case got := <-chunks:
+		if got != "Hello " {
+			t.Fatalf("first streamed chunk = %q, want %q", got, "Hello ")
+		}
+	case <-time.After(250 * time.Millisecond):
+		writer.Close()
+		<-result
+		t.Fatal("first assistant chunk was not published before stream EOF")
+	}
+
+	if closed := writer.Send(schema.AssistantMessage("world", nil), nil); closed {
+		t.Fatal("stream closed before second chunk was sent")
+	}
+	writer.Close()
+	got := <-result
+	if got.err != nil {
+		t.Fatalf("message output returned error: %v", got.err)
+	}
+	if got.msg == nil || got.msg.Content != "Hello world" {
+		t.Fatalf("message = %#v, want concatenated assistant content", got.msg)
+	}
+	select {
+	case chunk := <-chunks:
+		if chunk != "world" {
+			t.Fatalf("second streamed chunk = %q, want %q", chunk, "world")
+		}
+	default:
+		t.Fatal("second assistant chunk was not published")
 	}
 }
 

--- a/providers/app-studio/api/assistant_eino_engine_test.go
+++ b/providers/app-studio/api/assistant_eino_engine_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudwego/eino/adk"
 	einomodel "github.com/cloudwego/eino/components/model"
 	einotool "github.com/cloudwego/eino/components/tool"
 	"github.com/cloudwego/eino/schema"
@@ -44,6 +45,63 @@ func TestEinoAssistantEngineRequiresProject(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "project is required") {
 		t.Fatalf("StreamProjectAssistant error = %v, want missing project error", err)
+	}
+}
+
+func TestProjectEinoAssistantMessageOutputPublishesAssistantStreamChunks(t *testing.T) {
+	var chunks []string
+	output := &adk.TypedMessageVariant[*schema.Message]{
+		IsStreaming: true,
+		MessageStream: schema.StreamReaderFromArray([]*schema.Message{
+			schema.AssistantMessage("Hello ", nil),
+			schema.AssistantMessage("world", nil),
+		}),
+		Role: schema.Assistant,
+	}
+
+	msg, err := projectEinoAssistantMessageOutput(context.Background(), output, projectAssistantStreamCallbacks{
+		OnChunk: func(chunk string) { chunks = append(chunks, chunk) },
+	})
+	if err != nil {
+		t.Fatalf("message output returned error: %v", err)
+	}
+	if msg == nil || msg.Content != "Hello world" {
+		t.Fatalf("message = %#v, want concatenated assistant content", msg)
+	}
+	if strings.Join(chunks, "") != "Hello world" || len(chunks) != 2 {
+		t.Fatalf("chunks = %#v, want two public assistant chunks", chunks)
+	}
+}
+
+func TestProjectEinoAssistantMessageOutputSuppressesToolCallNarration(t *testing.T) {
+	var chunks []string
+	output := &adk.TypedMessageVariant[*schema.Message]{
+		IsStreaming: true,
+		MessageStream: schema.StreamReaderFromArray([]*schema.Message{
+			schema.AssistantMessage("I will inspect the project.", nil),
+			schema.AssistantMessage("", []schema.ToolCall{{
+				ID:   "call-readiness",
+				Type: "function",
+				Function: schema.FunctionCall{
+					Name:      projectToolCheckProjectReadiness,
+					Arguments: `{}`,
+				},
+			}}),
+		}),
+		Role: schema.Assistant,
+	}
+
+	msg, err := projectEinoAssistantMessageOutput(context.Background(), output, projectAssistantStreamCallbacks{
+		OnChunk: func(chunk string) { chunks = append(chunks, chunk) },
+	})
+	if err != nil {
+		t.Fatalf("message output returned error: %v", err)
+	}
+	if msg == nil || len(msg.ToolCalls) != 1 || msg.ToolCalls[0].Function.Name != projectToolCheckProjectReadiness {
+		t.Fatalf("message = %#v, want preserved tool call for existing tool summary UX", msg)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("chunks = %#v, want tool-call narration suppressed from public assistant content", chunks)
 	}
 }
 
@@ -103,6 +161,141 @@ func TestEinoAssistantEngineUsesToolSearchForReadToolCalls(t *testing.T) {
 	}
 	if !einoMessagesContainToolResult(chatModel.inputs[2], "call-inspect", "src/App.tsx") {
 		t.Fatalf("third model input = %#v, want Eino-propagated tool result", chatModel.inputs[2])
+	}
+}
+
+func TestEinoAssistantToolSearchUsesBundlesForProductToolbox(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	runState := newProjectEinoAssistantRunState()
+	var tools []einotool.BaseTool
+	for _, tool := range server.projectAssistantToolRegistry().Tools(true) {
+		tools = append(tools, newProjectEinoAssistantServerTool(server, tool, projectAssistantRunRequest{}, runState))
+	}
+
+	staticTools, dynamicTools, err := projectEinoAssistantToolSearchSets(context.Background(), tools)
+	if err != nil {
+		t.Fatalf("projectEinoAssistantToolSearchSets returned error: %v", err)
+	}
+	staticNames := einoToolNamesForTest(t, staticTools)
+	dynamicNames := einoToolNamesForTest(t, dynamicTools)
+
+	if !stringSliceEqual(staticNames, []string{projectToolAskFollowUp, projectToolRequestProjectPlanApproval}) {
+		t.Fatalf("static tools = %#v, want only collaboration tools", staticNames)
+	}
+	for _, want := range []string{
+		projectToolPlanProjectChanges,
+		projectToolCheckProjectReadiness,
+		projectToolPrepareProjectDeployment,
+		projectToolListProjectFiles,
+		projectToolReadProjectFile,
+		projectToolSearchProjectFiles,
+		projectToolWriteFile,
+		projectToolApplyPatch,
+		projectToolMkdir,
+		projectToolCommitProjectFiles,
+	} {
+		if !stringSliceContains(dynamicNames, want) {
+			t.Fatalf("dynamic tools = %#v, want %s", dynamicNames, want)
+		}
+	}
+}
+
+func TestEinoAssistantEngineAddsProjectSnapshotToInput(t *testing.T) {
+	chatModel := &capturingEinoChatModel{content: "snapshot received"}
+	workspaces := workspace.NewFileStore(t.TempDir())
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = "Demo App"
+	project.Spec.Memory.Requirements = []string{"ship a tested build"}
+	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", tenantPath: "root:org-a:ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "package.json", Content: `{"scripts":{"build":"vite build","test":"vitest"}}`}); err != nil {
+		t.Fatalf("WriteFile package.json returned error: %v", err)
+	}
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "src/App.tsx", Content: "export function App() { return null }\n"}); err != nil {
+		t.Fatalf("WriteFile src/App.tsx returned error: %v", err)
+	}
+	engine := projectEinoAssistantEngine{
+		newModel: func(context.Context, projectAssistantRunRequest, *projectEinoAssistantRunState) (einomodel.BaseChatModel, error) {
+			return chatModel, nil
+		},
+		newTools: func(context.Context, projectAssistantRunRequest, *projectEinoAssistantRunState) ([]einotool.BaseTool, error) {
+			return nil, nil
+		},
+	}
+
+	_, err := engine.StreamProjectAssistant(
+		context.Background(),
+		projectAssistantRunRequest{
+			Identity:       id,
+			Project:        project,
+			Repository:     &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady, Ready: true},
+			WorkspaceScope: scope,
+			Workspace:      workspaces,
+		},
+	)
+	if err != nil {
+		t.Fatalf("StreamProjectAssistant returned error: %v", err)
+	}
+	if len(chatModel.inputs) == 0 {
+		t.Fatal("model received no input")
+	}
+	if chatModel.sessionSnapshot == nil {
+		t.Fatal("model saw no App Studio project snapshot in Eino session values")
+	}
+	if !chatModel.sessionSnapshot.RepoReady {
+		t.Fatalf("session snapshot repoReady = false, want true")
+	}
+	if !stringSliceEqual(chatModel.sessionSnapshot.LastFileSnapshot, []string{"package.json", "src/App.tsx"}) {
+		t.Fatalf("session snapshot files = %#v, want package.json and src/App.tsx", chatModel.sessionSnapshot.LastFileSnapshot)
+	}
+	firstInput := chatModel.inputs[0]
+	if !einoMessagesContainContent(firstInput, "Current project snapshot:") {
+		t.Fatalf("input = %#v, want compact project snapshot system message", firstInput)
+	}
+	for _, want := range []string{
+		`"repoReady":true`,
+		`"lastKnownBranch"`,
+		`"lastFileSnapshot":["package.json","src/App.tsx"]`,
+		`"recommendedChecks":["build","test"]`,
+	} {
+		if !einoMessagesContainContent(firstInput, want) {
+			t.Fatalf("input = %#v, want snapshot content %s", firstInput, want)
+		}
+	}
+}
+
+func TestEinoAssistantRunStateCheckpointsProjectSnapshot(t *testing.T) {
+	runState := newProjectEinoAssistantRunState()
+	runState.SetSessionSnapshot(projectEinoAssistantSessionSnapshot{
+		ProjectName:       "demo",
+		RepoReady:         true,
+		LastKnownBranch:   "main",
+		LastFileSnapshot:  []string{"package.json"},
+		RecommendedChecks: []string{"build"},
+	})
+
+	checkpoint := runState.CheckpointState()
+	if checkpoint.SessionSnapshot == nil {
+		t.Fatal("checkpoint session snapshot = nil, want snapshot")
+	}
+	checkpoint.SessionSnapshot.LastFileSnapshot[0] = "mutated"
+
+	restored := newProjectEinoAssistantRunState()
+	restored.RestoreCheckpointState(checkpoint)
+	snapshot := restored.SessionSnapshot()
+	if snapshot == nil {
+		t.Fatal("restored session snapshot = nil, want snapshot")
+	}
+	if snapshot.ProjectName != "demo" || !snapshot.RepoReady || snapshot.LastKnownBranch != "main" {
+		t.Fatalf("restored snapshot = %#v, want project/repo state", snapshot)
+	}
+	if !stringSliceEqual(snapshot.LastFileSnapshot, []string{"mutated"}) {
+		t.Fatalf("restored files = %#v, want checkpoint value", snapshot.LastFileSnapshot)
+	}
+	checkpoint.SessionSnapshot.LastFileSnapshot[0] = "mutated-again"
+	if !stringSliceEqual(restored.SessionSnapshot().LastFileSnapshot, []string{"mutated"}) {
+		t.Fatalf("restored snapshot aliases checkpoint files")
 	}
 }
 
@@ -174,7 +367,8 @@ func TestEinoAssistantEngineSummarizesLongProjectSessions(t *testing.T) {
 
 func TestEinoAssistantEngineAsksFollowUpThroughEinoInterrupt(t *testing.T) {
 	messages := &countingAssistantRunStore{MemoryStore: store.NewMemoryStore()}
-	server := NewWithWorkspace(nil, messages, workspace.NewFileStore(t.TempDir()), "", false)
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
 	followUpTool, ok := server.projectAssistantToolRegistry().Get(projectToolAskFollowUp)
 	if !ok {
 		t.Fatal("ask_follow_up tool missing")
@@ -192,11 +386,17 @@ func TestEinoAssistantEngineAsksFollowUpThroughEinoInterrupt(t *testing.T) {
 	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", tenantPath: "root:org-a:ws-1"}
 	project := &aiv1alpha1.Project{}
 	project.Name = "demo"
+	project.Spec.Memory.Requirements = []string{"ship a tested build"}
 	req := projectAssistantRunRequest{
 		Identity:       id,
 		Project:        project,
+		Repository:     &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady, Ready: true},
 		WorkspaceScope: projectWorkspaceScope(id, project.Name),
 		MessageScope:   projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name),
+		Workspace:      workspaces,
+	}
+	if _, err := workspaces.WriteFile(context.Background(), req.WorkspaceScope, workspace.WriteOptions{Path: "package.json", Content: `{"scripts":{"build":"vite build","test":"vitest"}}`}); err != nil {
+		t.Fatalf("WriteFile package.json returned error: %v", err)
 	}
 	var assistantEvents []projectAssistantEvent
 	streamReq := req
@@ -232,6 +432,15 @@ func TestEinoAssistantEngineAsksFollowUpThroughEinoInterrupt(t *testing.T) {
 	if checkpoint.Eino == nil || checkpoint.Eino.InterruptType != projectAssistantInterruptTypeFollowUp || checkpoint.Eino.InterruptID == "" {
 		t.Fatalf("checkpoint eino state = %#v, want follow-up turn loop checkpoint and interrupt id", checkpoint.Eino)
 	}
+	if checkpoint.SessionSnapshot == nil {
+		t.Fatal("checkpoint session snapshot = nil, want persisted project snapshot")
+	}
+	if !checkpoint.SessionSnapshot.RepoReady || checkpoint.SessionSnapshot.RepositoryRef != "demo-repo" {
+		t.Fatalf("checkpoint snapshot repository = %#v, want ready demo-repo", checkpoint.SessionSnapshot)
+	}
+	if !stringSliceEqual(checkpoint.SessionSnapshot.LastFileSnapshot, []string{"package.json"}) {
+		t.Fatalf("checkpoint snapshot files = %#v, want package.json", checkpoint.SessionSnapshot.LastFileSnapshot)
+	}
 
 	result, err := engine.ResumeProjectAssistant(
 		context.Background(),
@@ -250,6 +459,12 @@ func TestEinoAssistantEngineAsksFollowUpThroughEinoInterrupt(t *testing.T) {
 	}
 	if len(chatModel.inputs) != 2 || !einoMessagesContainToolResult(chatModel.inputs[1], "call-follow-up", "solo founders") {
 		t.Fatalf("model inputs = %#v, want follow-up answer as tool result", chatModel.inputs)
+	}
+	if len(chatModel.sessionSnapshots) != 2 || chatModel.sessionSnapshots[1] == nil {
+		t.Fatalf("model session snapshots = %#v, want snapshot on resumed model call", chatModel.sessionSnapshots)
+	}
+	if !chatModel.sessionSnapshots[1].RepoReady || !stringSliceEqual(chatModel.sessionSnapshots[1].LastFileSnapshot, []string{"package.json"}) {
+		t.Fatalf("resumed session snapshot = %#v, want checkpointed project snapshot", chatModel.sessionSnapshots[1])
 	}
 }
 
@@ -272,8 +487,72 @@ func TestProjectEinoAssistantToolInfoPreservesSchemaAndRisk(t *testing.T) {
 	if info.Extra["risk"] != string(projectAssistantToolRiskWrite) {
 		t.Fatalf("tool risk = %#v, want write", info.Extra["risk"])
 	}
+	if info.Extra["bundle"] != string(projectAssistantToolBundleEdit) {
+		t.Fatalf("tool bundle = %#v, want edit", info.Extra["bundle"])
+	}
 	if info.ParamsOneOf == nil {
 		t.Fatal("ParamsOneOf is nil, want JSON schema parameters")
+	}
+}
+
+func TestProjectEinoAssistantToolInfoClassifiesProductWorkflowBundles(t *testing.T) {
+	tests := []struct {
+		name string
+		spec projectAssistantToolSpec
+		want projectAssistantToolBundle
+	}{
+		{
+			name: "workflow",
+			spec: projectAssistantToolSpec{Name: projectToolCheckProjectReadiness, Risk: projectAssistantToolRiskRead},
+			want: projectAssistantToolBundleWorkflow,
+		},
+		{
+			name: "workspace read",
+			spec: projectAssistantToolSpec{Name: projectToolReadProjectFile, Risk: projectAssistantToolRiskRead},
+			want: projectAssistantToolBundleWorkspaceRead,
+		},
+		{
+			name: "edit",
+			spec: projectAssistantToolSpec{Name: projectToolApplyPatch, Risk: projectAssistantToolRiskWrite},
+			want: projectAssistantToolBundleEdit,
+		},
+		{
+			name: "repo",
+			spec: projectAssistantToolSpec{Name: projectToolCommitProjectFiles, Risk: projectAssistantToolRiskCommit},
+			want: projectAssistantToolBundleRepo,
+		},
+		{
+			name: "runtime",
+			spec: projectAssistantToolSpec{Name: "deploy_project_runtime", Risk: projectAssistantToolRiskRuntime},
+			want: projectAssistantToolBundleRuntime,
+		},
+		{
+			name: "unknown write risk",
+			spec: projectAssistantToolSpec{Name: "replace_project_file", Risk: projectAssistantToolRiskWrite},
+			want: projectAssistantToolBundleEdit,
+		},
+		{
+			name: "unknown commit risk",
+			spec: projectAssistantToolSpec{Name: "push_project_changes", Risk: projectAssistantToolRiskCommit},
+			want: projectAssistantToolBundleRepo,
+		},
+		{
+			name: "collaboration",
+			spec: projectAssistantToolSpec{Name: projectToolAskFollowUp, Risk: projectAssistantToolRiskInput},
+			want: projectAssistantToolBundleCollaboration,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectTool := &recordingProjectAssistantTool{spec: tt.spec}
+			info, err := newProjectEinoAssistantTool(projectTool, projectAssistantRunRequest{}, newProjectEinoAssistantRunState()).Info(context.Background())
+			if err != nil {
+				t.Fatalf("Info returned error: %v", err)
+			}
+			if got := info.Extra["bundle"]; got != string(tt.want) {
+				t.Fatalf("bundle = %#v, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -360,6 +639,92 @@ func TestEinoAssistantEngineStopsToolBatchAfterPermissionRequest(t *testing.T) {
 	turnCheckpoint := decodeProjectEinoTurnLoopCheckpointForTest(t, checkpoint.Eino.Checkpoint)
 	if !turnCheckpoint.HasRunnerState || len(turnCheckpoint.CanceledItems) != 1 || turnCheckpoint.CanceledItems[0].Kind != projectAssistantTurnMessage {
 		t.Fatalf("turn loop checkpoint = %#v, want interrupted message turn with runner state", turnCheckpoint)
+	}
+}
+
+func TestEinoAssistantEngineRequestsPermissionForDynamicWriteTool(t *testing.T) {
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	chatModel := &dynamicWritePermissionEinoChatModel{}
+	engine := projectEinoAssistantEngine{
+		server: server,
+		newModel: func(context.Context, projectAssistantRunRequest, *projectEinoAssistantRunState) (einomodel.BaseChatModel, error) {
+			return chatModel, nil
+		},
+		newTools: func(_ context.Context, req projectAssistantRunRequest, state *projectEinoAssistantRunState) ([]einotool.BaseTool, error) {
+			var out []einotool.BaseTool
+			for _, tool := range server.projectAssistantToolRegistry().Tools(true) {
+				out = append(out, newProjectEinoAssistantServerTool(server, tool, req, state))
+			}
+			return out, nil
+		},
+	}
+	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", tenantPath: "root:org-a:ws-1"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+	req := projectAssistantRunRequest{
+		Identity:       id,
+		HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+		Project:        project,
+		WorkspaceScope: projectWorkspaceScope(id, project.Name),
+		MessageScope:   projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name),
+		Workspace:      workspaces,
+	}
+
+	_, err := engine.StreamProjectAssistant(context.Background(), req)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("StreamProjectAssistant error = %v, want dynamic write permission required", err)
+	}
+	if permissionErr.ToolName != projectToolWriteFile {
+		t.Fatalf("permission tool = %q, want write_file", permissionErr.ToolName)
+	}
+	if len(chatModel.toolNames) < 2 {
+		t.Fatalf("model tool names = %#v, want search and selected write tool calls", chatModel.toolNames)
+	}
+	if stringSliceContains(chatModel.toolNames[0], projectToolWriteFile) {
+		t.Fatalf("initial tools = %#v, want write_file deferred behind tool_search", chatModel.toolNames[0])
+	}
+	if !stringSliceContains(chatModel.toolNames[0], "tool_search") {
+		t.Fatalf("initial tools = %#v, want tool_search", chatModel.toolNames[0])
+	}
+	if !stringSliceContains(chatModel.toolNames[1], projectToolWriteFile) {
+		t.Fatalf("selected tools = %#v, want write_file loaded by tool_search", chatModel.toolNames[1])
+	}
+	run, err := messages.GetAssistantRun(context.Background(), req.MessageScope, permissionErr.RunID)
+	if err != nil {
+		t.Fatalf("GetAssistantRun returned error: %v", err)
+	}
+	var checkpoint projectAssistantCheckpointState
+	if err := json.Unmarshal(run.Checkpoint, &checkpoint); err != nil {
+		t.Fatalf("decode checkpoint returned error: %v", err)
+	}
+	if checkpoint.Eino == nil || checkpoint.Eino.InterruptType != projectAssistantInterruptTypePermission || checkpoint.Eino.ToolName != projectToolWriteFile {
+		t.Fatalf("checkpoint eino state = %#v, want dynamic write permission checkpoint", checkpoint.Eino)
+	}
+
+	result, err := engine.ResumeProjectAssistant(
+		context.Background(),
+		req,
+		projectAssistantResumeRequest{
+			RequestID: permissionErr.RequestID,
+			Decision:  string(projectAssistantPermissionAllow),
+		},
+		checkpoint,
+	)
+	if err != nil {
+		t.Fatalf("ResumeProjectAssistant returned error: %v", err)
+	}
+	if result.Content != "dynamic write completed" {
+		t.Fatalf("content = %q, want final dynamic write response", result.Content)
+	}
+	read, err := workspaces.ReadFile(context.Background(), req.WorkspaceScope, workspace.ReadOptions{Path: "src/App.tsx"})
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if read.Content != "dynamic write\n" {
+		t.Fatalf("content = %q, want approved dynamic write", read.Content)
 	}
 }
 
@@ -865,6 +1230,12 @@ type scriptedEinoChatModel struct {
 	toolNames [][]string
 }
 
+type capturingEinoChatModel struct {
+	inputs          [][]*schema.Message
+	sessionSnapshot *projectEinoAssistantSessionSnapshot
+	content         string
+}
+
 type emptyOutputEinoChatModel struct{}
 
 func (emptyOutputEinoChatModel) Generate(ctx context.Context, _ []*schema.Message, _ ...einomodel.Option) (*schema.Message, error) {
@@ -901,6 +1272,11 @@ func decodeProjectEinoTurnLoopCheckpointForTest(t *testing.T, checkpoint []byte)
 type multipleToolCallEinoChatModel struct {
 	inputs    [][]*schema.Message
 	toolCalls []schema.ToolCall
+}
+
+type dynamicWritePermissionEinoChatModel struct {
+	inputs    [][]*schema.Message
+	toolNames [][]string
 }
 
 type summarizingEinoChatModel struct {
@@ -940,6 +1316,51 @@ func (m *multipleToolCallEinoChatModel) Generate(ctx context.Context, input []*s
 }
 
 func (m *multipleToolCallEinoChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *dynamicWritePermissionEinoChatModel) Generate(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	common := einomodel.GetCommonOptions(nil, opts...)
+	names := make([]string, 0, len(common.Tools))
+	for _, tool := range common.Tools {
+		if tool != nil {
+			names = append(names, tool.Name)
+		}
+	}
+	m.toolNames = append(m.toolNames, names)
+	m.inputs = append(m.inputs, cloneEinoMessagesForTest(input))
+	switch len(m.inputs) {
+	case 1:
+		return schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "call-search-write",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      "tool_search",
+				Arguments: `{"query":"select:write_file"}`,
+			},
+		}}), nil
+	case 2:
+		return schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "call-write",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      projectToolWriteFile,
+				Arguments: `{"path":"src/App.tsx","content":"dynamic write\n"}`,
+			},
+		}}), nil
+	default:
+		return schema.AssistantMessage("dynamic write completed", nil), nil
+	}
+}
+
+func (m *dynamicWritePermissionEinoChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
 	msg, err := m.Generate(ctx, input, opts...)
 	if err != nil {
 		return nil, err
@@ -1108,7 +1529,8 @@ func (m *resumePermissionEinoChatModel) Stream(ctx context.Context, input []*sch
 }
 
 type followUpEinoChatModel struct {
-	inputs [][]*schema.Message
+	inputs           [][]*schema.Message
+	sessionSnapshots []*projectEinoAssistantSessionSnapshot
 }
 
 func (m *followUpEinoChatModel) Generate(ctx context.Context, input []*schema.Message, _ ...einomodel.Option) (*schema.Message, error) {
@@ -1116,6 +1538,13 @@ func (m *followUpEinoChatModel) Generate(ctx context.Context, input []*schema.Me
 		return nil, err
 	}
 	m.inputs = append(m.inputs, cloneEinoMessagesForTest(input))
+	var sessionSnapshot *projectEinoAssistantSessionSnapshot
+	if raw, ok := adk.GetSessionValue(ctx, projectEinoAssistantSessionSnapshotKey); ok {
+		if snapshot, ok := raw.(projectEinoAssistantSessionSnapshot); ok {
+			sessionSnapshot = &snapshot
+		}
+	}
+	m.sessionSnapshots = append(m.sessionSnapshots, sessionSnapshot)
 	if len(m.inputs) == 1 {
 		return schema.AssistantMessage("", []schema.ToolCall{{
 			ID:   "call-follow-up",
@@ -1180,6 +1609,40 @@ func (m *scriptedEinoChatModel) Stream(ctx context.Context, input []*schema.Mess
 		return nil, err
 	}
 	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func (m *capturingEinoChatModel) Generate(ctx context.Context, input []*schema.Message, _ ...einomodel.Option) (*schema.Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.inputs = append(m.inputs, cloneEinoMessagesForTest(input))
+	if raw, ok := adk.GetSessionValue(ctx, projectEinoAssistantSessionSnapshotKey); ok {
+		if snapshot, ok := raw.(projectEinoAssistantSessionSnapshot); ok {
+			m.sessionSnapshot = &snapshot
+		}
+	}
+	return schema.AssistantMessage(m.content, nil), nil
+}
+
+func (m *capturingEinoChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	msg, err := m.Generate(ctx, input, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{msg}), nil
+}
+
+func einoToolNamesForTest(t *testing.T, tools []einotool.BaseTool) []string {
+	t.Helper()
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		info, err := tool.Info(context.Background())
+		if err != nil {
+			t.Fatalf("tool Info returned error: %v", err)
+		}
+		names = append(names, info.Name)
+	}
+	return names
 }
 
 type recordingProjectAssistantTool struct {

--- a/providers/app-studio/api/assistant_eino_session.go
+++ b/providers/app-studio/api/assistant_eino_session.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/gob"
+	"encoding/json"
+	"strings"
+
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+const projectEinoAssistantSessionSnapshotKey = "appStudioProjectSnapshot"
+
+type projectEinoAssistantSessionSnapshot struct {
+	ProjectName           string                              `json:"projectName"`
+	DisplayName           string                              `json:"displayName,omitempty"`
+	RepoReady             bool                                `json:"repoReady"`
+	RepositoryRef         string                              `json:"repositoryRef,omitempty"`
+	RepositoryStatus      string                              `json:"repositoryStatus,omitempty"`
+	RepositoryMessage     string                              `json:"repositoryMessage,omitempty"`
+	LastKnownBranch       string                              `json:"lastKnownBranch"`
+	LastFileSnapshot      []string                            `json:"lastFileSnapshot"`
+	RecommendedChecks     []string                            `json:"recommendedChecks,omitempty"`
+	Memory                projectEinoAssistantSessionMemory   `json:"memory"`
+	LastBuildRun          *projectEinoAssistantSessionBuild   `json:"lastBuildRun,omitempty"`
+	LastRuntimeDeployment *projectEinoAssistantSessionRuntime `json:"lastRuntimeDeployment,omitempty"`
+	ContextIssue          string                              `json:"contextIssue,omitempty"`
+}
+
+type projectEinoAssistantSessionMemory struct {
+	Goals        int `json:"goals"`
+	Requirements int `json:"requirements"`
+	Constraints  int `json:"constraints"`
+}
+
+type projectEinoAssistantSessionBuild struct {
+	Name      string `json:"name,omitempty"`
+	Phase     string `json:"phase,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	CommitSHA string `json:"commitSHA,omitempty"`
+	CommitURL string `json:"commitURL,omitempty"`
+	Message   string `json:"message,omitempty"`
+	FileCount int64  `json:"fileCount,omitempty"`
+}
+
+type projectEinoAssistantSessionRuntime struct {
+	Status string `json:"status,omitempty"`
+	URL    string `json:"url,omitempty"`
+}
+
+func init() {
+	gob.Register(projectEinoAssistantSessionSnapshot{})
+}
+
+func projectEinoAssistantSessionContextMessage(ctx context.Context, req projectAssistantRunRequest, runState *projectEinoAssistantRunState) (chatMessage, bool) {
+	snapshot := projectEinoAssistantSnapshot(ctx, req)
+	if runState != nil {
+		runState.SetSessionSnapshot(snapshot)
+	}
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		return chatMessage{}, false
+	}
+	return chatMessage{
+		Role:    "system",
+		Content: "Current project snapshot:\n" + string(raw),
+	}, true
+}
+
+func projectEinoAssistantSnapshot(ctx context.Context, req projectAssistantRunRequest) projectEinoAssistantSessionSnapshot {
+	snapshot := projectEinoAssistantSessionSnapshot{
+		LastFileSnapshot: []string{},
+	}
+	if req.Project != nil {
+		snapshot.ProjectName = strings.TrimSpace(req.Project.Name)
+		snapshot.DisplayName = strings.TrimSpace(req.Project.Spec.DisplayName)
+		snapshot.Memory = projectEinoAssistantSessionMemory{
+			Goals:        len(req.Project.Spec.Memory.Goals),
+			Requirements: len(req.Project.Spec.Memory.Requirements),
+			Constraints:  len(req.Project.Spec.Memory.Constraints),
+		}
+	}
+	if req.Repository != nil {
+		snapshot.RepoReady = req.Repository.Ready || req.Repository.Status == projectRepositoryStatusReady
+		snapshot.RepositoryRef = strings.TrimSpace(req.Repository.Ref)
+		snapshot.RepositoryStatus = strings.TrimSpace(req.Repository.Status)
+		snapshot.RepositoryMessage = strings.TrimSpace(req.Repository.Message)
+		if build := projectEinoAssistantLatestBuild(req.Repository.Commits); build != nil {
+			snapshot.LastBuildRun = build
+			snapshot.LastKnownBranch = strings.TrimSpace(build.Branch)
+		}
+	}
+	files, issue := projectEinoAssistantWorkspaceSnapshot(ctx, req)
+	snapshot.LastFileSnapshot = files
+	snapshot.RecommendedChecks = projectAssistantRecommendedRuntimeChecks(files)
+	snapshot.ContextIssue = issue
+	return snapshot
+}
+
+func projectEinoAssistantLatestBuild(commits []ProjectRepositoryCommitView) *projectEinoAssistantSessionBuild {
+	for _, commit := range commits {
+		if strings.TrimSpace(commit.Name) == "" {
+			continue
+		}
+		return &projectEinoAssistantSessionBuild{
+			Name:      strings.TrimSpace(commit.Name),
+			Phase:     strings.TrimSpace(commit.Phase),
+			Branch:    strings.TrimSpace(commit.Branch),
+			CommitSHA: strings.TrimSpace(commit.CommitSHA),
+			CommitURL: strings.TrimSpace(commit.CommitURL),
+			Message:   strings.TrimSpace(commit.Message),
+			FileCount: commit.FileCount,
+		}
+	}
+	return nil
+}
+
+func projectEinoAssistantWorkspaceSnapshot(ctx context.Context, req projectAssistantRunRequest) ([]string, string) {
+	if req.Workspace == nil {
+		return []string{}, ""
+	}
+	files, err := req.Workspace.ListFiles(ctx, req.WorkspaceScope, workspace.ListOptions{Limit: boundedWorkflowFileLimit(0)})
+	if err != nil {
+		return []string{}, "workspace file snapshot unavailable: " + err.Error()
+	}
+	out := make([]string, 0, len(files.Files)+1)
+	for _, file := range files.Files {
+		if path := strings.TrimSpace(file.Path); path != "" {
+			out = append(out, path)
+		}
+	}
+	if files.Truncated {
+		out = append(out, "+more")
+	}
+	return out, ""
+}
+
+func cloneProjectEinoAssistantSessionSnapshot(src *projectEinoAssistantSessionSnapshot) *projectEinoAssistantSessionSnapshot {
+	if src == nil {
+		return nil
+	}
+	out := *src
+	out.LastFileSnapshot = append([]string(nil), src.LastFileSnapshot...)
+	out.RecommendedChecks = append([]string(nil), src.RecommendedChecks...)
+	if src.LastBuildRun != nil {
+		build := *src.LastBuildRun
+		out.LastBuildRun = &build
+	}
+	if src.LastRuntimeDeployment != nil {
+		runtime := *src.LastRuntimeDeployment
+		out.LastRuntimeDeployment = &runtime
+	}
+	return &out
+}

--- a/providers/app-studio/api/assistant_eino_session.go
+++ b/providers/app-studio/api/assistant_eino_session.go
@@ -28,19 +28,18 @@ import (
 const projectEinoAssistantSessionSnapshotKey = "appStudioProjectSnapshot"
 
 type projectEinoAssistantSessionSnapshot struct {
-	ProjectName           string                              `json:"projectName"`
-	DisplayName           string                              `json:"displayName,omitempty"`
-	RepoReady             bool                                `json:"repoReady"`
-	RepositoryRef         string                              `json:"repositoryRef,omitempty"`
-	RepositoryStatus      string                              `json:"repositoryStatus,omitempty"`
-	RepositoryMessage     string                              `json:"repositoryMessage,omitempty"`
-	LastKnownBranch       string                              `json:"lastKnownBranch"`
-	LastFileSnapshot      []string                            `json:"lastFileSnapshot"`
-	RecommendedChecks     []string                            `json:"recommendedChecks,omitempty"`
-	Memory                projectEinoAssistantSessionMemory   `json:"memory"`
-	LastBuildRun          *projectEinoAssistantSessionBuild   `json:"lastBuildRun,omitempty"`
-	LastRuntimeDeployment *projectEinoAssistantSessionRuntime `json:"lastRuntimeDeployment,omitempty"`
-	ContextIssue          string                              `json:"contextIssue,omitempty"`
+	ProjectName       string                            `json:"projectName"`
+	DisplayName       string                            `json:"displayName,omitempty"`
+	RepoReady         bool                              `json:"repoReady"`
+	RepositoryRef     string                            `json:"repositoryRef,omitempty"`
+	RepositoryStatus  string                            `json:"repositoryStatus,omitempty"`
+	RepositoryMessage string                            `json:"repositoryMessage,omitempty"`
+	LastKnownBranch   string                            `json:"lastKnownBranch"`
+	LastFileSnapshot  []string                          `json:"lastFileSnapshot"`
+	RecommendedChecks []string                          `json:"recommendedChecks,omitempty"`
+	Memory            projectEinoAssistantSessionMemory `json:"memory"`
+	LastBuildRun      *projectEinoAssistantSessionBuild `json:"lastBuildRun,omitempty"`
+	ContextIssue      string                            `json:"contextIssue,omitempty"`
 }
 
 type projectEinoAssistantSessionMemory struct {
@@ -57,11 +56,6 @@ type projectEinoAssistantSessionBuild struct {
 	CommitURL string `json:"commitURL,omitempty"`
 	Message   string `json:"message,omitempty"`
 	FileCount int64  `json:"fileCount,omitempty"`
-}
-
-type projectEinoAssistantSessionRuntime struct {
-	Status string `json:"status,omitempty"`
-	URL    string `json:"url,omitempty"`
 }
 
 func init() {
@@ -161,10 +155,6 @@ func cloneProjectEinoAssistantSessionSnapshot(src *projectEinoAssistantSessionSn
 	if src.LastBuildRun != nil {
 		build := *src.LastBuildRun
 		out.LastBuildRun = &build
-	}
-	if src.LastRuntimeDeployment != nil {
-		runtime := *src.LastRuntimeDeployment
-		out.LastRuntimeDeployment = &runtime
 	}
 	return &out
 }

--- a/providers/app-studio/api/assistant_eino_state.go
+++ b/providers/app-studio/api/assistant_eino_state.go
@@ -43,6 +43,7 @@ type projectEinoAssistantRunState struct {
 	projectRepositoryRef string
 	toolPrompt           string
 	toolDiscovery        *projectEinoAssistantToolDiscovery
+	sessionSnapshot      *projectEinoAssistantSessionSnapshot
 	permissionBarrier    bool
 	approvedPlan         *projectAssistantApprovedPlan
 }
@@ -94,6 +95,24 @@ func (s *projectEinoAssistantRunState) ToolPrompt() string {
 	return s.toolPrompt
 }
 
+func (s *projectEinoAssistantRunState) SetSessionSnapshot(snapshot projectEinoAssistantSessionSnapshot) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessionSnapshot = cloneProjectEinoAssistantSessionSnapshot(&snapshot)
+}
+
+func (s *projectEinoAssistantRunState) SessionSnapshot() *projectEinoAssistantSessionSnapshot {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneProjectEinoAssistantSessionSnapshot(s.sessionSnapshot)
+}
+
 func (s *projectEinoAssistantRunState) SetProjectRepositoryRef(ref string) {
 	if s == nil {
 		return
@@ -116,6 +135,7 @@ func (s *projectEinoAssistantRunState) RestoreCheckpointState(state projectAssis
 	s.turn = state.Turn
 	s.projectRepositoryRef = strings.TrimSpace(state.ProjectRepositoryRef)
 	s.approvedPlan = cloneProjectAssistantApprovedPlan(state.ApprovedPlan)
+	s.sessionSnapshot = cloneProjectEinoAssistantSessionSnapshot(state.SessionSnapshot)
 }
 
 func (s *projectEinoAssistantRunState) ProjectRepositoryRef() string {
@@ -259,6 +279,7 @@ func (s *projectEinoAssistantRunState) CheckpointState() projectAssistantCheckpo
 		Turn:                 s.turn,
 		ProjectRepositoryRef: strings.TrimSpace(s.projectRepositoryRef),
 		ApprovedPlan:         cloneProjectAssistantApprovedPlan(s.approvedPlan),
+		SessionSnapshot:      cloneProjectEinoAssistantSessionSnapshot(s.sessionSnapshot),
 	}
 }
 

--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -112,6 +112,7 @@ func (t projectEinoAssistantTool) Info(context.Context) (*schema.ToolInfo, error
 		Name: strings.TrimSpace(spec.Name),
 		Desc: strings.TrimSpace(spec.Description),
 		Extra: map[string]any{
+			"bundle":                          string(projectAssistantToolBundleForSpec(spec)),
 			"risk":                            string(spec.Risk),
 			projectEinoToolParametersExtraKey: string(spec.Parameters),
 		},
@@ -188,6 +189,7 @@ func (t projectEinoAssistantTool) invokeAllowedTool(ctx context.Context, callID 
 		ProjectRepositoryRef: t.runState.ProjectRepositoryRef(),
 		MCPEndpoint:          mcpServerURL(t.req.MCPBaseURL, t.req.Identity.tenantPath, "default"),
 		HTTPRequest:          t.req.HTTPRequest,
+		SessionSnapshot:      t.runState.SessionSnapshot(),
 		Arguments:            args,
 	})
 	if err != nil {

--- a/providers/app-studio/api/assistant_eino_tool_test.go
+++ b/providers/app-studio/api/assistant_eino_tool_test.go
@@ -47,10 +47,8 @@ func TestEinoApprovePlanToolRejectsMissingAllowedOperations(t *testing.T) {
 func TestEinoToolPassesSessionSnapshotToLocalTool(t *testing.T) {
 	runState := newProjectEinoAssistantRunState()
 	runState.SetSessionSnapshot(projectEinoAssistantSessionSnapshot{
-		LastRuntimeDeployment: &projectEinoAssistantSessionRuntime{
-			Status: "ready",
-			URL:    "https://demo.apps.example.com",
-		},
+		LastFileSnapshot:  []string{"package.json"},
+		RecommendedChecks: []string{"build"},
 	})
 	var got *projectEinoAssistantSessionSnapshot
 	localTool := projectAssistantToolFunc{
@@ -72,14 +70,14 @@ func TestEinoToolPassesSessionSnapshotToLocalTool(t *testing.T) {
 	if _, err := tool.invokeAllowedTool(context.Background(), "call-session", localTool.Spec(), nil); err != nil {
 		t.Fatalf("invokeAllowedTool returned error: %v", err)
 	}
-	if got == nil || got.LastRuntimeDeployment == nil {
-		t.Fatalf("session snapshot = %#v, want runtime deployment snapshot", got)
+	if got == nil || !stringSliceEqual(got.LastFileSnapshot, []string{"package.json"}) {
+		t.Fatalf("session snapshot = %#v, want file snapshot", got)
 	}
-	if got.LastRuntimeDeployment.URL != "https://demo.apps.example.com" {
-		t.Fatalf("runtime URL = %q, want session snapshot URL", got.LastRuntimeDeployment.URL)
+	if !stringSliceEqual(got.RecommendedChecks, []string{"build"}) {
+		t.Fatalf("recommended checks = %#v, want build", got.RecommendedChecks)
 	}
-	got.LastRuntimeDeployment.Status = "mutated"
-	if runState.SessionSnapshot().LastRuntimeDeployment.Status != "ready" {
+	got.LastFileSnapshot[0] = "mutated"
+	if !stringSliceEqual(runState.SessionSnapshot().LastFileSnapshot, []string{"package.json"}) {
 		t.Fatal("tool received mutable run-state session snapshot")
 	}
 }

--- a/providers/app-studio/api/assistant_eino_tool_test.go
+++ b/providers/app-studio/api/assistant_eino_tool_test.go
@@ -43,3 +43,43 @@ func TestEinoApprovePlanToolRejectsMissingAllowedOperations(t *testing.T) {
 		t.Fatalf("approved plan = %#v, want nil after malformed approve_plan", plan)
 	}
 }
+
+func TestEinoToolPassesSessionSnapshotToLocalTool(t *testing.T) {
+	runState := newProjectEinoAssistantRunState()
+	runState.SetSessionSnapshot(projectEinoAssistantSessionSnapshot{
+		LastRuntimeDeployment: &projectEinoAssistantSessionRuntime{
+			Status: "ready",
+			URL:    "https://demo.apps.example.com",
+		},
+	})
+	var got *projectEinoAssistantSessionSnapshot
+	localTool := projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name: "capture_session_snapshot",
+			Risk: projectAssistantToolRiskRead,
+		},
+		call: func(_ context.Context, req projectAssistantToolCallRequest) (string, error) {
+			got = req.SessionSnapshot
+			return `{"status":"captured"}`, nil
+		},
+	}
+	tool := projectEinoAssistantTool{
+		tool:     localTool,
+		req:      projectAssistantRunRequest{},
+		runState: runState,
+	}
+
+	if _, err := tool.invokeAllowedTool(context.Background(), "call-session", localTool.Spec(), nil); err != nil {
+		t.Fatalf("invokeAllowedTool returned error: %v", err)
+	}
+	if got == nil || got.LastRuntimeDeployment == nil {
+		t.Fatalf("session snapshot = %#v, want runtime deployment snapshot", got)
+	}
+	if got.LastRuntimeDeployment.URL != "https://demo.apps.example.com" {
+		t.Fatalf("runtime URL = %q, want session snapshot URL", got.LastRuntimeDeployment.URL)
+	}
+	got.LastRuntimeDeployment.Status = "mutated"
+	if runState.SessionSnapshot().LastRuntimeDeployment.Status != "ready" {
+		t.Fatal("tool received mutable run-state session snapshot")
+	}
+}

--- a/providers/app-studio/api/assistant_permission.go
+++ b/providers/app-studio/api/assistant_permission.go
@@ -55,9 +55,6 @@ func projectAssistantPermissionForToolWithRunState(spec projectAssistantToolSpec
 	case projectAssistantToolRiskCommit:
 		return projectAssistantPermissionAsk
 	case projectAssistantToolRiskRuntime:
-		if autoApprove {
-			return projectAssistantPermissionAllow
-		}
 		return projectAssistantPermissionAsk
 	default:
 		return projectAssistantPermissionDeny

--- a/providers/app-studio/api/assistant_permission_test.go
+++ b/providers/app-studio/api/assistant_permission_test.go
@@ -48,6 +48,16 @@ func TestProjectAssistantPermissionPolicy(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantRuntimePermissionIgnoresAutoApprove(t *testing.T) {
+	decision := projectAssistantPermissionForToolWithPolicy(projectAssistantToolSpec{
+		Name: projectToolDeployProjectRuntime,
+		Risk: projectAssistantToolRiskRuntime,
+	}, true)
+	if decision != projectAssistantPermissionAsk {
+		t.Fatalf("auto-approved runtime permission = %q, want %q", decision, projectAssistantPermissionAsk)
+	}
+}
+
 func TestProjectAssistantPlanApprovalAllowsScopedWritesButNotCommit(t *testing.T) {
 	state := newProjectEinoAssistantRunState()
 	state.ApprovePlan(projectAssistantApprovedPlan{

--- a/providers/app-studio/api/assistant_tool.go
+++ b/providers/app-studio/api/assistant_tool.go
@@ -27,6 +27,7 @@ import (
 )
 
 type projectAssistantToolRisk string
+type projectAssistantToolBundle string
 
 const (
 	projectAssistantToolRiskRead    projectAssistantToolRisk = "read"
@@ -35,6 +36,15 @@ const (
 	projectAssistantToolRiskWrite   projectAssistantToolRisk = "write"
 	projectAssistantToolRiskCommit  projectAssistantToolRisk = "commit"
 	projectAssistantToolRiskRuntime projectAssistantToolRisk = "runtime"
+)
+
+const (
+	projectAssistantToolBundleWorkflow      projectAssistantToolBundle = "workflow"
+	projectAssistantToolBundleWorkspaceRead projectAssistantToolBundle = "workspace_read"
+	projectAssistantToolBundleEdit          projectAssistantToolBundle = "edit"
+	projectAssistantToolBundleRepo          projectAssistantToolBundle = "repo"
+	projectAssistantToolBundleRuntime       projectAssistantToolBundle = "runtime"
+	projectAssistantToolBundleCollaboration projectAssistantToolBundle = "collaboration"
 )
 
 type projectAssistantToolSpec struct {
@@ -55,6 +65,38 @@ func (s projectAssistantToolSpec) chatTool() chatTool {
 	}
 }
 
+func projectAssistantToolBundleForSpec(spec projectAssistantToolSpec) projectAssistantToolBundle {
+	switch projectToolBaseName(spec.Name) {
+	case projectToolPlanProjectChanges, projectToolCheckProjectReadiness, projectToolPrepareProjectDeployment:
+		return projectAssistantToolBundleWorkflow
+	case projectToolDeployProjectRuntime, projectToolGetRuntimeStatus, projectToolGetPreviewURL:
+		return projectAssistantToolBundleRuntime
+	case projectToolListProjectFiles, projectToolReadProjectFile, projectToolSearchProjectFiles:
+		return projectAssistantToolBundleWorkspaceRead
+	case projectToolWriteFile, projectToolApplyPatch, projectToolMkdir:
+		return projectAssistantToolBundleEdit
+	case projectToolCommitProjectFiles, projectToolCommitFiles:
+		return projectAssistantToolBundleRepo
+	case projectToolAskFollowUp, projectToolRequestProjectPlanApproval:
+		return projectAssistantToolBundleCollaboration
+	}
+	switch spec.Risk {
+	case projectAssistantToolRiskPlan:
+		return projectAssistantToolBundleWorkflow
+	case projectAssistantToolRiskRead:
+		return projectAssistantToolBundleWorkspaceRead
+	case projectAssistantToolRiskWrite:
+		return projectAssistantToolBundleEdit
+	case projectAssistantToolRiskCommit:
+		return projectAssistantToolBundleRepo
+	case projectAssistantToolRiskRuntime:
+		return projectAssistantToolBundleRuntime
+	case projectAssistantToolRiskInput:
+		return projectAssistantToolBundleCollaboration
+	}
+	return projectAssistantToolBundleWorkflow
+}
+
 type projectAssistantToolCallRequest struct {
 	Identity             identity
 	Project              *aiv1alpha1.Project
@@ -63,6 +105,7 @@ type projectAssistantToolCallRequest struct {
 	ProjectRepositoryRef string
 	MCPEndpoint          string
 	HTTPRequest          *http.Request
+	SessionSnapshot      *projectEinoAssistantSessionSnapshot
 	Arguments            map[string]any
 }
 

--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -157,6 +157,10 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 		},
 		newProjectAssistantWorkflowTool(server),
 		newProjectAssistantReadinessWorkflowTool(server),
+		newProjectAssistantPrepareDeploymentWorkflowTool(server),
+		newProjectAssistantDeployRuntimeWorkflowTool(),
+		newProjectAssistantRuntimeStatusWorkflowTool(),
+		newProjectAssistantPreviewURLWorkflowTool(),
 		projectAssistantToolFunc{
 			spec: projectAssistantToolSpec{
 				Name:        projectToolAskFollowUp,

--- a/providers/app-studio/api/assistant_workflow.go
+++ b/providers/app-studio/api/assistant_workflow.go
@@ -224,7 +224,7 @@ func newProjectAssistantRuntimeStatusWorkflowTool() projectAssistantTool {
 	return projectAssistantToolFunc{
 		spec: projectAssistantToolSpec{
 			Name:        projectToolGetRuntimeStatus,
-			Description: "Return deterministic App Studio runtime deployment status from Eino session state, or a structured not-configured result when no runtime deployment exists.",
+			Description: "Return a structured not-configured App Studio runtime status until a runtime provider state reader is configured.",
 			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
 			Risk:        projectAssistantToolRiskRead,
 		},
@@ -242,7 +242,7 @@ func newProjectAssistantPreviewURLWorkflowTool() projectAssistantTool {
 	return projectAssistantToolFunc{
 		spec: projectAssistantToolSpec{
 			Name:        projectToolGetPreviewURL,
-			Description: "Return the current App Studio preview URL from Eino session state, or a structured unavailable result when no runtime preview exists.",
+			Description: "Return a structured not-configured App Studio preview URL result until a runtime provider state reader is configured.",
 			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
 			Risk:        projectAssistantToolRiskRead,
 		},
@@ -666,42 +666,12 @@ func formatProjectAssistantRuntimeStatusResult(ctx context.Context, input projec
 	if err := ctx.Err(); err != nil {
 		return projectAssistantRuntimeWorkflowResult{}, err
 	}
-	if runtime := projectAssistantRuntimeFromSession(input.SessionSnapshot); runtime != nil {
-		result := projectAssistantRuntimeWorkflowResult{
-			Status:     strings.TrimSpace(runtime.Status),
-			Runtime:    runtime,
-			PreviewURL: strings.TrimSpace(runtime.URL),
-		}
-		if result.Status == "" {
-			result.Status = "unknown"
-		}
-		result.Summary = "Runtime deployment status is " + result.Status + "."
-		return result, nil
-	}
 	return projectAssistantRuntimeNotConfiguredResult("Runtime deployment status is unavailable because no runtime deployment is recorded.")
 }
 
 func formatProjectAssistantPreviewURLResult(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
 	if err := ctx.Err(); err != nil {
 		return projectAssistantRuntimeWorkflowResult{}, err
-	}
-	if runtime := projectAssistantRuntimeFromSession(input.SessionSnapshot); runtime != nil {
-		result := projectAssistantRuntimeWorkflowResult{
-			Status:     strings.TrimSpace(runtime.Status),
-			Runtime:    runtime,
-			PreviewURL: strings.TrimSpace(runtime.URL),
-		}
-		if result.PreviewURL == "" {
-			result.Status = "unavailable"
-			result.Blockers = []string{"No preview URL is recorded for the current runtime deployment."}
-			result.Summary = "Preview URL is unavailable for the current runtime deployment."
-			return result, nil
-		}
-		if result.Status == "" {
-			result.Status = "ready"
-		}
-		result.Summary = "Preview URL is available."
-		return result, nil
 	}
 	return projectAssistantRuntimeNotConfiguredResult("Preview URL is unavailable because no runtime deployment is recorded.")
 }
@@ -724,16 +694,6 @@ func projectAssistantRuntimeNotConfigured() *projectAssistantDeploymentRuntime {
 	return &projectAssistantDeploymentRuntime{
 		Status:  "not_configured",
 		Message: "Runtime deployment is not configured for this App Studio project.",
-	}
-}
-
-func projectAssistantRuntimeFromSession(snapshot *projectEinoAssistantSessionSnapshot) *projectAssistantDeploymentRuntime {
-	if snapshot == nil || snapshot.LastRuntimeDeployment == nil {
-		return nil
-	}
-	return &projectAssistantDeploymentRuntime{
-		Status: strings.TrimSpace(snapshot.LastRuntimeDeployment.Status),
-		URL:    strings.TrimSpace(snapshot.LastRuntimeDeployment.URL),
 	}
 }
 

--- a/providers/app-studio/api/assistant_workflow.go
+++ b/providers/app-studio/api/assistant_workflow.go
@@ -39,6 +39,13 @@ type projectAssistantWorkflowInput struct {
 	MaxFiles       int
 }
 
+type projectAssistantRuntimeWorkflowInput struct {
+	Project         *aiv1alpha1.Project
+	Repository      *ProjectRepositoryView
+	SessionSnapshot *projectEinoAssistantSessionSnapshot
+	AppDeployment   projectAssistantAppDeploymentRequest
+}
+
 type projectAssistantWorkflowContext struct {
 	Project        *aiv1alpha1.Project
 	Repository     *ProjectRepositoryView
@@ -61,6 +68,48 @@ type projectAssistantReadinessWorkflowResult struct {
 	RecommendedChecks []string                      `json:"recommendedChecks,omitempty"`
 	Repository        *projectAssistantWorkflowRepo `json:"repository,omitempty"`
 	Files             []string                      `json:"files,omitempty"`
+}
+
+type projectAssistantDeploymentPreparationResult struct {
+	Status            string                              `json:"status"`
+	Summary           string                              `json:"summary"`
+	Artifact          *projectAssistantDeploymentArtifact `json:"artifact,omitempty"`
+	Runtime           *projectAssistantDeploymentRuntime  `json:"runtime,omitempty"`
+	RecommendedChecks []string                            `json:"recommendedChecks,omitempty"`
+	Repository        *projectAssistantWorkflowRepo       `json:"repository,omitempty"`
+	Files             []string                            `json:"files,omitempty"`
+	Blockers          []string                            `json:"blockers,omitempty"`
+	NextSteps         []string                            `json:"nextSteps,omitempty"`
+}
+
+type projectAssistantDeploymentArtifact struct {
+	Status string `json:"status"`
+	Type   string `json:"type"`
+	Source string `json:"source"`
+}
+
+type projectAssistantDeploymentRuntime struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+	URL     string `json:"url,omitempty"`
+}
+
+type projectAssistantRuntimeWorkflowResult struct {
+	Status        string                                `json:"status"`
+	Summary       string                                `json:"summary"`
+	AppDeployment *projectAssistantAppDeploymentRequest `json:"appDeployment,omitempty"`
+	Runtime       *projectAssistantDeploymentRuntime    `json:"runtime,omitempty"`
+	PreviewURL    string                                `json:"previewURL,omitempty"`
+	Blockers      []string                              `json:"blockers,omitempty"`
+	NextSteps     []string                              `json:"nextSteps,omitempty"`
+}
+
+type projectAssistantAppDeploymentRequest struct {
+	TargetRef string `json:"targetRef,omitempty"`
+	AppName   string `json:"appName,omitempty"`
+	Image     string `json:"image,omitempty"`
+	Port      int64  `json:"port,omitempty"`
+	Intent    string `json:"intent,omitempty"`
 }
 
 type projectAssistantWorkflowRepo struct {
@@ -117,6 +166,96 @@ func newProjectAssistantReadinessWorkflowTool(server *Server) projectAssistantTo
 	}
 }
 
+func newProjectAssistantPrepareDeploymentWorkflowTool(server *Server) projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolPrepareProjectDeployment,
+			Description: "Prepare deterministic App Studio deployment handoff context from project memory, repository status, workspace files, build checks, and runtime handoff constraints.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"includeFiles":{"type":"boolean","description":"Whether to include a bounded current workspace file list."},"maxFiles":{"type":"integer","minimum":1,"maximum":50,"description":"Maximum workspace file paths to include when includeFiles is true."}}}`),
+			Risk:        projectAssistantToolRiskRead,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			includeFiles := true
+			if rawIncludeFiles, ok := req.Arguments["includeFiles"]; ok {
+				includeFiles = projectToolBool(rawIncludeFiles)
+			}
+			input := projectAssistantWorkflowInput{
+				Server:         server,
+				Project:        req.Project,
+				Repository:     req.Repository,
+				WorkspaceScope: req.WorkspaceScope,
+				IncludeFiles:   includeFiles,
+				MaxFiles:       boundedWorkflowFileLimit(projectToolInt(req.Arguments["maxFiles"])),
+			}
+			return runProjectAssistantPrepareDeploymentWorkflow(ctx, input)
+		},
+	}
+}
+
+func newProjectAssistantDeployRuntimeWorkflowTool() projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolDeployProjectRuntime,
+			Description: "Create a deterministic AppDeployment handoff request from an OCI image, runtime target, port, and intent; returns structured blockers until a runtime provider is configured.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"targetRef":{"type":"string","description":"RuntimeTarget name or reference that should run this app."},"appName":{"type":"string","description":"Optional runtime app name; defaults to the App Studio project name."},"image":{"type":"string","description":"OCI image to deploy."},"port":{"type":"integer","minimum":1,"maximum":65535,"description":"Container port exposed by the app."},"intent":{"type":"string","enum":["preview","production"],"description":"Deployment intent."}},"required":["targetRef","image","port"]}`),
+			Risk:        projectAssistantToolRiskRuntime,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			input := projectAssistantRuntimeWorkflowInput{
+				Project:         req.Project,
+				Repository:      req.Repository,
+				SessionSnapshot: req.SessionSnapshot,
+				AppDeployment: projectAssistantAppDeploymentRequest{
+					TargetRef: projectToolString(req.Arguments["targetRef"]),
+					AppName:   projectToolString(req.Arguments["appName"]),
+					Image:     projectToolString(req.Arguments["image"]),
+					Intent:    projectToolString(req.Arguments["intent"]),
+				},
+			}
+			if port, ok := projectToolNumber(req.Arguments["port"]); ok {
+				input.AppDeployment.Port = port
+			}
+			return runProjectAssistantDeployRuntimeWorkflow(ctx, input)
+		},
+	}
+}
+
+func newProjectAssistantRuntimeStatusWorkflowTool() projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolGetRuntimeStatus,
+			Description: "Return deterministic App Studio runtime deployment status from Eino session state, or a structured not-configured result when no runtime deployment exists.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+			Risk:        projectAssistantToolRiskRead,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			return runProjectAssistantRuntimeStatusWorkflow(ctx, projectAssistantRuntimeWorkflowInput{
+				Project:         req.Project,
+				Repository:      req.Repository,
+				SessionSnapshot: req.SessionSnapshot,
+			})
+		},
+	}
+}
+
+func newProjectAssistantPreviewURLWorkflowTool() projectAssistantTool {
+	return projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{
+			Name:        projectToolGetPreviewURL,
+			Description: "Return the current App Studio preview URL from Eino session state, or a structured unavailable result when no runtime preview exists.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+			Risk:        projectAssistantToolRiskRead,
+		},
+		call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+			return runProjectAssistantPreviewURLWorkflow(ctx, projectAssistantRuntimeWorkflowInput{
+				Project:         req.Project,
+				Repository:      req.Repository,
+				SessionSnapshot: req.SessionSnapshot,
+			})
+		},
+	}
+}
+
 func runProjectAssistantPlanningWorkflow(ctx context.Context, input projectAssistantWorkflowInput) (string, error) {
 	runner, err := newProjectAssistantPlanningWorkflow(ctx)
 	if err != nil {
@@ -145,6 +284,70 @@ func runProjectAssistantReadinessWorkflow(ctx context.Context, input projectAssi
 	raw, err := marshalProjectAssistantWorkflowJSON(readiness)
 	if err != nil {
 		return "", fmt.Errorf("encode project readiness workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func runProjectAssistantPrepareDeploymentWorkflow(ctx context.Context, input projectAssistantWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantPrepareDeploymentWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	prepared, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowJSON(prepared)
+	if err != nil {
+		return "", fmt.Errorf("encode project deployment preparation workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func runProjectAssistantDeployRuntimeWorkflow(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantDeployRuntimeWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	result, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowJSON(result)
+	if err != nil {
+		return "", fmt.Errorf("encode project runtime deployment workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func runProjectAssistantRuntimeStatusWorkflow(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantRuntimeStatusWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	result, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowJSON(result)
+	if err != nil {
+		return "", fmt.Errorf("encode project runtime status workflow result: %w", err)
+	}
+	return string(raw), nil
+}
+
+func runProjectAssistantPreviewURLWorkflow(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (string, error) {
+	runner, err := newProjectAssistantPreviewURLWorkflow(ctx)
+	if err != nil {
+		return "", err
+	}
+	result, err := runner.Invoke(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	raw, err := marshalProjectAssistantWorkflowJSON(result)
+	if err != nil {
+		return "", fmt.Errorf("encode project preview URL workflow result: %w", err)
 	}
 	return string(raw), nil
 }
@@ -243,21 +446,69 @@ func trimProjectAssistantWorkflowString(value string, maxChars int) string {
 }
 
 func newProjectAssistantPlanningWorkflow(ctx context.Context) (compose.Runnable[projectAssistantWorkflowInput, projectAssistantWorkflowPlan], error) {
-	chain := compose.NewChain[projectAssistantWorkflowInput, projectAssistantWorkflowPlan]()
-	chain.
-		AppendLambda(compose.InvokableLambda(normalizeProjectAssistantWorkflowInput), compose.WithNodeKey("normalize")).
-		AppendLambda(compose.InvokableLambda(readProjectAssistantWorkflowContext), compose.WithNodeKey("read-context")).
-		AppendLambda(compose.InvokableLambda(formatProjectAssistantWorkflowPlan), compose.WithNodeKey("format-plan"))
-	return chain.Compile(ctx, compose.WithGraphName("app-studio-plan-project-changes"), compose.WithMaxRunSteps(8))
+	workflow := compose.NewWorkflow[projectAssistantWorkflowInput, projectAssistantWorkflowPlan]()
+	workflow.AddLambdaNode("normalize", compose.InvokableLambda(normalizeProjectAssistantWorkflowInput)).
+		AddInput(compose.START)
+	workflow.AddLambdaNode("read-context", compose.InvokableLambda(readProjectAssistantWorkflowContext)).
+		AddInput("normalize")
+	workflow.AddLambdaNode("format-plan", compose.InvokableLambda(formatProjectAssistantWorkflowPlan)).
+		AddInput("read-context")
+	workflow.End().AddInput("format-plan")
+	return workflow.Compile(ctx, compose.WithGraphName("app-studio-plan-project-changes"))
 }
 
 func newProjectAssistantReadinessWorkflow(ctx context.Context) (compose.Runnable[projectAssistantWorkflowInput, projectAssistantReadinessWorkflowResult], error) {
-	chain := compose.NewChain[projectAssistantWorkflowInput, projectAssistantReadinessWorkflowResult]()
-	chain.
-		AppendLambda(compose.InvokableLambda(normalizeProjectAssistantWorkflowInput), compose.WithNodeKey("normalize")).
-		AppendLambda(compose.InvokableLambda(readProjectAssistantReadinessWorkflowContext), compose.WithNodeKey("read-context")).
-		AppendLambda(compose.InvokableLambda(formatProjectAssistantReadinessWorkflow), compose.WithNodeKey("format-readiness"))
-	return chain.Compile(ctx, compose.WithGraphName("app-studio-check-project-readiness"), compose.WithMaxRunSteps(8))
+	workflow := compose.NewWorkflow[projectAssistantWorkflowInput, projectAssistantReadinessWorkflowResult]()
+	workflow.AddLambdaNode("normalize", compose.InvokableLambda(normalizeProjectAssistantWorkflowInput)).
+		AddInput(compose.START)
+	workflow.AddLambdaNode("read-context", compose.InvokableLambda(readProjectAssistantReadinessWorkflowContext)).
+		AddInput("normalize")
+	workflow.AddLambdaNode("format-readiness", compose.InvokableLambda(formatProjectAssistantReadinessWorkflow)).
+		AddInput("read-context")
+	workflow.End().AddInput("format-readiness")
+	return workflow.Compile(ctx, compose.WithGraphName("app-studio-check-project-readiness"))
+}
+
+func newProjectAssistantPrepareDeploymentWorkflow(ctx context.Context) (compose.Runnable[projectAssistantWorkflowInput, projectAssistantDeploymentPreparationResult], error) {
+	workflow := compose.NewWorkflow[projectAssistantWorkflowInput, projectAssistantDeploymentPreparationResult]()
+	workflow.AddLambdaNode("normalize", compose.InvokableLambda(normalizeProjectAssistantWorkflowInput)).
+		AddInput(compose.START)
+	workflow.AddLambdaNode("read-context", compose.InvokableLambda(readProjectAssistantWorkflowContext)).
+		AddInput("normalize")
+	workflow.AddLambdaNode("format-deployment-preparation", compose.InvokableLambda(formatProjectAssistantDeploymentPreparationWorkflow)).
+		AddInput("read-context")
+	workflow.End().AddInput("format-deployment-preparation")
+	return workflow.Compile(ctx, compose.WithGraphName("app-studio-prepare-project-deployment"))
+}
+
+func newProjectAssistantDeployRuntimeWorkflow(ctx context.Context) (compose.Runnable[projectAssistantRuntimeWorkflowInput, projectAssistantRuntimeWorkflowResult], error) {
+	workflow := compose.NewWorkflow[projectAssistantRuntimeWorkflowInput, projectAssistantRuntimeWorkflowResult]()
+	workflow.AddLambdaNode("normalize", compose.InvokableLambda(normalizeProjectAssistantRuntimeWorkflowInput)).
+		AddInput(compose.START)
+	workflow.AddLambdaNode("format-runtime-deployment", compose.InvokableLambda(formatProjectAssistantRuntimeDeploymentWorkflow)).
+		AddInput("normalize")
+	workflow.End().AddInput("format-runtime-deployment")
+	return workflow.Compile(ctx, compose.WithGraphName("app-studio-deploy-project-runtime"))
+}
+
+func newProjectAssistantRuntimeStatusWorkflow(ctx context.Context) (compose.Runnable[projectAssistantRuntimeWorkflowInput, projectAssistantRuntimeWorkflowResult], error) {
+	workflow := compose.NewWorkflow[projectAssistantRuntimeWorkflowInput, projectAssistantRuntimeWorkflowResult]()
+	workflow.AddLambdaNode("normalize", compose.InvokableLambda(normalizeProjectAssistantRuntimeWorkflowInput)).
+		AddInput(compose.START)
+	workflow.AddLambdaNode("format-runtime-status", compose.InvokableLambda(formatProjectAssistantRuntimeStatusWorkflow)).
+		AddInput("normalize")
+	workflow.End().AddInput("format-runtime-status")
+	return workflow.Compile(ctx, compose.WithGraphName("app-studio-get-runtime-status"))
+}
+
+func newProjectAssistantPreviewURLWorkflow(ctx context.Context) (compose.Runnable[projectAssistantRuntimeWorkflowInput, projectAssistantRuntimeWorkflowResult], error) {
+	workflow := compose.NewWorkflow[projectAssistantRuntimeWorkflowInput, projectAssistantRuntimeWorkflowResult]()
+	workflow.AddLambdaNode("normalize", compose.InvokableLambda(normalizeProjectAssistantRuntimeWorkflowInput)).
+		AddInput(compose.START)
+	workflow.AddLambdaNode("format-preview-url", compose.InvokableLambda(formatProjectAssistantPreviewURLWorkflow)).
+		AddInput("normalize")
+	workflow.End().AddInput("format-preview-url")
+	return workflow.Compile(ctx, compose.WithGraphName("app-studio-get-preview-url"))
 }
 
 func normalizeProjectAssistantWorkflowInput(ctx context.Context, input projectAssistantWorkflowInput) (projectAssistantWorkflowInput, error) {
@@ -267,6 +518,27 @@ func normalizeProjectAssistantWorkflowInput(ctx context.Context, input projectAs
 	input.MaxFiles = boundedWorkflowFileLimit(input.MaxFiles)
 	if input.Project == nil {
 		return projectAssistantWorkflowInput{}, fmt.Errorf("project is required")
+	}
+	return input, nil
+}
+
+func normalizeProjectAssistantRuntimeWorkflowInput(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowInput, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantRuntimeWorkflowInput{}, err
+	}
+	if input.Project == nil {
+		return projectAssistantRuntimeWorkflowInput{}, fmt.Errorf("project is required")
+	}
+	input.SessionSnapshot = cloneProjectEinoAssistantSessionSnapshot(input.SessionSnapshot)
+	input.AppDeployment.TargetRef = strings.TrimSpace(input.AppDeployment.TargetRef)
+	input.AppDeployment.AppName = strings.TrimSpace(input.AppDeployment.AppName)
+	if input.AppDeployment.AppName == "" {
+		input.AppDeployment.AppName = strings.TrimSpace(input.Project.Name)
+	}
+	input.AppDeployment.Image = strings.TrimSpace(input.AppDeployment.Image)
+	input.AppDeployment.Intent = strings.ToLower(strings.TrimSpace(input.AppDeployment.Intent))
+	if input.AppDeployment.Intent == "" {
+		input.AppDeployment.Intent = "preview"
 	}
 	return input, nil
 }
@@ -309,6 +581,22 @@ func formatProjectAssistantReadinessWorkflow(ctx context.Context, input projectA
 	return formatProjectAssistantReadinessWorkflowResult(ctx, input)
 }
 
+func formatProjectAssistantDeploymentPreparationWorkflow(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantDeploymentPreparationResult, error) {
+	return formatProjectAssistantDeploymentPreparationResult(ctx, input)
+}
+
+func formatProjectAssistantRuntimeDeploymentWorkflow(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
+	return formatProjectAssistantRuntimeDeploymentResult(ctx, input)
+}
+
+func formatProjectAssistantRuntimeStatusWorkflow(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
+	return formatProjectAssistantRuntimeStatusResult(ctx, input)
+}
+
+func formatProjectAssistantPreviewURLWorkflow(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
+	return formatProjectAssistantPreviewURLResult(ctx, input)
+}
+
 func formatProjectAssistantReadinessWorkflowResult(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantReadinessWorkflowResult, error) {
 	result := projectAssistantReadinessWorkflowResult{}
 	if err := ctx.Err(); err != nil {
@@ -340,6 +628,167 @@ func formatProjectAssistantReadinessWorkflowResult(ctx context.Context, input pr
 			Name:   input.Repository.Name,
 			Status: input.Repository.Status,
 		}
+	}
+	return result, nil
+}
+
+func formatProjectAssistantRuntimeDeploymentResult(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantRuntimeWorkflowResult{}, err
+	}
+	result := projectAssistantRuntimeWorkflowResult{
+		Status:        "blocked",
+		AppDeployment: &input.AppDeployment,
+		Runtime:       projectAssistantRuntimeNotConfigured(),
+		Summary:       "Runtime deployment is blocked because no App Studio runtime provider is configured.",
+		Blockers:      []string{"Runtime provider is not configured."},
+		NextSteps: []string{
+			"Configure a tenant-isolated RuntimeTarget before creating an AppDeployment.",
+			"Use prepare_project_deployment to verify build artifact readiness before retrying runtime deployment.",
+		},
+	}
+	if input.AppDeployment.TargetRef == "" {
+		result.Blockers = append(result.Blockers, "Runtime targetRef is required.")
+	}
+	if input.AppDeployment.Image == "" {
+		result.Blockers = append(result.Blockers, "Build artifact image is required.")
+	}
+	if input.AppDeployment.Port <= 0 {
+		result.Blockers = append(result.Blockers, "Container port is required.")
+	}
+	if input.AppDeployment.Intent != "preview" && input.AppDeployment.Intent != "production" {
+		result.Blockers = append(result.Blockers, "Deployment intent must be preview or production.")
+	}
+	return result, nil
+}
+
+func formatProjectAssistantRuntimeStatusResult(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantRuntimeWorkflowResult{}, err
+	}
+	if runtime := projectAssistantRuntimeFromSession(input.SessionSnapshot); runtime != nil {
+		result := projectAssistantRuntimeWorkflowResult{
+			Status:     strings.TrimSpace(runtime.Status),
+			Runtime:    runtime,
+			PreviewURL: strings.TrimSpace(runtime.URL),
+		}
+		if result.Status == "" {
+			result.Status = "unknown"
+		}
+		result.Summary = "Runtime deployment status is " + result.Status + "."
+		return result, nil
+	}
+	return projectAssistantRuntimeNotConfiguredResult("Runtime deployment status is unavailable because no runtime deployment is recorded.")
+}
+
+func formatProjectAssistantPreviewURLResult(ctx context.Context, input projectAssistantRuntimeWorkflowInput) (projectAssistantRuntimeWorkflowResult, error) {
+	if err := ctx.Err(); err != nil {
+		return projectAssistantRuntimeWorkflowResult{}, err
+	}
+	if runtime := projectAssistantRuntimeFromSession(input.SessionSnapshot); runtime != nil {
+		result := projectAssistantRuntimeWorkflowResult{
+			Status:     strings.TrimSpace(runtime.Status),
+			Runtime:    runtime,
+			PreviewURL: strings.TrimSpace(runtime.URL),
+		}
+		if result.PreviewURL == "" {
+			result.Status = "unavailable"
+			result.Blockers = []string{"No preview URL is recorded for the current runtime deployment."}
+			result.Summary = "Preview URL is unavailable for the current runtime deployment."
+			return result, nil
+		}
+		if result.Status == "" {
+			result.Status = "ready"
+		}
+		result.Summary = "Preview URL is available."
+		return result, nil
+	}
+	return projectAssistantRuntimeNotConfiguredResult("Preview URL is unavailable because no runtime deployment is recorded.")
+}
+
+func projectAssistantRuntimeNotConfiguredResult(summary string) (projectAssistantRuntimeWorkflowResult, error) {
+	return projectAssistantRuntimeWorkflowResult{
+		Status:  "not_configured",
+		Summary: summary,
+		Runtime: projectAssistantRuntimeNotConfigured(),
+		Blockers: []string{
+			"Runtime provider is not configured.",
+		},
+		NextSteps: []string{
+			"Configure a tenant-isolated RuntimeTarget before requesting runtime status or preview URL.",
+		},
+	}, nil
+}
+
+func projectAssistantRuntimeNotConfigured() *projectAssistantDeploymentRuntime {
+	return &projectAssistantDeploymentRuntime{
+		Status:  "not_configured",
+		Message: "Runtime deployment is not configured for this App Studio project.",
+	}
+}
+
+func projectAssistantRuntimeFromSession(snapshot *projectEinoAssistantSessionSnapshot) *projectAssistantDeploymentRuntime {
+	if snapshot == nil || snapshot.LastRuntimeDeployment == nil {
+		return nil
+	}
+	return &projectAssistantDeploymentRuntime{
+		Status: strings.TrimSpace(snapshot.LastRuntimeDeployment.Status),
+		URL:    strings.TrimSpace(snapshot.LastRuntimeDeployment.URL),
+	}
+}
+
+func formatProjectAssistantDeploymentPreparationResult(ctx context.Context, input projectAssistantWorkflowContext) (projectAssistantDeploymentPreparationResult, error) {
+	result := projectAssistantDeploymentPreparationResult{}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	p := input.Project
+	if p == nil {
+		return result, fmt.Errorf("project is required")
+	}
+	displayName := strings.TrimSpace(p.Spec.DisplayName)
+	if displayName == "" {
+		displayName = p.Name
+	}
+	result.Artifact = &projectAssistantDeploymentArtifact{
+		Status: "required",
+		Type:   "oci-image",
+		Source: "app-studio-build",
+	}
+	result.Runtime = &projectAssistantDeploymentRuntime{
+		Status:  "not_configured",
+		Message: "Runtime deployment is not configured; App Studio can prepare source and build handoff context only.",
+	}
+	result.RecommendedChecks = projectAssistantRecommendedRuntimeChecks(input.WorkspaceFiles)
+	result.Files = append([]string(nil), input.WorkspaceFiles...)
+	if input.Repository != nil {
+		result.Repository = &projectAssistantWorkflowRepo{
+			Ref:    input.Repository.Ref,
+			Name:   input.Repository.Name,
+			Status: input.Repository.Status,
+		}
+	}
+	if len(p.Spec.Memory.Requirements) == 0 {
+		result.Blockers = append(result.Blockers, "Project requirements are missing.")
+	}
+	if input.Repository == nil || input.Repository.Status != projectRepositoryStatusReady {
+		result.Blockers = append(result.Blockers, "Managed repository is not ready.")
+	}
+	if len(input.WorkspaceFiles) == 0 {
+		result.Blockers = append(result.Blockers, "Workspace file context is missing.")
+	}
+	if len(result.Blockers) > 0 {
+		result.Status = "blocked"
+		result.Summary = fmt.Sprintf("Project %s is blocked for deployment preparation.", displayName)
+		result.NextSteps = []string{"Resolve deployment preparation blockers before build or runtime handoff."}
+		return result, nil
+	}
+	result.Status = "ready_for_build"
+	result.Summary = fmt.Sprintf("Project %s is ready for App Studio build preparation; runtime deployment is not configured yet.", displayName)
+	result.NextSteps = []string{
+		"Build an OCI image for the current workspace before runtime deployment.",
+		"Run recommended checks before publishing the build artifact.",
+		"Create a runtime deployment only after a tenant-isolated runtime target is available.",
 	}
 	return result, nil
 }

--- a/providers/app-studio/api/assistant_workflow_test.go
+++ b/providers/app-studio/api/assistant_workflow_test.go
@@ -65,6 +65,61 @@ func TestProjectAssistantReadinessWorkflowRegisteredReadOnly(t *testing.T) {
 	}
 }
 
+func TestProjectAssistantPrepareDeploymentWorkflowRegisteredReadOnly(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	registry := server.projectAssistantToolRegistry()
+	tool, ok := registry.Get(projectToolPrepareProjectDeployment)
+	if !ok {
+		t.Fatal("prepare_project_deployment tool missing from registry")
+	}
+	spec := tool.Spec()
+	if spec.Risk != projectAssistantToolRiskRead {
+		t.Fatalf("risk = %q, want read", spec.Risk)
+	}
+	if got := projectAssistantPermissionForTool(spec); got != projectAssistantPermissionAllow {
+		t.Fatalf("permission = %q, want allow", got)
+	}
+	if strings.TrimSpace(string(spec.Parameters)) == "" {
+		t.Fatal("prepare deployment workflow tool parameters are empty")
+	}
+}
+
+func TestProjectAssistantRuntimeWorkflowToolsRegistered(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	registry := server.projectAssistantToolRegistry()
+	tests := []struct {
+		name       string
+		wantRisk   projectAssistantToolRisk
+		wantPerm   projectAssistantPermissionDecision
+		wantBundle projectAssistantToolBundle
+	}{
+		{name: "deploy_project_runtime", wantRisk: projectAssistantToolRiskRuntime, wantPerm: projectAssistantPermissionAsk, wantBundle: projectAssistantToolBundleRuntime},
+		{name: "get_runtime_status", wantRisk: projectAssistantToolRiskRead, wantPerm: projectAssistantPermissionAllow, wantBundle: projectAssistantToolBundleRuntime},
+		{name: "get_preview_url", wantRisk: projectAssistantToolRiskRead, wantPerm: projectAssistantPermissionAllow, wantBundle: projectAssistantToolBundleRuntime},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool, ok := registry.Get(tt.name)
+			if !ok {
+				t.Fatalf("%s tool missing from registry", tt.name)
+			}
+			spec := tool.Spec()
+			if spec.Risk != tt.wantRisk {
+				t.Fatalf("risk = %q, want %q", spec.Risk, tt.wantRisk)
+			}
+			if got := projectAssistantPermissionForTool(spec); got != tt.wantPerm {
+				t.Fatalf("permission = %q, want %q", got, tt.wantPerm)
+			}
+			if got := projectAssistantToolBundleForSpec(spec); got != tt.wantBundle {
+				t.Fatalf("bundle = %q, want %q", got, tt.wantBundle)
+			}
+			if strings.TrimSpace(string(spec.Parameters)) == "" {
+				t.Fatalf("%s parameters are empty", tt.name)
+			}
+		})
+	}
+}
+
 func TestProjectAssistantWorkflowPlansFromMemoryRepositoryAndWorkspace(t *testing.T) {
 	workspaces := workspace.NewFileStore(t.TempDir())
 	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
@@ -175,6 +230,94 @@ func TestProjectAssistantReadinessWorkflowReportsContextWithoutTrace(t *testing.
 	}
 }
 
+func TestProjectAssistantPrepareDeploymentWorkflowReportsBuildAndRuntimeReadiness(t *testing.T) {
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = "Demo App"
+	project.Spec.Memory.Requirements = []string{"ship a tested build"}
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "package.json", Content: `{"scripts":{"build":"vite build","test":"vitest"}}`}); err != nil {
+		t.Fatalf("WriteFile package.json returned error: %v", err)
+	}
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "src/App.tsx", Content: "export function App() { return null }\n"}); err != nil {
+		t.Fatalf("WriteFile src/App.tsx returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolPrepareProjectDeployment)
+	if !ok {
+		t.Fatal("prepare_project_deployment tool missing from registry")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		Repository:     &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		WorkspaceScope: scope,
+		Arguments:      map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if len(raw) > projectAssistantWorkflowMaxResultBytes {
+		t.Fatalf("workflow result length = %d, want <= %d", len(raw), projectAssistantWorkflowMaxResultBytes)
+	}
+	var prepared projectAssistantDeploymentPreparationResult
+	if err := json.Unmarshal([]byte(raw), &prepared); err != nil {
+		t.Fatalf("workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if prepared.Status != "ready_for_build" {
+		t.Fatalf("status = %q, want ready_for_build", prepared.Status)
+	}
+	if prepared.Artifact == nil || prepared.Artifact.Type != "oci-image" || prepared.Artifact.Source != "app-studio-build" || prepared.Artifact.Status != "required" {
+		t.Fatalf("artifact = %#v, want required App Studio OCI image build artifact", prepared.Artifact)
+	}
+	if prepared.Runtime == nil || prepared.Runtime.Status != "not_configured" {
+		t.Fatalf("runtime = %#v, want not_configured runtime handoff", prepared.Runtime)
+	}
+	if !containsString(prepared.RecommendedChecks, "build") || !containsString(prepared.RecommendedChecks, "test") {
+		t.Fatalf("recommended checks = %#v, want build and test", prepared.RecommendedChecks)
+	}
+	if !containsString(prepared.Files, "package.json") || !containsString(prepared.Files, "src/App.tsx") {
+		t.Fatalf("files = %#v, want workspace files", prepared.Files)
+	}
+	if len(prepared.Blockers) != 0 {
+		t.Fatalf("blockers = %#v, want none before runtime handoff", prepared.Blockers)
+	}
+	if !containsString(prepared.NextSteps, "Build an OCI image for the current workspace before runtime deployment.") {
+		t.Fatalf("next steps = %#v, want OCI build step", prepared.NextSteps)
+	}
+}
+
+func TestProjectAssistantPrepareDeploymentWorkflowReportsBlockers(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolPrepareProjectDeployment)
+	if !ok {
+		t.Fatal("prepare_project_deployment tool missing from registry")
+	}
+
+	raw, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Project:   project,
+		Arguments: map[string]any{"includeFiles": false},
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	var prepared projectAssistantDeploymentPreparationResult
+	if err := json.Unmarshal([]byte(raw), &prepared); err != nil {
+		t.Fatalf("workflow result is not JSON: %v\n%s", err, raw)
+	}
+	if prepared.Status != "blocked" {
+		t.Fatalf("status = %q, want blocked", prepared.Status)
+	}
+	if !containsString(prepared.Blockers, "Project requirements are missing.") || !containsString(prepared.Blockers, "Managed repository is not ready.") {
+		t.Fatalf("blockers = %#v, want requirements and repository blockers", prepared.Blockers)
+	}
+}
+
 func TestProjectAssistantWorkflowDoesNotMutateWorkspace(t *testing.T) {
 	workspaces := workspace.NewFileStore(t.TempDir())
 	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
@@ -207,6 +350,166 @@ func TestProjectAssistantWorkflowDoesNotMutateWorkspace(t *testing.T) {
 	}
 	if strings.Join(workflowTestFilePaths(before.Files), "\n") != strings.Join(workflowTestFilePaths(after.Files), "\n") {
 		t.Fatalf("files changed from %#v to %#v", before.Files, after.Files)
+	}
+}
+
+func TestProjectAssistantPrepareDeploymentWorkflowDoesNotMutateWorkspace(t *testing.T) {
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	scope := projectWorkspaceScope(id, project.Name)
+	if _, err := workspaces.WriteFile(context.Background(), scope, workspace.WriteOptions{Path: "README.md", Content: "# Demo\n"}); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	before, err := workspaces.ListFiles(context.Background(), scope, workspace.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListFiles before returned error: %v", err)
+	}
+	tool, ok := server.projectAssistantToolRegistry().Get(projectToolPrepareProjectDeployment)
+	if !ok {
+		t.Fatal("prepare_project_deployment tool missing from registry")
+	}
+	if _, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Identity:       id,
+		Project:        project,
+		WorkspaceScope: scope,
+		Arguments:      map[string]any{},
+	}); err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	after, err := workspaces.ListFiles(context.Background(), scope, workspace.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListFiles after returned error: %v", err)
+	}
+	if strings.Join(workflowTestFilePaths(before.Files), "\n") != strings.Join(workflowTestFilePaths(after.Files), "\n") {
+		t.Fatalf("files changed from %#v to %#v", before.Files, after.Files)
+	}
+}
+
+func TestProjectAssistantDeployRuntimeWorkflowReportsMissingRuntimeProvider(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	tool, ok := server.projectAssistantToolRegistry().Get("deploy_project_runtime")
+	if !ok {
+		t.Fatal("deploy_project_runtime tool missing from registry")
+	}
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	project.Spec.DisplayName = "Demo App"
+	result, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+		Project:    project,
+		Repository: &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		Arguments: map[string]any{
+			"targetRef": "default-web",
+			"image":     "registry.example.com/demo/app:abc123",
+			"port":      8080,
+			"intent":    "preview",
+		},
+	})
+	if err != nil {
+		t.Fatalf("deploy runtime workflow returned error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, result)
+	}
+	if got := projectToolString(decoded["status"]); got != "blocked" {
+		t.Fatalf("status = %q, want blocked", got)
+	}
+	if !containsString(projectToolStringList(decoded["blockers"]), "Runtime provider is not configured.") {
+		t.Fatalf("blockers = %#v, want runtime provider blocker", decoded["blockers"])
+	}
+	deployment, ok := decoded["appDeployment"].(map[string]any)
+	if !ok {
+		t.Fatalf("appDeployment = %#v, want object", decoded["appDeployment"])
+	}
+	if got := projectToolString(deployment["targetRef"]); got != "default-web" {
+		t.Fatalf("targetRef = %q, want default-web", got)
+	}
+	if got := projectToolString(deployment["image"]); got != "registry.example.com/demo/app:abc123" {
+		t.Fatalf("image = %q, want requested image", got)
+	}
+	if got, _ := projectToolNumber(deployment["port"]); got != 8080 {
+		t.Fatalf("port = %d, want 8080", got)
+	}
+	runtime, ok := decoded["runtime"].(map[string]any)
+	if !ok || projectToolString(runtime["status"]) != "not_configured" {
+		t.Fatalf("runtime = %#v, want not_configured object", decoded["runtime"])
+	}
+}
+
+func TestProjectAssistantRuntimeStatusAndPreviewWorkflowsReportSessionRuntime(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	snapshot := &projectEinoAssistantSessionSnapshot{
+		LastRuntimeDeployment: &projectEinoAssistantSessionRuntime{
+			Status: "ready",
+			URL:    "https://demo.apps.example.com",
+		},
+	}
+	tests := []struct {
+		name        string
+		wantStatus  string
+		wantPreview string
+	}{
+		{name: "get_runtime_status", wantStatus: "ready", wantPreview: "https://demo.apps.example.com"},
+		{name: "get_preview_url", wantStatus: "ready", wantPreview: "https://demo.apps.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool, ok := server.projectAssistantToolRegistry().Get(tt.name)
+			if !ok {
+				t.Fatalf("%s tool missing from registry", tt.name)
+			}
+			result, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+				Project:         projectWithRepository("demo-repo", "demo", "github"),
+				SessionSnapshot: snapshot,
+			})
+			if err != nil {
+				t.Fatalf("%s returned error: %v", tt.name, err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, result)
+			}
+			if got := projectToolString(decoded["status"]); got != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", got, tt.wantStatus)
+			}
+			if got := projectToolString(decoded["previewURL"]); got != tt.wantPreview {
+				t.Fatalf("previewURL = %q, want %q", got, tt.wantPreview)
+			}
+		})
+	}
+}
+
+func TestProjectAssistantRuntimeStatusAndPreviewWorkflowsReportNotConfiguredWithoutSessionRuntime(t *testing.T) {
+	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
+	for _, name := range []string{"get_runtime_status", "get_preview_url"} {
+		t.Run(name, func(t *testing.T) {
+			tool, ok := server.projectAssistantToolRegistry().Get(name)
+			if !ok {
+				t.Fatalf("%s tool missing from registry", name)
+			}
+			result, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
+				Project: projectWithRepository("demo-repo", "demo", "github"),
+			})
+			if err != nil {
+				t.Fatalf("%s returned error: %v", name, err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+				t.Fatalf("decode result: %v\n%s", err, result)
+			}
+			if got := projectToolString(decoded["status"]); got != "not_configured" {
+				t.Fatalf("status = %q, want not_configured", got)
+			}
+			if got := projectToolString(decoded["previewURL"]); got != "" {
+				t.Fatalf("previewURL = %q, want empty without runtime session", got)
+			}
+			if !containsString(projectToolStringList(decoded["blockers"]), "Runtime provider is not configured.") {
+				t.Fatalf("blockers = %#v, want runtime provider blocker", decoded["blockers"])
+			}
+		})
 	}
 }
 

--- a/providers/app-studio/api/assistant_workflow_test.go
+++ b/providers/app-studio/api/assistant_workflow_test.go
@@ -439,49 +439,6 @@ func TestProjectAssistantDeployRuntimeWorkflowReportsMissingRuntimeProvider(t *t
 	}
 }
 
-func TestProjectAssistantRuntimeStatusAndPreviewWorkflowsReportSessionRuntime(t *testing.T) {
-	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
-	snapshot := &projectEinoAssistantSessionSnapshot{
-		LastRuntimeDeployment: &projectEinoAssistantSessionRuntime{
-			Status: "ready",
-			URL:    "https://demo.apps.example.com",
-		},
-	}
-	tests := []struct {
-		name        string
-		wantStatus  string
-		wantPreview string
-	}{
-		{name: "get_runtime_status", wantStatus: "ready", wantPreview: "https://demo.apps.example.com"},
-		{name: "get_preview_url", wantStatus: "ready", wantPreview: "https://demo.apps.example.com"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tool, ok := server.projectAssistantToolRegistry().Get(tt.name)
-			if !ok {
-				t.Fatalf("%s tool missing from registry", tt.name)
-			}
-			result, err := tool.Call(context.Background(), projectAssistantToolCallRequest{
-				Project:         projectWithRepository("demo-repo", "demo", "github"),
-				SessionSnapshot: snapshot,
-			})
-			if err != nil {
-				t.Fatalf("%s returned error: %v", tt.name, err)
-			}
-			var decoded map[string]any
-			if err := json.Unmarshal([]byte(result), &decoded); err != nil {
-				t.Fatalf("decode result: %v\n%s", err, result)
-			}
-			if got := projectToolString(decoded["status"]); got != tt.wantStatus {
-				t.Fatalf("status = %q, want %q", got, tt.wantStatus)
-			}
-			if got := projectToolString(decoded["previewURL"]); got != tt.wantPreview {
-				t.Fatalf("previewURL = %q, want %q", got, tt.wantPreview)
-			}
-		})
-	}
-}
-
 func TestProjectAssistantRuntimeStatusAndPreviewWorkflowsReportNotConfiguredWithoutSessionRuntime(t *testing.T) {
 	server := NewWithWorkspace(nil, store.NewMemoryStore(), workspace.NewFileStore(t.TempDir()), "", false)
 	for _, name := range []string{"get_runtime_status", "get_preview_url"} {

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -71,6 +71,10 @@ const (
 	projectToolSearchProjectFiles         = "search_project_files"
 	projectToolPlanProjectChanges         = "plan_project_changes"
 	projectToolCheckProjectReadiness      = "check_project_readiness"
+	projectToolPrepareProjectDeployment   = "prepare_project_deployment"
+	projectToolDeployProjectRuntime       = "deploy_project_runtime"
+	projectToolGetRuntimeStatus           = "get_runtime_status"
+	projectToolGetPreviewURL              = "get_preview_url"
 	projectToolAskFollowUp                = "ask_follow_up"
 	projectToolRequestProjectPlanApproval = "request_project_plan_approval"
 	projectToolWriteFile                  = "write_file"
@@ -600,8 +604,12 @@ func summarizeProjectToolArgumentsMap(name string, args map[string]any) string {
 		return summarizeProjectToolKeyValues(args, []string{"path", "maxBytes"})
 	case projectToolSearchProjectFiles:
 		return summarizeProjectToolKeyValues(args, []string{"query", "maxResults"})
-	case projectToolPlanProjectChanges, projectToolCheckProjectReadiness:
+	case projectToolPlanProjectChanges, projectToolCheckProjectReadiness, projectToolPrepareProjectDeployment:
 		return summarizeProjectPlanningWorkflowArgs(args)
+	case projectToolDeployProjectRuntime:
+		return summarizeProjectToolKeyValues(args, []string{"targetRef", "appName", "image", "port", "intent"})
+	case projectToolGetRuntimeStatus, projectToolGetPreviewURL:
+		return ""
 	case projectToolAskFollowUp:
 		if questions := projectToolStringList(args["questions"]); len(questions) > 0 {
 			return truncateProjectToolInfo(fmt.Sprintf("%d question(s): %s", len(questions), summarizeProjectToolList(questions, 3)))
@@ -682,8 +690,10 @@ func summarizeProjectToolResult(name, result string) string {
 			if len(parts) > 0 {
 				return truncateProjectToolInfo(strings.Join(parts, "; "))
 			}
-		case projectToolCheckProjectReadiness:
+		case projectToolCheckProjectReadiness, projectToolPrepareProjectDeployment:
 			return summarizeProjectReadinessWorkflowResult(decoded)
+		case projectToolDeployProjectRuntime, projectToolGetRuntimeStatus, projectToolGetPreviewURL:
+			return summarizeProjectRuntimeWorkflowResult(decoded)
 		case projectToolAskFollowUp:
 			if answer := projectToolString(decoded["answer"]); answer != "" {
 				return truncateProjectToolInfo("answered: " + answer)
@@ -787,6 +797,23 @@ func summarizeProjectReadinessWorkflowResult(decoded map[string]any) string {
 	}
 	if files := projectToolStringList(decoded["files"]); len(files) > 0 {
 		parts = append(parts, fmt.Sprintf("%d file(s): %s", len(files), summarizeProjectToolList(files, 5)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return truncateProjectToolInfo(strings.Join(parts, "; "))
+}
+
+func summarizeProjectRuntimeWorkflowResult(decoded map[string]any) string {
+	parts := []string{}
+	if status := projectToolString(decoded["status"]); status != "" {
+		parts = append(parts, "status "+status)
+	}
+	if previewURL := projectToolString(decoded["previewURL"]); previewURL != "" {
+		parts = append(parts, "preview "+previewURL)
+	}
+	if blockers := projectToolStringList(decoded["blockers"]); len(blockers) > 0 {
+		parts = append(parts, "blockers "+summarizeProjectToolList(blockers, 3))
 	}
 	if len(parts) == 0 {
 		return ""
@@ -1522,7 +1549,8 @@ func projectSystemPrompt(p *aiv1alpha1.Project, repository *ProjectRepositoryVie
 	var b strings.Builder
 	b.WriteString("You are the assistant for a persistent Kedge Project workspace. ")
 	b.WriteString("Help the user reason about and build the application represented by this Project. ")
-	b.WriteString("Report tool use when you actually call tools, but do not claim that you changed files or deployed resources unless a tool result or other evidence supports it. ")
+	b.WriteString("Do not narrate tool calls or say what tool you will call next in assistant prose; App Studio shows tool progress through its status and tool summary UI. ")
+	b.WriteString("Do not claim that you changed files or deployed resources unless a tool result or other evidence supports it. ")
 	b.WriteString("When requirements are unclear, call ask_follow_up with at most three concise questions instead of guessing.\n\n")
 	b.WriteString("Project metadata:\n")
 	b.WriteString("- Name: " + p.Name + "\n")
@@ -1548,6 +1576,9 @@ func projectSystemPrompt(p *aiv1alpha1.Project, repository *ProjectRepositoryVie
 			b.WriteString("Do not attempt to commit files until the user restores the missing Code repository or connection.\n")
 		} else {
 			b.WriteString("Use check_project_readiness before mutating or verifying existing work so repository, memory, workspace context, and recommended checks come from the App Studio graph workflow. ")
+			b.WriteString("When a named App Studio tool is deferred, load it first with tool_search using select:<tool_name>, then call the loaded tool. ")
+			b.WriteString("Use prepare_project_deployment before discussing deployment handoff so build artifact readiness, blockers, and runtime handoff constraints come from the App Studio graph workflow. ")
+			b.WriteString("Use deploy_project_runtime, get_runtime_status, and get_preview_url only as App Studio runtime graph workflows; they return structured not_configured blockers until a tenant RuntimeTarget exists. ")
 			b.WriteString("For existing projects, inspect relevant files in the App Studio workspace before editing: use list_project_files to discover paths, read_project_file for targeted files, and search_project_files when you need to locate code. ")
 			b.WriteString("Before source edits, call request_project_plan_approval with a concise batch plan, target path envelope, allowed edit operations, and acceptance criteria; after approval, keep workspace edits inside that envelope. ")
 			b.WriteString("Prefer small App Studio workspace mutations with write_file, apply_patch, and mkdir instead of rewriting a whole project. ")

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -100,6 +100,10 @@ func TestProjectToolAllowlistSeparatesWorkspaceAndGitTools(t *testing.T) {
 		"search_project_files",
 		"plan_project_changes",
 		"check_project_readiness",
+		"prepare_project_deployment",
+		"deploy_project_runtime",
+		"get_runtime_status",
+		"get_preview_url",
 		"ask_follow_up",
 		"request_project_plan_approval",
 		"write_file",
@@ -125,6 +129,10 @@ func TestProjectAssistantToolRegistryListsLocalToolsInOrder(t *testing.T) {
 		"search_project_files",
 		"plan_project_changes",
 		"check_project_readiness",
+		"prepare_project_deployment",
+		"deploy_project_runtime",
+		"get_runtime_status",
+		"get_preview_url",
 		"ask_follow_up",
 		"request_project_plan_approval",
 		"write_file",
@@ -251,8 +259,11 @@ func TestGenerateProjectAssistantStreamIncludesDiscoveredToolPromptOnFirstInput(
 	if !strings.Contains(joined, "Available tools in this workspace") || !strings.Contains(joined, "commit_project_files") {
 		t.Fatalf("first model input missing discovered tool prompt:\n%s", joined)
 	}
-	if !projectChatToolsInclude(model.Inputs[0].Tools, projectToolCommitProjectFiles) {
-		t.Fatalf("model tools = %#v, want commit_project_files from discovered commit bridge", model.Inputs[0].Tools)
+	if projectChatToolsInclude(model.Inputs[0].Tools, projectToolCommitProjectFiles) {
+		t.Fatalf("model tools = %#v, want commit_project_files deferred behind tool_search", model.Inputs[0].Tools)
+	}
+	if !projectChatToolsInclude(model.Inputs[0].Tools, "tool_search") {
+		t.Fatalf("model tools = %#v, want tool_search for deferred commit bridge", model.Inputs[0].Tools)
 	}
 }
 
@@ -268,7 +279,7 @@ func TestProjectSystemPromptRequiresWorkspaceInspectBeforeEdit(t *testing.T) {
 	}
 
 	prompt := projectSystemPrompt(project, repository)
-	for _, want := range []string{"check_project_readiness", "list_project_files", "read_project_file", "search_project_files", "write_file", "apply_patch", "mkdir", "commit_project_files"} {
+	for _, want := range []string{"check_project_readiness", "prepare_project_deployment", "deploy_project_runtime", "get_runtime_status", "get_preview_url", "list_project_files", "read_project_file", "search_project_files", "write_file", "apply_patch", "mkdir", "commit_project_files"} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
@@ -281,8 +292,37 @@ func TestProjectSystemPromptRequiresWorkspaceInspectBeforeEdit(t *testing.T) {
 	if !strings.Contains(prompt, "provider-code only as the git-source boundary") {
 		t.Fatalf("prompt missing provider-code boundary guidance:\n%s", prompt)
 	}
+	if !strings.Contains(prompt, "Do not narrate tool calls") {
+		t.Fatalf("prompt missing tool-call narration guidance:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "tool_search") || !strings.Contains(prompt, "select:") {
+		t.Fatalf("prompt missing deferred tool_search guidance:\n%s", prompt)
+	}
 	if !strings.Contains(strings.ToLower(prompt), "before") || !strings.Contains(strings.ToLower(prompt), "inspect") {
 		t.Fatalf("prompt does not require inspect-before-edit guidance:\n%s", prompt)
+	}
+}
+
+func TestProjectAssistantDoesNotAdvertiseLegacyRuntimeCommandTools(t *testing.T) {
+	registry := projectAssistantLocalToolRegistry(nil)
+	toolNames := strings.Join(projectChatToolNames(registry.ChatTools(true)), "\n")
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo-project"
+	prompt := projectSystemPrompt(project, &ProjectRepositoryView{
+		Ref:    "demo-repo",
+		Name:   "demo",
+		Status: projectRepositoryStatusReady,
+		Ready:  true,
+	})
+	combined := toolNames + "\n" + prompt
+	for _, unwanted := range []string{
+		"runtime_command",
+		"verify_project_runtime",
+		"preview_project_runtime",
+	} {
+		if strings.Contains(combined, unwanted) {
+			t.Fatalf("App Studio should not advertise legacy runtime command tool %q:\n%s", unwanted, combined)
+		}
 	}
 }
 

--- a/providers/app-studio/deploy/chart/templates/catalogentry.yaml
+++ b/providers/app-studio/deploy/chart/templates/catalogentry.yaml
@@ -57,7 +57,7 @@ metadata:
 data:
   catalogentry.yaml: |
 {{ include "appstudio.catalogEntry" . | indent 4 }}
-{{- else }}
+{{- else if .Values.catalogEntry.renderDirect }}
 {{ include "appstudio.catalogEntry" . }}
 {{- end }}
 {{- end }}

--- a/providers/app-studio/deploy/chart/templates/catalogentry.yaml
+++ b/providers/app-studio/deploy/chart/templates/catalogentry.yaml
@@ -57,7 +57,5 @@ metadata:
 data:
   catalogentry.yaml: |
 {{ include "appstudio.catalogEntry" . | indent 4 }}
-{{- else if .Values.catalogEntry.renderDirect }}
-{{ include "appstudio.catalogEntry" . }}
 {{- end }}
 {{- end }}

--- a/providers/app-studio/deploy/chart/templates/catalogentry.yaml
+++ b/providers/app-studio/deploy/chart/templates/catalogentry.yaml
@@ -1,4 +1,40 @@
+{{- define "appstudio.catalogEntry" -}}
+apiVersion: providers.kedge.faros.sh/v1alpha1
+kind: CatalogEntry
+metadata:
+  name: app-studio
+  annotations:
+    providers.kedge.faros.sh/builtin: "false"
+spec:
+  displayName: "App Studio"
+  description: "Persistent AI project workspace for planning, memory, and chat."
+  vendor: "kedge"
+  version: {{ .Chart.AppVersion | quote }}
+  category: "AI"
+  iconURL: "/ui/providers/app-studio/icon.svg"
+  dependencies:
+    - name: code
+  ui:
+    url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.uiURL | quote }}
+    indexPath: "/"
+  backend:
+    # The hub backend proxy forwards /services/providers/app-studio/* here,
+    # injecting the verified X-Kedge-Tenant/X-Kedge-User headers and the
+    # caller's bearer token. The provider serves /api/projects/* + /healthz.
+    url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.backendURL | quote }}
+    healthPath: "/healthz"
+  # Reference-only: the APIExport, schemas, slice, and bind grant are created by
+  # this chart's init container (provider `init`, via the kedge-provider-sdk).
+  apiExport:
+    name: "ai.kedge.faros.sh"
+    permissionClaims:
+      - resource: secrets
+        verbs: ["get", "list", "watch", "create", "update", "delete"]
+        tenantScoped: true
+{{- end -}}
+
 {{- if .Values.catalogEntry.enabled -}}
+{{- if .Values.catalogEntry.renderAsConfigMap }}
 # CatalogEntry registers this provider with the kedge hub for routing + the
 # portal Enable flow. It is a kcp resource (providers.kedge.faros.sh/v1alpha1),
 # so it MUST NOT be applied to the hosting cluster where this chart installs.
@@ -20,36 +56,8 @@ metadata:
     {{- include "appstudio.labels" . | nindent 4 }}
 data:
   catalogentry.yaml: |
-    apiVersion: providers.kedge.faros.sh/v1alpha1
-    kind: CatalogEntry
-    metadata:
-      name: app-studio
-      annotations:
-        providers.kedge.faros.sh/builtin: "false"
-    spec:
-      displayName: "App Studio"
-      description: "Persistent AI project workspace for planning, memory, and chat."
-      vendor: "kedge"
-      version: {{ .Chart.AppVersion | quote }}
-      category: "AI"
-      iconURL: "/ui/providers/app-studio/icon.svg"
-      dependencies:
-        - name: code
-      ui:
-        url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.uiURL | quote }}
-        indexPath: "/"
-      backend:
-        # The hub backend proxy forwards /services/providers/app-studio/* here,
-        # injecting the verified X-Kedge-Tenant/X-Kedge-User headers and the
-        # caller's bearer token. The provider serves /api/projects/* + /healthz.
-        url: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "appstudio.fullname" .) .Release.Namespace .Values.service.port) .Values.catalogEntry.backendURL | quote }}
-        healthPath: "/healthz"
-      # Reference-only: the APIExport, schemas, slice, and bind grant are created by
-      # this chart's init container (provider `init`, via the kedge-provider-sdk).
-      apiExport:
-        name: "ai.kedge.faros.sh"
-        permissionClaims:
-          - resource: secrets
-            verbs: ["get", "list", "watch", "create", "update", "delete"]
-            tenantScoped: true
+{{ include "appstudio.catalogEntry" . | indent 4 }}
+{{- else }}
+{{ include "appstudio.catalogEntry" . }}
+{{- end }}
 {{- end }}

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $catalogEntryConfigMap := and .Values.catalogEntry.enabled .Values.catalogEntry.renderAsConfigMap -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,7 +40,7 @@ spec:
               value: /var/run/secrets/kedge/kedge-provider-kubeconfig
             - name: KEDGE_SCHEMAS_DIR
               value: /etc/kedge/schemas
-            {{- if .Values.catalogEntry.enabled }}
+            {{- if $catalogEntryConfigMap }}
             # The CatalogEntry is a kcp resource, so the chart cannot apply it to
             # the hosting cluster. It is rendered into a ConfigMap (mounted below)
             # and init self-registers it into the provider workspace via the
@@ -51,7 +52,7 @@ spec:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
               readOnly: true
-            {{- if .Values.catalogEntry.enabled }}
+            {{- if $catalogEntryConfigMap }}
             - name: catalogentry
               mountPath: /etc/kedge/catalogentry
               readOnly: true
@@ -142,7 +143,7 @@ spec:
             items:
               - key: kubeconfig
                 path: kedge-provider-kubeconfig
-        {{- if .Values.catalogEntry.enabled }}
+        {{- if $catalogEntryConfigMap }}
         - name: catalogentry
           configMap:
             name: {{ include "appstudio.fullname" . }}-catalogentry

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -24,13 +24,7 @@ service:
 # different rollout cadence).
 catalogEntry:
   enabled: true
-  # Production Helm installs render the kcp CatalogEntry into a ConfigMap that
-  # the init container self-applies. Local/Tilt dev registration sets
-  # renderAsConfigMap=false and renderDirect=true only with
-  # `helm template --show-only templates/catalogentry.yaml`, so the CatalogEntry
-  # can be rendered directly for kubectl apply against kcp.
   renderAsConfigMap: true
-  renderDirect: false
   uiURL: ""
   backendURL: ""
 

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -25,10 +25,12 @@ service:
 catalogEntry:
   enabled: true
   # Production Helm installs render the kcp CatalogEntry into a ConfigMap that
-  # the init container self-applies. Local/Tilt dev registration sets this false
-  # only with `helm template --show-only templates/catalogentry.yaml`, so the
-  # CatalogEntry can be rendered directly for kubectl apply against kcp.
+  # the init container self-applies. Local/Tilt dev registration sets
+  # renderAsConfigMap=false and renderDirect=true only with
+  # `helm template --show-only templates/catalogentry.yaml`, so the CatalogEntry
+  # can be rendered directly for kubectl apply against kcp.
   renderAsConfigMap: true
+  renderDirect: false
   uiURL: ""
   backendURL: ""
 

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -24,6 +24,11 @@ service:
 # different rollout cadence).
 catalogEntry:
   enabled: true
+  # Production Helm installs render the kcp CatalogEntry into a ConfigMap that
+  # the init container self-applies. Local/Tilt dev registration sets this false
+  # only with `helm template --show-only templates/catalogentry.yaml`, so the
+  # CatalogEntry can be rendered directly for kubectl apply against kcp.
+  renderAsConfigMap: true
   uiURL: ""
   backendURL: ""
 

--- a/providers/code/backend/github/backend.go
+++ b/providers/code/backend/github/backend.go
@@ -258,9 +258,9 @@ func (b *Backend) CommitFiles(ctx context.Context, conn *codev1alpha1.Connection
 		_, resp, err = c.Git.UpdateRef(ctx, org, repo.Spec.Name, nextRef, false)
 	}
 	if err != nil {
-		if headSHA != "" && isNotFastForward(resp, err) {
-			if res, ok, recoverErr := recoverConcurrentCommit(ctx, c, org, repo, branch, tree.GetSHA(), files); recoverErr != nil {
-				return backend.RepositoryCommitResult{}, recoverErr
+		if isRecoverableRefRace(resp, err) {
+			if res, ok, retryErr := recoverOrRetryConcurrentCommit(ctx, c, org, repo, branch, commit.GetSHA(), input.IdempotencyKey, message, entries, files); retryErr != nil {
+				return backend.RepositoryCommitResult{}, retryErr
 			} else if ok {
 				return res, nil
 			}
@@ -279,27 +279,85 @@ func shouldReuseHeadCommit(parent *gogithub.Commit, tree *gogithub.Tree, baseTre
 	return parent != nil && tree != nil && tree.GetSHA() != "" && tree.GetSHA() == baseTree
 }
 
-func recoverConcurrentCommit(ctx context.Context, c *gogithub.Client, org string, repo *codev1alpha1.Repository, branch, desiredTree string, files []string) (backend.RepositoryCommitResult, bool, error) {
-	ref, resp, err := c.Git.GetRef(ctx, org, repo.Spec.Name, "heads/"+branch)
+func recoverOrRetryConcurrentCommit(ctx context.Context, c *gogithub.Client, org string, repo *codev1alpha1.Repository, branch, attemptedCommitSHA, idempotencyKey, message string, entries []*gogithub.TreeEntry, files []string) (backend.RepositoryCommitResult, bool, error) {
+	head, ok, err := currentBranchHead(ctx, c, org, repo, branch)
+	if err != nil {
+		return backend.RepositoryCommitResult{}, false, err
+	}
+	if !ok {
+		return backend.RepositoryCommitResult{}, false, nil
+	}
+	baseTree := ""
+	if head.GetTree() != nil {
+		baseTree = head.GetTree().GetSHA()
+	}
+	if concurrentHeadMatchesCommitRequest(head, attemptedCommitSHA, idempotencyKey) {
+		return backend.RepositoryCommitResult{
+			CommitSHA: head.GetSHA(),
+			CommitURL: commitURL(org, repo, head),
+			Branch:    branch,
+			Files:     files,
+		}, true, nil
+	}
+	tree, resp, err := c.Git.CreateTree(ctx, org, repo.Spec.Name, baseTree, entries)
 	if err != nil {
 		return backend.RepositoryCommitResult{}, false, classify(resp, err)
 	}
-	if ref == nil || ref.GetObject() == nil || ref.GetObject().GetSHA() == "" {
-		return backend.RepositoryCommitResult{}, false, nil
-	}
-	head, resp, err := c.Git.GetCommit(ctx, org, repo.Spec.Name, ref.GetObject().GetSHA())
+	commit, resp, err := c.Git.CreateCommit(ctx, org, repo.Spec.Name, &gogithub.Commit{
+		Message: gogithub.String(message),
+		Tree:    tree,
+		Parents: []*gogithub.Commit{{SHA: gogithub.String(head.GetSHA())}},
+	}, nil)
 	if err != nil {
 		return backend.RepositoryCommitResult{}, false, classify(resp, err)
 	}
-	if head == nil || head.GetTree() == nil || head.GetTree().GetSHA() != desiredTree {
-		return backend.RepositoryCommitResult{}, false, nil
+	nextRef := &gogithub.Reference{
+		Ref: gogithub.String("refs/heads/" + branch),
+		Object: &gogithub.GitObject{
+			SHA: commit.SHA,
+		},
+	}
+	if _, resp, err = c.Git.UpdateRef(ctx, org, repo.Spec.Name, nextRef, false); err != nil {
+		return backend.RepositoryCommitResult{}, false, classify(resp, err)
 	}
 	return backend.RepositoryCommitResult{
-		CommitSHA: head.GetSHA(),
-		CommitURL: commitURL(org, repo, head),
+		CommitSHA: commit.GetSHA(),
+		CommitURL: commitURL(org, repo, commit),
 		Branch:    branch,
 		Files:     files,
 	}, true, nil
+}
+
+func concurrentHeadMatchesCommitRequest(head *gogithub.Commit, attemptedCommitSHA, idempotencyKey string) bool {
+	if head == nil {
+		return false
+	}
+	if attemptedCommitSHA != "" && head.GetSHA() == attemptedCommitSHA {
+		return true
+	}
+	return commitMessageHasIdempotencyKey(head.GetMessage(), idempotencyKey)
+}
+
+func currentBranchHead(ctx context.Context, c *gogithub.Client, org string, repo *codev1alpha1.Repository, branch string) (*gogithub.Commit, bool, error) {
+	ref, resp, err := c.Git.GetRef(ctx, org, repo.Spec.Name, "heads/"+branch)
+	if err != nil {
+		return nil, false, classify(resp, err)
+	}
+	if ref == nil || ref.GetObject() == nil || ref.GetObject().GetSHA() == "" {
+		return nil, false, nil
+	}
+	head, resp, err := c.Git.GetCommit(ctx, org, repo.Spec.Name, ref.GetObject().GetSHA())
+	if err != nil {
+		return nil, false, classify(resp, err)
+	}
+	if head == nil {
+		return nil, false, nil
+	}
+	return head, true, nil
+}
+
+func isRecoverableRefRace(resp *gogithub.Response, err error) bool {
+	return isNotFastForward(resp, err) || isReferenceAlreadyExists(resp, err)
 }
 
 func isNotFastForward(resp *gogithub.Response, err error) bool {
@@ -307,6 +365,13 @@ func isNotFastForward(resp *gogithub.Response, err error) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "not a fast forward")
+}
+
+func isReferenceAlreadyExists(resp *gogithub.Response, err error) bool {
+	if resp == nil || resp.StatusCode != http.StatusUnprocessableEntity || err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "reference already exists")
 }
 
 func commitMessageWithIdempotencyKey(message, key string) string {

--- a/providers/code/backend/github/backend.go
+++ b/providers/code/backend/github/backend.go
@@ -258,6 +258,13 @@ func (b *Backend) CommitFiles(ctx context.Context, conn *codev1alpha1.Connection
 		_, resp, err = c.Git.UpdateRef(ctx, org, repo.Spec.Name, nextRef, false)
 	}
 	if err != nil {
+		if headSHA != "" && isNotFastForward(resp, err) {
+			if res, ok, recoverErr := recoverConcurrentCommit(ctx, c, org, repo, branch, tree.GetSHA(), files); recoverErr != nil {
+				return backend.RepositoryCommitResult{}, recoverErr
+			} else if ok {
+				return res, nil
+			}
+		}
 		return backend.RepositoryCommitResult{}, classify(resp, err)
 	}
 	return backend.RepositoryCommitResult{
@@ -270,6 +277,36 @@ func (b *Backend) CommitFiles(ctx context.Context, conn *codev1alpha1.Connection
 
 func shouldReuseHeadCommit(parent *gogithub.Commit, tree *gogithub.Tree, baseTree string) bool {
 	return parent != nil && tree != nil && tree.GetSHA() != "" && tree.GetSHA() == baseTree
+}
+
+func recoverConcurrentCommit(ctx context.Context, c *gogithub.Client, org string, repo *codev1alpha1.Repository, branch, desiredTree string, files []string) (backend.RepositoryCommitResult, bool, error) {
+	ref, resp, err := c.Git.GetRef(ctx, org, repo.Spec.Name, "heads/"+branch)
+	if err != nil {
+		return backend.RepositoryCommitResult{}, false, classify(resp, err)
+	}
+	if ref == nil || ref.GetObject() == nil || ref.GetObject().GetSHA() == "" {
+		return backend.RepositoryCommitResult{}, false, nil
+	}
+	head, resp, err := c.Git.GetCommit(ctx, org, repo.Spec.Name, ref.GetObject().GetSHA())
+	if err != nil {
+		return backend.RepositoryCommitResult{}, false, classify(resp, err)
+	}
+	if head == nil || head.GetTree() == nil || head.GetTree().GetSHA() != desiredTree {
+		return backend.RepositoryCommitResult{}, false, nil
+	}
+	return backend.RepositoryCommitResult{
+		CommitSHA: head.GetSHA(),
+		CommitURL: commitURL(org, repo, head),
+		Branch:    branch,
+		Files:     files,
+	}, true, nil
+}
+
+func isNotFastForward(resp *gogithub.Response, err error) bool {
+	if resp == nil || resp.StatusCode != http.StatusUnprocessableEntity || err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not a fast forward")
 }
 
 func commitMessageWithIdempotencyKey(message, key string) string {

--- a/providers/code/backend/github/commit_test.go
+++ b/providers/code/backend/github/commit_test.go
@@ -19,6 +19,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -200,4 +201,305 @@ func TestCommitFilesRecoversWhenConcurrentUpdateAlreadyAppliedDesiredTree(t *tes
 	if getRefCalls != 2 {
 		t.Fatalf("get ref calls = %d, want initial + recovery", getRefCalls)
 	}
+}
+
+func TestCommitFilesRetriesWhenConcurrentUpdateMovedBranchToDifferentTree(t *testing.T) {
+	const (
+		baseTreeSHA       = "tree-base"
+		concurrentTreeSHA = "tree-concurrent"
+		mergedTreeSHA     = "tree-merged"
+		baseCommitSHA     = "commit-base"
+		concurrentSHA     = "commit-concurrent"
+		orphanCommitSHA   = "commit-orphan"
+		retryCommitSHA    = "commit-retry"
+	)
+	var getRefCalls int
+	var createTreeBases []string
+	var createCommitParents []string
+	var updateRefSHAs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/ref/heads/main" && r.Method == http.MethodGet {
+			getRefCalls++
+			w.Header().Set("Content-Type", "application/json")
+			sha := baseCommitSHA
+			if getRefCalls > 1 {
+				sha = concurrentSHA
+			}
+			_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/main","object":{"type":"commit","sha":%q}}`, sha)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/commits" && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+baseCommitSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, baseCommitSHA, baseTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+concurrentSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, concurrentSHA, concurrentTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/trees" && r.Method == http.MethodPost {
+			body := mustReadRequestBody(t, r)
+			if strings.Contains(body, baseTreeSHA) {
+				createTreeBases = append(createTreeBases, baseTreeSHA)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"sha":"tree-orphan"}`)
+				return
+			}
+			if strings.Contains(body, concurrentTreeSHA) {
+				createTreeBases = append(createTreeBases, concurrentTreeSHA)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"sha":%q}`, mergedTreeSHA)
+				return
+			}
+			t.Fatalf("unexpected CreateTree body: %s", body)
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits" && r.Method == http.MethodPost {
+			body := mustReadRequestBody(t, r)
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(body, baseCommitSHA) {
+				createCommitParents = append(createCommitParents, baseCommitSHA)
+				_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":"tree-orphan"}}`, orphanCommitSHA)
+				return
+			}
+			if strings.Contains(body, concurrentSHA) {
+				createCommitParents = append(createCommitParents, concurrentSHA)
+				_, _ = fmt.Fprintf(w, `{"sha":%q,"html_url":"https://example.test/acme/widgets/commit/%s","tree":{"sha":%q}}`, retryCommitSHA, retryCommitSHA, mergedTreeSHA)
+				return
+			}
+			t.Fatalf("unexpected CreateCommit body: %s", body)
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/refs/heads/main" && r.Method == http.MethodPatch {
+			body := mustReadRequestBody(t, r)
+			if strings.Contains(body, orphanCommitSHA) {
+				updateRefSHAs = append(updateRefSHAs, orphanCommitSHA)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"message":"Update is not a fast forward"}`))
+				return
+			}
+			if strings.Contains(body, retryCommitSHA) {
+				updateRefSHAs = append(updateRefSHAs, retryCommitSHA)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/main","object":{"type":"commit","sha":%q}}`, retryCommitSHA)
+				return
+			}
+			t.Fatalf("unexpected UpdateRef body: %s", body)
+		}
+		t.Fatalf("unexpected GitHub request %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	got, err := New().CommitFiles(context.Background(),
+		&codev1alpha1.Connection{Spec: codev1alpha1.ConnectionSpec{Owner: "acme", BaseURL: srv.URL}},
+		backend.Credential{Token: "token"},
+		&codev1alpha1.Repository{Spec: codev1alpha1.RepositorySpec{Name: "widgets", DefaultBranch: "main"}},
+		backend.RepositoryCommitInput{
+			Message:        "Update",
+			IdempotencyKey: "commit-uid",
+			Files:          []backend.RepositoryCommitFile{{Path: "index.html", Content: "hello"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("CommitFiles returned error: %v", err)
+	}
+	if got.CommitSHA != retryCommitSHA {
+		t.Fatalf("commit SHA = %q, want %q", got.CommitSHA, retryCommitSHA)
+	}
+	if strings.Join(createTreeBases, ",") != baseTreeSHA+","+concurrentTreeSHA {
+		t.Fatalf("CreateTree bases = %#v, want base then concurrent tree", createTreeBases)
+	}
+	if strings.Join(createCommitParents, ",") != baseCommitSHA+","+concurrentSHA {
+		t.Fatalf("CreateCommit parents = %#v, want base then concurrent commit", createCommitParents)
+	}
+	if strings.Join(updateRefSHAs, ",") != orphanCommitSHA+","+retryCommitSHA {
+		t.Fatalf("UpdateRef SHAs = %#v, want orphan then retry commit", updateRefSHAs)
+	}
+}
+
+func TestCommitFilesRetriesWhenConcurrentUpdateAlreadyAppliedSameTreeWithoutProof(t *testing.T) {
+	const (
+		baseTreeSHA     = "tree-base"
+		desiredTreeSHA  = "tree-desired"
+		baseCommitSHA   = "commit-base"
+		orphanCommitSHA = "commit-orphan"
+		concurrentSHA   = "commit-concurrent"
+		retryCommitSHA  = "commit-retry"
+	)
+	var getRefCalls int
+	var createCommitParents []string
+	var updateRefSHAs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/ref/heads/main" && r.Method == http.MethodGet {
+			getRefCalls++
+			w.Header().Set("Content-Type", "application/json")
+			sha := baseCommitSHA
+			if getRefCalls > 1 {
+				sha = concurrentSHA
+			}
+			_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/main","object":{"type":"commit","sha":%q}}`, sha)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/commits" && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+baseCommitSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, baseCommitSHA, baseTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+concurrentSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q},"message":"Other automation wrote the same files"}`, concurrentSHA, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/trees" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q}`, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits" && r.Method == http.MethodPost {
+			body := mustReadRequestBody(t, r)
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(body, baseCommitSHA) {
+				createCommitParents = append(createCommitParents, baseCommitSHA)
+				_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, orphanCommitSHA, desiredTreeSHA)
+				return
+			}
+			if strings.Contains(body, concurrentSHA) {
+				createCommitParents = append(createCommitParents, concurrentSHA)
+				_, _ = fmt.Fprintf(w, `{"sha":%q,"html_url":"https://example.test/acme/widgets/commit/%s","tree":{"sha":%q}}`, retryCommitSHA, retryCommitSHA, desiredTreeSHA)
+				return
+			}
+			t.Fatalf("unexpected CreateCommit body: %s", body)
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/refs/heads/main" && r.Method == http.MethodPatch {
+			body := mustReadRequestBody(t, r)
+			if strings.Contains(body, orphanCommitSHA) {
+				updateRefSHAs = append(updateRefSHAs, orphanCommitSHA)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"message":"Update is not a fast forward"}`))
+				return
+			}
+			if strings.Contains(body, retryCommitSHA) {
+				updateRefSHAs = append(updateRefSHAs, retryCommitSHA)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/main","object":{"type":"commit","sha":%q}}`, retryCommitSHA)
+				return
+			}
+			t.Fatalf("unexpected UpdateRef body: %s", body)
+		}
+		t.Fatalf("unexpected GitHub request %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	got, err := New().CommitFiles(context.Background(),
+		&codev1alpha1.Connection{Spec: codev1alpha1.ConnectionSpec{Owner: "acme", BaseURL: srv.URL}},
+		backend.Credential{Token: "token"},
+		&codev1alpha1.Repository{Spec: codev1alpha1.RepositorySpec{Name: "widgets", DefaultBranch: "main"}},
+		backend.RepositoryCommitInput{
+			Message: "Update",
+			Files:   []backend.RepositoryCommitFile{{Path: "index.html", Content: "hello"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("CommitFiles returned error: %v", err)
+	}
+	if got.CommitSHA != retryCommitSHA {
+		t.Fatalf("commit SHA = %q, want retried commit %q", got.CommitSHA, retryCommitSHA)
+	}
+	if strings.Join(createCommitParents, ",") != baseCommitSHA+","+concurrentSHA {
+		t.Fatalf("CreateCommit parents = %#v, want base then concurrent commit", createCommitParents)
+	}
+	if strings.Join(updateRefSHAs, ",") != orphanCommitSHA+","+retryCommitSHA {
+		t.Fatalf("UpdateRef SHAs = %#v, want orphan then retry commit", updateRefSHAs)
+	}
+}
+
+func TestCommitFilesRecoversWhenConcurrentCreateRefAlreadyAppliedDesiredTree(t *testing.T) {
+	const (
+		desiredTreeSHA = "tree-desired"
+		nextCommitSHA  = "commit-next"
+		idempotencyKey = "commit-uid"
+	)
+	var getRefCalls int
+	var createRefCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/ref/heads/main" && r.Method == http.MethodGet {
+			getRefCalls++
+			if getRefCalls == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/main","object":{"type":"commit","sha":%q}}`, nextCommitSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+nextCommitSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"html_url":"https://example.test/acme/widgets/commit/%s","message":"Initial app\n\n%s %s","tree":{"sha":%q}}`, nextCommitSHA, nextCommitSHA, repositoryCommitIdempotencyTrailer, idempotencyKey, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/trees" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q}`, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, nextCommitSHA, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/refs" && r.Method == http.MethodPost {
+			createRefCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Reference already exists"}`))
+			return
+		}
+		t.Fatalf("unexpected GitHub request %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	got, err := New().CommitFiles(context.Background(),
+		&codev1alpha1.Connection{Spec: codev1alpha1.ConnectionSpec{Owner: "acme", BaseURL: srv.URL}},
+		backend.Credential{Token: "token"},
+		&codev1alpha1.Repository{Spec: codev1alpha1.RepositorySpec{Name: "widgets", DefaultBranch: "main"}},
+		backend.RepositoryCommitInput{
+			Message:        "Initial app",
+			IdempotencyKey: idempotencyKey,
+			Files:          []backend.RepositoryCommitFile{{Path: "index.html", Content: "hello"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("CommitFiles returned error: %v", err)
+	}
+	if got.CommitSHA != nextCommitSHA {
+		t.Fatalf("commit SHA = %q, want %q", got.CommitSHA, nextCommitSHA)
+	}
+	if createRefCalls != 1 {
+		t.Fatalf("create ref calls = %d, want 1", createRefCalls)
+	}
+	if getRefCalls != 2 {
+		t.Fatalf("get ref calls = %d, want initial miss + recovery", getRefCalls)
+	}
+}
+
+func mustReadRequestBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	return string(body)
 }

--- a/providers/code/backend/github/commit_test.go
+++ b/providers/code/backend/github/commit_test.go
@@ -17,10 +17,16 @@ limitations under the License.
 package github
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	gogithub "github.com/google/go-github/v66/github"
 
+	codev1alpha1 "github.com/faroshq/provider-code/apis/v1alpha1"
 	"github.com/faroshq/provider-code/backend"
 )
 
@@ -103,5 +109,95 @@ func TestCommitMessageHasIdempotencyKey(t *testing.T) {
 	}
 	if commitMessageHasIdempotencyKey("Initial app Kedge-RepositoryCommit: root:acme/demo", "root:acme/demo") {
 		t.Fatal("commitMessageHasIdempotencyKey returned true for an inline substring")
+	}
+}
+
+func TestCommitFilesRecoversWhenConcurrentUpdateAlreadyAppliedDesiredTree(t *testing.T) {
+	const (
+		baseTreeSHA    = "tree-base"
+		desiredTreeSHA = "tree-desired"
+		baseCommitSHA  = "commit-base"
+		nextCommitSHA  = "commit-next"
+		idempotencyKey = "commit-uid"
+	)
+	var getRefCalls int
+	var updateRefCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/ref/heads/main" && r.Method == http.MethodGet {
+			getRefCalls++
+			w.Header().Set("Content-Type", "application/json")
+			sha := baseCommitSHA
+			if getRefCalls > 1 {
+				sha = nextCommitSHA
+			}
+			_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/main","object":{"type":"commit","sha":%q}}`, sha)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/commits" && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+baseCommitSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, baseCommitSHA, baseTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits/"+nextCommitSHA && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"html_url":"https://example.test/acme/widgets/commit/%s","message":"Update\n\n%s %s","tree":{"sha":%q}}`, nextCommitSHA, nextCommitSHA, repositoryCommitIdempotencyTrailer, idempotencyKey, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/trees" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q}`, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/commits" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, nextCommitSHA, desiredTreeSHA)
+			return
+		}
+		if r.URL.Path == "/api/v3/repos/acme/widgets/git/refs/heads/main" && r.Method == http.MethodPatch {
+			updateRefCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Update is not a fast forward"}`))
+			return
+		}
+		t.Fatalf("unexpected GitHub request %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	got, err := New().CommitFiles(context.Background(),
+		&codev1alpha1.Connection{Spec: codev1alpha1.ConnectionSpec{Owner: "acme", BaseURL: srv.URL}},
+		backend.Credential{Token: "token"},
+		&codev1alpha1.Repository{Spec: codev1alpha1.RepositorySpec{Name: "widgets", DefaultBranch: "main"}},
+		backend.RepositoryCommitInput{
+			Message:        "Update",
+			IdempotencyKey: idempotencyKey,
+			Files:          []backend.RepositoryCommitFile{{Path: "index.html", Content: "hello"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("CommitFiles returned error: %v", err)
+	}
+	if got.CommitSHA != nextCommitSHA {
+		t.Fatalf("commit SHA = %q, want %q", got.CommitSHA, nextCommitSHA)
+	}
+	if len(got.Files) != 1 || got.Files[0] != "index.html" {
+		t.Fatalf("files = %#v, want index.html", got.Files)
+	}
+	if got.Branch != "main" {
+		t.Fatalf("branch = %q, want main", got.Branch)
+	}
+	if !strings.Contains(got.CommitURL, nextCommitSHA) {
+		t.Fatalf("commit URL = %q, want SHA", got.CommitURL)
+	}
+	if updateRefCalls != 1 {
+		t.Fatalf("update ref calls = %d, want 1", updateRefCalls)
+	}
+	if getRefCalls != 2 {
+		t.Fatalf("get ref calls = %d, want initial + recovery", getRefCalls)
 	}
 }

--- a/providers/code/controller/repositorycommit/controller.go
+++ b/providers/code/controller/repositorycommit/controller.go
@@ -163,7 +163,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	}
 	next.Status.Files = fileStatus
 	shared.SetCondition(&next.Status.Conditions, codev1alpha1.ConditionReady, metav1.ConditionTrue, codev1alpha1.ReasonReady, "Commit succeeded.", commit.Generation)
-	if err := c.Status().Update(ctx, next); err != nil {
+	if err := updateStatusIfChanged(ctx, c, next); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update repositorycommit %q status: %w", commit.Name, err)
 	}
 	if err := r.Bundles.Delete(ctx, bundleScope, bundleRef.Name, bundleRef.Digest); err != nil {
@@ -183,7 +183,7 @@ func (r *Reconciler) fail(ctx context.Context, c client.Client, commit *codev1al
 	next.Status.ObservedGeneration = commit.Generation
 	next.Status.Phase = codev1alpha1.RepositoryCommitPhaseFailed
 	shared.SetCondition(&next.Status.Conditions, codev1alpha1.ConditionReady, metav1.ConditionFalse, codev1alpha1.ReasonError, message, commit.Generation)
-	if err := c.Status().Update(ctx, next); err != nil {
+	if err := updateStatusIfChanged(ctx, c, next); err != nil {
 		return fmt.Errorf("update repositorycommit %q failure status: %w", commit.Name, err)
 	}
 	return nil

--- a/providers/code/controller/repositorycommit/controller_test.go
+++ b/providers/code/controller/repositorycommit/controller_test.go
@@ -81,6 +81,31 @@ func TestFailAndDeleteBundleRemovesStoredBundle(t *testing.T) {
 	}
 }
 
+func TestFailUpdatesCurrentObjectStatus(t *testing.T) {
+	ctx := context.Background()
+	current := &codev1alpha1.RepositoryCommit{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-commit", ResourceVersion: "2"},
+		Status:     codev1alpha1.RepositoryCommitStatus{Phase: codev1alpha1.RepositoryCommitPhaseRunning},
+	}
+	c := &recordingStatusClient{Client: fake.NewClientBuilder().
+		WithScheme(codescheme.NewScheme()).
+		WithStatusSubresource(&codev1alpha1.RepositoryCommit{}).
+		WithObjects(current).
+		Build()}
+	stale := current.DeepCopy()
+	stale.ResourceVersion = "1"
+
+	if err := (&Reconciler{}).fail(ctx, c, stale, "github failed"); err != nil {
+		t.Fatalf("fail returned error: %v", err)
+	}
+	if c.updated == nil {
+		t.Fatal("Status().Update was not called")
+	}
+	if got := c.updated.GetResourceVersion(); got != "2" {
+		t.Fatalf("updated object resourceVersion = %q, want 2", got)
+	}
+}
+
 func TestUpdateStatusIfChangedUpdatesCurrentObject(t *testing.T) {
 	ctx := context.Background()
 	current := &codev1alpha1.RepositoryCommit{


### PR DESCRIPTION
## Summary

- Move repeatable App Studio assistant flows into Eino-native session context, dynamic tool selection, and workflow tools.
- Add App Studio runtime/deployment workflow tools and chart configuration for runtime targets.
- Keep the chat UI conversational by suppressing raw tool-intent narration while preserving the existing status/tool summary UX.
- Harden provider-code commit handling so already-created GitHub commits are reflected consistently when the controller retries.

## Why

App Studio was behaving too much like an LLM with a broad bag of tools. This shifts product workflows toward deterministic Eino session state and graph-style tools while keeping the assistant response surface chat-first.

## Validation

- `git diff --check`
- `go test ./...` in `providers/app-studio`
- `go test ./...` in `providers/code`
- `make build-app-studio-provider`

Draft for review because this is a larger provider workflow branch.
