### PR TITLE
fix(kuery): postgres store fixes + run dev on postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery install-provider-kuery init-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart init-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-app-studio-provider build-app-studio-provider-portal codegen-app-studio-provider app-studio-db-up app-studio-db-down run-provider-app-studio install-provider-app-studio init-provider-app-studio uninstall-provider-app-studio build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
+.PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery kuery-db-up kuery-db-down install-provider-kuery init-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart init-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-app-studio-provider build-app-studio-provider-portal codegen-app-studio-provider app-studio-db-up app-studio-db-down run-provider-app-studio install-provider-app-studio init-provider-app-studio uninstall-provider-app-studio build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code dev-kro-up dev-kro-down dev-kro-seed dev-kro-register-self e2e-infrastructure portal-provider-symlinks build-mcp-provider-portal build-kubernetes-edges-provider-portal build-server-edges-provider-portal e2e-provider e2e-provider-flags e2e-provider-all
 
 BINDIR ?= bin
 GOFLAGS ?=
@@ -676,7 +676,65 @@ KUERY_EDGES_IDENTITY_HASH ?=
 # init-provider-kuery from the provider SA token the hub mints.
 KUERY_RUNTIME_KUBECONFIG ?= $(KCP_DATA_DIR)/kuery-runtime.kubeconfig
 
-run-provider-kuery: build-kuery-provider ## Run the kuery provider (requires: make run-hub-embedded-static + make install-provider-kuery; engagement needs init-provider-kuery)
+# Local store backend. Dev always runs Postgres — the same backend as
+# production — because Postgres-only SQL (jsonb_array_elements, uuid columns,
+# …) diverges from SQLite and passing on SQLite has shipped real query bugs.
+# kuery-db-up starts a throwaway container matching KUERY_DEV_DATABASE_URL.
+KUERY_POSTGRES_CONTAINER ?= kedge-kuery-postgres
+KUERY_POSTGRES_IMAGE ?= postgres:16-alpine
+KUERY_POSTGRES_PORT ?= 55433
+KUERY_POSTGRES_DATA_DIR ?= $(KCP_DATA_DIR)/kuery-postgres
+KUERY_POSTGRES_USER ?= kuery
+KUERY_POSTGRES_PASSWORD ?= kuery
+KUERY_POSTGRES_DB ?= kuery
+KUERY_DEV_DATABASE_URL ?= postgres://$(KUERY_POSTGRES_USER):$(KUERY_POSTGRES_PASSWORD)@localhost:$(KUERY_POSTGRES_PORT)/$(KUERY_POSTGRES_DB)?sslmode=disable
+# Connection string the provider uses. Defaults to the local dev container
+# above; point it at any external Postgres to override.
+KUERY_STORE_DSN ?=
+
+kuery-db-up: ## Start/reuse local Postgres for the kuery store (no-op when KUERY_STORE_DSN points at an external DB)
+	@if [ -n "$(KUERY_STORE_DSN)" ]; then \
+		echo "Using externally configured KUERY_STORE_DSN; not starting local kuery Postgres"; \
+		exit 0; \
+	fi; \
+	mkdir -p "$(KUERY_POSTGRES_DATA_DIR)"; \
+	if docker ps --format '{{.Names}}' | grep -qx "$(KUERY_POSTGRES_CONTAINER)"; then \
+		echo "kuery Postgres already running ($(KUERY_POSTGRES_CONTAINER))"; \
+	elif docker ps -a --format '{{.Names}}' | grep -qx "$(KUERY_POSTGRES_CONTAINER)"; then \
+		echo "Starting existing kuery Postgres container ($(KUERY_POSTGRES_CONTAINER))"; \
+		docker start "$(KUERY_POSTGRES_CONTAINER)" >/dev/null; \
+	else \
+		echo "Creating kuery Postgres container ($(KUERY_POSTGRES_CONTAINER))"; \
+		docker run -d \
+			--name "$(KUERY_POSTGRES_CONTAINER)" \
+			-e POSTGRES_USER="$(KUERY_POSTGRES_USER)" \
+			-e POSTGRES_PASSWORD="$(KUERY_POSTGRES_PASSWORD)" \
+			-e POSTGRES_DB="$(KUERY_POSTGRES_DB)" \
+			-p 127.0.0.1:$(KUERY_POSTGRES_PORT):5432 \
+			-v "$(abspath $(KUERY_POSTGRES_DATA_DIR)):/var/lib/postgresql/data" \
+			"$(KUERY_POSTGRES_IMAGE)" >/dev/null; \
+	fi; \
+	echo "Waiting for kuery Postgres..."; \
+	for _ in $$(seq 1 30); do \
+		if docker exec "$(KUERY_POSTGRES_CONTAINER)" pg_isready -U "$(KUERY_POSTGRES_USER)" -d "$(KUERY_POSTGRES_DB)" >/dev/null 2>&1; then \
+			echo "  database: $(KUERY_DEV_DATABASE_URL)"; \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	echo "ERROR: kuery Postgres did not become ready"; \
+	docker logs "$(KUERY_POSTGRES_CONTAINER)" --tail=50; \
+	exit 1
+
+kuery-db-down: ## Stop and remove the local kuery Postgres container (data remains in KUERY_POSTGRES_DATA_DIR)
+	@if docker ps -a --format '{{.Names}}' | grep -qx "$(KUERY_POSTGRES_CONTAINER)"; then \
+		echo "Removing kuery Postgres container ($(KUERY_POSTGRES_CONTAINER))"; \
+		docker rm -f "$(KUERY_POSTGRES_CONTAINER)" >/dev/null; \
+	else \
+		echo "No kuery Postgres container to remove ($(KUERY_POSTGRES_CONTAINER))"; \
+	fi
+
+run-provider-kuery: build-kuery-provider kuery-db-up ## Run the kuery provider (requires: make run-hub-embedded-static + make install-provider-kuery; engagement needs init-provider-kuery)
 	@echo "Starting kuery provider on :$(KUERY_PORT)"
 	@echo "  hub:   $(KUERY_HUB_URL)"
 	@echo "  token: $(KUERY_TOKEN)"
@@ -685,6 +743,13 @@ run-provider-kuery: build-kuery-provider ## Run the kuery provider (requires: ma
 	else \
 		echo "  engagement: DISABLED (run 'make init-provider-kuery' after install-provider-kuery)"; \
 	fi
+	@# Dev always runs Postgres. Fall back to the local dev container DSN when
+	@# KUERY_STORE_DSN is unset (external Postgres overrides it).
+	STORE_DSN="$${KUERY_STORE_DSN:-$(KUERY_STORE_DSN)}"; \
+	if [ -z "$$STORE_DSN" ]; then \
+		STORE_DSN="$(KUERY_DEV_DATABASE_URL)"; \
+	fi; \
+	echo "  store: postgres ($$STORE_DSN)"; \
 	PORT=$(KUERY_PORT) \
 	KEDGE_HUB_URL=$(KUERY_HUB_URL) \
 	KEDGE_HUB_TOKEN=$(KUERY_TOKEN) \
@@ -692,6 +757,8 @@ run-provider-kuery: build-kuery-provider ## Run the kuery provider (requires: ma
 	KEDGE_PROVIDER_NAME=kuery \
 	KEDGE_PROVIDER_KUBECONFIG=$(KUERY_RUNTIME_KUBECONFIG) \
 	KEDGE_DEV_ALLOW_TENANT_QUERY=true \
+	KUERY_STORE_DRIVER=postgres \
+	KUERY_STORE_DSN="$$STORE_DSN" \
 		$(BINDIR)/kuery-provider
 
 install-provider-kuery: ## Apply kuery Provider + CatalogEntry into root:kedge:providers

--- a/Tiltfile
+++ b/Tiltfile
@@ -319,6 +319,18 @@ local_resource(
 )
 
 # --- providers-kuery (fleet query engine) ---
+# Local Postgres for the kuery store. Dev always runs the same SQL backend
+# as production — SQLite hid real Postgres-only query bugs, so it is not an
+# option here. make run-provider-kuery also depends on this; the resource
+# gives Tilt visibility + a restart button.
+local_resource(
+    'kuery-db',
+    cmd='make kuery-db-up',
+    deps=['Makefile'],
+    resource_deps=['hub'],
+    labels=['providers-kuery'],
+)
+
 # Long-lived provider embedding the kuery engine. Serves the portal +
 # /api/query + MCP on :8084 immediately; the edge engagement controller
 # additionally needs the dev runtime kubeconfig, minted by ▶ kuery-init
@@ -341,11 +353,19 @@ local_resource(
         'providers/kuery/go.sum',
         '.kcp/kuery-runtime.kubeconfig',
     ],
-    resource_deps=['hub'],
+    resource_deps=['hub', 'kuery-db'],
     readiness_probe=probe(
         period_secs=5,
         http_get=http_get_action(port=8084, path='/healthz'),
     ),
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-db-down',
+    cmd='make kuery-db-down',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
     labels=['providers-kuery'],
 )
 

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -569,6 +569,17 @@ local_resource(
 )
 
 # --- providers-kuery (fleet query engine, port :8084) ---
+# Local Postgres for the kuery store. Dev always runs the same SQL backend
+# as production — SQLite hid real Postgres-only query bugs, so it is not an
+# option here. make run-provider-kuery depends on this too.
+local_resource(
+    'kuery-db',
+    cmd='make kuery-db-up',
+    deps=['Makefile'],
+    resource_deps=['kedge-hub'],
+    labels=['providers-kuery'],
+)
+
 # Same shape as the embedded Tiltfile: serve immediately; engagement
 # needs ▶ kuery-register then ▶ kuery-init (mints the runtime kubeconfig
 # from the provider SA token + ensures the APIExportEndpointSlice).
@@ -588,11 +599,19 @@ local_resource(
         'providers/kuery/go.mod',
         '.kcp/kuery-runtime.kubeconfig',
     ],
-    resource_deps=['kedge-hub'],
+    resource_deps=['kedge-hub', 'kuery-db'],
     readiness_probe=probe(
         period_secs=5,
         http_get=http_get_action(port=8084, path='/healthz'),
     ),
+    labels=['providers-kuery'],
+)
+
+local_resource(
+    'kuery-db-down',
+    cmd='make kuery-db-down',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
     labels=['providers-kuery'],
 )
 

--- a/cmd/kedge-release/main.go
+++ b/cmd/kedge-release/main.go
@@ -29,6 +29,7 @@
 //
 //	kedge-release <component|all> [flags]
 //
+//	kedge-release current               # print every component's latest tag
 //	kedge-release quickstart            # bump providers/quickstart/v* patch and push
 //	kedge-release hub --minor           # bump v* minor
 //	kedge-release quickstart --tag v0.0.1   # explicit version
@@ -99,6 +100,9 @@ func run(args []string) error {
 		return nil
 	}
 	target := args[0]
+	if target == "current" {
+		return printCurrent()
+	}
 	opts := options{bump: "patch", ref: "HEAD"}
 
 	for i := 1; i < len(args); i++ {
@@ -220,6 +224,27 @@ func run(args []string) error {
 		fmt.Printf("pushed %s\n", p.fullTag)
 	}
 	fmt.Println("\nDone — the release workflows will pick these up.")
+	return nil
+}
+
+// printCurrent prints the latest existing tag for every component, in
+// componentOrder, so you can see each release line's current version at a
+// glance without cutting anything.
+func printCurrent() error {
+	fmt.Println("Current latest versions:")
+	fmt.Println()
+	for _, name := range componentOrder {
+		comp := components[name]
+		latest, hasLatest, err := latestTag(comp.prefix)
+		if err != nil {
+			return err
+		}
+		current := "(none)"
+		if hasLatest {
+			current = comp.prefix + strings.TrimPrefix(latest.String(), "v")
+		}
+		fmt.Printf("  %-15s %s\n", name, current)
+	}
 	return nil
 }
 
@@ -352,6 +377,7 @@ Components:
   infrastructure  providers/infrastructure/v<X.Y.Z>
   code            providers/code/v<X.Y.Z>
   all             every component (independent versions)
+  current         print every component's latest existing tag (no changes)
 
 Flags:
   --tag <vX.Y.Z>   set the exact version (single component only)
@@ -362,6 +388,7 @@ Flags:
   -y, --yes        skip the confirmation prompt
 
 Examples:
+  kedge-release current               print every component's latest tag
   kedge-release quickstart            bump providers/quickstart/v* patch and push
   kedge-release hub --minor           bump v* minor
   kedge-release quickstart --tag v0.0.1

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -3,7 +3,7 @@ module github.com/faroshq/provider-kuery
 go 1.26.3
 
 require (
-	github.com/faroshq/kuery v0.0.0-20260620185321-788efcebcc4f
+	github.com/faroshq/kuery v0.0.0-20260621053041-5342a07fc777
 	github.com/faroshq/provider-sdk v0.0.1
 	github.com/kcp-dev/multicluster-provider v0.8.0
 	github.com/kcp-dev/sdk v0.32.0

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -50,8 +50,8 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/kuery v0.0.0-20260620185321-788efcebcc4f h1:gYDb4pLUtmmSE/VeLH2gQ6qJ5YIRDL1yGZ7H0h2iBSs=
-github.com/faroshq/kuery v0.0.0-20260620185321-788efcebcc4f/go.mod h1:TfZU4DmN/ir3/3XSkVoLhXXoIed8cu8jaQMBYWigJmY=
+github.com/faroshq/kuery v0.0.0-20260621053041-5342a07fc777 h1:K50qMui1ThmLOYKz9Dwau3UFxKU0DJwsmYcD8ShoWFs=
+github.com/faroshq/kuery v0.0.0-20260621053041-5342a07fc777/go.mod h1:TfZU4DmN/ir3/3XSkVoLhXXoIed8cu8jaQMBYWigJmY=
 github.com/faroshq/provider-sdk v0.0.1 h1:nJeNHfYfuUf+nyd6/iSC6xWAJuSjiSZYtnDW6yAMWys=
 github.com/faroshq/provider-sdk v0.0.1/go.mod h1:0nSxc6lF9tux2DHDc7mPx3z3x98xZUduNjStTgdqG/E=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=


### PR DESCRIPTION
## Why

The kuery provider runs Postgres in production but local dev used SQLite, so Postgres-only query bugs shipped unnoticed. Two such bugs were hit in prod:

1. **`cannot extract elements from a scalar` (SQLSTATE 22023)** — objects with no `ownerReferences` were stored as JSON `null`; `jsonb_array_elements('null')` throws. SQLite's `json_each` quietly returned 0 rows.
2. **`invalid input syntax for type uuid` (SQLSTATE 22P02)** — the portal filters virtual relation nodes by synthetic ids like `<uid>:references:0`; comparing that against the uuid `id` column aborts the query.

Both are fixed upstream in `github.com/faroshq/kuery` (`main`); this PR revendors the bump and, more importantly, makes local dev run the **same Postgres backend as prod** so this class of bug surfaces locally.

## What

- **Revendor** `github.com/faroshq/kuery` → `v0.0.0-20260621053041-5342a07fc777` (the two fixes above).
- **Makefile**: `kuery-db-up` / `kuery-db-down` spin a throwaway `postgres:16-alpine` container on `127.0.0.1:55433` (mirrors the existing `app-studio-db-*` pattern). `run-provider-kuery` depends on `kuery-db-up` and always runs `KUERY_STORE_DRIVER=postgres`. Point `KUERY_STORE_DSN` at an external Postgres to override. **No SQLite option** in the dev path.
- **Tiltfile + Tiltfile.cluster**: `kuery-db` resource (+ manual `kuery-db-down` teardown) under the `providers-kuery` label; the `kuery` resource now depends on it.

## Test

- `make kuery-db-up` / `kuery-db-down` run; dev DSN connects (`connected as kuery to kuery`).
- `go build ./...` + `go mod verify` pass in `providers/kuery`.
- Upstream engine + sync tests pass in the kuery repo.

## Follow-up (not in this PR)

Prod still needs a new `kedge-kuery-provider` image built from this revendored `go.mod`, then `helm upgrade --set image.tag=<new>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)