### PR TITLE
fix(infrastructure): require CachedResource virtual storage for templates (never CRD fallback)

### DIFF
--- a/providers/infrastructure/controller_manager.go
+++ b/providers/infrastructure/controller_manager.go
@@ -61,10 +61,11 @@ func startControllerManager(ctx context.Context, config *rest.Config) error {
 		if err := install.CRDs(ctx, config); err != nil {
 			return fmt.Errorf("install CRDs: %w", err)
 		}
-		// Legacy single-binary path: CachedResource + EndpointSlice
-		// before APIExport so we can use virtual storage for templates.
-		// IdentityHash wait is best-effort; fall back to CRD storage
-		// when it times out so the binary still boots in stub-only mode.
+		// Legacy single-binary path: CachedResource + EndpointSlice before
+		// APIExport so templates use virtual storage. Templates MUST be served
+		// via virtual storage (to project into tenant workspaces) — never fall
+		// back to CRD storage; fail so a restart retries until the identityHash
+		// is ready.
 		if err := install.PlatformCachedResources(ctx, config); err != nil {
 			return fmt.Errorf("install CachedResources: %w", err)
 		}
@@ -73,8 +74,10 @@ func startControllerManager(ctx context.Context, config *rest.Config) error {
 		}
 		hash, err := install.WaitForCachedResourceIdentity(ctx, config)
 		if err != nil {
-			log.Printf("controller manager: WARNING %v — using CRD storage for templates", err)
-			hash = ""
+			return fmt.Errorf("CachedResource identityHash not ready (templates require virtual storage): %w", err)
+		}
+		if hash == "" {
+			return fmt.Errorf("CachedResource identityHash empty (templates require virtual storage)")
 		}
 		if err := install.PlatformSchemaInAPIExport(ctx, config, hash); err != nil {
 			return fmt.Errorf("register platform schemas on APIExport: %w", err)

--- a/providers/infrastructure/init_cmd.go
+++ b/providers/infrastructure/init_cmd.go
@@ -121,13 +121,15 @@ func runInitCmd(ctx context.Context) error {
 	}
 
 	log.Printf("init: waiting for CachedResource identityHash")
+	// Templates MUST use the CachedResource virtual storage (so they project into
+	// tenant workspaces). Never fall back to CRD storage — fail so the init
+	// container retries until the identityHash is ready.
 	templatesIdentityHash, err := install.WaitForCachedResourceIdentity(ctx, adminConfig)
 	if err != nil {
-		// Non-fatal: fall back to CRD storage so a single missing hash
-		// doesn't block boot. Operators can re-run init once the
-		// CachedResource catches up.
-		log.Printf("init: WARNING %v — falling back to CRD storage for templates", err)
-		templatesIdentityHash = ""
+		return fmt.Errorf("CachedResource identityHash not ready (templates require virtual storage): %w", err)
+	}
+	if templatesIdentityHash == "" {
+		return fmt.Errorf("CachedResource identityHash empty (templates require virtual storage)")
 	}
 
 	log.Printf("init: registering platform schemas on APIExport (templates storage=%s)", storageLabel(templatesIdentityHash))

--- a/providers/infrastructure/operator/bootstrap.go
+++ b/providers/infrastructure/operator/bootstrap.go
@@ -76,12 +76,16 @@ func Bootstrap(ctx context.Context, providerCfg *rest.Config, opts BootstrapOpti
 		return fmt.Errorf("install APIExportEndpointSlice: %w", err)
 	}
 
+	// Templates MUST be served via the CachedResource virtual storage so they
+	// project into tenant workspaces. Never fall back to CRD storage (which is an
+	// empty per-tenant CRD — tenants would see no templates). Fail instead and
+	// let the reconcile retry until the CachedResource identityHash is ready.
 	hash, err := install.WaitForCachedResourceIdentity(ctx, providerCfg)
 	if err != nil {
-		// Non-fatal: fall back to CRD storage this pass; a later reconcile
-		// upgrades to virtual storage once the identityHash settles.
-		log.Info("CachedResource identityHash not ready; using CRD storage for templates this pass", "err", err.Error())
-		hash = ""
+		return fmt.Errorf("CachedResource identityHash not ready (templates require virtual storage): %w", err)
+	}
+	if hash == "" {
+		return fmt.Errorf("CachedResource identityHash empty (templates require virtual storage)")
 	}
 	if err := install.PlatformSchemaInAPIExport(ctx, providerCfg, hash); err != nil {
 		return fmt.Errorf("register APIExport schemas: %w", err)


### PR DESCRIPTION
## Why

Tenants saw **no templates** in the portal. Root cause: the provider's APIExport was serving `templates` via **CRD storage** (an empty per-tenant CRD) instead of the **CachedResource virtual storage** that projects the real Template data.

That happened because the bootstrap **silently fell back to CRD storage** when the CachedResource `identityHash` wasn't ready yet (`hash = ""`). If the hash never settled (e.g. a stalled CachedResource), the provider stayed permanently on the empty CRD path and tenants got `Templates.items: []`.

## Change

Never fall back to CRD storage. All three bootstrap paths now **fail and retry** until the CachedResource `identityHash` is ready, then register the APIExport `templates` schema with virtual storage:

- `operator/bootstrap.go` (operator reconcile — requeues every 2m)
- `init_cmd.go` (init container — restarts)
- `controller_manager.go` (legacy single-binary serve)

So a provider is either serving templates via the projecting virtual storage, or it's visibly not-ready — never silently broken.

## Verification
`go build`, `go vet`, `gofmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)