### PR TITLE
Centralize portal auth session-expiry detection

### DIFF
--- a/portal/src/auth/session.ts
+++ b/portal/src/auth/session.ts
@@ -1,0 +1,128 @@
+// Single source of truth for "the session is dead — bounce to /login".
+//
+// Before this module the detection was scattered: the GraphQL layer had
+// its own 401/403/404 handler, while every REST `fetch` in the stores
+// re-implemented its own `if (!res.ok)` check and silently swallowed an
+// expired token (the user kept seeing errors instead of being sent to
+// login). Now both paths funnel through here:
+//   - REST callers use authFetch(), which injects the bearer and fires
+//     notifySessionExpired() on a 401.
+//   - The GraphQL handler (composables/useGraphQL.ts) and the auth store
+//     call notifySessionExpired() directly.
+//
+// The redirect itself lives in the shell (App.vue), reached via a window
+// event. We deliberately do NOT import `@/router` or any Pinia store
+// here: this module is pulled into provider micro-frontend bundles via
+// the `@kedge-edges` alias, and a static router/store import drags the
+// entire portal SPA into each provider's IIFE (see the long note in
+// composables/useGraphQL.ts). Depending only on `@/auth/token` (pure
+// functions) and the DOM keeps this leaf-level and cycle-free.
+import { loadAuth, isExpired, refreshToken } from '@/auth/token'
+
+// Window event the shell listens for to drop a dead session and redirect
+// to /login (see portal/src/App.vue). No-op inside provider
+// micro-frontends, which register no listener.
+export const SESSION_EXPIRED_EVENT = 'kedge-session-expired'
+
+// One page load can fan out a dozen authenticated requests (provider
+// list + admin probe + N GraphQL queries). When the token dies they all
+// come back 401 at once; without this latch each one would fire the event
+// and race a separate logout()+router.replace(). Latch until the next
+// successful login re-arms it via resetSessionExpired().
+let notified = false
+
+// notifySessionExpired signals the shell that the persisted session can
+// no longer authenticate the user, exactly once per dead session.
+export function notifySessionExpired(): void {
+  if (notified) return
+  notified = true
+  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+}
+
+// resetSessionExpired re-arms the latch. Call it on a successful login so
+// a later expiry triggers the redirect again.
+export function resetSessionExpired(): void {
+  notified = false
+}
+
+// getBearerToken returns a usable bearer, refreshing an expired one
+// in-place. Returns null when there is no session, or when an expired
+// token can't be refreshed — in the latter case it also fires
+// notifySessionExpired(), so callers don't have to detect dead sessions
+// themselves. This is the store-free core; useAuthStore.getValidToken()
+// wraps it to also sync the reactive token ref.
+export async function getBearerToken(): Promise<string | null> {
+  const stored = loadAuth()
+  if (!stored) return null
+  if (!isExpired(stored)) return stored.idToken
+
+  const refreshed = await refreshToken(stored)
+  if (refreshed) return refreshed.idToken
+
+  // Expired and unrefreshable: the session is dead.
+  notifySessionExpired()
+  return null
+}
+
+// Tenant selection persisted by stores/tenant.ts. Kept as a literal (not
+// imported) for the same cycle-avoidance reason as the rest of this file.
+const TENANT_STORAGE_KEY = 'kedge:portal:tenant'
+
+interface AuthHeaderOptions {
+  // tenant: include X-Kedge-Org / X-Kedge-Workspace from the sidebar
+  // selection so workspace-scoped hub endpoints (/api/orgs/.../providers)
+  // target the workspace the user is viewing. The hub re-verifies these
+  // against the caller's membership, so they can't be spoofed.
+  tenant?: boolean
+}
+
+function tenantHeaders(): Record<string, string> {
+  const h: Record<string, string> = {}
+  try {
+    const raw = localStorage.getItem(TENANT_STORAGE_KEY)
+    if (raw) {
+      const t = JSON.parse(raw) as { orgUUID?: string | null; workspaceUUID?: string | null }
+      if (t.orgUUID) h['X-Kedge-Org'] = t.orgUUID
+      if (t.workspaceUUID) h['X-Kedge-Workspace'] = t.workspaceUUID
+    }
+  } catch {
+    /* ignore parse errors — header is best-effort */
+  }
+  return h
+}
+
+// authFetch is the single entrypoint for authenticated REST calls to the
+// hub. It injects a refreshed bearer (and, when opts.tenant is set, the
+// org/workspace headers) and centrally detects a dead session: a 401
+// means the token was rejected, so it fires notifySessionExpired() before
+// returning the response. Callers keep their own `if (!res.ok)` handling
+// for endpoint-specific errors.
+//
+// 403 and 404 are intentionally NOT treated as session failures here:
+// for an authenticated user they're legitimate authorization / not-found
+// answers (e.g. /api/admin/* returns 403 to a non-admin), and logging the
+// user out on them would be wrong. (The GraphQL gateway is the exception —
+// there a 403/404 means the cluster route itself is gone — so that nuance
+// stays in composables/useGraphQL.ts.)
+export async function authFetch(
+  path: string,
+  opts: RequestInit & AuthHeaderOptions = {},
+): Promise<Response> {
+  const { tenant, headers, ...init } = opts
+  const token = await getBearerToken()
+
+  const merged: Record<string, string> = {
+    ...(tenant ? tenantHeaders() : {}),
+    ...(headers as Record<string, string> | undefined),
+  }
+  if (token) merged['Authorization'] = `Bearer ${token}`
+
+  const res = await fetch(path, {
+    credentials: 'same-origin',
+    ...init,
+    headers: merged,
+  })
+
+  if (res.status === 401) notifySessionExpired()
+  return res
+}

--- a/portal/src/auth/session.ts
+++ b/portal/src/auth/session.ts
@@ -111,11 +111,14 @@ export async function authFetch(
   const { tenant, headers, ...init } = opts
   const token = await getBearerToken()
 
-  const merged: Record<string, string> = {
-    ...(tenant ? tenantHeaders() : {}),
-    ...(headers as Record<string, string> | undefined),
-  }
-  if (token) merged['Authorization'] = `Bearer ${token}`
+  // Build via the Headers API so every HeadersInit shape a caller might
+  // pass (plain object, [name,value][], or a Headers instance) is merged
+  // correctly — a plain spread/cast would silently drop the latter two.
+  // Order matters: tenant headers first, then caller headers (so a caller
+  // can override them), then Authorization last so it always wins.
+  const merged = new Headers(tenant ? tenantHeaders() : undefined)
+  if (headers) new Headers(headers).forEach((value, key) => merged.set(key, value))
+  if (token) merged.set('Authorization', `Bearer ${token}`)
 
   const res = await fetch(path, {
     credentials: 'same-origin',

--- a/portal/src/composables/useGraphQL.ts
+++ b/portal/src/composables/useGraphQL.ts
@@ -2,20 +2,13 @@ import { ref, watchEffect, onUnmounted, type Ref } from 'vue'
 import { createGraphQLClient } from '@/graphql/client'
 import { useAuthStore } from '@/stores/auth'
 import { useTenantStore } from '@/stores/tenant'
+import { notifySessionExpired } from '@/auth/session'
 import type { CombinedError } from '@urql/vue'
 
-// Window event the shell listens for to drop a dead session and bounce
-// to /login (see portal/src/App.vue). Decoupled from a direct
-// `@/router` import on purpose: this composable is reused by provider
-// micro-frontends via the `@kedge-edges` alias, and a static
-// `import { router } from '@/router'` dragged the ENTIRE portal SPA
-// (every route page → AppLayout → TerminalDock) into each provider's
-// IIFE bundle. That bundled TerminalDock's terminal-session store got
-// shadowed by the provider's dispatch-only terminal-adapter, killing
-// the SSH-terminal bridge in production builds. A window event keeps the
-// shell's redirect behaviour while staying a no-op inside providers
-// (they register no listener).
-export const SESSION_EXPIRED_EVENT = 'kedge-session-expired'
+// SESSION_EXPIRED_EVENT and the dead-session detection now live in
+// @/auth/session so the REST stores share the exact same redirect path.
+// Re-exported here for the existing importers (App.vue, tests).
+export { SESSION_EXPIRED_EVENT } from '@/auth/session'
 
 interface UseQueryResult<T> {
   data: Ref<T | null>
@@ -50,9 +43,9 @@ function handleSessionFailure(err: CombinedError | undefined): boolean {
 
   // Hand the actual logout + redirect to the shell (App.vue) so this
   // composable never has to touch `@/router` or assume a portal-shaped
-  // auth store — see SESSION_EXPIRED_EVENT above. No-op inside provider
+  // auth store — see @/auth/session. No-op inside provider
   // micro-frontends, where a dead query shouldn't tear down the host.
-  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+  notifySessionExpired()
   return true
 }
 

--- a/portal/src/stores/admin.ts
+++ b/portal/src/stores/admin.ts
@@ -4,21 +4,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-import { STORAGE_KEYS } from '@/lib/constants'
-
-// authHeader mirrors the tenant store: read the bearer from the persisted auth
-// blob directly to avoid an import cycle with the auth store.
-function authHeader(): Record<string, string> {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEYS.auth)
-    if (!raw) return {}
-    const parsed = JSON.parse(raw) as { idToken?: string }
-    if (parsed.idToken) return { Authorization: `Bearer ${parsed.idToken}` }
-  } catch {
-    /* ignore */
-  }
-  return {}
-}
+import { authFetch } from '@/auth/session'
 
 export interface AdminUser {
   name: string
@@ -77,7 +63,7 @@ export const useAdminStore = defineStore('admin', () => {
   // sessions stay quiet.
   async function checkAccess(): Promise<boolean> {
     try {
-      const resp = await fetch('/api/admin/access', { headers: { ...authHeader() } })
+      const resp = await authFetch('/api/admin/access')
       isAdmin.value = resp.ok
     } catch {
       isAdmin.value = false
@@ -86,7 +72,7 @@ export const useAdminStore = defineStore('admin', () => {
   }
 
   async function get<T>(path: string): Promise<T[]> {
-    const resp = await fetch(path, { headers: { ...authHeader() } })
+    const resp = await authFetch(path)
     if (resp.status === 403) {
       forbidden.value = true
       throw new Error('forbidden')
@@ -124,9 +110,9 @@ export const useAdminStore = defineStore('admin', () => {
   // The hub's Provider controller then provisions the sub-workspace +
   // ServiceAccount + kubeconfig Secret. Declarative — no imperative onboard.
   async function createProvider(name: string, displayName: string): Promise<void> {
-    const resp = await fetch('/api/admin/providers', {
+    const resp = await authFetch('/api/admin/providers', {
       method: 'POST',
-      headers: { ...authHeader(), 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, displayName }),
     })
     if (resp.status === 403) {
@@ -139,9 +125,8 @@ export const useAdminStore = defineStore('admin', () => {
   // deleteProvider removes the Provider object; the controller's finalizer
   // tears down the provisioned sub-workspace.
   async function deleteProvider(name: string): Promise<void> {
-    const resp = await fetch(`/api/admin/providers/${encodeURIComponent(name)}`, {
+    const resp = await authFetch(`/api/admin/providers/${encodeURIComponent(name)}`, {
       method: 'DELETE',
-      headers: { ...authHeader() },
     })
     if (resp.status === 403) {
       forbidden.value = true
@@ -156,9 +141,7 @@ export const useAdminStore = defineStore('admin', () => {
   // Secret the Provider controller wrote into root:kedge:system:providers) and
   // triggers a browser download.
   async function downloadProviderKubeconfig(name: string): Promise<void> {
-    const resp = await fetch(`/api/admin/providers/${encodeURIComponent(name)}/kubeconfig`, {
-      headers: { ...authHeader() },
-    })
+    const resp = await authFetch(`/api/admin/providers/${encodeURIComponent(name)}/kubeconfig`)
     if (resp.status === 403) {
       forbidden.value = true
       throw new Error('forbidden')

--- a/portal/src/stores/auth.ts
+++ b/portal/src/stores/auth.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { AuthMode, HealthzResponse, StoredAuth } from '@/auth/types'
-import { loadAuth, saveAuth, clearAuth, isExpired, refreshToken, parseClusterName } from '@/auth/token'
+import { loadAuth, saveAuth, clearAuth, parseClusterName } from '@/auth/token'
+import { getBearerToken, resetSessionExpired } from '@/auth/session'
 import { fetchHealthz, loginWithToken } from '@/lib/api'
 import { STORAGE_KEYS } from '@/lib/constants'
 
@@ -53,6 +54,7 @@ export const useAuthStore = defineStore('auth', () => {
       token.value = auth.idToken
       user.value = { email: auth.email, userId: auth.userId }
       clusterName.value = auth.clusterName
+      resetSessionExpired()
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Login failed'
       throw e
@@ -66,21 +68,19 @@ export const useAuthStore = defineStore('auth', () => {
     token.value = auth.idToken
     user.value = { email: auth.email, userId: auth.userId }
     clusterName.value = auth.clusterName
+    resetSessionExpired()
   }
 
   async function getValidToken(): Promise<string> {
-    const stored = loadAuth()
-    if (!stored) throw new Error('Not authenticated')
-
-    if (!isExpired(stored)) return stored.idToken
-
-    const refreshed = await refreshToken(stored)
-    if (refreshed) {
-      token.value = refreshed.idToken
-      return refreshed.idToken
+    // Shared load/refresh core (also used by REST authFetch). It fires
+    // SESSION_EXPIRED_EVENT itself when an expired token can't be
+    // refreshed, so the shell already redirects; we still clear local
+    // state and throw so in-flight callers stop.
+    const valid = await getBearerToken()
+    if (valid) {
+      token.value = valid
+      return valid
     }
-
-    // Token expired and refresh failed — force re-login
     logout()
     throw new Error('Session expired')
   }

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { STORAGE_KEYS } from '@/lib/constants'
+import { authFetch } from '@/auth/session'
 
 // ProviderDTO is the wire shape returned by the hub's GET /api/providers.
 // Keep it aligned with pkg/hub/providers/api.go:providerDTO.
@@ -228,10 +228,7 @@ export const useProvidersStore = defineStore('providers', () => {
     loading.value = true
     error.value = null
     try {
-      const res = await fetch('/api/providers', {
-        headers: authHeaders(),
-        credentials: 'same-origin',
-      })
+      const res = await authFetch('/api/providers', { tenant: true })
       if (!res.ok) {
         throw new Error(`provider list failed: ${res.status} ${res.statusText}`)
       }
@@ -267,10 +264,7 @@ export const useProvidersStore = defineStore('providers', () => {
     const t = readTenantSelection()
     if (!t.orgUUID || !t.workspaceUUID) return
     const url = `/api/orgs/${encodeURIComponent(t.orgUUID)}/workspaces/${encodeURIComponent(t.workspaceUUID)}/providers/enabled`
-    const res = await fetch(url, {
-      headers: authHeaders(),
-      credentials: 'same-origin',
-    })
+    const res = await authFetch(url, { tenant: true })
     if (!res.ok) throw new Error(`list enabled providers: ${res.status}`)
     const body = (await res.json()) as { bindingNamesByProvider?: Record<string, string> }
     bindingNamesByProvider.value = body.bindingNamesByProvider ?? {}
@@ -312,10 +306,10 @@ export const useProvidersStore = defineStore('providers', () => {
       acceptedClaims: accept.map((c) => ({ group: c.group ?? '', resource: c.resource })),
     }
     const url = `/api/orgs/${encodeURIComponent(t.orgUUID)}/workspaces/${encodeURIComponent(t.workspaceUUID)}/providers/${encodeURIComponent(p.name)}/enable`
-    const res = await fetch(url, {
+    const res = await authFetch(url, {
       method: 'POST',
-      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-      credentials: 'same-origin',
+      tenant: true,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     })
     if (!res.ok) {
@@ -327,7 +321,8 @@ export const useProvidersStore = defineStore('providers', () => {
 
   // readTenantSelection mirrors the storage shape written by
   // tenant.ts's savePersisted — kept inline to avoid an import cycle
-  // with @/stores/tenant (same pattern as authHeaders above).
+  // with @/stores/tenant. Used for the enable/disable request *body*;
+  // the org/workspace request *headers* come from authFetch({tenant:true}).
   function readTenantSelection(): { orgUUID: string | null; workspaceUUID: string | null } {
     try {
       const raw = localStorage.getItem('kedge:portal:tenant')
@@ -351,11 +346,7 @@ export const useProvidersStore = defineStore('providers', () => {
       throw new Error('select an organization and workspace before disabling a provider')
     }
     const url = `/api/orgs/${encodeURIComponent(t.orgUUID)}/workspaces/${encodeURIComponent(t.workspaceUUID)}/providers/${encodeURIComponent(p.name)}/disable`
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: authHeaders(),
-      credentials: 'same-origin',
-    })
+    const res = await authFetch(url, { method: 'POST', tenant: true })
     // Idempotent server-side; 404 means the route target is already gone.
     if (!res.ok && res.status !== 404) {
       const detail = await res.text().catch(() => '')
@@ -391,43 +382,3 @@ export const useProvidersStore = defineStore('providers', () => {
     byName,
   }
 })
-
-// authHeaders reads the same localStorage slots the rest of the portal
-// uses — kept inline (not imported from @/stores/auth or @/stores/tenant)
-// to avoid an import cycle with stores that themselves import providers.
-//
-// Returns:
-//   Authorization      — OIDC bearer the hub authenticates
-//   X-Kedge-Org        — sidebar-selected org (so /services/providers/*
-//                        scopes operations to the workspace the user is
-//                        viewing instead of always landing in the
-//                        personal-org default)
-//   X-Kedge-Workspace  — sidebar-selected child workspace (optional;
-//                        omitted = org-scope)
-//
-// Hub resolver verifies the org/workspace headers against the
-// authenticated user's UserMembershipIndex before honoring them, so a
-// client can't spoof workspace access just by setting these.
-function authHeaders(): Record<string, string> {
-  const h: Record<string, string> = {}
-  try {
-    const raw = localStorage.getItem(STORAGE_KEYS.auth)
-    if (raw) {
-      const parsed = JSON.parse(raw) as { idToken?: string }
-      if (parsed.idToken) h['Authorization'] = `Bearer ${parsed.idToken}`
-    }
-  } catch {
-    /* ignore */
-  }
-  try {
-    const raw = localStorage.getItem('kedge:portal:tenant')
-    if (raw) {
-      const t = JSON.parse(raw) as { orgUUID?: string | null; workspaceUUID?: string | null }
-      if (t.orgUUID) h['X-Kedge-Org'] = t.orgUUID
-      if (t.workspaceUUID) h['X-Kedge-Workspace'] = t.workspaceUUID
-    }
-  } catch {
-    /* ignore */
-  }
-  return h
-}

--- a/portal/src/stores/tenant.ts
+++ b/portal/src/stores/tenant.ts
@@ -26,7 +26,7 @@ limitations under the License.
 
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
-import { STORAGE_KEYS } from '@/lib/constants'
+import { authFetch } from '@/auth/session'
 
 const STORAGE_KEY = 'kedge:portal:tenant'
 
@@ -103,23 +103,6 @@ function savePersisted(value: PersistedTenant) {
   }
 }
 
-// authHeader pulls the OIDC token out of the existing auth storage
-// slot. Reads via the shared STORAGE_KEYS constant so the key stays
-// in lockstep with @/auth/token + the providers store. Kept inline
-// (no @/stores/auth import) to avoid an import cycle with the auth
-// store, which already depends on transitive Pinia state.
-function authHeader(): Record<string, string> {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEYS.auth)
-    if (!raw) return {}
-    const parsed = JSON.parse(raw) as { idToken?: string }
-    if (parsed.idToken) return { Authorization: `Bearer ${parsed.idToken}` }
-  } catch {
-    /* ignore */
-  }
-  return {}
-}
-
 export const useTenantStore = defineStore('tenant', () => {
   const persisted = loadPersisted()
   const orgUUID = ref<string | null>(persisted.orgUUID)
@@ -183,9 +166,7 @@ export const useTenantStore = defineStore('tenant', () => {
     loading.value = true
     error.value = null
     try {
-      const resp = await fetch('/api/orgs', {
-        headers: { ...authHeader() },
-      })
+      const resp = await authFetch('/api/orgs')
       if (!resp.ok) {
         error.value = `failed to list orgs: ${resp.status}`
         orgs.value = []
@@ -215,8 +196,8 @@ export const useTenantStore = defineStore('tenant', () => {
     loading.value = true
     error.value = null
     try {
-      const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces`, {
-        headers: { ...authHeader(), 'X-Kedge-Org': targetOrgUUID },
+      const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces`, {
+        headers: { 'X-Kedge-Org': targetOrgUUID },
       })
       if (!resp.ok) {
         error.value = `failed to list workspaces: ${resp.status}`
@@ -260,9 +241,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function createOrg(displayName: string): Promise<OrgRow | null> {
-    const resp = await fetch('/api/orgs', {
+    const resp = await authFetch('/api/orgs', {
       method: 'POST',
-      headers: { ...authHeader(), 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ displayName }),
     })
     if (!resp.ok) {
@@ -276,10 +257,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function createWorkspace(targetOrgUUID: string, displayName: string): Promise<WorkspaceRow | null> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces`, {
       method: 'POST',
       headers: {
-        ...authHeader(),
         'Content-Type': 'application/json',
         'X-Kedge-Org': targetOrgUUID,
       },
@@ -370,9 +350,9 @@ export const useTenantStore = defineStore('tenant', () => {
   // ===== org-level CRUD =====
 
   async function patchOrgDisplayName(targetOrgUUID: string, displayName: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}`, {
       method: 'PATCH',
-      headers: { ...authHeader(), 'Content-Type': 'application/json', 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'Content-Type': 'application/json', 'X-Kedge-Org': targetOrgUUID },
       body: JSON.stringify({ displayName }),
     })
     if (!resp.ok) {
@@ -384,9 +364,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function deleteOrg(targetOrgUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}`, {
       method: 'DELETE',
-      headers: { ...authHeader(), 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'X-Kedge-Org': targetOrgUUID },
     })
     if (!resp.ok) {
       error.value = `failed to delete org: ${resp.status}`
@@ -397,9 +377,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function undeleteOrg(targetOrgUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/undelete`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/undelete`, {
       method: 'POST',
-      headers: { ...authHeader(), 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'X-Kedge-Org': targetOrgUUID },
     })
     if (!resp.ok) {
       error.value = `failed to undelete org: ${resp.status}`
@@ -412,10 +392,9 @@ export const useTenantStore = defineStore('tenant', () => {
   // ===== workspace CRUD =====
 
   async function patchWorkspaceDisplayName(targetOrgUUID: string, wsUUID: string, displayName: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}`, {
       method: 'PATCH',
       headers: {
-        ...authHeader(),
         'Content-Type': 'application/json',
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
@@ -431,10 +410,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function deleteWorkspace(targetOrgUUID: string, wsUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}`, {
       method: 'DELETE',
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },
@@ -448,10 +426,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function undeleteWorkspace(targetOrgUUID: string, wsUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/undelete`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/undelete`, {
       method: 'POST',
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },
@@ -467,8 +444,8 @@ export const useTenantStore = defineStore('tenant', () => {
   // ===== Org membership =====
 
   async function listOrgMembers(targetOrgUUID: string): Promise<MemberRow[]> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/memberships`, {
-      headers: { ...authHeader(), 'X-Kedge-Org': targetOrgUUID },
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/memberships`, {
+      headers: { 'X-Kedge-Org': targetOrgUUID },
     })
     if (!resp.ok) {
       error.value = `failed to list org members: ${resp.status}`
@@ -479,9 +456,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function addOrgMember(targetOrgUUID: string, user: string, role: 'admin' | 'member'): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/memberships`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/memberships`, {
       method: 'POST',
-      headers: { ...authHeader(), 'Content-Type': 'application/json', 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'Content-Type': 'application/json', 'X-Kedge-Org': targetOrgUUID },
       body: JSON.stringify({ user, role }),
     })
     if (!resp.ok) {
@@ -492,9 +469,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function patchOrgMemberRole(targetOrgUUID: string, user: string, role: 'admin' | 'member'): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/memberships/${user}`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/memberships/${user}`, {
       method: 'PATCH',
-      headers: { ...authHeader(), 'Content-Type': 'application/json', 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'Content-Type': 'application/json', 'X-Kedge-Org': targetOrgUUID },
       body: JSON.stringify({ role }),
     })
     if (!resp.ok) {
@@ -506,9 +483,9 @@ export const useTenantStore = defineStore('tenant', () => {
 
   async function removeOrgMember(targetOrgUUID: string, user: string, cascade = false): Promise<boolean> {
     const url = `/api/orgs/${targetOrgUUID}/memberships/${user}${cascade ? '?cascade=true' : ''}`
-    const resp = await fetch(url, {
+    const resp = await authFetch(url, {
       method: 'DELETE',
-      headers: { ...authHeader(), 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'X-Kedge-Org': targetOrgUUID },
     })
     if (!resp.ok) {
       error.value = `failed to remove member: ${resp.status}`
@@ -518,9 +495,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function leaveOrg(targetOrgUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/memberships/me`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/memberships/me`, {
       method: 'DELETE',
-      headers: { ...authHeader(), 'X-Kedge-Org': targetOrgUUID },
+      headers: { 'X-Kedge-Org': targetOrgUUID },
     })
     if (!resp.ok) {
       error.value = `failed to leave org: ${resp.status}`
@@ -533,9 +510,8 @@ export const useTenantStore = defineStore('tenant', () => {
   // ===== Service Accounts =====
 
   async function listServiceAccounts(targetOrgUUID: string, wsUUID: string): Promise<SARow[]> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts`, {
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },
@@ -554,10 +530,9 @@ export const useTenantStore = defineStore('tenant', () => {
     displayName: string,
     role: 'admin' | 'member',
   ): Promise<SARow | null> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts`, {
       method: 'POST',
       headers: {
-        ...authHeader(),
         'Content-Type': 'application/json',
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
@@ -572,10 +547,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function deleteServiceAccount(targetOrgUUID: string, wsUUID: string, saUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts/${saUUID}`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts/${saUUID}`, {
       method: 'DELETE',
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },
@@ -588,10 +562,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function issueSAToken(targetOrgUUID: string, wsUUID: string, saUUID: string): Promise<TokenResponse | null> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts/${saUUID}/tokens`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts/${saUUID}/tokens`, {
       method: 'POST',
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },
@@ -621,9 +594,8 @@ export const useTenantStore = defineStore('tenant', () => {
     install: 'kedge' | 'krew' = 'kedge',
   ): Promise<boolean> {
     const url = `/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/kubeconfig?install=${encodeURIComponent(install)}`
-    const resp = await fetch(url, {
+    const resp = await authFetch(url, {
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },
@@ -651,10 +623,9 @@ export const useTenantStore = defineStore('tenant', () => {
   }
 
   async function revokeSATokens(targetOrgUUID: string, wsUUID: string, saUUID: string): Promise<boolean> {
-    const resp = await fetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts/${saUUID}/tokens`, {
+    const resp = await authFetch(`/api/orgs/${targetOrgUUID}/workspaces/${wsUUID}/serviceaccounts/${saUUID}/tokens`, {
       method: 'DELETE',
       headers: {
-        ...authHeader(),
         'X-Kedge-Org': targetOrgUUID,
         'X-Kedge-Workspace': wsUUID,
       },


### PR DESCRIPTION
## What

Token-expiry detection in the portal was centralized only for the GraphQL layer (a `401/403/404` → `SESSION_EXPIRED_EVENT` window event). Every REST `fetch` in the `providers` / `admin` / `tenant` stores (~25 call sites) re-implemented its own `if (!res.ok)` check and **silently swallowed an expired token** — so some calls redirected to login while others left the user "logged in" looking at a raw error. The detection logic was, as reported, all over the place.

## How

New module **`portal/src/auth/session.ts`** is now the single source of truth for "session is dead → go to login":

- **`SESSION_EXPIRED_EVENT` + `notifySessionExpired()`** — fires the redirect signal **once per dead session** (a latch, so a page that fans out a dozen parallel 401s doesn't race a dozen `logout()` + `router.replace()` calls). `resetSessionExpired()` re-arms on login.
- **`getBearerToken()`** — the shared load-or-refresh core; fires the expired signal itself when an expired token can't be refreshed.
- **`authFetch()`** — the single entrypoint for authenticated hub calls: injects a refreshed bearer (and optional `X-Kedge-Org`/`X-Kedge-Workspace` via `{tenant:true}`), and on a **401** fires `notifySessionExpired()`.

`401` anywhere — GraphQL or REST — now drops the session through one code path. `403`/`404` are deliberately left as legitimate authz / not-found answers (e.g. `/api/admin/*` for a non-admin), and the GraphQL gateway's special 403/404 cluster-route handling stays where it belongs.

The module depends only on `@/auth/token` + the DOM — no `@/router`, no Pinia store — preserving the constraint that keeps this code out of the provider micro-frontend bundles.

### Wired through it
- `useGraphQL.ts` — re-exports the event and calls `notifySessionExpired()` (tenant-provisioning guard kept).
- `stores/auth.ts` — `getValidToken()` delegates to the shared core (refresh-failure now also redirects — a previous gap); both login paths re-arm the latch.
- `stores/providers.ts`, `stores/admin.ts`, `stores/tenant.ts` — all REST calls now use `authFetch`; the three duplicated `authHeader`/`authHeaders` helpers are deleted.

## Testing
- `vue-tsc -b` typecheck passes
- `vite build` passes (the portal has no test/lint harness)

## Note for review
REST `403`s still set local `forbidden`/error flags rather than redirecting (correct for authz-denied). If the hub ever returns `403` instead of `401` for an expired token, the `authFetch` detection should be widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)