### PR TITLE
revert(app-studio): restore /clusters/<path> tenant addressing

### DIFF
--- a/providers/app-studio/tenant/client.go
+++ b/providers/app-studio/tenant/client.go
@@ -16,11 +16,7 @@ You may obtain a copy of the License at
 // The base kubeconfig (the provider's own kcp connection) supplies only the
 // front-proxy host + TLS; its credential is dropped so the factory can never
 // authenticate as the provider. Per request we build a config with that host
-// (no /clusters/ segment) and the caller's bearer token: the kedge hub proxy
-// scopes bare paths to the caller's own DefaultCluster, which is the only
-// workspace this factory ever talks to. Addressing by the tenant's workspace
-// *path* instead would be rejected — the proxy's cluster gate accepts only the
-// caller's DefaultCluster *ID* (or ID:mount), not a path.
+// (cluster segment swapped for the tenant's path) and the caller's bearer token.
 package tenant
 
 import (
@@ -74,14 +70,8 @@ func NewClientFactory(base *rest.Config) *ClientFactory {
 	}
 }
 
-// For returns a dynamic client scoped to the caller's own workspace,
-// authenticating as the caller via token. Cached per (tenant, token).
-//
-// The host carries no /clusters/ segment: the hub proxy scopes bare paths to
-// the token's DefaultCluster. tenantPath is retained only as a cache key — the
-// caller always acts within its own default workspace, so a request must never
-// be addressed by the workspace path (the proxy's gate rejects paths, accepting
-// only the DefaultCluster ID).
+// For returns a dynamic client scoped to tenantPath, authenticating as the
+// caller via token. Cached per (tenant, token).
 func (f *ClientFactory) For(tenantPath, token string) (dynamic.Interface, error) {
 	if token == "" {
 		return nil, fmt.Errorf("no bearer token on request — cannot act on the tenant's behalf")
@@ -93,7 +83,7 @@ func (f *ClientFactory) For(tenantPath, token string) (dynamic.Interface, error)
 	}
 
 	cfg := &rest.Config{
-		Host:            f.baseHost,
+		Host:            f.baseHost + "/clusters/" + tenantPath,
 		BearerToken:     token,
 		TLSClientConfig: f.baseTLS,
 	}


### PR DESCRIPTION
## Why

PR #357 changed the app-studio tenant client to send **bare paths**, which the hub proxy scopes to the user's `DefaultCluster`. But `DefaultCluster` is the user's *home* workspace — not the workspace they have selected. For any user working in a non-default workspace, app-studio would then **silently read/write the wrong workspace's projects** (a 200 against the home workspace) instead of the selected one.

That's strictly worse than the original 403: a silent data-misrouting bug vs. an honest failure.

## What

Restore the original `/clusters/<tenantPath>` addressing. This reinstates the hub-proxy 403 for non-default workspaces — which is correct behavior to surface until the proper fix lands.

## Follow-up

The real fix is the app-studio → GraphQL migration (per-workspace access via the hub's `/graphql/clusters/{id}` gateway, which isn't DefaultCluster-gated), now unblocked by the `update<Kind>Status` mutation added to the gateway fork. That work is in progress on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)