### PR TITLE
fix(infrastructure): delete application db PVC on instance teardown

### DIFF
--- a/providers/infrastructure/install/templates/application.yaml
+++ b/providers/infrastructure/install/templates/application.yaml
@@ -311,6 +311,18 @@ spec:
           spec:
             serviceName: ${schema.spec.name}-db
             replicas: 1
+            # Tie the data PVC's lifecycle to the StatefulSet. The PVC is
+            # created by the StatefulSet controller from volumeClaimTemplates
+            # (NOT by kro), so it carries no kro labels and isn't in kro's
+            # applyset — kro never garbage-collects it. With the k8s default
+            # (whenDeleted: Retain) the PVC also outlives a StatefulSet delete,
+            # so deleting an Application orphaned the volume: a same-name
+            # recreate minted a fresh db password but Postgres recovered the old
+            # data (old password) → "password authentication failed". Delete the
+            # PVC when kro deletes the StatefulSet so a recreate starts clean.
+            persistentVolumeClaimRetentionPolicy:
+              whenDeleted: Delete
+              whenScaled: Retain
             selector:
               matchLabels:
                 app: ${schema.spec.name}-db


### PR DESCRIPTION
## Problem

Deleting an `Application` and recreating it with the same name fails with:

```
pq: password authentication failed for user "appuser" (28P01)
```

The Postgres data PVC outlives the delete, so on recreate the pwgen Job mints a **fresh** password into the new credentials Secret while Postgres **recovers the orphaned volume** (old password) → mismatch, backend CrashLoopBackOff.

### Why the PVC survived (verified in prod)

1. **kro doesn't own it.** The PVC `data-<name>-db-0` is created by the *StatefulSet controller* from `volumeClaimTemplates`, not by kro. It carries no `kro.run/*` labels and isn't in kro's applyset, so kro's GC (which only prunes RGD-applied objects) never touches it — even though kro does delete the StatefulSet itself.
2. **Kubernetes keeps it by default.** StatefulSet `volumeClaimTemplate` PVCs have no ownerReference to the StatefulSet and a default `persistentVolumeClaimRetentionPolicy: {whenDeleted: Retain}`, so a StatefulSet delete leaves them (deliberate data protection).
3. The runtime namespace is per-tenant (shared), so namespace teardown doesn't sweep it either.

→ The volume orphans at every layer.

## Fix

Set `persistentVolumeClaimRetentionPolicy.whenDeleted: Delete` on the `dbStatefulSet` so the PVC's lifecycle follows the StatefulSet kro deletes on instance teardown. A same-name recreate then starts from a fresh database that matches the new password. `whenScaled` stays `Retain` (single-replica; no horizontal scaling).

Trade-off (correct for this template): deleting an Application now destroys its database — there's no separate DB-retention story here.

## Verification

`TestSeedTemplatesBuildValidRGDs` (builds the RGD from the real `application.yaml`) passes.

> Observed live in prod while validating the Gateway-API exposure path; the orphaned 15h PVC was the last thing keeping `demo` from coming up green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)