### PR TITLE
[codex] Add App Studio workbench launcher tabs

### DIFF
--- a/providers/app-studio/api/assistant_events.go
+++ b/providers/app-studio/api/assistant_events.go
@@ -28,9 +28,17 @@ type projectAssistantStreamWriter struct {
 	msgIdx            int
 	assistantDataKey  string
 	assistantShellSet bool
+	toolCards         map[string]projectAssistantToolCardIDs
 	pendingPermission *projectAssistantPermission
 	pendingFollowUp   *projectAssistantFollowUp
 	write             func(projectMessageStreamEvent) error
+}
+
+type projectAssistantToolCardIDs struct {
+	cardID  string
+	colID   string
+	labelID string
+	textID  string
 }
 
 func (w *projectAssistantStreamWriter) EmitProjectAssistantEvent(
@@ -60,7 +68,7 @@ func (w *projectAssistantStreamWriter) EmitProjectAssistantEvent(
 		if event.Type == projectAssistantEventToolCallFinished {
 			kind = "tool result"
 		}
-		return w.writeToolCard(ctx, kind, projectAssistantUIToolCardText(action))
+		return w.writeToolCard(ctx, event.ToolCall.ID, kind, projectAssistantUIToolCardText(action))
 	case projectAssistantEventPermissionNeeded:
 		if event.Permission == nil || event.Permission.ID == "" {
 			return nil
@@ -73,7 +81,7 @@ func (w *projectAssistantStreamWriter) EmitProjectAssistantEvent(
 		if text == "" {
 			text = projectAssistantUIToolCardText(action)
 		}
-		return w.writeToolCard(ctx, "approval needed", text)
+		return w.writeToolCard(ctx, "", "approval needed", text)
 	case projectAssistantEventInputNeeded:
 		if event.FollowUp == nil || event.FollowUp.ID == "" {
 			return nil
@@ -85,7 +93,7 @@ func (w *projectAssistantStreamWriter) EmitProjectAssistantEvent(
 		if text == "" {
 			text = projectAssistantUIToolCardText(action)
 		}
-		return w.writeToolCard(ctx, "approval needed", text)
+		return w.writeToolCard(ctx, "", "approval needed", text)
 	case projectAssistantEventCheckpointSaved:
 		if event.Checkpoint == nil || event.Checkpoint.ID == "" {
 			return nil
@@ -160,25 +168,42 @@ func (w *projectAssistantStreamWriter) writeAssistantContent(ctx context.Context
 	return w.write(projectMessageStreamEventFromUI(projectAssistantUIDataAppendEvent(w.assistantID, w.assistantDataKey, delta)))
 }
 
-func (w *projectAssistantStreamWriter) writeToolCard(ctx context.Context, kind, text string) error {
+func (w *projectAssistantStreamWriter) writeToolCard(ctx context.Context, stableKey, kind, text string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if err := w.ensureBegin(ctx); err != nil {
 		return err
 	}
-	cardID, colID, labelID, textID := w.nextMessageComponentIDs()
-	w.rootChildren = append(w.rootChildren, cardID)
+	ids, ok := w.toolCardIDs(stableKey)
+	if !ok {
+		ids.cardID, ids.colID, ids.labelID, ids.textID = w.nextMessageComponentIDs()
+		w.rootChildren = append(w.rootChildren, ids.cardID)
+		if stableKey != "" {
+			if w.toolCards == nil {
+				w.toolCards = map[string]projectAssistantToolCardIDs{}
+			}
+			w.toolCards[stableKey] = ids
+		}
+	}
 	return w.write(projectMessageStreamEventFromUI(projectAssistantUIToolCardEvent(
 		w.assistantID,
 		w.rootChildren,
-		cardID,
-		colID,
-		labelID,
-		textID,
+		ids.cardID,
+		ids.colID,
+		ids.labelID,
+		ids.textID,
 		kind,
 		text,
 	)))
+}
+
+func (w *projectAssistantStreamWriter) toolCardIDs(stableKey string) (projectAssistantToolCardIDs, bool) {
+	if stableKey == "" || w.toolCards == nil {
+		return projectAssistantToolCardIDs{}, false
+	}
+	ids, ok := w.toolCards[stableKey]
+	return ids, ok
 }
 
 func (w *projectAssistantStreamWriter) writeUI(ctx context.Context, assistantID string, ui projectAssistantUIEvent, begin bool) error {

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -174,6 +174,15 @@ func TestProjectAssistantStreamWriterEmitsCanonicalLifecycleSequence(t *testing.
 	}
 	assertA2UICard(t, got[5], "tool call", "Editing files")
 	assertA2UICard(t, got[6], "tool result", "Edited files")
+	firstToolCardID := assertSingleA2UICardID(t, got[1], "tool call")
+	runningToolCardID := assertSingleA2UICardID(t, got[5], "tool call")
+	finishedToolCardID := assertSingleA2UICardID(t, got[6], "tool result")
+	if runningToolCardID != firstToolCardID || finishedToolCardID != firstToolCardID {
+		t.Fatalf("tool card IDs = %q, %q, %q; want lifecycle updates to reuse one A2UI card", firstToolCardID, runningToolCardID, finishedToolCardID)
+	}
+	if children := assertA2UIRootChildren(t, got[6]); countString(children, firstToolCardID) != 1 {
+		t.Fatalf("root children = %#v, want tool card %q listed once", children, firstToolCardID)
+	}
 	if got[7].Type != string(projectAssistantEventRunFinished) || got[7].AssistantMessageID != "assistant-1" {
 		t.Fatalf("final event = %#v, want run_finished", got[7])
 	}
@@ -422,6 +431,12 @@ func TestStreamProjectAssistantEmitsCanonicalLifecycleSequence(t *testing.T) {
 	assertA2UICard(t, got[1], "tool call", "Editing files")
 	assertA2UICard(t, got[5], "tool call", "Editing files")
 	assertA2UICard(t, got[6], "tool result", "Edited files")
+	firstToolCardID := assertSingleA2UICardID(t, got[1], "tool call")
+	runningToolCardID := assertSingleA2UICardID(t, got[5], "tool call")
+	finishedToolCardID := assertSingleA2UICardID(t, got[6], "tool result")
+	if runningToolCardID != firstToolCardID || finishedToolCardID != firstToolCardID {
+		t.Fatalf("tool card IDs = %q, %q, %q; want lifecycle updates to reuse one A2UI card", firstToolCardID, runningToolCardID, finishedToolCardID)
+	}
 	if !projectMessageStreamEventsHaveContent([]projectMessageStreamEvent{got[7]}, projectAssistantUIDevelopmentPreviewRefreshKey) {
 		t.Fatalf("preview refresh event = %#v, want preview refresh signal", got[7])
 	}
@@ -637,6 +652,55 @@ func assertA2UICard(t *testing.T, event projectMessageStreamEvent, role, bodyCon
 		t.Fatalf("card role %q body = %q, want to contain %q", role, body, bodyContains)
 	}
 	t.Fatalf("components = %#v, want A2UI card with role %q", event.SurfaceUpdate.Components, role)
+}
+
+func assertSingleA2UICardID(t *testing.T, event projectMessageStreamEvent, role string) string {
+	t.Helper()
+	if event.SurfaceUpdate == nil {
+		t.Fatalf("event = %#v, want surfaceUpdate", event)
+	}
+	var found []string
+	components := map[string]projectAssistantUIComponent{}
+	for _, component := range event.SurfaceUpdate.Components {
+		components[component.ID] = component
+	}
+	for _, component := range event.SurfaceUpdate.Components {
+		if component.Component.Card == nil {
+			continue
+		}
+		texts := a2uiCardTexts(components, component.Component.Card.Children)
+		if len(texts) > 0 && texts[0] == role {
+			found = append(found, component.ID)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("components = %#v, want one A2UI card with role %q, got IDs %#v", event.SurfaceUpdate.Components, role, found)
+	}
+	return found[0]
+}
+
+func assertA2UIRootChildren(t *testing.T, event projectMessageStreamEvent) []string {
+	t.Helper()
+	if event.SurfaceUpdate == nil {
+		t.Fatalf("event = %#v, want surfaceUpdate", event)
+	}
+	for _, component := range event.SurfaceUpdate.Components {
+		if component.ID == projectAssistantUIRootComponentID && component.Component.Column != nil {
+			return component.Component.Column.Children
+		}
+	}
+	t.Fatalf("components = %#v, want root column component", event.SurfaceUpdate.Components)
+	return nil
+}
+
+func countString(values []string, want string) int {
+	var count int
+	for _, value := range values {
+		if value == want {
+			count++
+		}
+	}
+	return count
 }
 
 func a2uiCardTexts(components map[string]projectAssistantUIComponent, children []string) []string {

--- a/providers/app-studio/portal/package.json
+++ b/providers/app-studio/portal/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "vite build && cp index.html icon.svg dist/ && touch dist/.gitkeep",
     "dev": "vite",
+    "test:workbench": "node --test src/workbench.test.mjs",
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -30,6 +30,19 @@ import { api, isProjectAPIInitializingError } from './api'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import { useEscapeKey } from '@/composables/useEscapeKey'
+import {
+  activateWorkbenchTab,
+  closeWorkbenchTab,
+  createDefaultWorkbenchState,
+  openWorkbenchBuiltInTab,
+  openWorkbenchProviderTool,
+  reorderWorkbenchTab,
+  updateWorkbenchProviderToolPath,
+  type WorkbenchBuiltInTab,
+  type WorkbenchProviderToolRef,
+  type WorkbenchTabDropPlacement,
+  type WorkbenchTabDescriptor,
+} from './workbench'
 import type {
   KedgeContext,
   Project,
@@ -50,14 +63,8 @@ const props = defineProps<{
   navigate: (path: string) => void
 }>()
 
-interface ProviderTool {
-  id: string
+interface ProviderTool extends WorkbenchProviderToolRef {
   provider: ProviderItem
-  providerName: string
-  title: string
-  subtitle: string
-  path: string
-  iconURL?: string
 }
 
 interface LandingCategoryTile {
@@ -67,6 +74,16 @@ interface LandingCategoryTile {
   promptSeed: string
   icon: Component
   iconURL?: string
+}
+
+interface WorkbenchLauncherItem {
+  id: string
+  title: string
+  subtitle: string
+  icon: Component
+  iconURL?: string
+  builtInTab?: WorkbenchBuiltInTab
+  providerTool?: ProviderTool
 }
 
 type LLMCredentialMode = 'api-key' | 'service-account-json'
@@ -97,7 +114,6 @@ type ProjectMessageView = ProjectMessage & {
   surface?: ProjectAssistantSurface
   interrupt?: ProjectAssistantUIInterruptRequest
 }
-type WorkbenchTab = 'preview' | 'review' | 'providers'
 interface PendingApprovalView {
   message: ProjectMessageView
   interrupt: ProjectAssistantUIInterruptRequest
@@ -251,6 +267,7 @@ const pendingFollowUp = computed<PendingFollowUpView | null>(() => {
   }
   return null
 })
+const hasPendingReview = computed(() => pendingFollowUp.value !== null || pendingApproval.value !== null)
 const loading = ref(true)
 const projectsLoaded = ref(false)
 const providersLoading = ref(false)
@@ -271,6 +288,7 @@ const deletingProject = ref(false)
 const prompt = ref('')
 const projectQuery = ref('')
 const providerQuery = ref('')
+const workbenchLauncherQuery = ref('')
 const developmentSyncBusy = ref(false)
 const developmentSyncStatus = ref<string | null>(null)
 const developmentSyncError = ref<string | null>(null)
@@ -287,9 +305,11 @@ const permissionErrors = ref<Record<string, string>>({})
 const followUpAnswers = ref<Record<string, string>>({})
 const followUpBusy = ref<Record<string, boolean>>({})
 const followUpErrors = ref<Record<string, string>>({})
-const selectedTool = ref<ProviderTool | null>(null)
 const toolState = ref<'idle' | 'loading' | 'ready' | 'error'>('idle')
-const workbenchTab = ref<WorkbenchTab>('providers')
+const workbench = ref(createDefaultWorkbenchState())
+const draggedWorkbenchTabID = ref<string | null>(null)
+const dragOverWorkbenchTabID = ref<string | null>(null)
+const dragOverWorkbenchTabPlacement = ref<WorkbenchTabDropPlacement>('before')
 const llmSettings = ref<ProjectLLMSettings | null>(null)
 const llmProvider = ref(OPENAI_COMPATIBLE_PROVIDER)
 const llmBaseURL = ref('https://api.openai.com/v1')
@@ -493,6 +513,73 @@ const providerTools = computed<ProviderTool[]>(() => {
   return out.sort((a, b) => a.title.localeCompare(b.title))
 })
 
+const activeWorkbenchTab = computed<WorkbenchTabDescriptor | null>(() => {
+  return workbench.value.tabs.find((tab) => tab.id === workbench.value.activeTabID) ?? workbench.value.tabs[0] ?? null
+})
+
+const activeProviderToolRef = computed(() => {
+  const tab = activeWorkbenchTab.value
+  return tab?.kind === 'provider' ? tab.providerTool ?? null : null
+})
+
+const activeProviderTool = computed<ProviderTool | null>(() => {
+  const toolRef = activeProviderToolRef.value
+  if (!toolRef) return null
+  const tool = providerTools.value.find((item) => item.id === toolRef.id)
+  return tool ? { ...tool, path: toolRef.path } : null
+})
+
+const workbenchLauncherQueryNormalized = computed(() => workbenchLauncherQuery.value.trim().toLowerCase())
+
+const launcherExistingTabs = computed(() => {
+  const q = workbenchLauncherQueryNormalized.value
+  return workbench.value.tabs.filter((tab) => {
+    if (tab.id === workbench.value.activeTabID) return false
+    if (!q) return true
+    return `${tab.title} ${tab.subtitle ?? ''}`.toLowerCase().includes(q)
+  })
+})
+
+const launcherBuiltInItems = computed<WorkbenchLauncherItem[]>(() => [
+  {
+    id: 'builtin:preview',
+    title: 'Preview',
+    subtitle: 'Preview your app',
+    icon: AppWindow,
+    builtInTab: 'preview',
+  },
+  {
+    id: 'builtin:providers',
+    title: 'Providers',
+    subtitle: 'Browse provider views and project tools',
+    icon: PanelRight,
+    builtInTab: 'providers',
+  },
+  {
+    id: 'builtin:review',
+    title: 'Review',
+    subtitle: hasPendingReview.value ? 'Resolve pending approvals and follow-up questions' : 'Inspect approvals and follow-up requests',
+    icon: ClipboardList,
+    builtInTab: 'review',
+  },
+])
+
+const launcherProviderItems = computed<WorkbenchLauncherItem[]>(() => providerTools.value.map((tool) => ({
+  id: `provider:${tool.id}`,
+  title: tool.title,
+  subtitle: tool.subtitle,
+  icon: Wrench,
+  iconURL: tool.iconURL,
+  providerTool: tool,
+})))
+
+const launcherSuggestedItems = computed(() => {
+  const q = workbenchLauncherQueryNormalized.value
+  const items = [...launcherBuiltInItems.value, ...launcherProviderItems.value]
+  if (!q) return items
+  return items.filter((item) => `${item.title} ${item.subtitle}`.toLowerCase().includes(q))
+})
+
 const landingCategoryTiles = computed<LandingCategoryTile[]>(() => {
   const tiles: LandingCategoryTile[] = []
   const seen = new Set<string>()
@@ -650,6 +737,35 @@ watch(
   },
 )
 
+watch(
+  () => activeProviderToolRef.value?.id ?? '',
+  async (toolID) => {
+    toolLoadSerial += 1
+    if (!toolID) {
+      toolState.value = 'idle'
+      toolError.value = null
+      detachMountedTool()
+      return
+    }
+    await nextTick()
+    await mountActiveProviderTool()
+  },
+)
+
+watch(
+  () => [
+    activeProviderToolRef.value?.path,
+    props.ctx?.token,
+    props.ctx?.user,
+    props.ctx?.tenant,
+    props.ctx?.theme,
+    props.ctx?.subPath,
+  ],
+  () => {
+    void nextTick(pushToolContext)
+  },
+)
+
 watch(llmProvider, () => {
   llmBaseURL.value = normalizeLLMBaseURLInput(llmProvider.value, llmBaseURL.value, llmCredentialMode.value)
   llmModel.value = normalizeLLMModelInput(llmProvider.value, llmModel.value, llmCredentialMode.value)
@@ -665,13 +781,6 @@ watch(llmCredentialMode, () => {
   llmBaseURL.value = normalizeLLMBaseURLInput(llmProvider.value, llmBaseURL.value, llmCredentialMode.value)
   llmModel.value = normalizeLLMModelInput(llmProvider.value, llmModel.value, llmCredentialMode.value)
 })
-
-watch(
-  () => [props.ctx?.token, props.ctx?.tenant, props.ctx?.theme],
-  () => {
-    pushToolContext()
-  },
-)
 
 watch(settingsProject, () => {
   if (showSettings.value) syncProjectSettingsForm()
@@ -720,13 +829,13 @@ async function load() {
     if (isCreateRoute.value) {
       selected.value = null
       messages.value = []
-      closeTool()
+      resetWorkbench()
       return
     }
     if (projects.value.length === 0) {
       selected.value = null
       messages.value = []
-      closeTool()
+      resetWorkbench()
       props.navigate(CREATE_PROJECT_ROUTE)
       return
     }
@@ -736,7 +845,7 @@ async function load() {
     } else {
       selected.value = null
       messages.value = []
-      closeTool()
+      resetWorkbench()
     }
   } catch (e) {
     if (handleProjectAPIInitializing(e)) return
@@ -1076,7 +1185,7 @@ async function createProjectAndStartConversation(content: string) {
   error.value = null
   prompt.value = ''
   selectedLandingCategory.value = null
-  closeTool()
+  resetWorkbench()
   selected.value = {
     name: draftName,
     displayName: 'New project',
@@ -1084,7 +1193,6 @@ async function createProjectAndStartConversation(content: string) {
     phase: 'Creating',
     createdAt: now,
   }
-  workbenchTab.value = 'providers'
   messages.value = [
     {
       id: `temp-${Date.now()}-user`,
@@ -1450,10 +1558,107 @@ function developmentPreviewTokenExpiresSoon(): boolean {
   return Number.isFinite(expiresMs) && expiresMs <= Date.now() + DEVELOPMENT_PREVIEW_AUTH_RENEWAL_SKEW_MS
 }
 
-function workbenchTabButtonClass(tab: WorkbenchTab): string {
-  return workbenchTab.value === tab
+function resetWorkbench() {
+  workbench.value = createDefaultWorkbenchState()
+}
+
+function openBuiltInWorkbenchTab(kind: WorkbenchBuiltInTab) {
+  workbench.value = openWorkbenchBuiltInTab(workbench.value, kind)
+}
+
+function openWorkbenchLauncher() {
+  workbenchLauncherQuery.value = ''
+  openBuiltInWorkbenchTab('launcher')
+}
+
+function openWorkbenchLauncherItem(item: WorkbenchLauncherItem) {
+  if (item.providerTool) {
+    openTool(item.providerTool)
+    return
+  }
+  if (item.builtInTab) {
+    openBuiltInWorkbenchTab(item.builtInTab)
+  }
+}
+
+function activateWorkbenchTabByID(tabID: string) {
+  workbench.value = activateWorkbenchTab(workbench.value, tabID)
+}
+
+function closeWorkbenchTabByID(tabID: string) {
+  workbench.value = closeWorkbenchTab(workbench.value, tabID)
+}
+
+function startWorkbenchTabDrag(event: DragEvent, tab: WorkbenchTabDescriptor) {
+  draggedWorkbenchTabID.value = tab.id
+  dragOverWorkbenchTabID.value = null
+  dragOverWorkbenchTabPlacement.value = 'before'
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', tab.id)
+  }
+}
+
+function dragOverWorkbenchTab(event: DragEvent, tab: WorkbenchTabDescriptor) {
+  const draggedTabID = draggedWorkbenchTabID.value
+  if (!draggedTabID || draggedTabID === tab.id) return
+  event.preventDefault()
+  dragOverWorkbenchTabID.value = tab.id
+  dragOverWorkbenchTabPlacement.value = workbenchTabDropPlacement(event)
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'move'
+  }
+}
+
+function dropWorkbenchTab(event: DragEvent, tab: WorkbenchTabDescriptor) {
+  event.preventDefault()
+  const draggedTabID = draggedWorkbenchTabID.value || event.dataTransfer?.getData('text/plain') || ''
+  if (draggedTabID && draggedTabID !== tab.id) {
+    workbench.value = reorderWorkbenchTab(workbench.value, draggedTabID, tab.id, workbenchTabDropPlacement(event))
+  }
+  clearWorkbenchTabDragState()
+}
+
+function clearWorkbenchTabDragState() {
+  draggedWorkbenchTabID.value = null
+  dragOverWorkbenchTabID.value = null
+  dragOverWorkbenchTabPlacement.value = 'before'
+}
+
+function workbenchTabDropPlacement(event: DragEvent): WorkbenchTabDropPlacement {
+  const target = event.currentTarget
+  if (!(target instanceof HTMLElement)) return 'before'
+  const rect = target.getBoundingClientRect()
+  return event.clientX > rect.left + rect.width / 2 ? 'after' : 'before'
+}
+
+function workbenchTabButtonClass(tab: WorkbenchTabDescriptor): string {
+  const classes = workbench.value.activeTabID === tab.id
     ? 'border-accent/40 bg-accent/10 text-accent'
     : 'border-transparent text-text-muted hover:border-border-subtle hover:bg-surface-hover hover:text-text-primary'
+  const dragClasses = [
+    draggedWorkbenchTabID.value === tab.id ? 'opacity-60' : '',
+    dragOverWorkbenchTabID.value === tab.id ? 'border-accent/60 bg-accent/10' : '',
+    dragOverWorkbenchTabID.value === tab.id && dragOverWorkbenchTabPlacement.value === 'after' ? 'shadow-[inset_-2px_0_0_var(--color-accent)]' : '',
+    dragOverWorkbenchTabID.value === tab.id && dragOverWorkbenchTabPlacement.value === 'before' ? 'shadow-[inset_2px_0_0_var(--color-accent)]' : '',
+  ].filter(Boolean).join(' ')
+  return dragClasses ? `${classes} ${dragClasses}` : classes
+}
+
+function workbenchTabIcon(tab: WorkbenchTabDescriptor): Component {
+  if (tab.kind === 'preview') return AppWindow
+  if (tab.kind === 'review') return ClipboardList
+  if (tab.kind === 'providers') return PanelRight
+  if (tab.kind === 'launcher') return Plus
+  return Wrench
+}
+
+function workbenchTabPanelID(tab: WorkbenchTabDescriptor): string {
+  return `app-studio-workbench-panel-${tab.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+}
+
+function workbenchTabControlID(tab: WorkbenchTabDescriptor): string {
+  return `app-studio-workbench-tab-${tab.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
 }
 
 function requestDeleteProject(project: Project) {
@@ -1479,7 +1684,7 @@ async function confirmDeleteProject() {
       selected.value = null
       messages.value = []
       props.navigate('')
-      closeTool()
+      resetWorkbench()
       showSettings.value = false
     }
     deleteProjectTarget.value = null
@@ -1974,31 +2179,31 @@ function isAbortError(err: unknown): boolean {
     : err instanceof Error && err.name === 'AbortError'
 }
 
-async function openTool(tool: ProviderTool) {
-  selectedTool.value = tool
+function openTool(tool: ProviderTool) {
+  workbench.value = openWorkbenchProviderTool(workbench.value, tool)
   toolError.value = null
-  await nextTick()
-  await mountSelectedTool()
-}
-
-function closeTool() {
-  selectedTool.value = null
-  toolState.value = 'idle'
-  detachMountedTool()
 }
 
 function openToolFull() {
-  if (!selectedTool.value) return
-  const path = selectedTool.value.path ? `/${selectedTool.value.path.replace(/^\/+/, '')}` : ''
-  window.location.assign(`/ui/providers/${selectedTool.value.providerName}${path}`)
+  const tool = activeProviderTool.value
+  if (!tool) return
+  const path = tool.path ? `/${tool.path.replace(/^\/+/, '')}` : ''
+  window.location.assign(`/ui/providers/${tool.providerName}${path}`)
 }
 
-async function mountSelectedTool() {
-  const tool = selectedTool.value
+async function mountActiveProviderTool() {
+  const tool = activeProviderTool.value
   const host = toolHostRef.value
-  if (!tool || !host) return
+  if (!activeProviderToolRef.value) return
+  if (!tool) {
+    toolState.value = 'error'
+    toolError.value = 'Provider view is unavailable.'
+    detachMountedTool()
+    return
+  }
+  if (!host) return
 
-  const serial = ++toolLoadSerial
+  const serial = toolLoadSerial
   toolState.value = 'loading'
   toolError.value = null
   detachMountedTool()
@@ -2006,7 +2211,7 @@ async function mountSelectedTool() {
   try {
     const tag = tagForProvider(tool.providerName)
     await ensureProviderScript(tool)
-    if (serial !== toolLoadSerial || !selectedTool.value) return
+    if (serial !== toolLoadSerial || activeProviderTool.value?.id !== tool.id) return
 
     const el = document.createElement(tag) as HTMLElement & { kedgeContext?: unknown }
     el.className = 'block h-full min-h-0 w-full overflow-auto'
@@ -2048,7 +2253,7 @@ async function ensureProviderScript(tool: ProviderTool) {
 
 function pushToolContext() {
   const el = mountedToolEl.value as (HTMLElement & { kedgeContext?: unknown }) | null
-  const tool = selectedTool.value
+  const tool = activeProviderTool.value
   if (!el || !tool) return
   el.kedgeContext = {
     subPath: tool.path,
@@ -2063,9 +2268,10 @@ function pushToolContext() {
 function onNestedProviderNavigate(e: Event) {
   e.stopPropagation()
   const path = ((e as CustomEvent<{ path?: string }>).detail?.path ?? '').replace(/^\/+/, '')
-  if (!selectedTool.value) return
-  selectedTool.value = { ...selectedTool.value, path }
-  pushToolContext()
+  const tab = activeWorkbenchTab.value
+  if (!tab || tab.kind !== 'provider') return
+  workbench.value = updateWorkbenchProviderToolPath(workbench.value, tab.id, path)
+  void nextTick(pushToolContext)
 }
 
 function detachMountedTool() {
@@ -3091,67 +3297,167 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
 
     <section class="flex min-h-[360px] min-w-0 flex-1 flex-col md:min-h-0">
       <header class="flex h-14 shrink-0 items-center gap-2 border-b border-border-subtle px-3">
-        <template v-if="selectedTool">
-          <button
-            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle text-text-muted transition hover:bg-surface-hover hover:text-text-primary"
-            title="Back"
-            @click="closeTool"
+        <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
+          <PanelRight class="h-4 w-4 text-accent" :stroke-width="1.75" />
+        </div>
+        <div
+          class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+          role="tablist"
+          aria-label="Workbench tabs"
+        >
+          <div
+            v-for="tab in workbench.tabs"
+            :key="tab.id"
+            class="inline-flex h-8 shrink-0 cursor-grab items-center overflow-hidden rounded-md border text-[12px] font-medium transition active:cursor-grabbing"
+            :class="workbenchTabButtonClass(tab)"
+            draggable="true"
+            @dragstart="startWorkbenchTabDrag($event, tab)"
+            @dragover="dragOverWorkbenchTab($event, tab)"
+            @drop="dropWorkbenchTab($event, tab)"
+            @dragend="clearWorkbenchTabDragState"
           >
-            <ArrowLeft class="h-4 w-4" :stroke-width="1.75" />
-          </button>
-          <div class="min-w-0 flex-1">
-            <div class="truncate text-[13px] font-semibold text-text-primary">{{ selectedTool.title }}</div>
-            <div class="truncate text-[11px] text-text-muted">{{ selectedTool.subtitle }}</div>
+            <GripVertical class="ml-1 h-3 w-3 shrink-0 text-current/50" :stroke-width="2" aria-hidden="true" />
+            <button
+              type="button"
+              role="tab"
+              class="inline-flex h-full min-w-0 items-center gap-1.5 px-2 outline-none"
+              :id="workbenchTabControlID(tab)"
+              :aria-selected="workbench.activeTabID === tab.id"
+              :aria-controls="workbenchTabPanelID(tab)"
+              :title="tab.title"
+              @click="activateWorkbenchTabByID(tab.id)"
+            >
+              <img v-if="tab.kind === 'provider' && tab.providerTool?.iconURL" :src="tab.providerTool.iconURL" alt="" class="h-3.5 w-3.5 object-contain" />
+              <component v-else :is="workbenchTabIcon(tab)" class="h-3.5 w-3.5 shrink-0" :stroke-width="1.75" />
+              <span class="max-w-[9rem] truncate">{{ tab.title }}</span>
+              <span
+                v-if="tab.kind === 'review' && hasPendingReview"
+                class="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
+                aria-hidden="true"
+              />
+            </button>
+            <button
+              v-if="tab.closeable"
+              type="button"
+              class="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-current/70 transition hover:bg-surface-hover hover:text-text-primary"
+              :title="`Close ${tab.title}`"
+              :aria-label="`Close ${tab.title}`"
+              @click="closeWorkbenchTabByID(tab.id)"
+            >
+              <X class="h-3 w-3" :stroke-width="2" />
+            </button>
           </div>
+        </div>
+        <button
+          type="button"
+          class="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-transparent text-text-muted transition hover:border-border-subtle hover:bg-surface-hover hover:text-text-primary"
+          :class="hasPendingReview ? 'text-accent' : ''"
+          title="New tab"
+          aria-label="New tab"
+          @click="openWorkbenchLauncher"
+        >
+          <Plus class="h-4 w-4" :stroke-width="1.75" />
+          <span
+            v-if="hasPendingReview"
+            class="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-accent"
+            aria-hidden="true"
+          />
+        </button>
+        <div class="flex shrink-0 items-center gap-1">
           <button
-            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle text-text-muted transition hover:bg-surface-hover hover:text-text-primary"
+            v-if="activeProviderTool"
+            class="flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle text-text-muted transition hover:bg-surface-hover hover:text-text-primary"
             title="Open full provider"
+            aria-label="Open full provider"
             @click="openToolFull"
           >
             <ExternalLink class="h-4 w-4" :stroke-width="1.75" />
           </button>
-        </template>
-        <template v-else>
-          <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
-            <PanelRight class="h-4 w-4 text-accent" :stroke-width="1.75" />
-          </div>
-          <div class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
-            <button
-              type="button"
-              class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2 text-[12px] font-medium transition"
-              :class="workbenchTabButtonClass('preview')"
-              title="Preview"
-              @click="workbenchTab = 'preview'"
-            >
-              <AppWindow class="h-3.5 w-3.5" :stroke-width="1.75" />
-              Preview
-            </button>
-            <button
-              type="button"
-              class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2 text-[12px] font-medium transition"
-              :class="workbenchTabButtonClass('review')"
-              title="Review"
-              @click="workbenchTab = 'review'"
-            >
-              <Check class="h-3.5 w-3.5" :stroke-width="1.75" />
-              Review
-            </button>
-            <button
-              type="button"
-              class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-2 text-[12px] font-medium transition"
-              :class="workbenchTabButtonClass('providers')"
-              title="Providers"
-              @click="workbenchTab = 'providers'"
-            >
-              <PanelRight class="h-3.5 w-3.5" :stroke-width="1.75" />
-              Providers
-            </button>
-          </div>
-        </template>
+        </div>
       </header>
 
-      <div v-if="!selectedTool" class="min-h-0 flex-1 overflow-auto p-3">
-        <div v-if="workbenchTab === 'preview'" class="flex h-full min-h-[420px] flex-col gap-3">
+      <div
+        v-if="activeWorkbenchTab?.kind === 'launcher'"
+        class="min-h-0 flex-1 overflow-auto p-4"
+        role="tabpanel"
+        :id="workbenchTabPanelID(activeWorkbenchTab)"
+        :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
+      >
+        <div class="mx-auto grid w-full max-w-2xl gap-4">
+          <div class="relative min-w-0">
+            <Search class="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-text-muted" :stroke-width="1.75" />
+            <input
+              v-model="workbenchLauncherQuery"
+              class="h-9 w-full rounded-md border border-border-subtle bg-surface py-1.5 pl-8 pr-8 text-[13px] text-text-primary outline-none transition focus:border-accent/50"
+              placeholder="Search for tools..."
+              aria-label="Search workbench tools"
+            />
+            <button
+              v-if="workbenchLauncherQuery"
+              class="absolute right-1 top-1.5 flex h-6 w-6 items-center justify-center rounded-md text-text-muted hover:bg-surface-hover hover:text-text-primary"
+              title="Clear search"
+              aria-label="Clear search"
+              @click="workbenchLauncherQuery = ''"
+            >
+              <X class="h-3.5 w-3.5" :stroke-width="1.75" />
+            </button>
+          </div>
+
+          <section v-if="launcherExistingTabs.length" class="grid gap-1.5">
+            <h3 class="px-1 text-[11px] font-semibold uppercase tracking-wide text-text-muted">Jump to existing tab</h3>
+            <button
+              v-for="tab in launcherExistingTabs"
+              :key="tab.id"
+              type="button"
+              class="group flex min-h-[56px] w-full items-center gap-3 rounded-md border border-transparent bg-surface-hover/60 px-2.5 py-2 text-left transition hover:border-border-subtle hover:bg-surface-hover"
+              @click="activateWorkbenchTabByID(tab.id)"
+            >
+              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
+                <img v-if="tab.kind === 'provider' && tab.providerTool?.iconURL" :src="tab.providerTool.iconURL" alt="" class="h-5 w-5 object-contain" />
+                <component v-else :is="workbenchTabIcon(tab)" class="h-4 w-4 text-accent" :stroke-width="1.75" />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-[13px] font-semibold text-text-primary">{{ tab.title }}</div>
+                <div class="truncate text-[12px] text-text-muted">{{ tab.subtitle || (tab.kind === 'preview' ? 'Preview your app' : 'Open tab') }}</div>
+              </div>
+              <ArrowRight class="h-4 w-4 shrink-0 text-text-muted opacity-0 transition group-hover:opacity-100" :stroke-width="1.75" />
+            </button>
+          </section>
+
+          <section class="grid gap-1.5">
+            <h3 class="px-1 text-[11px] font-semibold uppercase tracking-wide text-text-muted">Suggested</h3>
+            <button
+              v-for="item in launcherSuggestedItems"
+              :key="item.id"
+              type="button"
+              class="group flex min-h-[56px] w-full items-center gap-3 rounded-md border border-transparent px-2.5 py-2 text-left transition hover:border-border-subtle hover:bg-surface-hover"
+              @click="openWorkbenchLauncherItem(item)"
+            >
+              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
+                <img v-if="item.iconURL" :src="item.iconURL" alt="" class="h-5 w-5 object-contain" />
+                <component v-else :is="item.icon" class="h-4 w-4 text-accent" :stroke-width="1.75" />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-[13px] font-semibold text-text-primary">{{ item.title }}</div>
+                <div class="line-clamp-2 text-[12px] leading-5 text-text-muted">{{ item.subtitle }}</div>
+              </div>
+              <ArrowRight class="h-4 w-4 shrink-0 text-text-muted opacity-0 transition group-hover:opacity-100" :stroke-width="1.75" />
+            </button>
+            <div v-if="launcherSuggestedItems.length === 0" class="rounded-md border border-border-subtle bg-surface/80 p-4 text-center text-[13px] text-text-muted">
+              No workbench tabs found.
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <div
+        v-else-if="activeWorkbenchTab?.kind === 'preview'"
+        class="min-h-0 flex-1 overflow-auto p-3"
+        role="tabpanel"
+        :id="workbenchTabPanelID(activeWorkbenchTab)"
+        :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
+      >
+        <div class="flex h-full min-h-[420px] flex-col gap-3">
           <div class="flex min-w-0 items-center justify-between gap-3">
             <div class="flex min-w-0 items-center gap-2">
               <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
@@ -3202,8 +3508,16 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
             </div>
           </div>
         </div>
+      </div>
 
-        <div v-else-if="workbenchTab === 'review'" class="grid gap-3">
+      <div
+        v-else-if="activeWorkbenchTab?.kind === 'review'"
+        class="min-h-0 flex-1 overflow-auto p-3"
+        role="tabpanel"
+        :id="workbenchTabPanelID(activeWorkbenchTab)"
+        :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
+      >
+        <div class="grid gap-3">
           <div v-if="pendingFollowUp" class="grid gap-2 rounded-md border border-accent/25 bg-accent-subtle p-3">
             <div class="flex min-w-0 items-start justify-between gap-3">
               <div class="min-w-0">
@@ -3279,8 +3593,15 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
             No reviews are waiting.
           </div>
         </div>
+      </div>
 
-        <template v-else>
+      <div
+        v-else-if="activeWorkbenchTab?.kind === 'providers'"
+        class="min-h-0 flex-1 overflow-auto p-3"
+        role="tabpanel"
+        :id="workbenchTabPanelID(activeWorkbenchTab)"
+        :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
+      >
         <div class="relative mb-3 min-w-0">
           <Search class="pointer-events-none absolute left-2.5 top-2 h-4 w-4 text-text-muted" :stroke-width="1.75" />
           <input
@@ -3325,16 +3646,21 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
             No provider views found.
           </div>
         </div>
-        </template>
       </div>
 
-      <div v-else class="relative min-h-0 flex-1 overflow-hidden bg-surface">
+      <div
+        v-else-if="activeWorkbenchTab?.kind === 'provider'"
+        class="relative min-h-0 flex-1 overflow-hidden bg-surface"
+        role="tabpanel"
+        :id="workbenchTabPanelID(activeWorkbenchTab)"
+        :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
+      >
         <div
           v-if="toolState === 'loading'"
           class="absolute inset-0 z-10 flex items-center justify-center bg-surface/80 text-[13px] text-text-muted"
         >
           <Loader2 class="mr-2 h-4 w-4 animate-spin" :stroke-width="1.75" />
-          Loading {{ selectedTool.title }}...
+          Loading {{ activeWorkbenchTab.title }}...
         </div>
         <div
           v-if="toolState === 'error'"

--- a/providers/app-studio/portal/src/workbench.test.mjs
+++ b/providers/app-studio/portal/src/workbench.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import ts from 'typescript'
+
+const source = await readFile(new URL('./workbench.ts', import.meta.url), 'utf8')
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+})
+const moduleURL = `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
+const {
+  closeWorkbenchTab,
+  createDefaultWorkbenchState,
+  openWorkbenchBuiltInTab,
+  openWorkbenchProviderTool,
+  reorderWorkbenchTab,
+} = await import(moduleURL)
+
+const connectionsTool = {
+  id: 'code/connections',
+  providerName: 'code',
+  title: 'Connections',
+  subtitle: 'Code',
+  path: 'connections',
+}
+
+test('starts with preview plus an active launcher tab while review stays closed', () => {
+  const state = createDefaultWorkbenchState()
+
+  assert.deepEqual(
+    state.tabs.map((tab) => ({ id: tab.id, closeable: tab.closeable })),
+    [
+      { id: 'preview', closeable: true },
+      { id: 'launcher', closeable: true },
+    ],
+  )
+  assert.equal(state.activeTabID, 'launcher')
+})
+
+test('opens the launcher from the plus nub without duplicating it', () => {
+  const closedLauncher = closeWorkbenchTab(createDefaultWorkbenchState(), 'launcher')
+  const reopened = openWorkbenchBuiltInTab(closedLauncher, 'launcher')
+  const activatedAgain = openWorkbenchBuiltInTab(reopened, 'launcher')
+
+  assert.deepEqual(closedLauncher.tabs.map((tab) => tab.id), ['preview'])
+  assert.equal(activatedAgain.activeTabID, 'launcher')
+  assert.equal(activatedAgain.tabs.filter((tab) => tab.id === 'launcher').length, 1)
+})
+
+test('opens a provider tool as a closeable active tab without duplicating it', () => {
+  const first = openWorkbenchProviderTool(createDefaultWorkbenchState(), connectionsTool)
+  const second = openWorkbenchProviderTool(first, connectionsTool)
+
+  assert.equal(second.activeTabID, 'provider:code/connections')
+  assert.equal(second.tabs.filter((tab) => tab.id === 'provider:code/connections').length, 1)
+  assert.deepEqual(second.tabs[second.tabs.length - 1], {
+    id: 'provider:code/connections',
+    kind: 'provider',
+    title: 'Connections',
+    subtitle: 'Code',
+    closeable: true,
+    providerTool: connectionsTool,
+  })
+})
+
+test('closing the active tab activates the nearest remaining tab without forcing providers open', () => {
+  const withTool = openWorkbenchProviderTool(createDefaultWorkbenchState(), connectionsTool)
+  const withoutTool = closeWorkbenchTab(withTool, 'provider:code/connections')
+
+  assert.equal(withoutTool.activeTabID, 'launcher')
+  assert.deepEqual(withoutTool.tabs.map((tab) => tab.id), ['preview', 'launcher'])
+})
+
+test('providers is a closeable built-in tab that opens from the launcher catalog', () => {
+  const withProviders = openWorkbenchBuiltInTab(createDefaultWorkbenchState(), 'providers')
+  const closedProviders = closeWorkbenchTab(withProviders, 'providers')
+
+  assert.deepEqual(withProviders.tabs[withProviders.tabs.length - 1], {
+    id: 'providers',
+    kind: 'providers',
+    title: 'Providers',
+    closeable: true,
+  })
+  assert.equal(withProviders.activeTabID, 'providers')
+  assert.equal(closedProviders.tabs.some((tab) => tab.id === 'providers'), false)
+  assert.equal(closedProviders.activeTabID, 'launcher')
+})
+
+test('review is a closeable built-in tab without being forced open by default', () => {
+  const defaultState = createDefaultWorkbenchState()
+  const withReview = openWorkbenchBuiltInTab(defaultState, 'review')
+  const closedReview = closeWorkbenchTab(withReview, 'review')
+
+  assert.equal(defaultState.tabs.some((tab) => tab.id === 'review'), false)
+  assert.deepEqual(withReview.tabs[withReview.tabs.length - 1], {
+    id: 'review',
+    kind: 'review',
+    title: 'Review',
+    closeable: true,
+  })
+  assert.equal(closedReview.tabs.some((tab) => tab.id === 'review'), false)
+})
+
+test('reorders tabs by moving the dragged tab before the target tab while preserving active tab', () => {
+  const state = openWorkbenchProviderTool(openWorkbenchBuiltInTab(createDefaultWorkbenchState(), 'providers'), connectionsTool)
+  const reordered = reorderWorkbenchTab(state, 'provider:code/connections', 'preview')
+
+  assert.deepEqual(reordered.tabs.map((tab) => tab.id), [
+    'provider:code/connections',
+    'preview',
+    'launcher',
+    'providers',
+  ])
+  assert.equal(reordered.activeTabID, 'provider:code/connections')
+})
+
+test('reorders tabs by moving the dragged tab after the target tab', () => {
+  const state = openWorkbenchProviderTool(openWorkbenchBuiltInTab(createDefaultWorkbenchState(), 'providers'), connectionsTool)
+  const reordered = reorderWorkbenchTab(state, 'preview', 'provider:code/connections', 'after')
+
+  assert.deepEqual(reordered.tabs.map((tab) => tab.id), [
+    'launcher',
+    'providers',
+    'provider:code/connections',
+    'preview',
+  ])
+  assert.equal(reordered.activeTabID, 'provider:code/connections')
+})
+
+test('does not reorder when the dragged or target tab is missing', () => {
+  const state = openWorkbenchBuiltInTab(createDefaultWorkbenchState(), 'providers')
+
+  assert.deepEqual(reorderWorkbenchTab(state, 'missing', 'preview'), state)
+  assert.deepEqual(reorderWorkbenchTab(state, 'providers', 'missing'), state)
+})

--- a/providers/app-studio/portal/src/workbench.ts
+++ b/providers/app-studio/portal/src/workbench.ts
@@ -1,0 +1,164 @@
+export type WorkbenchBuiltInTab = 'preview' | 'review' | 'providers' | 'launcher'
+export type WorkbenchTabKind = WorkbenchBuiltInTab | 'provider'
+
+export interface WorkbenchProviderToolRef {
+  id: string
+  providerName: string
+  title: string
+  subtitle: string
+  path: string
+  iconURL?: string
+}
+
+export interface WorkbenchTabDescriptor {
+  id: string
+  kind: WorkbenchTabKind
+  title: string
+  subtitle?: string
+  closeable: boolean
+  providerTool?: WorkbenchProviderToolRef
+}
+
+export interface WorkbenchState {
+  tabs: WorkbenchTabDescriptor[]
+  activeTabID: string
+}
+
+export type WorkbenchTabDropPlacement = 'before' | 'after'
+
+const builtInTabs: Record<WorkbenchBuiltInTab, WorkbenchTabDescriptor> = {
+  preview: {
+    id: 'preview',
+    kind: 'preview',
+    title: 'Preview',
+    closeable: true,
+  },
+  review: {
+    id: 'review',
+    kind: 'review',
+    title: 'Review',
+    closeable: true,
+  },
+  providers: {
+    id: 'providers',
+    kind: 'providers',
+    title: 'Providers',
+    closeable: true,
+  },
+  launcher: {
+    id: 'launcher',
+    kind: 'launcher',
+    title: 'New tab',
+    closeable: true,
+  },
+}
+
+export function createDefaultWorkbenchState(): WorkbenchState {
+  return {
+    tabs: [cloneWorkbenchTab(builtInTabs.preview), cloneWorkbenchTab(builtInTabs.launcher)],
+    activeTabID: builtInTabs.launcher.id,
+  }
+}
+
+export function openWorkbenchBuiltInTab(state: WorkbenchState, kind: WorkbenchBuiltInTab): WorkbenchState {
+  const tab = cloneWorkbenchTab(builtInTabs[kind])
+  return upsertWorkbenchTab(state, tab, true)
+}
+
+export function openWorkbenchProviderTool(state: WorkbenchState, tool: WorkbenchProviderToolRef): WorkbenchState {
+  return upsertWorkbenchTab(
+    state,
+    {
+      id: providerWorkbenchTabID(tool),
+      kind: 'provider',
+      title: tool.title,
+      subtitle: tool.subtitle,
+      closeable: true,
+      providerTool: { ...tool },
+    },
+    true,
+  )
+}
+
+export function activateWorkbenchTab(state: WorkbenchState, tabID: string): WorkbenchState {
+  if (!state.tabs.some((tab) => tab.id === tabID)) return normalizeWorkbenchState(state)
+  return { ...state, activeTabID: tabID }
+}
+
+export function closeWorkbenchTab(state: WorkbenchState, tabID: string): WorkbenchState {
+  const currentIndex = state.tabs.findIndex((tab) => tab.id === tabID)
+  const current = state.tabs[currentIndex]
+  if (!current?.closeable) return normalizeWorkbenchState(state)
+
+  const tabs = state.tabs.filter((tab) => tab.id !== tabID)
+  if (state.activeTabID !== tabID) return normalizeWorkbenchState({ ...state, tabs })
+
+  const fallback = tabs[Math.max(0, currentIndex - 1)] ?? tabs[tabs.length - 1] ?? builtInTabs.launcher
+  return normalizeWorkbenchState({ tabs, activeTabID: fallback.id })
+}
+
+export function updateWorkbenchProviderToolPath(state: WorkbenchState, tabID: string, path: string): WorkbenchState {
+  return normalizeWorkbenchState({
+    ...state,
+    tabs: state.tabs.map((tab) => {
+      if (tab.id !== tabID || tab.kind !== 'provider' || !tab.providerTool) return tab
+      return {
+        ...tab,
+        providerTool: {
+          ...tab.providerTool,
+          path,
+        },
+      }
+    }),
+  })
+}
+
+export function reorderWorkbenchTab(
+  state: WorkbenchState,
+  draggedTabID: string,
+  targetTabID: string,
+  placement: WorkbenchTabDropPlacement = 'before',
+): WorkbenchState {
+  if (draggedTabID === targetTabID) return normalizeWorkbenchState(state)
+  const draggedIndex = state.tabs.findIndex((tab) => tab.id === draggedTabID)
+  const targetIndex = state.tabs.findIndex((tab) => tab.id === targetTabID)
+  if (draggedIndex < 0 || targetIndex < 0) return state
+
+  const tabs = [...state.tabs]
+  const [dragged] = tabs.splice(draggedIndex, 1)
+  const adjustedTargetIndex = targetIndex > draggedIndex ? targetIndex - 1 : targetIndex
+  const insertIndex = placement === 'after' ? adjustedTargetIndex + 1 : adjustedTargetIndex
+  tabs.splice(insertIndex, 0, dragged)
+  return normalizeWorkbenchState({ ...state, tabs })
+}
+
+export function providerWorkbenchTabID(tool: Pick<WorkbenchProviderToolRef, 'id'>): string {
+  return `provider:${tool.id}`
+}
+
+function upsertWorkbenchTab(state: WorkbenchState, tab: WorkbenchTabDescriptor, activate: boolean): WorkbenchState {
+  const tabs = state.tabs.some((item) => item.id === tab.id)
+    ? state.tabs.map((item) => (item.id === tab.id ? tab : item))
+    : [...state.tabs, tab]
+  return normalizeWorkbenchState({
+    tabs,
+    activeTabID: activate ? tab.id : state.activeTabID,
+  })
+}
+
+function normalizeWorkbenchState(state: WorkbenchState): WorkbenchState {
+  const tabs = state.tabs.length > 0
+    ? state.tabs
+    : [cloneWorkbenchTab(builtInTabs.launcher)]
+  const activeTabID = tabs.some((tab) => tab.id === state.activeTabID)
+    ? state.activeTabID
+    : tabs[0]?.id ?? builtInTabs.launcher.id
+  return { tabs, activeTabID }
+}
+
+function cloneWorkbenchTab(tab: WorkbenchTabDescriptor): WorkbenchTabDescriptor {
+  return {
+    ...tab,
+    ...(tab.providerTool ? { providerTool: { ...tab.providerTool } } : {}),
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the fixed App Studio workbench tabs with a Replit-style launcher tab and closeable, reorderable tabs.
- Make provider tools launch from the workbench catalog instead of living in an always-on Providers tab.
- Keep Review optional rather than forced open by default.
- Reuse assistant tool-call cards across lifecycle updates so one tool call does not render as repeated rows.

## Validation

- `go test ./api`
- `npm run test:workbench`
- `npm run typecheck`
- `npm run build`