### PR TITLE
fix(infrastructure): example backend defaults to sslmode=disable

### DIFF
--- a/providers/infrastructure/examples/application/apps/backend/main.go
+++ b/providers/infrastructure/examples/application/apps/backend/main.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -84,6 +85,12 @@ func main() {
 // database StatefulSet still coming up alongside it (no ordering guarantees in
 // the RGD).
 func openDB(dsn string) (*sql.DB, error) {
+	// The injected DATABASE_URL carries no sslmode, and the in-cluster Postgres
+	// has TLS disabled — but lib/pq defaults to sslmode=require, which fails with
+	// "SSL is not enabled on the server". Default to sslmode=disable unless the
+	// DSN already sets one. See the application template's agent.usage contract.
+	dsn = ensureSSLModeDisable(dsn)
+
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		return nil, err
@@ -100,6 +107,23 @@ func openDB(dsn string) (*sql.DB, error) {
 		time.Sleep(2 * time.Second)
 	}
 	return nil, fmt.Errorf("postgres not reachable after retries: %w", lastErr)
+}
+
+// ensureSSLModeDisable appends sslmode=disable to the postgres:// DATABASE_URL
+// when it doesn't already carry an sslmode, so lib/pq (which defaults to
+// sslmode=require) can reach the TLS-disabled in-cluster Postgres. A DSN that
+// already sets sslmode, or one we can't parse as a URL, is left untouched.
+func ensureSSLModeDisable(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil || u.Scheme == "" {
+		return dsn
+	}
+	q := u.Query()
+	if q.Get("sslmode") == "" {
+		q.Set("sslmode", "disable")
+		u.RawQuery = q.Encode()
+	}
+	return u.String()
 }
 
 func (s *server) initSchema() error {


### PR DESCRIPTION
## Problem

The 3-tier `application` template's example **backend** crashloops in any cluster whose Postgres has TLS disabled (the default — the template's `dbStatefulSet` runs plain Postgres):

```
waiting for postgres (30/30): pq: SSL is not enabled on the server
connect to postgres: postgres not reachable after retries: pq: SSL is not enabled on the server
→ exit 1, CrashLoopBackOff
```

`lib/pq` defaults to `sslmode=require`. The injected `DATABASE_URL` (minted by the template's pwgen Job as `postgres://appuser:…@<name>-db:5432/appdb`) carries **no** sslmode, so the driver demands TLS the server doesn't offer. Frontend (`/`) and the DB come up fine; only the backend (`/api`) is down.

The template's own `agent.usage` already documents the contract — *"connect with sslmode=disable"* — the example just didn't follow it.

## Fix

Run the DSN through `ensureSSLModeDisable` in `openDB`: append `sslmode=disable` when the URL doesn't already set one. A DSN that already specifies `sslmode`, or one that isn't a parseable URL, is left untouched.

## Notes

- Observed live in prod (`demo-backend` CrashLoopBackOff) while validating the Gateway-API exposure path — the platform/routing side was healthy (HTTPRoute `Accepted=True`), this was the only remaining failure.
- The backend runs `:latest`, rebuilt + pushed by `.github/workflows/infrastructure-examples.yaml` on merge to main; the running pod picks it up on its next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)