### PR TITLE
[codex] POC deterministic App Studio build config reconciliation

### DIFF
--- a/providers/app-studio/api/build_reconciler.go
+++ b/providers/app-studio/api/build_reconciler.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"strings"
+
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+const (
+	projectBuildConfigPath          = ".kedge/build.json"
+	projectBuildWorkflowPath        = ".github/workflows/kedge-app-studio-build.yml"
+	projectBuildArtifactPath        = ".kedge/build-artifact.json"
+	projectBuildArtifactName        = "kedge-app-studio-build"
+	projectBuildConfigCommitMessage = "chore(app-studio): configure Railpack build"
+	projectBuildBuilderRailpack     = "railpack"
+)
+
+type projectBuildReconcileResponse struct {
+	Status       string   `json:"status"`
+	Builder      string   `json:"builder"`
+	Profile      string   `json:"profile,omitempty"`
+	Files        []string `json:"files,omitempty"`
+	CommitResult string   `json:"commitResult,omitempty"`
+	Reason       string   `json:"reason,omitempty"`
+	Error        string   `json:"error,omitempty"`
+}
+
+type projectBuildConfigDocument struct {
+	SchemaVersion string                    `json:"schemaVersion"`
+	ManagedBy     string                    `json:"managedBy"`
+	Builder       string                    `json:"builder"`
+	Profile       string                    `json:"profile"`
+	Railpack      projectBuildRailpackBlock `json:"railpack"`
+	CI            projectBuildCIBlock       `json:"ci"`
+	Image         projectBuildImageBlock    `json:"image"`
+}
+
+type projectBuildRailpackBlock struct {
+	ActionRef string `json:"actionRef"`
+	Context   string `json:"context"`
+}
+
+type projectBuildCIBlock struct {
+	Provider     string `json:"provider"`
+	WorkflowPath string `json:"workflowPath"`
+	ArtifactName string `json:"artifactName"`
+	ArtifactPath string `json:"artifactPath"`
+}
+
+type projectBuildImageBlock struct {
+	Registry         string `json:"registry"`
+	PackagePattern   string `json:"packagePattern"`
+	TagPattern       string `json:"tagPattern"`
+	DeploymentRef    string `json:"deploymentRef"`
+	EvidenceContract string `json:"evidenceContract"`
+}
+
+func (s *Server) reconcileProjectBuildConfigAfterCommit(ctx context.Context, id identity, scope workspace.Scope, projectRepositoryRef, mcpEndpoint string, r *http.Request, args map[string]any, commitResult string) (string, error) {
+	if projectBuildReconcileIsSelfCommit(args) {
+		return commitResult, nil
+	}
+	if projectToolCallResultStatus(projectToolCodeCommitFiles, commitResult) != "succeeded" {
+		return commitResult, nil
+	}
+
+	buildResult, err := s.reconcileProjectBuildConfig(ctx, id, scope, projectRepositoryRef, mcpEndpoint, r, args)
+	if err != nil {
+		return "", err
+	}
+	if buildResult == nil {
+		return commitResult, nil
+	}
+	return projectCommitFilesBuildResponse(commitResult, buildResult), nil
+}
+
+func (s *Server) reconcileProjectBuildConfig(ctx context.Context, id identity, scope workspace.Scope, projectRepositoryRef, mcpEndpoint string, r *http.Request, args map[string]any) (*projectBuildReconcileResponse, error) {
+	fileList, err := s.workspaces.ListFiles(ctx, scope, workspace.ListOptions{Limit: workspace.MaxListLimit})
+	if err != nil {
+		return nil, err
+	}
+	profile := projectBuildProfile(fileList)
+	desired := projectManagedBuildFiles(profile)
+	changed := make([]workspace.File, 0, len(desired))
+
+	for _, f := range desired {
+		read, err := s.workspaces.ReadFile(ctx, scope, workspace.ReadOptions{Path: f.Path, MaxBytes: workspace.MaxWriteBytes})
+		switch {
+		case err == nil && !read.Binary && !read.Truncated && read.Content == f.Content:
+			continue
+		case err == nil:
+			changed = append(changed, f)
+		case errors.Is(err, fs.ErrNotExist):
+			changed = append(changed, f)
+		default:
+			return nil, err
+		}
+	}
+
+	if len(changed) == 0 {
+		return &projectBuildReconcileResponse{
+			Status:  "current",
+			Builder: projectBuildBuilderRailpack,
+			Profile: profile,
+			Reason:  "managed build configuration is already current",
+		}, nil
+	}
+
+	files := make([]map[string]string, 0, len(changed))
+	paths := make([]string, 0, len(changed))
+	for _, f := range changed {
+		files = append(files, map[string]string{"path": f.Path, "content": f.Content})
+		paths = append(paths, f.Path)
+	}
+
+	commitArgs := map[string]any{
+		"repositoryRef": projectRepositoryRef,
+		"message":       projectBuildConfigCommitMessage,
+		"files":         files,
+	}
+	if branch := projectToolString(args["branch"]); branch != "" {
+		commitArgs["branch"] = branch
+	}
+	resp, err := callProjectMCPTool(ctx, mcpEndpoint, r, id.tenantPath, s.mcpInsecureSkipTLSVerify, projectToolCodeCommitFiles, commitArgs)
+	if err != nil {
+		return &projectBuildReconcileResponse{
+			Status:  "failed",
+			Builder: projectBuildBuilderRailpack,
+			Profile: profile,
+			Files:   paths,
+			Error:   err.Error(),
+		}, nil
+	}
+	status := projectToolCallResultStatus(projectToolCodeCommitFiles, resp)
+	if status != "succeeded" {
+		return &projectBuildReconcileResponse{
+			Status:       status,
+			Builder:      projectBuildBuilderRailpack,
+			Profile:      profile,
+			Files:        paths,
+			CommitResult: resp,
+		}, nil
+	}
+	for _, f := range changed {
+		if _, err := s.workspaces.WriteFile(ctx, scope, workspace.WriteOptions{Path: f.Path, Content: f.Content}); err != nil {
+			return nil, err
+		}
+	}
+	return &projectBuildReconcileResponse{
+		Status:       "committed",
+		Builder:      projectBuildBuilderRailpack,
+		Profile:      profile,
+		Files:        paths,
+		CommitResult: resp,
+	}, nil
+}
+
+func projectBuildReconcileIsSelfCommit(args map[string]any) bool {
+	if projectToolString(args["message"]) == projectBuildConfigCommitMessage {
+		return true
+	}
+	paths := projectToolStringList(args["paths"])
+	if len(paths) == 0 {
+		return false
+	}
+	for _, p := range paths {
+		clean, err := workspace.CleanProjectPath(p)
+		if err != nil || !projectManagedBuildPath(clean) {
+			return false
+		}
+	}
+	return true
+}
+
+func projectManagedBuildPath(path string) bool {
+	switch path {
+	case projectBuildConfigPath, projectBuildWorkflowPath:
+		return true
+	default:
+		return false
+	}
+}
+
+func projectManagedBuildFiles(profile string) []workspace.File {
+	return []workspace.File{
+		{Path: projectBuildConfigPath, Content: projectBuildConfigJSON(profile)},
+		{Path: projectBuildWorkflowPath, Content: projectBuildWorkflowYAML()},
+	}
+}
+
+func projectBuildProfile(fileList workspace.FileList) string {
+	paths := map[string]struct{}{}
+	for _, f := range fileList.Files {
+		paths[f.Path] = struct{}{}
+	}
+	switch {
+	case projectHasPath(paths, "package.json"):
+		return "node"
+	case projectHasPath(paths, "pyproject.toml"), projectHasPath(paths, "requirements.txt"):
+		return "python"
+	case projectHasPath(paths, "go.mod"):
+		return "go"
+	case projectHasPath(paths, "Cargo.toml"):
+		return "rust"
+	case projectHasPath(paths, "composer.json"):
+		return "php"
+	case projectHasPath(paths, "pom.xml"), projectHasPath(paths, "build.gradle"), projectHasPath(paths, "build.gradle.kts"), projectHasPath(paths, "gradlew"):
+		return "java"
+	case projectHasPath(paths, "index.html"):
+		return "static"
+	default:
+		return "auto"
+	}
+}
+
+func projectHasPath(paths map[string]struct{}, path string) bool {
+	_, ok := paths[path]
+	return ok
+}
+
+func projectBuildConfigJSON(profile string) string {
+	doc := projectBuildConfigDocument{
+		SchemaVersion: "app-studio.build/v1alpha1",
+		ManagedBy:     "app-studio",
+		Builder:       projectBuildBuilderRailpack,
+		Profile:       profile,
+		Railpack: projectBuildRailpackBlock{
+			ActionRef: "iloveitaly/github-action-railpack@master",
+			Context:   ".",
+		},
+		CI: projectBuildCIBlock{
+			Provider:     "github-actions",
+			WorkflowPath: projectBuildWorkflowPath,
+			ArtifactName: projectBuildArtifactName,
+			ArtifactPath: projectBuildArtifactPath,
+		},
+		Image: projectBuildImageBlock{
+			Registry:         "ghcr.io",
+			PackagePattern:   "ghcr.io/{owner}/{repo}",
+			TagPattern:       "sha-{commitSHA}",
+			DeploymentRef:    "digest",
+			EvidenceContract: projectBuildArtifactPath,
+		},
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "{}\n"
+	}
+	return string(out) + "\n"
+}
+
+func projectCommitFilesBuildResponse(commitResult string, buildResult *projectBuildReconcileResponse) string {
+	payload := map[string]any{}
+	if err := json.Unmarshal([]byte(commitResult), &payload); err != nil {
+		if phase := projectCommitResultPhase(commitResult); phase != "" {
+			payload["phase"] = phase
+		}
+		payload["commitResult"] = commitResult
+	}
+	payload["buildConfiguration"] = buildResult
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return commitResult
+	}
+	return string(out)
+}
+
+func projectCommitResultPhase(commitResult string) string {
+	var parsed struct {
+		Phase string `json:"phase"`
+	}
+	if err := json.Unmarshal([]byte(commitResult), &parsed); err == nil && strings.TrimSpace(parsed.Phase) != "" {
+		return parsed.Phase
+	}
+	switch projectToolCallResultStatus(projectToolCodeCommitFiles, commitResult) {
+	case "succeeded":
+		return "Succeeded"
+	case "running":
+		return "Running"
+	case "failed":
+		return "Failed"
+	default:
+		return ""
+	}
+}
+
+func projectBuildWorkflowYAML() string {
+	lines := []string{
+		"name: App Studio Build",
+		"",
+		"on:",
+		"  push:",
+		"    branches:",
+		"      - \"**\"",
+		"  workflow_dispatch:",
+		"",
+		"permissions:",
+		"  contents: read",
+		"  packages: write",
+		"",
+		"jobs:",
+		"  build:",
+		"    name: Build OCI image with Railpack",
+		"    runs-on: ubuntu-latest",
+		"    steps:",
+		"      - name: Check out repository",
+		"        uses: actions/checkout@v4",
+		"",
+		"      - name: Compute image coordinates",
+		"        id: image",
+		"        shell: bash",
+		"        run: |",
+		"          image=\"ghcr.io/${GITHUB_REPOSITORY,,}\"",
+		"          tag=\"sha-${GITHUB_SHA}\"",
+		"          echo \"name=${image}\" >> \"$GITHUB_OUTPUT\"",
+		"          echo \"tag=${tag}\" >> \"$GITHUB_OUTPUT\"",
+		"",
+		"      - name: Log in to GitHub Container Registry",
+		"        uses: docker/login-action@v3",
+		"        with:",
+		"          registry: ghcr.io",
+		"          username: ${{ github.actor }}",
+		"          password: ${{ secrets.GITHUB_TOKEN }}",
+		"",
+		"      - name: Build and push image with Railpack",
+		"        uses: iloveitaly/github-action-railpack@master",
+		"        with:",
+		"          context: .",
+		"          push: true",
+		"          cache: true",
+		"          cache_tag: ${{ steps.image.outputs.name }}:buildcache",
+		"          tags: |",
+		"            ${{ steps.image.outputs.name }}:${{ steps.image.outputs.tag }}",
+		"",
+		"      - name: Capture build evidence",
+		"        shell: bash",
+		"        env:",
+		"          BUILD_ARTIFACT_PATH: " + projectBuildArtifactPath,
+		"        run: |",
+		"          set -euo pipefail",
+		"          image=\"${{ steps.image.outputs.name }}\"",
+		"          tag=\"${{ steps.image.outputs.tag }}\"",
+		"          digest=\"$(docker buildx imagetools inspect \"${image}:${tag}\" --format '{{json .Manifest.Digest}}' | tr -d '\"')\"",
+		"          mkdir -p .kedge",
+		"          cat > \"$BUILD_ARTIFACT_PATH\" <<JSON",
+		"          {",
+		"            \"commit\": \"${GITHUB_SHA}\",",
+		"            \"image\": \"${image}@${digest}\",",
+		"            \"digest\": \"${digest}\",",
+		"            \"tag\": \"${tag}\",",
+		"            \"registry\": \"ghcr.io\",",
+		"            \"package\": \"${image}\",",
+		"            \"builder\": \"railpack\"",
+		"          }",
+		"          JSON",
+		"",
+		"      - name: Upload build evidence",
+		"        uses: actions/upload-artifact@v4",
+		"        with:",
+		"          name: " + projectBuildArtifactName,
+		"          path: " + projectBuildArtifactPath,
+		"          if-no-files-found: error",
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/providers/app-studio/api/build_reconciler.go
+++ b/providers/app-studio/api/build_reconciler.go
@@ -34,6 +34,7 @@ const (
 	projectBuildArtifactName        = "kedge-app-studio-build"
 	projectBuildConfigCommitMessage = "chore(app-studio): configure Railpack build"
 	projectBuildBuilderRailpack     = "railpack"
+	projectBuildRailpackAction      = "iloveitaly/github-action-railpack@167ed71230addc378f3fb13122046c09f71c0e5f"
 )
 
 type projectBuildReconcileResponse struct {
@@ -245,7 +246,7 @@ func projectBuildConfigJSON(profile string) string {
 		Builder:       projectBuildBuilderRailpack,
 		Profile:       profile,
 		Railpack: projectBuildRailpackBlock{
-			ActionRef: "iloveitaly/github-action-railpack@master",
+			ActionRef: projectBuildRailpackAction,
 			Context:   ".",
 		},
 		CI: projectBuildCIBlock{
@@ -343,7 +344,7 @@ func projectBuildWorkflowYAML() string {
 		"          password: ${{ secrets.GITHUB_TOKEN }}",
 		"",
 		"      - name: Build and push image with Railpack",
-		"        uses: iloveitaly/github-action-railpack@master",
+		"        uses: " + projectBuildRailpackAction,
 		"        with:",
 		"          context: .",
 		"          push: true",

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -552,7 +552,11 @@ func (s *Server) commitProjectWorkspaceFiles(ctx context.Context, id identity, s
 	if branch := projectToolString(args["branch"]); branch != "" {
 		commitArgs["branch"] = branch
 	}
-	return callProjectMCPTool(ctx, mcpEndpoint, r, id.tenantPath, s.mcpInsecureSkipTLSVerify, projectToolCodeCommitFiles, commitArgs)
+	resp, err := callProjectMCPTool(ctx, mcpEndpoint, r, id.tenantPath, s.mcpInsecureSkipTLSVerify, projectToolCodeCommitFiles, commitArgs)
+	if err != nil {
+		return "", err
+	}
+	return s.reconcileProjectBuildConfigAfterCommit(ctx, id, scope, projectRepositoryRef, mcpEndpoint, r, args, resp)
 }
 
 func ensureProjectToolCallIDs(toolCalls []chatToolCall) {

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -2695,7 +2695,7 @@ func TestCommitProjectWorkspaceFilesCommitsThroughCodeProvider(t *testing.T) {
 			if !strings.Contains(seen[projectBuildConfigPath], `"builder": "railpack"`) {
 				t.Fatalf("build config content = %q, want railpack builder", seen[projectBuildConfigPath])
 			}
-			if !strings.Contains(seen[projectBuildWorkflowPath], "iloveitaly/github-action-railpack@master") {
+			if !strings.Contains(seen[projectBuildWorkflowPath], projectBuildRailpackAction) {
 				t.Fatalf("workflow content = %q, want railpack action", seen[projectBuildWorkflowPath])
 			}
 			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":[".kedge/build.json",".github/workflows/kedge-app-studio-build.yml"],"commitSHA":"buildabcdef123456"}}}`)

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -2634,7 +2634,13 @@ func (r projectSettingsDynamicResource) Get(_ context.Context, name string, _ me
 }
 
 func TestCommitProjectWorkspaceFilesCommitsThroughCodeProvider(t *testing.T) {
-	var sawCommit bool
+	var calls []struct {
+		message string
+		files   []struct {
+			Path    string `json:"path"`
+			Content string `json:"content"`
+		}
+	}
 	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var envelope struct {
 			Method string `json:"method"`
@@ -2656,21 +2662,53 @@ func TestCommitProjectWorkspaceFilesCommitsThroughCodeProvider(t *testing.T) {
 		if envelope.Method != "tools/call" || envelope.Params.Name != "code__commit_files" {
 			t.Fatalf("unexpected MCP request: %#v", envelope)
 		}
-		if envelope.Params.Arguments.RepositoryRef != "demo-repo" || envelope.Params.Arguments.Message != "Update app" {
+		if envelope.Params.Arguments.RepositoryRef != "demo-repo" {
 			t.Fatalf("unexpected commit args: %#v", envelope.Params.Arguments)
 		}
-		if len(envelope.Params.Arguments.Files) != 1 || envelope.Params.Arguments.Files[0].Path != "src/App.tsx" || envelope.Params.Arguments.Files[0].Content != "committed from workspace\n" {
-			t.Fatalf("unexpected commit files: %#v", envelope.Params.Arguments.Files)
+		calls = append(calls, struct {
+			message string
+			files   []struct {
+				Path    string `json:"path"`
+				Content string `json:"content"`
+			}
+		}{message: envelope.Params.Arguments.Message, files: envelope.Params.Arguments.Files})
+		switch len(calls) {
+		case 1:
+			if envelope.Params.Arguments.Message != "Update app" {
+				t.Fatalf("first commit message = %q, want Update app", envelope.Params.Arguments.Message)
+			}
+			if len(envelope.Params.Arguments.Files) != 1 || envelope.Params.Arguments.Files[0].Path != "src/App.tsx" || envelope.Params.Arguments.Files[0].Content != "committed from workspace\n" {
+				t.Fatalf("unexpected source commit files: %#v", envelope.Params.Arguments.Files)
+			}
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":["src/App.tsx"],"commitSHA":"abcdef1234567890"}}}`)
+		case 2:
+			if envelope.Params.Arguments.Message != projectBuildConfigCommitMessage {
+				t.Fatalf("second commit message = %q, want build config message", envelope.Params.Arguments.Message)
+			}
+			if len(envelope.Params.Arguments.Files) != 2 {
+				t.Fatalf("build config commit files = %#v, want build config and workflow", envelope.Params.Arguments.Files)
+			}
+			seen := map[string]string{}
+			for _, f := range envelope.Params.Arguments.Files {
+				seen[f.Path] = f.Content
+			}
+			if !strings.Contains(seen[projectBuildConfigPath], `"builder": "railpack"`) {
+				t.Fatalf("build config content = %q, want railpack builder", seen[projectBuildConfigPath])
+			}
+			if !strings.Contains(seen[projectBuildWorkflowPath], "iloveitaly/github-action-railpack@master") {
+				t.Fatalf("workflow content = %q, want railpack action", seen[projectBuildWorkflowPath])
+			}
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":[".kedge/build.json",".github/workflows/kedge-app-studio-build.yml"],"commitSHA":"buildabcdef123456"}}}`)
+		default:
+			t.Fatalf("unexpected extra commit call: %#v", envelope.Params.Arguments)
 		}
-		sawCommit = true
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":["src/App.tsx"],"commitSHA":"abcdef1234567890"}}}`)
 	}))
 	defer mcp.Close()
 
 	workspaces := workspace.NewFileStore(t.TempDir())
 	scope := workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
 	if err := workspaces.ApplyFiles(context.Background(), scope, []workspace.File{
+		{Path: "package.json", Content: `{"scripts":{"build":"vite build"}}` + "\n"},
 		{Path: "src/App.tsx", Content: "committed from workspace\n"},
 	}); err != nil {
 		t.Fatalf("ApplyFiles returned error: %v", err)
@@ -2693,11 +2731,159 @@ func TestCommitProjectWorkspaceFilesCommitsThroughCodeProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commitProjectWorkspaceFiles returned error: %v", err)
 	}
-	if !sawCommit {
-		t.Fatal("MCP server did not receive commit call")
+	if len(calls) != 2 {
+		t.Fatalf("MCP commit calls = %d, want source commit plus build config commit", len(calls))
 	}
-	if !strings.Contains(resp, "abcdef1234567890") {
-		t.Fatalf("tool response = %s, want commit response", resp)
+	if !strings.Contains(resp, "abcdef1234567890") || !strings.Contains(resp, "buildConfiguration") || !strings.Contains(resp, "buildabcdef123456") {
+		t.Fatalf("tool response = %s, want source commit and build configuration evidence", resp)
+	}
+	decoded := map[string]any{}
+	if err := json.Unmarshal([]byte(resp), &decoded); err != nil {
+		t.Fatalf("decode tool response: %v", err)
+	}
+	if decoded["commitSHA"] != "abcdef1234567890" {
+		t.Fatalf("commitSHA = %#v, want original source commit SHA preserved at top level", decoded["commitSHA"])
+	}
+	if _, ok := decoded["commitResult"]; ok {
+		t.Fatalf("tool response includes nested commitResult = %#v, want original commit response shape preserved", decoded["commitResult"])
+	}
+	read, err := workspaces.ReadFile(context.Background(), scope, workspace.ReadOptions{Path: projectBuildWorkflowPath, MaxBytes: workspace.MaxWriteBytes})
+	if err != nil {
+		t.Fatalf("generated workflow read returned error: %v", err)
+	}
+	if !strings.Contains(read.Content, "Railpack") {
+		t.Fatalf("generated workflow = %q, want Railpack workflow", read.Content)
+	}
+}
+
+func TestCommitProjectWorkspaceFilesSkipsBuildConfigCommitWhenCurrent(t *testing.T) {
+	var commitCalls int
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var envelope struct {
+			Method string `json:"method"`
+			Params struct {
+				Name      string `json:"name"`
+				Arguments struct {
+					Message string `json:"message"`
+				} `json:"arguments"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode MCP request: %v", err)
+		}
+		if envelope.Method != "tools/call" || envelope.Params.Name != "code__commit_files" {
+			t.Fatalf("unexpected MCP request: %#v", envelope)
+		}
+		if envelope.Params.Arguments.Message == projectBuildConfigCommitMessage {
+			t.Fatal("build config was committed even though managed files were current")
+		}
+		commitCalls++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":["src/App.tsx"],"commitSHA":"abcdef1234567890"}}}`)
+	}))
+	defer mcp.Close()
+
+	workspaces := workspace.NewFileStore(t.TempDir())
+	scope := workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
+	files := []workspace.File{
+		{Path: "package.json", Content: `{"scripts":{"build":"vite build"}}` + "\n"},
+		{Path: "src/App.tsx", Content: "committed from workspace\n"},
+	}
+	files = append(files, projectManagedBuildFiles("node")...)
+	if err := workspaces.ApplyFiles(context.Background(), scope, files); err != nil {
+		t.Fatalf("ApplyFiles returned error: %v", err)
+	}
+	server := NewWithWorkspace(nil, nil, workspaces, mcp.URL, false)
+
+	resp, err := server.commitProjectWorkspaceFiles(
+		context.Background(),
+		identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+		scope,
+		"demo-repo",
+		mcp.URL,
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		map[string]any{
+			"repositoryRef": "demo-repo",
+			"message":       "Update app",
+			"paths":         []any{"src/App.tsx"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("commitProjectWorkspaceFiles returned error: %v", err)
+	}
+	if commitCalls != 1 {
+		t.Fatalf("MCP commit calls = %d, want only the source commit", commitCalls)
+	}
+	if !strings.Contains(resp, `"status":"current"`) {
+		t.Fatalf("tool response = %s, want current build configuration status", resp)
+	}
+}
+
+func TestCommitProjectWorkspaceFilesRetriesBuildConfigWhenBuildCommitFails(t *testing.T) {
+	var buildCommitCalls int
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var envelope struct {
+			Method string `json:"method"`
+			Params struct {
+				Name      string `json:"name"`
+				Arguments struct {
+					Message string `json:"message"`
+				} `json:"arguments"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+			t.Fatalf("decode MCP request: %v", err)
+		}
+		if envelope.Method != "tools/call" || envelope.Params.Name != "code__commit_files" {
+			t.Fatalf("unexpected MCP request: %#v", envelope)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if envelope.Params.Arguments.Message == projectBuildConfigCommitMessage {
+			buildCommitCalls++
+			fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Failed","message":"registry denied"}}}`)
+			return
+		}
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"structuredContent":{"phase":"Succeeded","files":["src/App.tsx"],"commitSHA":"abcdef1234567890"}}}`)
+	}))
+	defer mcp.Close()
+
+	workspaces := workspace.NewFileStore(t.TempDir())
+	scope := workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo"}
+	if err := workspaces.ApplyFiles(context.Background(), scope, []workspace.File{
+		{Path: "package.json", Content: `{"scripts":{"build":"vite build"}}` + "\n"},
+		{Path: "src/App.tsx", Content: "committed from workspace\n"},
+	}); err != nil {
+		t.Fatalf("ApplyFiles returned error: %v", err)
+	}
+	server := NewWithWorkspace(nil, nil, workspaces, mcp.URL, false)
+	args := map[string]any{
+		"repositoryRef": "demo-repo",
+		"message":       "Update app",
+		"paths":         []any{"src/App.tsx"},
+	}
+
+	for i := 0; i < 2; i++ {
+		resp, err := server.commitProjectWorkspaceFiles(
+			context.Background(),
+			identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"},
+			scope,
+			"demo-repo",
+			mcp.URL,
+			httptest.NewRequest(http.MethodPost, "/", nil),
+			args,
+		)
+		if err != nil {
+			t.Fatalf("commitProjectWorkspaceFiles run %d returned error: %v", i+1, err)
+		}
+		if !strings.Contains(resp, `"status":"failed"`) {
+			t.Fatalf("tool response = %s, want failed build configuration status", resp)
+		}
+		if _, err := workspaces.ReadFile(context.Background(), scope, workspace.ReadOptions{Path: projectBuildConfigPath, MaxBytes: workspace.MaxWriteBytes}); err == nil {
+			t.Fatalf("managed build config was written to workspace after failed build commit on run %d", i+1)
+		}
+	}
+	if buildCommitCalls != 2 {
+		t.Fatalf("build commit calls = %d, want retry after failed build commit", buildCommitCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a procedural App Studio build-config reconciler that runs after successful `commit_project_files` handoffs.
- Generates managed Railpack/GitHub Actions build assets when missing or stale:
  - `.kedge/build.json`
  - `.github/workflows/kedge-app-studio-build.yml`
- Commits build config through provider-code as a separate deterministic follow-up commit, without relying on the LLM to call a setup tool.
- Preserves the original provider-code commit response shape while adding `buildConfiguration` metadata.
- Keeps failed/running build-config handoffs retryable by only writing managed files into the App Studio workspace after a successful build-config commit.

## Why

The previous POC still depended on the assistant remembering to invoke a build setup tool. This explores a more reliable path: App Studio owns the reconciliation step procedurally whenever project source is committed.

## Validation

Not run in this session. The Go files were formatted with `gofmt`.
