### PR TITLE
feat(infrastructure): align instances table with edges UI + add delete

### DIFF
--- a/providers/infrastructure/portal/src/DashboardTile.vue
+++ b/providers/infrastructure/portal/src/DashboardTile.vue
@@ -237,30 +237,30 @@ function styleFor(phase: string) {
     <div v-else-if="error" class="text-[11px] text-danger">Failed to load: {{ error }}</div>
 
     <template v-else>
-      <!-- Totals + per-phase counts, all in a single card so the four
-           numbers read as one summary block (Total | Ready | Pending |
-           Failed) rather than four detached boxes. Dividers separate the
-           columns inside the shared border. -->
-      <div class="grid grid-cols-4 divide-x divide-border-subtle rounded-lg border border-border-subtle bg-surface-overlay/60">
-        <div class="px-2 py-2">
-          <div class="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-text-muted">
-            <Layers class="h-3 w-3" :stroke-width="2" />
-            Total
-          </div>
-          <div class="mt-1 text-[18px] font-bold tabular-nums text-text-primary">{{ stats.total }}</div>
-        </div>
-        <div class="px-2 py-2">
-          <div class="text-[10px] font-medium uppercase tracking-wider text-success">Ready</div>
-          <div class="mt-1 text-[18px] font-bold tabular-nums text-text-primary">{{ stats.ready }}</div>
-        </div>
-        <div class="px-2 py-2">
-          <div class="text-[10px] font-medium uppercase tracking-wider text-text-muted">Pending</div>
-          <div class="mt-1 text-[18px] font-bold tabular-nums text-text-primary">{{ stats.pending }}</div>
-        </div>
-        <div class="px-2 py-2">
-          <div class="text-[10px] font-medium uppercase tracking-wider text-danger">Failed</div>
-          <div class="mt-1 text-[18px] font-bold tabular-nums text-text-primary">{{ stats.failed }}</div>
-        </div>
+      <!-- Slim horizontal status row (matches the clusters/edges tiles): a
+           single inline line of icon + count + label chips rather than four
+           stacked boxes, so the tile stays compact. -->
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+        <span class="inline-flex items-center gap-1 text-text-primary">
+          <Layers class="h-3 w-3 text-text-muted" :stroke-width="1.75" />
+          <span class="font-semibold tabular-nums">{{ stats.total }}</span>
+          <span class="text-text-muted">total</span>
+        </span>
+        <span class="inline-flex items-center gap-1 text-success">
+          <CheckCircle2 class="h-3 w-3" :stroke-width="1.75" />
+          <span class="tabular-nums">{{ stats.ready }}</span>
+          <span class="text-text-muted">ready</span>
+        </span>
+        <span v-if="stats.pending > 0" class="inline-flex items-center gap-1 text-text-muted">
+          <Clock class="h-3 w-3" :stroke-width="1.75" />
+          <span class="tabular-nums">{{ stats.pending }}</span>
+          <span class="text-text-muted">pending</span>
+        </span>
+        <span v-if="stats.failed > 0" class="inline-flex items-center gap-1 text-danger">
+          <AlertCircle class="h-3 w-3" :stroke-width="1.75" />
+          <span class="tabular-nums">{{ stats.failed }}</span>
+          <span class="text-text-muted">failed</span>
+        </span>
       </div>
 
       <!-- Health bar — only meaningful when there's anything to be

--- a/providers/infrastructure/portal/src/components/ConfirmDialog.vue
+++ b/providers/infrastructure/portal/src/components/ConfirmDialog.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+// Mirrors the host portal's @/components/ConfirmDialog (and the edges providers'
+// delete UX) so the infrastructure provider's confirmations look identical.
+// Dependency-free: inline SVGs instead of lucide (this bundle ships no icon lib).
+import { onMounted, onUnmounted } from 'vue'
+
+defineProps<{
+  title: string
+  message: string
+  confirmLabel?: string
+  busy?: boolean
+  error?: string | null
+}>()
+
+const emit = defineEmits<{ confirm: []; cancel: [] }>()
+
+function onKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('cancel')
+}
+onMounted(() => window.addEventListener('keydown', onKey))
+onUnmounted(() => window.removeEventListener('keydown', onKey))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      @click.self="emit('cancel')"
+    >
+      <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
+        <div class="flex items-start justify-between gap-4">
+          <div class="flex items-start gap-3">
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-danger/20 bg-danger-subtle">
+              <svg viewBox="0 0 24 24" class="h-4 w-4 text-danger" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </div>
+            <div>
+              <h2 class="text-[14px] font-semibold text-text-primary">{{ title }}</h2>
+              <p class="mt-1.5 text-[12px] leading-relaxed text-text-secondary">{{ message }}</p>
+            </div>
+          </div>
+          <button
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-text-muted transition-all hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+            :disabled="busy"
+            @click="emit('cancel')"
+          >
+            <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div v-if="error" class="mt-4 rounded-lg border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger">
+          {{ error }}
+        </div>
+
+        <div class="mt-6 flex items-center justify-end gap-2">
+          <button
+            class="rounded-lg border border-border-subtle px-4 py-2 text-[12px] font-medium text-text-secondary transition-all hover:bg-surface-hover disabled:opacity-50"
+            :disabled="busy"
+            @click="emit('cancel')"
+          >
+            Cancel
+          </button>
+          <button
+            class="rounded-lg bg-danger px-4 py-2 text-[12px] font-medium text-white transition-all hover:bg-danger/80 disabled:opacity-50"
+            :disabled="busy"
+            @click="emit('confirm')"
+          >
+            {{ busy ? 'Working…' : confirmLabel ?? 'Confirm' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/providers/infrastructure/portal/src/views/InstanceDetailPage.vue
+++ b/providers/infrastructure/portal/src/views/InstanceDetailPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 import StatusBadge from '../components/StatusBadge.vue'
+import ConfirmDialog from '../components/ConfirmDialog.vue'
 import { api } from '../api'
 import type { Instance } from '../types'
 
@@ -10,6 +11,10 @@ const emit = defineEmits<{ (e: 'navigate', view: string): void }>()
 const inst = ref<Instance | null>(null)
 const error = ref<string | null>(null)
 let pollHandle: number | null = null
+
+const showDelete = ref(false)
+const deleting = ref(false)
+const deleteError = ref<string | null>(null)
 
 async function refresh() {
   try {
@@ -28,72 +33,127 @@ onUnmounted(() => {
 })
 watch(() => props.instanceName, refresh)
 
-async function del() {
-  if (!confirm(`Delete instance ${props.instanceName}? This removes the underlying resource and its bridged credentials Secret.`)) {
-    return
-  }
+async function executeDelete() {
+  deleting.value = true
+  deleteError.value = null
   try {
     await api.deleteInstance(props.instanceName)
     emit('navigate', 'instances')
   } catch (e: unknown) {
-    error.value = (e as { message?: string }).message ?? 'delete failed'
+    deleteError.value = (e as { message?: string }).message ?? 'delete failed'
+  } finally {
+    deleting.value = false
   }
 }
 </script>
 
 <template>
-  <section class="page">
-    <button class="link back" @click="emit('navigate', 'instances')">← Back to instances</button>
-    <div v-if="error" class="error">Error: {{ error }}</div>
-    <div v-else-if="!inst" class="muted">Loading…</div>
+  <div>
+    <button
+      class="mb-4 inline-flex items-center gap-1.5 text-[12px] font-medium text-text-muted transition-colors hover:text-text-primary"
+      @click="emit('navigate', 'instances')"
+    >
+      <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="19" y1="12" x2="5" y2="12" /><polyline points="12 19 5 12 12 5" />
+      </svg>
+      Back to instances
+    </button>
+
+    <div v-if="error" class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-4 text-[13px] text-danger">
+      {{ error }}
+    </div>
+    <div v-else-if="!inst" class="p-6 text-[12px] text-text-muted">Loading…</div>
+
     <template v-else>
-      <header class="page-head">
+      <!-- Header -->
+      <div class="mb-5 flex items-start gap-3 flex-wrap">
         <div>
-          <h2 class="page-title">{{ inst.name }}</h2>
-          <p class="page-meta">{{ inst.template }}</p>
+          <div class="flex items-center gap-2.5">
+            <h2 class="text-[16px] font-bold text-text-primary">{{ inst.name }}</h2>
+            <StatusBadge :phase="inst.phase" />
+          </div>
+          <p class="mt-0.5 text-[12px] text-text-muted">{{ inst.template }}</p>
         </div>
-        <StatusBadge :phase="inst.phase" />
-      </header>
-      <p v-if="inst.message" class="status-message">{{ inst.message }}</p>
+        <div class="ml-auto">
+          <button
+            class="flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-overlay/80 px-3 py-1.5 text-[11px] font-medium text-text-secondary transition-all hover:border-danger/30 hover:bg-danger-subtle hover:text-danger"
+            @click="showDelete = true"
+          >
+            <svg viewBox="0 0 24 24" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+              <line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" />
+            </svg>
+            Delete
+          </button>
+        </div>
+      </div>
 
-      <section class="panel">
-        <h3 class="panel-title">Values</h3>
-        <pre>{{ JSON.stringify(inst.values, null, 2) }}</pre>
-      </section>
+      <div v-if="inst.message" class="mb-5 rounded-lg border border-border-subtle bg-surface-overlay px-3 py-2 text-[12px] text-text-secondary">
+        {{ inst.message }}
+      </div>
 
-      <section v-if="inst.conditions && inst.conditions.length" class="panel">
-        <h3 class="panel-title">Conditions</h3>
-        <table class="table">
-          <thead><tr><th>Type</th><th>Status</th><th>Reason</th><th>Message</th></tr></thead>
+      <!-- Values -->
+      <div class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+        <div class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Values</div>
+        <pre class="overflow-auto p-4 font-mono text-[12px] leading-relaxed text-text-secondary">{{ JSON.stringify(inst.values, null, 2) }}</pre>
+      </div>
+
+      <!-- Conditions -->
+      <div v-if="inst.conditions && inst.conditions.length" class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+        <div class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Conditions</div>
+        <table class="w-full border-collapse text-left">
+          <thead>
+            <tr class="border-b border-border-subtle">
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Type</th>
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Status</th>
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Reason</th>
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Message</th>
+            </tr>
+          </thead>
           <tbody>
-            <tr v-for="c in inst.conditions" :key="c.type">
-              <td>{{ c.type }}</td>
-              <td><StatusBadge :phase="c.status" /></td>
-              <td>{{ c.reason }}</td>
-              <td class="muted">{{ c.message }}</td>
+            <tr v-for="c in inst.conditions" :key="c.type" class="border-b border-border-subtle/60 last:border-0">
+              <td class="px-4 py-2.5 text-[12px] text-text-primary">{{ c.type }}</td>
+              <td class="px-4 py-2.5"><StatusBadge :phase="c.status" /></td>
+              <td class="px-4 py-2.5 text-[12px] text-text-secondary">{{ c.reason }}</td>
+              <td class="px-4 py-2.5 text-[12px] text-text-muted">{{ c.message }}</td>
             </tr>
           </tbody>
         </table>
-      </section>
+      </div>
 
-      <section v-if="inst.children && inst.children.length" class="panel">
-        <h3 class="panel-title">Child resources</h3>
-        <table class="table">
-          <thead><tr><th>Kind</th><th>Name</th><th>Namespace</th><th>Phase</th></tr></thead>
+      <!-- Child resources -->
+      <div v-if="inst.children && inst.children.length" class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+        <div class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Child resources</div>
+        <table class="w-full border-collapse text-left">
+          <thead>
+            <tr class="border-b border-border-subtle">
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Kind</th>
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Name</th>
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Namespace</th>
+              <th class="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Phase</th>
+            </tr>
+          </thead>
           <tbody>
-            <tr v-for="c in inst.children" :key="c.kind + '/' + c.name">
-              <td>{{ c.kind }}</td>
-              <td>{{ c.name }}</td>
-              <td>{{ c.namespace }}</td>
-              <td>{{ c.phase }}</td>
+            <tr v-for="c in inst.children" :key="c.kind + '/' + c.name" class="border-b border-border-subtle/60 last:border-0">
+              <td class="px-4 py-2.5 text-[12px] text-text-primary">{{ c.kind }}</td>
+              <td class="px-4 py-2.5 text-[12px] text-text-secondary">{{ c.name }}</td>
+              <td class="px-4 py-2.5 text-[12px] text-text-muted">{{ c.namespace }}</td>
+              <td class="px-4 py-2.5 text-[12px] text-text-secondary">{{ c.phase }}</td>
             </tr>
           </tbody>
         </table>
-      </section>
-
-      <div class="actions">
-        <button class="danger" @click="del">Delete instance</button>
       </div>
     </template>
-  </section>
+
+    <ConfirmDialog
+      v-if="showDelete"
+      title="Delete instance?"
+      :message="`This permanently deletes ${props.instanceName} and the resources (and bridged credentials Secret) it provisioned. This cannot be undone.`"
+      confirm-label="Delete"
+      :busy="deleting"
+      :error="deleteError"
+      @cancel="showDelete = false"
+      @confirm="executeDelete"
+    />
+  </div>
 </template>

--- a/providers/infrastructure/portal/src/views/InstanceListPage.vue
+++ b/providers/infrastructure/portal/src/views/InstanceListPage.vue
@@ -14,6 +14,11 @@ const error = ref<string | null>(null)
 const loading = ref(true)
 let pollHandle: number | null = null
 
+// Delete confirmation state (mirrors the edges providers' table UX).
+const deleteConfirm = ref<Instance | null>(null)
+const deleting = ref(false)
+const deleteError = ref<string | null>(null)
+
 async function refresh() {
   try {
     const r = await api.listInstances()
@@ -26,12 +31,43 @@ async function refresh() {
   }
 }
 
+function confirmDelete(inst: Instance) {
+  deleteConfirm.value = inst
+  deleteError.value = null
+}
+
+async function executeDelete() {
+  if (!deleteConfirm.value) return
+  deleting.value = true
+  deleteError.value = null
+  try {
+    await api.deleteInstance(deleteConfirm.value.name)
+    deleteConfirm.value = null
+    await refresh()
+  } catch (e: unknown) {
+    deleteError.value = (e as { message?: string }).message ?? 'delete failed'
+  } finally {
+    deleting.value = false
+  }
+}
+
+// Compact relative age from a creationTimestamp, matching the edges tables.
+function formatAge(ts?: string): string {
+  if (!ts) return '-'
+  const then = new Date(ts).getTime()
+  if (Number.isNaN(then)) return '-'
+  const s = Math.max(0, Math.floor((Date.now() - then) / 1000))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h`
+  return `${Math.floor(h / 24)}d`
+}
+
 onMounted(() => {
   refresh()
-  // Poll every 10s while the page is mounted so the user sees status
-  // transitions without a manual refresh. The window.setInterval cast
-  // returns number in browsers; explicit type lets TS keep the
-  // clearInterval signature happy.
+  // Poll every 10s so status transitions show without a manual refresh.
   pollHandle = window.setInterval(refresh, 10000)
 })
 onUnmounted(() => {
@@ -40,44 +76,119 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <section class="page">
-    <header class="page-head">
+  <div>
+    <!-- Header -->
+    <div class="mb-5 flex items-center gap-3 flex-wrap">
       <div>
-        <h2 class="page-title">My instances</h2>
-        <p class="page-meta">Updates automatically.</p>
+        <h2 class="text-[15px] font-bold text-text-primary">My instances</h2>
+        <p class="text-[12px] text-text-muted">Provisioned into the active workspace.</p>
       </div>
-      <button class="link" @click="emit('navigate', 'catalog')">← Browse templates</button>
-    </header>
-    <div v-if="loading" class="muted">Loading…</div>
-    <div v-else-if="error" class="error">Error: {{ error }}</div>
-    <div v-else-if="items.length === 0" class="muted">
-      <p>No instances in this workspace yet.</p>
-      <p style="margin-top: 0.5rem; font-size: 0.85em;">
-        Each workspace has its own instances — switching the active workspace
-        in the portal sidebar changes what you see here.
-        <a href="#" @click.prevent="emit('navigate', 'catalog')">Browse templates</a>
-        to provision one.
-      </p>
+      <div class="ml-auto flex items-center gap-3">
+        <div class="flex items-center gap-1.5">
+          <div class="h-1.5 w-1.5 rounded-full bg-success" />
+          <span class="font-mono text-[10px] text-text-muted">auto-refresh 10s</span>
+        </div>
+        <button
+          class="flex items-center gap-2 rounded-xl border border-accent/30 bg-accent/10 px-3.5 py-2 text-[12px] font-medium text-accent transition-all hover:bg-accent/20"
+          @click="emit('navigate', 'catalog')"
+        >
+          Browse templates
+        </button>
+      </div>
     </div>
-    <table v-else class="table">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Template</th>
-          <th>Phase</th>
-          <th>Created</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="i in items" :key="i.name">
-          <td><button class="link" @click="emit('select', i.name)">{{ i.name }}</button></td>
-          <td>{{ i.template }}</td>
-          <td><StatusBadge :phase="i.phase" /></td>
-          <td class="muted">{{ i.createdAt }}</td>
-          <td><button class="link" @click="emit('select', i.name)">Details →</button></td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
+
+    <!-- Table -->
+    <div class="overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+      <div v-if="loading" class="p-6 text-[12px] text-text-muted">Loading…</div>
+      <div v-else-if="error" class="m-4 rounded-lg border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger">
+        {{ error }}
+      </div>
+      <div v-else-if="items.length === 0" class="p-8 text-center">
+        <p class="text-[13px] text-text-secondary">No instances in this workspace yet.</p>
+        <p class="mt-1 text-[12px] text-text-muted">
+          Each workspace has its own instances.
+          <a href="#" class="text-accent hover:underline" @click.prevent="emit('navigate', 'catalog')">Browse templates</a>
+          to provision one.
+        </p>
+      </div>
+      <table v-else class="w-full border-collapse text-left">
+        <thead>
+          <tr class="border-b border-border-subtle">
+            <th class="px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Name</th>
+            <th class="px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Template</th>
+            <th class="px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Status</th>
+            <th class="px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Age</th>
+            <th class="px-4 py-2.5"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="i in items"
+            :key="i.name"
+            class="group cursor-pointer border-b border-border-subtle/60 transition-colors last:border-0 hover:bg-surface-hover"
+            @click="emit('select', i.name)"
+          >
+            <td class="px-4 py-3">
+              <span class="text-[13px] font-medium text-text-primary">{{ i.name }}</span>
+            </td>
+            <td class="px-4 py-3">
+              <span class="rounded-md border border-border-subtle bg-surface-overlay px-2 py-0.5 text-[11px] text-text-secondary">{{ i.template }}</span>
+            </td>
+            <td class="px-4 py-3"><StatusBadge :phase="i.phase" /></td>
+            <td class="px-4 py-3 font-mono text-[12px] text-text-muted">{{ formatAge(i.createdAt) }}</td>
+            <td class="px-4 py-3 text-right">
+              <button
+                class="inline-flex h-7 w-7 items-center justify-center rounded-lg text-text-muted/40 opacity-0 transition-all group-hover:opacity-100 hover:bg-danger-subtle hover:text-danger"
+                title="Delete instance"
+                @click.stop="confirmDelete(i)"
+              >
+                <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+                  <line x1="10" y1="11" x2="10" y2="17" />
+                  <line x1="14" y1="11" x2="14" y2="17" />
+                </svg>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Delete confirmation -->
+    <Teleport to="body">
+      <div
+        v-if="deleteConfirm"
+        class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+        @click.self="deleting ? null : (deleteConfirm = null)"
+      >
+        <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
+          <h3 class="text-[14px] font-bold text-text-primary">Delete instance?</h3>
+          <p class="mt-2 text-[12px] text-text-muted">
+            This permanently deletes
+            <span class="font-mono font-medium text-text-secondary">{{ deleteConfirm.name }}</span>
+            ({{ deleteConfirm.template }}) and the resources it provisioned.
+          </p>
+          <div v-if="deleteError" class="mt-3 rounded-lg border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger">
+            {{ deleteError }}
+          </div>
+          <div class="mt-5 flex items-center justify-end gap-3">
+            <button
+              class="rounded-lg border border-border-subtle px-4 py-2 text-[12px] font-medium text-text-secondary transition-all hover:bg-surface-hover disabled:opacity-50"
+              :disabled="deleting"
+              @click="deleteConfirm = null"
+            >
+              Cancel
+            </button>
+            <button
+              class="rounded-lg bg-danger px-4 py-2 text-[12px] font-medium text-white transition-all hover:bg-danger/80 disabled:opacity-50"
+              :disabled="deleting"
+              @click="executeDelete"
+            >
+              {{ deleting ? 'Deleting…' : 'Delete' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
 </template>


### PR DESCRIPTION
## What

The infrastructure provider's **instances table** looked nothing like the other providers (it used the old standalone `.table`/`.link` CSS). Realigned it to the **edges/servers** providers' table style and added a **delete** action.

- Rebuilt `InstanceListPage.vue` with the shared Tailwind design tokens (`text-text-*`, `surface-raised/overlay/hover`, `border-border-subtle`, `danger`, `accent`, `success`) — the same ones `WorkloadsPage`/`DashboardTile` use, compiled by the host portal (it already `@source`s the infra portal).
- Rounded bordered table, uppercase column headers, hover rows, status badge, relative **Age**, and an "auto-refresh 10s" indicator — matching the edges look.
- **Per-row delete button** (reveals on row hover) → confirmation modal → `api.deleteInstance(name)` → refresh. Same UX as the edges `WorkloadsPage` delete.
- Dependency-free: inline trash SVG (the infra portal doesn't bundle lucide).

## Notes
- The infra portal renders in light DOM and the host portal compiles its Tailwind, so the tokens resolve at runtime — no CSS shipped by this bundle.
- `providers/infrastructure/portal/dist/` is gitignored (built at image-build time); only the source changed. Verified with `npm run build` (✓ built).
- Not visually verified in a running portal (no browser here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)