### PR TITLE
fix(infrastructure): don't retarget scoped provider kubeconfig; auto-discover workspace path

### DIFF
--- a/providers/infrastructure/apis/v1alpha1/types_infrastructureprovider.go
+++ b/providers/infrastructure/apis/v1alpha1/types_infrastructureprovider.go
@@ -50,9 +50,14 @@ type InfrastructureProvider struct {
 // InfrastructureProviderSpec is the operator's input.
 type InfrastructureProviderSpec struct {
 	// ProviderWorkspace is the kcp workspace path the provider is bootstrapped
-	// into, e.g. "root:kedge:providers:infrastructure". The provider kubeconfig
-	// is retargeted at this workspace.
-	ProviderWorkspace string `json:"providerWorkspace"`
+	// into, e.g. "root:kedge:providers:infrastructure". Optional: when the
+	// provider kubeconfig is already scoped to the provider workspace (as the
+	// admin portal issues it), the operator discovers the path from the
+	// workspace's kcp.io/path annotation, so you don't need to set this. Set it
+	// only when supplying a root-scoped (admin) kubeconfig that must be retargeted
+	// at a workspace.
+	// +optional
+	ProviderWorkspace string `json:"providerWorkspace,omitempty"`
 
 	// ProviderKubeconfigSecret references a Secret holding the kcp provider
 	// kubeconfig (the credential the admin portal issues for the provider

--- a/providers/infrastructure/config/crds/infrastructure.kedge.faros.sh_infrastructureproviders.yaml
+++ b/providers/infrastructure/config/crds/infrastructure.kedge.faros.sh_infrastructureproviders.yaml
@@ -187,8 +187,12 @@ spec:
               providerWorkspace:
                 description: |-
                   ProviderWorkspace is the kcp workspace path the provider is bootstrapped
-                  into, e.g. "root:kedge:providers:infrastructure". The provider kubeconfig
-                  is retargeted at this workspace.
+                  into, e.g. "root:kedge:providers:infrastructure". Optional: when the
+                  provider kubeconfig is already scoped to the provider workspace (as the
+                  admin portal issues it), the operator discovers the path from the
+                  workspace's kcp.io/path annotation, so you don't need to set this. Set it
+                  only when supplying a root-scoped (admin) kubeconfig that must be retargeted
+                  at a workspace.
                 type: string
               runtimeKubeconfigSecret:
                 description: |-
@@ -212,7 +216,6 @@ spec:
             - kro
             - provider
             - providerKubeconfigSecret
-            - providerWorkspace
             type: object
           status:
             description: InfrastructureProviderStatus reports the operator's reconcile

--- a/providers/infrastructure/deploy/chart/crds/infrastructure.kedge.faros.sh_infrastructureproviders.yaml
+++ b/providers/infrastructure/deploy/chart/crds/infrastructure.kedge.faros.sh_infrastructureproviders.yaml
@@ -187,8 +187,12 @@ spec:
               providerWorkspace:
                 description: |-
                   ProviderWorkspace is the kcp workspace path the provider is bootstrapped
-                  into, e.g. "root:kedge:providers:infrastructure". The provider kubeconfig
-                  is retargeted at this workspace.
+                  into, e.g. "root:kedge:providers:infrastructure". Optional: when the
+                  provider kubeconfig is already scoped to the provider workspace (as the
+                  admin portal issues it), the operator discovers the path from the
+                  workspace's kcp.io/path annotation, so you don't need to set this. Set it
+                  only when supplying a root-scoped (admin) kubeconfig that must be retargeted
+                  at a workspace.
                 type: string
               runtimeKubeconfigSecret:
                 description: |-
@@ -212,7 +216,6 @@ spec:
             - kro
             - provider
             - providerKubeconfigSecret
-            - providerWorkspace
             type: object
           status:
             description: InfrastructureProviderStatus reports the operator's reconcile

--- a/providers/infrastructure/deploy/chart/templates/operator-config.yaml
+++ b/providers/infrastructure/deploy/chart/templates/operator-config.yaml
@@ -40,7 +40,9 @@ metadata:
   labels:
     {{- include "infrastructure.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.operator.providerWorkspace }}
   providerWorkspace: {{ .Values.operator.providerWorkspace | quote }}
+  {{- end }}
   providerKubeconfigSecret:
     name: {{ $providerSecret }}
     key: {{ .Values.operator.providerKubeconfigSecret.key | default "kubeconfig" }}

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -157,8 +157,11 @@ operator:
       cpu: 50m
       memory: 64Mi
 
-  # kcp workspace the provider is bootstrapped into.
-  providerWorkspace: root:kedge:providers:infrastructure
+  # kcp workspace the provider is bootstrapped into. Leave empty when the
+  # provider kubeconfig is already scoped to the provider workspace (the operator
+  # discovers the path from the workspace's kcp.io/path annotation). Set it only
+  # for a root-scoped (admin) kubeconfig that must be retargeted at a workspace.
+  providerWorkspace: ""
 
   # Provider (kcp) kubeconfig. Either set it inline via
   #   --set-file operator.providerKubeconfig=./provider-infrastructure.kubeconfig

--- a/providers/infrastructure/install/operatorseed.go
+++ b/providers/infrastructure/install/operatorseed.go
@@ -40,6 +40,15 @@ func RetargetHostToWorkspace(host, workspacePath string) (string, error) {
 		return "", fmt.Errorf("parse host %q: %w", host, err)
 	}
 	if idx := strings.Index(u.Path, "/clusters/"); idx >= 0 {
+		// Already cluster-scoped. Leave a specific workspace (cluster ID, e.g.
+		// the admin-portal-issued provider kubeconfig, or a workspace path)
+		// untouched — only a "root"-scoped host is retargeted. Front proxies that
+		// route by cluster ID 404 on a path form, so rewriting an already-scoped
+		// kubeconfig breaks access.
+		seg := strings.SplitN(strings.TrimPrefix(u.Path[idx:], "/clusters/"), "/", 2)[0]
+		if seg != "" && seg != "root" {
+			return host, nil
+		}
 		u.Path = u.Path[:idx]
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/clusters/" + workspacePath

--- a/providers/infrastructure/operator/controller.go
+++ b/providers/infrastructure/operator/controller.go
@@ -76,6 +76,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.fail(ctx, &cr, v1alpha1.ConditionBootstrapped, "ProviderKubeconfigInvalid", err)
 	}
 
+	// The workspace path is only needed to stamp spec.export.path on the
+	// APIExportEndpointSlice. When the CR doesn't set it, discover it from the
+	// workspace the provider kubeconfig is scoped to (its kcp.io/path annotation)
+	// — so a workspace-scoped provider kubeconfig needs no providerWorkspace.
+	workspacePath := cr.Spec.ProviderWorkspace
+	if workspacePath == "" {
+		workspacePath, err = discoverWorkspacePath(ctx, providerCfg)
+		if err != nil {
+			return r.fail(ctx, &cr, v1alpha1.ConditionBootstrapped, "WorkspacePathUnknown", err)
+		}
+	}
+
 	// Runtime cluster: an explicit kubeconfig Secret, or — when omitted — the
 	// operator's own cluster (in-cluster / current context). In the in-cluster
 	// case runtimeKC stays nil: helm runs without a KUBECONFIG override (using
@@ -103,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// 1. Bootstrap the provider workspace.
 	if err := Bootstrap(ctx, providerCfg, BootstrapOptions{
-		WorkspacePath: cr.Spec.ProviderWorkspace,
+		WorkspacePath: workspacePath,
 		APIExportName: APIExportName,
 	}); err != nil {
 		return r.fail(ctx, &cr, v1alpha1.ConditionBootstrapped, "BootstrapFailed", err)
@@ -118,7 +130,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := ensureNamespace(ctx, cs, cr.Spec.Kro.Namespace); err != nil {
 		return r.fail(ctx, &cr, v1alpha1.ConditionKroReleased, "KroNamespaceFailed", err)
 	}
-	if err := install.SeedKroClusterFromKubeconfig(ctx, runtimeCfg, providerKC, cr.Spec.ProviderWorkspace); err != nil {
+	if err := install.SeedKroClusterFromKubeconfig(ctx, runtimeCfg, providerKC, workspacePath); err != nil {
 		return r.fail(ctx, &cr, v1alpha1.ConditionKroReleased, "KroSeedFailed", err)
 	}
 	// helm needs a KUBECONFIG file only for an explicit runtime; for the

--- a/providers/infrastructure/operator/discover.go
+++ b/providers/infrastructure/operator/discover.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// logicalClusterGVR is kcp's per-workspace LogicalCluster singleton.
+var logicalClusterGVR = schema.GroupVersionResource{
+	Group:    "core.kcp.io",
+	Version:  "v1alpha1",
+	Resource: "logicalclusters",
+}
+
+// discoverWorkspacePath returns the kcp workspace path the supplied config is
+// scoped to, read from the LogicalCluster's kcp.io/path annotation. This lets a
+// workspace-scoped provider kubeconfig drive the operator without the caller
+// having to also pass spec.providerWorkspace.
+func discoverWorkspacePath(ctx context.Context, cfg *rest.Config) (string, error) {
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return "", err
+	}
+	obj, err := dyn.Resource(logicalClusterGVR).Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get LogicalCluster to resolve workspace path: %w", err)
+	}
+	if path := obj.GetAnnotations()["kcp.io/path"]; path != "" {
+		return path, nil
+	}
+	return "", fmt.Errorf("LogicalCluster has no kcp.io/path annotation; set spec.providerWorkspace explicitly")
+}


### PR DESCRIPTION
## The bug

The operator deploy failed at bootstrap with `the server could not find the requested resource` when creating the Templates CRD.

Root cause: the admin-portal provider kubeconfig is already scoped to the provider workspace **by cluster ID** (`https://console.faros.sh/clusters/<id>`), but the operator **rewrote** that host to the workspace **path** form (`/clusters/root:kedge:providers:infrastructure`). The front proxy routes by cluster ID and **404s on the path form** (verified: cluster-ID URL → 200, path URL → 404). So every kcp call failed.

## Fix

- `RetargetHostToWorkspace` now leaves an **already-scoped (non-root)** host untouched — it only retargets a root-scoped/unscoped host (the dev admin-kubeconfig case). An already-scoped provider kubeconfig is used as-is.
- **`providerWorkspace` is now optional.** It was only used for (a) the now-removed retarget and (b) stamping `spec.export.path` on the `APIExportEndpointSlice`. When unset, the operator **discovers the path** from the workspace's `kcp.io/path` annotation (its `LogicalCluster`). So you no longer need to pass `operator.providerWorkspace`.
- CRD: `providerWorkspace` `+optional` (regenerated). Chart defaults it to `""` and omits it from the CR when empty.

Answers "why does the operator even need `providerWorkspace`?" — it (mostly) doesn't anymore.

## Verification
`go build`, `go vet`, `gofmt`, `helm lint`, `helm template` pass. Confirmed against the live cluster that the cluster-ID URL works (200) and the path form 404s.

> [!NOTE]
> Helm does not upgrade CRDs in `crds/`. After releasing this, the updated CRD must be `kubectl apply`'d to clusters that already have the old one (same as the `runtimeKubeconfigSecret` optional change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)