### PR TITLE
feat(app-studio): per-workspace tenant access via the GraphQL gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -327,6 +327,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace github.com/platform-mesh/kubernetes-graphql-gateway => github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260612154300-f9c2b298c4cd
+replace github.com/platform-mesh/kubernetes-graphql-gateway => github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -327,6 +327,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace github.com/platform-mesh/kubernetes-graphql-gateway => github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22
+replace github.com/platform-mesh/kubernetes-graphql-gateway => github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626181934-a2eab00748ed
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -327,6 +327,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
 
-replace github.com/platform-mesh/kubernetes-graphql-gateway => github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626181934-a2eab00748ed
+replace github.com/platform-mesh/kubernetes-graphql-gateway => github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626182922-d10b61a76a93
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260612154300-f9c2b298c4cd
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260612154300-f9c2b298c4cd/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22 h1:MGjoHiISmJLY+lMbfaeA8qIUG6PhfKqOCotXyZt1ygY=
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
+github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626181934-a2eab00748ed h1:3s49oo4zW5ElcRDgxcWsxKWieqMhlNx+wVde/0BOP1Q=
+github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626181934-a2eab00748ed/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626181934-a2eab00748ed h1:3s49oo4zW5ElcRDgxcWsxKWieqMhlNx+wVde/0BOP1Q=
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626181934-a2eab00748ed/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
+github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626182922-d10b61a76a93 h1:Ex8FjE9zP4KBWU5wVjKVs9YX57D/ZpGCO0vsG5m6AiA=
+github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626182922-d10b61a76a93/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260612154300-f9c2b298c4cd h1:c/SnMtn9/6CXoB/+EATPqP87gOt5ENSFLq6xzGWqNOM=
 github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260612154300-f9c2b298c4cd/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
+github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22 h1:MGjoHiISmJLY+lMbfaeA8qIUG6PhfKqOCotXyZt1ygY=
+github.com/faroshq/kubernetes-graphql-gateway v0.0.0-20260626173633-9c3bfe012c22/go.mod h1:FTy6tfcfD1XoN081U3WaG+4t1GpgWNRYPYy+AcDYRKU=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/pkg/hub/provider_cluster_resolver.go
+++ b/pkg/hub/provider_cluster_resolver.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/faroshq/faros-kedge/pkg/apiurl"
+)
+
+// logicalClusterGVR addresses the well-known per-workspace LogicalCluster
+// object named "cluster", whose kcp.io/cluster annotation is the workspace's
+// logical-cluster ID.
+var logicalClusterGVR = schema.GroupVersionResource{
+	Group: "core.kcp.io", Version: "v1alpha1", Resource: "logicalclusters",
+}
+
+// clusterIDResolverTTL bounds how long a (tenantPath → clusterID) mapping is
+// cached. The mapping is effectively stable for a workspace's lifetime, so a
+// generous TTL keeps the warm path free of kcp round-trips while still letting
+// a deleted-and-recreated workspace's stale ID age out.
+const clusterIDResolverTTL = 10 * time.Minute
+
+// newClusterIDResolver returns a function mapping a tenant workspace path
+// (root:kedge:tenants:<org>[:<ws>]) to its kcp logical-cluster ID, for the
+// backend proxy to inject as X-Kedge-Cluster. It reads the workspace's
+// LogicalCluster "cluster" object via the hub's kcp admin config, scoping the
+// host to /clusters/<path> through the front-proxy (which resolves paths).
+//
+// Results are cached per path with a TTL; resolution failures are not cached so
+// a transient kcp hiccup self-heals on the next request.
+func newClusterIDResolver(kcpConfig *rest.Config) func(ctx context.Context, tenantPath string) (string, error) {
+	type entry struct {
+		id        string
+		expiresAt time.Time
+	}
+	var (
+		mu  sync.RWMutex
+		hot = map[string]entry{}
+	)
+
+	return func(ctx context.Context, tenantPath string) (string, error) {
+		now := time.Now()
+
+		mu.RLock()
+		e, ok := hot[tenantPath]
+		mu.RUnlock()
+		if ok && now.Before(e.expiresAt) {
+			return e.id, nil
+		}
+
+		cfg := rest.CopyConfig(kcpConfig)
+		cfg.Host = apiurl.KCPClusterURL(cfg.Host, tenantPath)
+		dyn, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return "", fmt.Errorf("dynamic client for %q: %w", tenantPath, err)
+		}
+		lc, err := dyn.Resource(logicalClusterGVR).Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("getting LogicalCluster for %q: %w", tenantPath, err)
+		}
+		id := lc.GetAnnotations()["kcp.io/cluster"]
+		if id == "" {
+			return "", fmt.Errorf("LogicalCluster for %q has no kcp.io/cluster annotation", tenantPath)
+		}
+
+		mu.Lock()
+		hot[tenantPath] = entry{id: id, expiresAt: now.Add(clusterIDResolverTTL)}
+		mu.Unlock()
+		return id, nil
+	}
+}

--- a/pkg/hub/providers/proxy.go
+++ b/pkg/hub/providers/proxy.go
@@ -18,6 +18,7 @@ package providers
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -114,6 +115,7 @@ func NewBackendProxy(reg *Registry, log logr.Logger) *ProviderProxy {
 	p.setHeaders = func(req *http.Request, name, _ string) {
 		req.Header.Del("X-Kedge-User")
 		req.Header.Del("X-Kedge-Tenant")
+		req.Header.Del("X-Kedge-Cluster")
 		if p.tenantResolver == nil {
 			// V(2) so tests / non-bootstrapper hubs don't spam, but
 			// devs can flip on verbosity to see the dropped path.
@@ -150,6 +152,17 @@ func NewBackendProxy(reg *Registry, log logr.Logger) *ProviderProxy {
 		} else {
 			p.log.Info("tenant resolved but tenantPath empty — forwarding without X-Kedge-Tenant", "provider", name, "user", user, "hint", "user may not have a personal Organization workspace bootstrapped yet")
 		}
+		// Resolve the workspace path to its kcp logical-cluster ID and inject
+		// X-Kedge-Cluster. Best-effort: a resolve failure drops only this
+		// header (the provider still has X-Kedge-Tenant), so a provider that
+		// doesn't need the ID is unaffected.
+		if tenantPath != "" && p.clusterResolver != nil {
+			if clusterID, err := p.clusterResolver(req.Context(), tenantPath); err != nil {
+				p.log.Info("cluster-id resolve failed — forwarding without X-Kedge-Cluster", "provider", name, "tenant", tenantPath, "err", err.Error())
+			} else if clusterID != "" {
+				req.Header.Set("X-Kedge-Cluster", clusterID)
+			}
+		}
 	}
 	return p
 }
@@ -161,6 +174,14 @@ func NewBackendProxy(reg *Registry, log logr.Logger) *ProviderProxy {
 // inbound-header stripping below still runs.
 func (p *ProviderProxy) SetTenantResolver(r TenantResolver) {
 	p.tenantResolver = r
+}
+
+// SetClusterResolver installs an optional resolver mapping a tenant workspace
+// path to its kcp logical-cluster ID, injected as X-Kedge-Cluster on
+// backend-proxied requests. Wire alongside SetTenantResolver; without it the
+// header is simply omitted (and any inbound value is still stripped).
+func (p *ProviderProxy) SetClusterResolver(f func(ctx context.Context, tenantPath string) (string, error)) {
+	p.clusterResolver = f
 }
 
 // ProviderProxy is the shared implementation backing both proxies. Exported
@@ -188,6 +209,14 @@ type ProviderProxy struct {
 	// UI proxy serves static assets and has no use for caller identity.
 	// See SetTenantResolver.
 	tenantResolver TenantResolver
+
+	// clusterResolver, when set, maps the resolved tenant workspace path to
+	// its kcp logical-cluster ID, injected as X-Kedge-Cluster. Providers need
+	// the ID (not the path) to address per-workspace surfaces that key on it —
+	// notably the hub's GraphQL gateway at /graphql/clusters/{id}, whose
+	// per-cluster schema lookup only matches a cluster ID. See
+	// SetClusterResolver.
+	clusterResolver func(ctx context.Context, tenantPath string) (string, error)
 }
 
 // SetFallback installs the portal SPA handler invoked for non-asset paths

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -533,6 +533,10 @@ func (s *Server) Run(ctx context.Context) error {
 			// resolver (lives here to avoid a providers→proxy→kcp→providers
 			// import cycle).
 			backendProxy.SetTenantResolver(newKCPTenantResolver(kcpProxy, userClient))
+			// Inject X-Kedge-Cluster (the resolved tenant's logical-cluster
+			// ID) so providers can address per-workspace surfaces that key on
+			// the ID — notably the GraphQL gateway at /graphql/clusters/{id}.
+			backendProxy.SetClusterResolver(newClusterIDResolver(kcpConfig))
 
 			// Step 10: Org / Workspace / Membership / User REST
 			apiMgr := restapi.NewManager(userClient, bootstrapper)

--- a/providers/app-studio/api/code_repository.go
+++ b/providers/app-studio/api/code_repository.go
@@ -101,7 +101,7 @@ func (s *Server) prepareProjectRepository(ctx context.Context, c *asclient.Clien
 
 func selectCodeConnection(ctx context.Context, c *asclient.Client, requested string) (string, error) {
 	if requested != "" {
-		conn, err := c.Dynamic().Resource(codeConnectionsGVR).Get(ctx, requested, metav1.GetOptions{})
+		conn, err := c.Resource(codeConnectionResource, "").Get(ctx, requested, metav1.GetOptions{})
 		if err != nil {
 			return "", codeProviderRequestError("get Code connection", err)
 		}
@@ -111,7 +111,7 @@ func selectCodeConnection(ctx context.Context, c *asclient.Client, requested str
 		return requested, nil
 	}
 
-	list, err := c.Dynamic().Resource(codeConnectionsGVR).List(ctx, metav1.ListOptions{})
+	list, err := c.Resource(codeConnectionResource, "").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", codeProviderRequestError("list Code connections", err)
 	}
@@ -142,7 +142,7 @@ func repositoryName(ctx context.Context, c *asclient.Client, requested, displayN
 		if i > 0 {
 			name = dns1123LabelWithSuffix(base, uuid.NewString()[:6])
 		}
-		if _, err := c.Dynamic().Resource(codeRepositoriesGVR).Get(ctx, name, metav1.GetOptions{}); apierrors.IsNotFound(err) {
+		if _, err := c.Resource(codeRepositoryResource, "").Get(ctx, name, metav1.GetOptions{}); apierrors.IsNotFound(err) {
 			return name, nil
 		} else if err != nil {
 			return "", codeProviderRequestError("get Code repository", err)
@@ -169,7 +169,7 @@ func (s *Server) createProjectRepository(ctx context.Context, c *asclient.Client
 		"description":   plan.Description,
 		"autoInit":      true,
 	}
-	if _, err := c.Dynamic().Resource(codeRepositoriesGVR).Create(ctx, repo, metav1.CreateOptions{}); err != nil {
+	if _, err := c.Resource(codeRepositoryResource, "").Create(ctx, repo, metav1.CreateOptions{}); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return newValidationError(fmt.Sprintf("Code repository %q already exists", plan.Ref))
 		}
@@ -183,10 +183,10 @@ func projectRepositoryView(ctx context.Context, c *asclient.Client, p *aiv1alpha
 	var list codeResourceLister
 	if c != nil {
 		get = func(ctx context.Context, gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error) {
-			return c.Dynamic().Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+			return c.Resource(codeResourceFor(gvr), "").Get(ctx, name, metav1.GetOptions{})
 		}
 		list = func(ctx context.Context, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-			return c.Dynamic().Resource(gvr).List(ctx, opts)
+			return c.Resource(codeResourceFor(gvr), "").List(ctx, opts)
 		}
 	}
 	return projectRepositoryViewFromResources(ctx, p, get, list)

--- a/providers/app-studio/api/development_runtime.go
+++ b/providers/app-studio/api/development_runtime.go
@@ -68,7 +68,7 @@ func (s *Server) runtimeTargetForProject(ctx context.Context, c *asclient.Client
 	if strings.TrimSpace(name) == "" {
 		return runtimeTarget{}, nil, fmt.Errorf("sandbox runner name is empty")
 	}
-	obj, err := c.Dynamic().Resource(sandboxRunnerGVR).Get(ctx, name, metav1.GetOptions{})
+	obj, err := c.Resource(sandboxRunnerResource, "").Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return runtimeTarget{}, nil, err
 	}
@@ -332,14 +332,14 @@ func patchLastSync(ctx context.Context, c *asclient.Client, name string, t metav
 	if c == nil {
 		return nil
 	}
-	obj, err := c.Dynamic().Resource(sandboxRunnerGVR).Get(ctx, name, metav1.GetOptions{})
+	obj, err := c.Resource(sandboxRunnerResource, "").Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	if err := unstructured.SetNestedField(obj.Object, t.Format("2006-01-02T15:04:05Z07:00"), "status", "lastSyncTime"); err != nil {
 		return err
 	}
-	_, err = c.Dynamic().Resource(sandboxRunnerGVR).UpdateStatus(ctx, obj, metav1.UpdateOptions{})
+	_, err = c.Resource(sandboxRunnerResource, "").UpdateStatus(ctx, obj, metav1.UpdateOptions{})
 	if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 		return nil
 	}

--- a/providers/app-studio/api/development_sync.go
+++ b/providers/app-studio/api/development_sync.go
@@ -457,8 +457,8 @@ func (s *Server) scheduleDevelopmentSyncAfterMutation(id identity, p *aiv1alpha1
 }
 
 func (s *Server) syncDevelopmentAfterMutation(id identity, p *aiv1alpha1.Project, name string) {
-	if s.clients == nil {
-		klog.V(2).Infof("development sandbox sync after %s skipped for project %s: tenant client factory is not configured", projectToolBaseName(name), p.Name)
+	if s.gql == nil {
+		klog.V(2).Infof("development sandbox sync after %s skipped for project %s: tenant GraphQL client is not configured", projectToolBaseName(name), p.Name)
 		return
 	}
 	c, err := s.clientFor(id)

--- a/providers/app-studio/api/http.go
+++ b/providers/app-studio/api/http.go
@@ -31,6 +31,7 @@ import (
 // headers (defense in depth — a spoofed header cannot mis-scope storage).
 type identity struct {
 	tenantPath    string // X-Kedge-Tenant, e.g. root:kedge:orgs:<org>:<ws>
+	clusterID     string // X-Kedge-Cluster, the workspace's kcp logical-cluster ID
 	orgUUID       string // parsed from tenantPath
 	workspaceUUID string // parsed from tenantPath ("" when the path is org-only)
 	user          string // X-Kedge-User
@@ -50,6 +51,7 @@ func identityFromRequest(w http.ResponseWriter, r *http.Request) (identity, bool
 	org, ws := parseTenantPath(tenantPath)
 	return identity{
 		tenantPath:    tenantPath,
+		clusterID:     strings.TrimSpace(r.Header.Get("X-Kedge-Cluster")),
 		orgUUID:       org,
 		workspaceUUID: ws,
 		user:          strings.TrimSpace(r.Header.Get("X-Kedge-User")),

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -1279,7 +1279,7 @@ func firstSSELine(body []byte) (json.RawMessage, bool) {
 
 func readProjectLLMSettings(ctx context.Context, c *asclient.Client) (projectLLMSettings, error) {
 	settings := defaultProjectLLMSettings()
-	secret, err := c.Dynamic().Resource(secretGVR).Namespace(projectLLMSecretNamespace).Get(ctx, projectLLMSecretName, metav1.GetOptions{})
+	secret, err := c.Resource(secretResource, projectLLMSecretNamespace).Get(ctx, projectLLMSecretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return settings, nil
 	}
@@ -1301,16 +1301,16 @@ func readProjectLLMSettings(ctx context.Context, c *asclient.Client) (projectLLM
 
 func writeProjectLLMSettings(ctx context.Context, c *asclient.Client, settings projectLLMSettings) error {
 	secret := projectLLMSettingsSecret(settings)
-	existing, err := c.Dynamic().Resource(secretGVR).Namespace(projectLLMSecretNamespace).Get(ctx, projectLLMSecretName, metav1.GetOptions{})
+	existing, err := c.Resource(secretResource, projectLLMSecretNamespace).Get(ctx, projectLLMSecretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = c.Dynamic().Resource(secretGVR).Namespace(projectLLMSecretNamespace).Create(ctx, secret, metav1.CreateOptions{})
+		_, err = c.Resource(secretResource, projectLLMSecretNamespace).Create(ctx, secret, metav1.CreateOptions{})
 		return err
 	}
 	if err != nil {
 		return err
 	}
 	secret.SetResourceVersion(existing.GetResourceVersion())
-	_, err = c.Dynamic().Resource(secretGVR).Namespace(projectLLMSecretNamespace).Update(ctx, secret, metav1.UpdateOptions{})
+	_, err = c.Resource(secretResource, projectLLMSecretNamespace).Update(ctx, secret, metav1.UpdateOptions{})
 	return err
 }
 

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -167,10 +167,20 @@ func writeProjectError(w http.ResponseWriter, err error) {
 }
 
 func isProjectAPIInitializingError(err error) bool {
-	if !apierrors.IsNotFound(err) {
+	if err == nil {
 		return false
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "server could not find the requested resource")
+	low := strings.ToLower(err.Error())
+	// kcp dynamic path: the Project API isn't served in the workspace yet.
+	if apierrors.IsNotFound(err) && strings.Contains(low, "server could not find the requested resource") {
+		return true
+	}
+	// GraphQL path: either the gateway has no schema for the workspace cluster
+	// yet, or the schema lacks the Project type (APIBinding not established) —
+	// both surface while the workspace is still being provisioned.
+	return strings.Contains(low, "workspace initializing") ||
+		strings.Contains(low, "cannot query field") ||
+		strings.Contains(low, "unknown field")
 }
 
 func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
@@ -297,7 +307,7 @@ func (s *Server) cleanupCreatedProjectSetup(ctx context.Context, c *asclient.Cli
 	_ = s.deleteProjectProviderResources(ctx, c, p, id)
 	if p.Spec.Repository != nil {
 		if ref := strings.TrimSpace(p.Spec.Repository.RepositoryRef); ref != "" {
-			_ = c.Dynamic().Resource(codeRepositoriesGVR).Delete(ctx, ref, metav1.DeleteOptions{})
+			_ = c.Resource(codeRepositoryResource, "").Delete(ctx, ref, metav1.DeleteOptions{})
 		}
 	}
 	if name := strings.TrimSpace(p.Name); name != "" {

--- a/providers/app-studio/api/provider_resources.go
+++ b/providers/app-studio/api/provider_resources.go
@@ -89,7 +89,7 @@ func ensureProjectProviderResource(ctx context.Context, c *asclient.Client, p *a
 	if owner := projectProviderResourceOwnerRef(p); owner != nil {
 		want.SetOwnerReferences([]metav1.OwnerReference{*owner})
 	}
-	res := c.Dynamic().Resource(gvr)
+	res := c.Resource(providerBindingResource(gvr, binding.ResourceRef.Kind), "")
 	existing, err := res.Get(ctx, name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return res.Create(ctx, want, metav1.CreateOptions{})
@@ -138,7 +138,7 @@ func (s *Server) deleteProjectProviderResources(ctx context.Context, c *asclient
 			}
 			runtimeNamespace := ""
 			if isSandboxRunnerBinding(binding) && s != nil && s.runtimeClient != nil {
-				obj, err := c.Dynamic().Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+				obj, err := c.Resource(providerBindingResource(gvr, binding.ResourceRef.Kind), "").Get(ctx, name, metav1.GetOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -149,7 +149,7 @@ func (s *Server) deleteProjectProviderResources(ctx context.Context, c *asclient
 					}
 				}
 			}
-			err = c.Dynamic().Resource(gvr).Delete(ctx, name, metav1.DeleteOptions{})
+			err = c.Resource(providerBindingResource(gvr, binding.ResourceRef.Kind), "").Delete(ctx, name, metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
@@ -291,7 +291,7 @@ func projectProviderBindingStatus(ctx context.Context, c *asclient.Client, p *ai
 		status.Phase = "Invalid"
 		return status
 	}
-	obj, err := c.Dynamic().Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+	obj, err := c.Resource(providerBindingResource(gvr, binding.ResourceRef.Kind), "").Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		status.Phase = "Pending"
 		return status

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -46,7 +46,7 @@ import (
 // for dev MCP calls; workspaces stores project files owned by App Studio; and
 // assistantEngine runs project assistant turns.
 type Server struct {
-	clients                      *tenant.ClientFactory
+	gql                          *tenant.GraphQLClient
 	store                        store.Store
 	workspaces                   *workspace.FileStore
 	hubBase                      string
@@ -65,14 +65,14 @@ type Server struct {
 }
 
 // New constructs a Server.
-func New(clients *tenant.ClientFactory, msgStore store.Store, hubBase string, mcpInsecureSkipTLSVerify bool) *Server {
-	return NewWithWorkspace(clients, msgStore, nil, hubBase, mcpInsecureSkipTLSVerify)
+func New(gql *tenant.GraphQLClient, msgStore store.Store, hubBase string, mcpInsecureSkipTLSVerify bool) *Server {
+	return NewWithWorkspace(gql, msgStore, nil, hubBase, mcpInsecureSkipTLSVerify)
 }
 
 // NewWithWorkspace constructs a Server with an explicit project workspace store.
-func NewWithWorkspace(clients *tenant.ClientFactory, msgStore store.Store, workspaces *workspace.FileStore, hubBase string, mcpInsecureSkipTLSVerify bool) *Server {
+func NewWithWorkspace(gql *tenant.GraphQLClient, msgStore store.Store, workspaces *workspace.FileStore, hubBase string, mcpInsecureSkipTLSVerify bool) *Server {
 	s := &Server{
-		clients:                  clients,
+		gql:                      gql,
 		store:                    msgStore,
 		workspaces:               workspaces,
 		hubBase:                  hubBase,
@@ -190,13 +190,14 @@ func (s *Server) Register(r *mux.Router) {
 	r.HandleFunc("/api/projects/{project}/memory", s.patchProjectMemory).Methods(http.MethodPatch)
 }
 
-// clientFor builds a workspace-scoped client acting as the caller.
+// clientFor builds a workspace-scoped client acting as the caller, talking to
+// the hub's GraphQL gateway for the caller's current workspace cluster.
 func (s *Server) clientFor(id identity) (*asclient.Client, error) {
-	dyn, err := s.clients.For(id.tenantPath, id.token)
+	scope, err := s.gql.For(id.clusterID, id.token)
 	if err != nil {
 		return nil, err
 	}
-	return asclient.NewFromDynamic(dyn), nil
+	return asclient.NewFromGraphQL(scope), nil
 }
 
 // requireProjectClient resolves the caller identity and a workspace-scoped
@@ -210,8 +211,12 @@ func (s *Server) requireProjectClient(w http.ResponseWriter, r *http.Request) (*
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "a workspace is required for this endpoint — select an organization and workspace first")
 		return nil, identity{}, false
 	}
-	if s.clients == nil {
-		writeStatus(w, http.StatusNotImplemented, "NotImplemented", "tenant client factory not configured — provider has no kubeconfig")
+	if s.gql == nil {
+		writeStatus(w, http.StatusNotImplemented, "NotImplemented", "tenant GraphQL client not configured — provider has no hub URL")
+		return nil, identity{}, false
+	}
+	if id.clusterID == "" {
+		writeStatus(w, http.StatusBadRequest, "BadRequest", "no workspace cluster on request (X-Kedge-Cluster missing) — the hub did not resolve a cluster for this workspace")
 		return nil, identity{}, false
 	}
 	c, err := s.clientFor(id)

--- a/providers/app-studio/api/tenant_resources.go
+++ b/providers/app-studio/api/tenant_resources.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/faroshq/provider-app-studio/tenant"
+)
+
+// tenant.Resource descriptors for the workspace resources App Studio accesses
+// through asclient.Client.Resource. Kind/Plural drive the GraphQL field names
+// (<Kind>Yaml / <Plural>Yaml / delete<Kind>); they must match the CRD's kind
+// and its pluralization.
+var (
+	secretResource         = tenant.Resource{GVR: secretGVR, Kind: "Secret", Plural: "Secrets", Namespaced: true}
+	sandboxRunnerResource  = tenant.Resource{GVR: sandboxRunnerGVR, Kind: "SandboxRunner", Plural: "SandboxRunners"}
+	codeConnectionResource = tenant.Resource{GVR: codeConnectionsGVR, Kind: "Connection", Plural: "Connections"}
+	codeRepositoryResource = tenant.Resource{GVR: codeRepositoriesGVR, Kind: "Repository", Plural: "Repositories"}
+)
+
+// codeResourceFor maps a code-provider GVR to its descriptor, for the
+// repository-view getter/lister closures that are keyed by GVR.
+func codeResourceFor(gvr schema.GroupVersionResource) tenant.Resource {
+	switch gvr {
+	case codeRepositoriesGVR:
+		return codeRepositoryResource
+	case codeConnectionsGVR:
+		return codeConnectionResource
+	default:
+		return tenant.Resource{GVR: gvr, Kind: "", Plural: ""}
+	}
+}
+
+// providerBindingResource builds a descriptor for a project provider-binding's
+// target CR. The kind comes from the binding's ResourceRef; these CRs are
+// cluster-scoped in the workspace.
+func providerBindingResource(gvr schema.GroupVersionResource, kind string) tenant.Resource {
+	return tenant.Resource{GVR: gvr, Kind: kind, Plural: kind + "s"}
+}

--- a/providers/app-studio/client/client.go
+++ b/providers/app-studio/client/client.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	"github.com/faroshq/provider-app-studio/tenant"
 )
 
 // ProjectGVR points at the workspace-scoped Project CRD.
@@ -43,17 +44,63 @@ var ProjectGVR = schema.GroupVersionResource{
 	Resource: "projects",
 }
 
-// Client provides typed access to App Studio resources via the dynamic client.
+// projectResource describes the Project CRD for the GraphQL tenant client. The
+// Project is cluster-scoped in the workspace.
+var projectResource = tenant.Resource{
+	GVR:        ProjectGVR,
+	Kind:       "Project",
+	Plural:     "Projects",
+	Namespaced: false,
+}
+
+// ResourceClient is the per-resource surface App Studio needs. Its signatures
+// match dynamic.ResourceInterface's subset exactly, so both a real
+// dynamic.ResourceInterface (tests) and the GraphQL-backed gqlResource
+// (production) satisfy it.
+type ResourceClient interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+// Client provides typed access to App Studio resources. It is backed by either
+// the GraphQL tenant client (production: the hub's gateway, which serves any
+// workspace the caller has access to) or a dynamic client (tests).
 type Client struct {
+	scope   *tenant.Scope
 	dynamic dynamic.Interface
 }
 
-// NewFromDynamic creates a Client from an existing dynamic.Interface.
+// NewFromGraphQL creates a Client backed by the hub's GraphQL gateway.
+func NewFromGraphQL(scope *tenant.Scope) *Client {
+	return &Client{scope: scope}
+}
+
+// NewFromDynamic creates a Client from an existing dynamic.Interface (tests).
 func NewFromDynamic(d dynamic.Interface) *Client {
 	return &Client{dynamic: d}
 }
 
-// Dynamic returns the underlying dynamic client.
+// Resource returns a ResourceClient for an arbitrary resource (e.g. provider
+// CRs, secrets). namespace is "" for cluster-scoped access.
+func (c *Client) Resource(res tenant.Resource, namespace string) ResourceClient {
+	if c.scope != nil {
+		return &gqlResource{scope: c.scope, res: res, namespace: namespace}
+	}
+	nri := c.dynamic.Resource(res.GVR)
+	if namespace != "" {
+		return nri.Namespace(namespace)
+	}
+	return nri
+}
+
+// Dynamic returns the underlying dynamic client. Only valid for clients built
+// with NewFromDynamic (tests); nil in GraphQL mode. Production code paths must
+// use Resource() so they work against either backend.
 func (c *Client) Dynamic() dynamic.Interface {
 	return c.dynamic
 }
@@ -62,16 +109,16 @@ func (c *Client) Dynamic() dynamic.Interface {
 // workspace.
 func (c *Client) Projects() *TypedResource[aiv1alpha1.Project, aiv1alpha1.ProjectList] {
 	return &TypedResource[aiv1alpha1.Project, aiv1alpha1.ProjectList]{
-		client: c.dynamic.Resource(ProjectGVR),
+		client: c.Resource(projectResource, ""),
 		gvk:    ProjectGVR.GroupVersion().WithKind("Project"),
 	}
 }
 
 // TypedResource provides typed CRUD operations for a specific resource type.
 // gvk is used to populate apiVersion/kind on objects before sending them to
-// the dynamic client.
+// the backing client.
 type TypedResource[T any, L any] struct {
-	client dynamic.ResourceInterface
+	client ResourceClient
 	gvk    schema.GroupVersionKind
 }
 
@@ -178,6 +225,74 @@ func fromUnstructured[T any](u *unstructured.Unstructured) (*T, error) {
 		return nil, fmt.Errorf("converting from unstructured: %w", err)
 	}
 	return &obj, nil
+}
+
+// gqlResource adapts a GraphQL tenant Scope to the ResourceClient surface.
+// Create/Update map to the gateway's generic applyYaml (create-or-update);
+// status writes map to applyStatusYaml.
+type gqlResource struct {
+	scope     *tenant.Scope
+	res       tenant.Resource
+	namespace string
+}
+
+func (g *gqlResource) Get(ctx context.Context, name string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+	return g.scope.Get(ctx, g.res, g.namespace, name)
+}
+
+func (g *gqlResource) List(ctx context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	items, err := g.scope.List(ctx, g.res, g.namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.UnstructuredList{Items: items}, nil
+}
+
+func (g *gqlResource) Create(ctx context.Context, obj *unstructured.Unstructured, _ metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(subresources) == 1 && subresources[0] == "status" {
+		return g.UpdateStatus(ctx, obj, metav1.UpdateOptions{})
+	}
+	return g.scope.Apply(ctx, obj)
+}
+
+func (g *gqlResource) Update(ctx context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(subresources) == 1 && subresources[0] == "status" {
+		return g.UpdateStatus(ctx, obj, metav1.UpdateOptions{})
+	}
+	return g.scope.Apply(ctx, obj)
+}
+
+func (g *gqlResource) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	if err := g.scope.ApplyStatus(ctx, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (g *gqlResource) Delete(ctx context.Context, name string, _ metav1.DeleteOptions, _ ...string) error {
+	return g.scope.Delete(ctx, g.res, g.namespace, name)
+}
+
+// Patch supports only the status subresource (the sole patch App Studio uses).
+// The merge-patch body is applied to the object's status via applyStatusYaml.
+func (g *gqlResource) Patch(ctx context.Context, name string, _ types.PatchType, data []byte, _ metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(subresources) != 1 || subresources[0] != "status" {
+		return nil, fmt.Errorf("graphql client: Patch supports only the status subresource, got %v", subresources)
+	}
+	patch := map[string]any{}
+	if err := json.Unmarshal(data, &patch); err != nil {
+		return nil, fmt.Errorf("decode status patch: %w", err)
+	}
+	obj := &unstructured.Unstructured{Object: patch}
+	obj.SetGroupVersionKind(g.res.GVR.GroupVersion().WithKind(g.res.Kind))
+	obj.SetName(name)
+	if g.namespace != "" {
+		obj.SetNamespace(g.namespace)
+	}
+	if err := g.scope.ApplyStatus(ctx, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
 }
 
 func fromUnstructuredList[L any](u *unstructured.UnstructuredList) (*L, error) {

--- a/providers/app-studio/main.go
+++ b/providers/app-studio/main.go
@@ -165,13 +165,14 @@ func runServe() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Provider config → tenant client factory. Without a kubeconfig the project
-	// API returns 501 (useful for UI-only dev), with a loud warning.
-	var clientFactory *tenant.ClientFactory
-	if cfg, err := loadProviderConfig(); err != nil {
-		log.Printf("WARNING project API disabled (no provider kubeconfig): %v", err)
+	// Tenant access goes through the hub's GraphQL gateway (the hub injects
+	// X-Kedge-Cluster per request). Without a hub URL the project API returns
+	// 501 (useful for UI-only dev), with a loud warning.
+	var gqlClient *tenant.GraphQLClient
+	if hubURL := os.Getenv("KEDGE_HUB_URL"); hubURL == "" {
+		log.Printf("WARNING project API disabled (no KEDGE_HUB_URL)")
 	} else {
-		clientFactory = tenant.NewClientFactory(cfg)
+		gqlClient = tenant.NewGraphQLClient(hubURL, os.Getenv("KEDGE_HUB_INSECURE") == "true")
 	}
 
 	msgStore, closeStore, err := openMessageStore(ctx)
@@ -181,7 +182,7 @@ func runServe() {
 	defer closeStore()
 
 	apiServer := api.NewWithWorkspace(
-		clientFactory,
+		gqlClient,
 		msgStore,
 		openWorkspaceStore(),
 		os.Getenv("KEDGE_HUB_URL"),

--- a/providers/app-studio/tenant/client.go
+++ b/providers/app-studio/tenant/client.go
@@ -16,11 +16,7 @@ You may obtain a copy of the License at
 // The base kubeconfig (the provider's own kcp connection) supplies only the
 // front-proxy host + TLS; its credential is dropped so the factory can never
 // authenticate as the provider. Per request we build a config with that host
-// (no /clusters/ segment) and the caller's bearer token: the kedge hub proxy
-// scopes bare paths to the caller's own DefaultCluster, which is the only
-// workspace this factory ever talks to. Addressing by the tenant's workspace
-// *path* instead would be rejected — the proxy's cluster gate accepts only the
-// caller's DefaultCluster *ID* (or ID:mount), not a path.
+// (cluster segment swapped for the tenant's path) and the caller's bearer token.
 package tenant
 
 import (
@@ -74,14 +70,8 @@ func NewClientFactory(base *rest.Config) *ClientFactory {
 	}
 }
 
-// For returns a dynamic client scoped to the caller's own workspace,
-// authenticating as the caller via token. Cached per (tenant, token).
-//
-// The host carries no /clusters/ segment: the hub proxy scopes bare paths to
-// the token's DefaultCluster. tenantPath is retained only as a cache key — the
-// caller always acts within its own default workspace, so a request must never
-// be addressed by the workspace path (the proxy's gate rejects paths, accepting
-// only the DefaultCluster ID).
+// For returns a dynamic client scoped to tenantPath, authenticating as the
+// caller via token. Cached per (tenant, token).
 func (f *ClientFactory) For(tenantPath, token string) (dynamic.Interface, error) {
 	if token == "" {
 		return nil, fmt.Errorf("no bearer token on request — cannot act on the tenant's behalf")
@@ -93,7 +83,7 @@ func (f *ClientFactory) For(tenantPath, token string) (dynamic.Interface, error)
 	}
 
 	cfg := &rest.Config{
-		Host:            f.baseHost,
+		Host:            f.baseHost + "/clusters/" + tenantPath,
 		BearerToken:     token,
 		TLSClientConfig: f.baseTLS,
 	}

--- a/providers/app-studio/tenant/graphql.go
+++ b/providers/app-studio/tenant/graphql.go
@@ -151,14 +151,10 @@ func (s *Scope) exec(ctx context.Context, query string, vars map[string]any, res
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		// No schema for this cluster: the gateway hasn't (yet) generated a
-		// schema for the workspace. Surface a NotFound the caller can treat as
-		// "initializing" rather than a hard failure.
-		gr := schema.GroupResource{}
-		if res != nil {
-			gr = res.GVR.GroupResource()
-		}
-		return nil, apierrors.NewNotFound(gr, name)
+		// No schema for this cluster yet: the gateway hasn't generated a schema
+		// for the workspace. Distinct from an object-not-found (which comes back
+		// as a GraphQL error) so callers can treat it as "initializing".
+		return nil, fmt.Errorf("graphql gateway has no schema for cluster %q yet — workspace initializing", s.clusterID)
 	}
 	if resp.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("graphql gateway HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))

--- a/providers/app-studio/tenant/graphql.go
+++ b/providers/app-studio/tenant/graphql.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// GraphQL-backed tenant access. App Studio reaches a tenant's kcp workspace
+// through the hub's embedded GraphQL gateway at <hubBase>/graphql/<clusterID>,
+// authenticating as the caller. Unlike the hub's kcp user-proxy (which gates
+// every request to the caller's DefaultCluster), the gateway serves any
+// workspace the caller has RBAC in, so App Studio works in non-default
+// workspaces.
+//
+// Every operation exchanges whole serialized objects (the gateway's <Kind>Yaml
+// / <Plural>Yaml queries and applyYaml / applyStatusYaml mutations), so this
+// client never needs a typed GraphQL field-selection set over App Studio's
+// unstructured resources. GraphQL errors are mapped back onto k8s apierrors so
+// callers' IsNotFound / IsConflict / IsAlreadyExists checks keep working.
+package tenant
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+)
+
+// GraphQLClient is a factory for per-(cluster, caller) GraphQL access to the
+// hub's embedded gateway.
+type GraphQLClient struct {
+	hubBase string
+	http    *http.Client
+}
+
+// NewGraphQLClient targets the hub's GraphQL gateway under hubBase (the hub's
+// base URL, e.g. https://kedge-hub.kedge.svc:9443). insecureSkipVerify relaxes
+// TLS for in-cluster hub certs that aren't in the provider's trust store.
+func NewGraphQLClient(hubBase string, insecureSkipVerify bool) *GraphQLClient {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if insecureSkipVerify {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // opt-in for in-cluster hub cert
+	}
+	return &GraphQLClient{
+		hubBase: strings.TrimRight(hubBase, "/"),
+		http:    &http.Client{Transport: tr},
+	}
+}
+
+// Resource identifies a kcp resource for GraphQL field-name derivation. The
+// gateway nests fields as <sanitizedGroup>.<version>.<field>, with field names
+// derived from the Kind (singular) and its pluralization.
+type Resource struct {
+	GVR        schema.GroupVersionResource
+	Kind       string // e.g. "Project" — GraphQL singular field + create/update/delete suffix
+	Plural     string // e.g. "Projects" — GraphQL list field
+	Namespaced bool
+}
+
+var (
+	invalidGroupChar = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	validGroupStart  = regexp.MustCompile(`^[a-zA-Z_]`)
+)
+
+// groupField mirrors the gateway's SanitizeGroupName: non-[a-zA-Z0-9_] become
+// "_", and a leading invalid char gets an "_" prefix.
+func groupField(group string) string {
+	s := invalidGroupChar.ReplaceAllString(group, "_")
+	if s != "" && !validGroupStart.MatchString(s) {
+		s = "_" + s
+	}
+	return s
+}
+
+// Scope is a GraphQL client bound to one workspace cluster and caller token.
+type Scope struct {
+	c         *GraphQLClient
+	clusterID string
+	token     string
+}
+
+// For returns a client scoped to clusterID (the X-Kedge-Cluster the hub
+// injected) authenticating as the caller via token.
+func (c *GraphQLClient) For(clusterID, token string) (*Scope, error) {
+	if clusterID == "" {
+		return nil, fmt.Errorf("no cluster id (X-Kedge-Cluster missing) — cannot target the tenant workspace")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("no bearer token on request — cannot act on the tenant's behalf")
+	}
+	return &Scope{c: c, clusterID: clusterID, token: token}, nil
+}
+
+type gqlError struct {
+	Message string `json:"message"`
+}
+
+type gqlResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []gqlError      `json:"errors"`
+}
+
+// exec POSTs a GraphQL request and returns the raw data object. res/name give
+// error mapping the resource + object identity for apierrors construction.
+func (s *Scope) exec(ctx context.Context, query string, vars map[string]any, res *Resource, name string) (json.RawMessage, error) {
+	reqBody, err := json.Marshal(map[string]any{"query": query, "variables": vars})
+	if err != nil {
+		return nil, err
+	}
+	url := s.c.hubBase + "/graphql/" + s.clusterID
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+s.token)
+
+	resp, err := s.c.http.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// No schema for this cluster: the gateway hasn't (yet) generated a
+		// schema for the workspace. Surface a NotFound the caller can treat as
+		// "initializing" rather than a hard failure.
+		gr := schema.GroupResource{}
+		if res != nil {
+			gr = res.GVR.GroupResource()
+		}
+		return nil, apierrors.NewNotFound(gr, name)
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("graphql gateway HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out gqlResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode graphql response: %w", err)
+	}
+	if len(out.Errors) > 0 {
+		return nil, mapGraphQLError(out.Errors, res, name)
+	}
+	return out.Data, nil
+}
+
+// mapGraphQLError converts a gateway error into a k8s apierror where the
+// message identifies a well-known condition, so callers' apierrors.Is* checks
+// keep working across the migration.
+func mapGraphQLError(errs []gqlError, res *Resource, name string) error {
+	first := errs[0].Message
+	low := strings.ToLower(first)
+	gr := schema.GroupResource{}
+	if res != nil {
+		gr = res.GVR.GroupResource()
+	}
+	switch {
+	case strings.Contains(low, "not found"), strings.Contains(low, "could not find"):
+		return apierrors.NewNotFound(gr, name)
+	case strings.Contains(low, "already exists"):
+		return apierrors.NewAlreadyExists(gr, name)
+	case strings.Contains(low, "conflict"):
+		return apierrors.NewConflict(gr, name, fmt.Errorf("%s", first))
+	}
+	msgs := make([]string, 0, len(errs))
+	for _, e := range errs {
+		msgs = append(msgs, e.Message)
+	}
+	return fmt.Errorf("graphql: %s", strings.Join(msgs, "; "))
+}
+
+// Get fetches one object via the <Kind>Yaml query.
+func (s *Scope) Get(ctx context.Context, res Resource, namespace, name string) (*unstructured.Unstructured, error) {
+	field := res.Kind + "Yaml"
+	varDefs, args, vars := itemArgs(res, namespace, name)
+	q := fmt.Sprintf("query(%s) { %s { %s { %s(%s) } } }",
+		varDefs, groupField(res.GVR.Group), res.GVR.Version, field, args)
+
+	data, err := s.exec(ctx, q, vars, &res, name)
+	if err != nil {
+		return nil, err
+	}
+	str, err := nestedString(data, groupField(res.GVR.Group), res.GVR.Version, field)
+	if err != nil {
+		return nil, err
+	}
+	return decodeObject(str)
+}
+
+// List fetches all objects via the <Plural>Yaml query. namespace is optional
+// (empty lists across all namespaces for namespaced resources).
+func (s *Scope) List(ctx context.Context, res Resource, namespace string) ([]unstructured.Unstructured, error) {
+	field := res.Plural + "Yaml"
+	var (
+		varDefs string
+		args    string
+		vars    = map[string]any{}
+	)
+	if res.Namespaced && namespace != "" {
+		varDefs = "$namespace: String"
+		args = "namespace: $namespace"
+		vars["namespace"] = namespace
+	}
+	q := ""
+	if varDefs != "" {
+		q = fmt.Sprintf("query(%s) { %s { %s { %s(%s) } } }",
+			varDefs, groupField(res.GVR.Group), res.GVR.Version, field, args)
+	} else {
+		q = fmt.Sprintf("query { %s { %s { %s } } }",
+			groupField(res.GVR.Group), res.GVR.Version, field)
+	}
+
+	data, err := s.exec(ctx, q, vars, &res, "")
+	if err != nil {
+		return nil, err
+	}
+	str, err := nestedString(data, groupField(res.GVR.Group), res.GVR.Version, field)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(str)
+}
+
+// Apply create-or-updates obj via the generic applyYaml mutation.
+func (s *Scope) Apply(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	y, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return nil, err
+	}
+	q := "mutation($yaml: String!) { applyYaml(yaml: $yaml) }"
+	res := resourceFromObject(obj)
+	data, err := s.exec(ctx, q, map[string]any{"yaml": string(y)}, res, obj.GetName())
+	if err != nil {
+		return nil, err
+	}
+	str, err := nestedString(data, "applyYaml")
+	if err != nil {
+		return nil, err
+	}
+	return decodeObject(str)
+}
+
+// ApplyStatus merge-patches obj's status subresource via applyStatusYaml.
+func (s *Scope) ApplyStatus(ctx context.Context, obj *unstructured.Unstructured) error {
+	y, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return err
+	}
+	q := "mutation($yaml: String!) { applyStatusYaml(yaml: $yaml) }"
+	res := resourceFromObject(obj)
+	_, err = s.exec(ctx, q, map[string]any{"yaml": string(y)}, res, obj.GetName())
+	return err
+}
+
+// Delete removes one object via the delete<Kind> mutation.
+func (s *Scope) Delete(ctx context.Context, res Resource, namespace, name string) error {
+	field := "delete" + res.Kind
+	varDefs, args, vars := itemArgs(res, namespace, name)
+	q := fmt.Sprintf("mutation(%s) { %s { %s { %s(%s) } } }",
+		varDefs, groupField(res.GVR.Group), res.GVR.Version, field, args)
+	_, err := s.exec(ctx, q, vars, &res, name)
+	return err
+}
+
+// itemArgs builds the (varDefs, args, vars) for a single-item operation.
+func itemArgs(res Resource, namespace, name string) (string, string, map[string]any) {
+	varDefs := "$name: String!"
+	args := "name: $name"
+	vars := map[string]any{"name": name}
+	if res.Namespaced {
+		varDefs += ", $namespace: String!"
+		args += ", namespace: $namespace"
+		vars["namespace"] = namespace
+	}
+	return varDefs, args, vars
+}
+
+// resourceFromObject derives a Resource for error mapping from an object's GVK.
+func resourceFromObject(obj *unstructured.Unstructured) *Resource {
+	gvk := obj.GroupVersionKind()
+	return &Resource{
+		GVR:  schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: strings.ToLower(gvk.Kind) + "s"},
+		Kind: gvk.Kind,
+	}
+}
+
+// nestedString walks the GraphQL data object along path and returns the leaf
+// string (the serialized object/list the *Yaml fields return).
+func nestedString(data json.RawMessage, path ...string) (string, error) {
+	var cur any
+	if err := json.Unmarshal(data, &cur); err != nil {
+		return "", fmt.Errorf("decode graphql data: %w", err)
+	}
+	for _, key := range path {
+		m, ok := cur.(map[string]any)
+		if !ok || m[key] == nil {
+			return "", fmt.Errorf("graphql response missing field %q", key)
+		}
+		cur = m[key]
+	}
+	str, ok := cur.(string)
+	if !ok {
+		return "", fmt.Errorf("graphql field %q is not a string", path[len(path)-1])
+	}
+	return str, nil
+}
+
+// decodeObject parses a serialized (YAML or JSON) object into unstructured.
+func decodeObject(s string) (*unstructured.Unstructured, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf("empty object payload")
+	}
+	m := map[string]any{}
+	if err := yaml.Unmarshal([]byte(s), &m); err != nil {
+		return nil, fmt.Errorf("decode object: %w", err)
+	}
+	return &unstructured.Unstructured{Object: m}, nil
+}
+
+// decodeList parses a serialized YAML sequence of objects into unstructured.
+func decodeList(s string) ([]unstructured.Unstructured, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	var raw []map[string]any
+	if err := yaml.Unmarshal([]byte(s), &raw); err != nil {
+		return nil, fmt.Errorf("decode list: %w", err)
+	}
+	out := make([]unstructured.Unstructured, 0, len(raw))
+	for _, m := range raw {
+		out = append(out, unstructured.Unstructured{Object: m})
+	}
+	return out, nil
+}

--- a/providers/app-studio/tenant/graphql.go
+++ b/providers/app-studio/tenant/graphql.go
@@ -76,13 +76,26 @@ var (
 )
 
 // groupField mirrors the gateway's SanitizeGroupName: non-[a-zA-Z0-9_] become
-// "_", and a leading invalid char gets an "_" prefix.
+// "_", and a leading invalid char gets an "_" prefix. The core group ("")
+// returns "" — its versions sit directly on the root, with no group wrapper.
 func groupField(group string) string {
 	s := invalidGroupChar.ReplaceAllString(group, "_")
 	if s != "" && !validGroupStart.MatchString(s) {
 		s = "_" + s
 	}
 	return s
+}
+
+// wrapSelection nests the inner field selection under the resource's group and
+// version, and returns the matching response-data path. The core group ("")
+// has no group wrapper — its version sits directly on the root query/mutation.
+func wrapSelection(res Resource, inner string) (selection string, path []string) {
+	gf := groupField(res.GVR.Group)
+	v := res.GVR.Version
+	if gf == "" {
+		return fmt.Sprintf("%s { %s }", v, inner), []string{v}
+	}
+	return fmt.Sprintf("%s { %s { %s } }", gf, v, inner), []string{gf, v}
 }
 
 // Scope is a GraphQL client bound to one workspace cluster and caller token.
@@ -189,14 +202,14 @@ func mapGraphQLError(errs []gqlError, res *Resource, name string) error {
 func (s *Scope) Get(ctx context.Context, res Resource, namespace, name string) (*unstructured.Unstructured, error) {
 	field := res.Kind + "Yaml"
 	varDefs, args, vars := itemArgs(res, namespace, name)
-	q := fmt.Sprintf("query(%s) { %s { %s { %s(%s) } } }",
-		varDefs, groupField(res.GVR.Group), res.GVR.Version, field, args)
+	sel, path := wrapSelection(res, fmt.Sprintf("%s(%s)", field, args))
+	q := fmt.Sprintf("query(%s) { %s }", varDefs, sel)
 
 	data, err := s.exec(ctx, q, vars, &res, name)
 	if err != nil {
 		return nil, err
 	}
-	str, err := nestedString(data, groupField(res.GVR.Group), res.GVR.Version, field)
+	str, err := nestedString(data, append(path, field)...)
 	if err != nil {
 		return nil, err
 	}
@@ -209,28 +222,27 @@ func (s *Scope) List(ctx context.Context, res Resource, namespace string) ([]uns
 	field := res.Plural + "Yaml"
 	var (
 		varDefs string
-		args    string
+		inner   = field
 		vars    = map[string]any{}
 	)
 	if res.Namespaced && namespace != "" {
 		varDefs = "$namespace: String"
-		args = "namespace: $namespace"
+		inner = field + "(namespace: $namespace)"
 		vars["namespace"] = namespace
 	}
+	sel, path := wrapSelection(res, inner)
 	q := ""
 	if varDefs != "" {
-		q = fmt.Sprintf("query(%s) { %s { %s { %s(%s) } } }",
-			varDefs, groupField(res.GVR.Group), res.GVR.Version, field, args)
+		q = fmt.Sprintf("query(%s) { %s }", varDefs, sel)
 	} else {
-		q = fmt.Sprintf("query { %s { %s { %s } } }",
-			groupField(res.GVR.Group), res.GVR.Version, field)
+		q = fmt.Sprintf("query { %s }", sel)
 	}
 
 	data, err := s.exec(ctx, q, vars, &res, "")
 	if err != nil {
 		return nil, err
 	}
-	str, err := nestedString(data, groupField(res.GVR.Group), res.GVR.Version, field)
+	str, err := nestedString(data, append(path, field)...)
 	if err != nil {
 		return nil, err
 	}
@@ -272,8 +284,8 @@ func (s *Scope) ApplyStatus(ctx context.Context, obj *unstructured.Unstructured)
 func (s *Scope) Delete(ctx context.Context, res Resource, namespace, name string) error {
 	field := "delete" + res.Kind
 	varDefs, args, vars := itemArgs(res, namespace, name)
-	q := fmt.Sprintf("mutation(%s) { %s { %s { %s(%s) } } }",
-		varDefs, groupField(res.GVR.Group), res.GVR.Version, field, args)
+	sel, _ := wrapSelection(res, fmt.Sprintf("%s(%s)", field, args))
+	q := fmt.Sprintf("mutation(%s) { %s }", varDefs, sel)
 	_, err := s.exec(ctx, q, vars, &res, name)
 	return err
 }


### PR DESCRIPTION
## Problem

App Studio reached a tenant's kcp workspace through the hub's **kcp user-proxy**, which hard-gates every request to the caller's `User.Spec.DefaultCluster`. When a user works in any **non-default** workspace, that proxy 403s — so App Studio's `/api/projects` failed (and PR #357's bare-path "fix" silently mis-routed to the home workspace instead, reverted in #358).

## Approach

Move App Studio's tenant access onto the hub's **embedded GraphQL gateway** (`/graphql/{clusterID}`), which serves *any* workspace the caller has RBAC in (schemas are generated per-workspace via the universal `core.faros.sh` anchor) and is **not** DefaultCluster-gated.

### Hub
- The backend proxy now injects **`X-Kedge-Cluster`** — the resolved tenant's kcp logical-cluster ID (cached, best-effort) — so providers can address the gateway.

### Gateway fork (`faroshq/kubernetes-graphql-gateway`)
Three primitives so an **unstructured** client can do full CRUD+status with only serialized objects (no typed field-selection sets):
- `update<Kind>Status` — status-subresource mutation
- `<Plural>Yaml` — list query returning serialized objects
- `applyStatusYaml` — generic status write via serialized object

### App Studio
- New `tenant.GraphQLClient` → `Get`/`List`/`Apply`/`ApplyStatus`/`Delete` over `<hubURL>/graphql/{clusterID}`, GraphQL errors mapped to `apierrors` so `IsNotFound`/`IsConflict` checks keep working.
- `asclient.Client` reshaped onto a `ResourceClient` interface, backed by the GraphQL scope (prod) or a dynamic client (tests) — both satisfy it.
- All ~18 `c.Dynamic().Resource(gvr)` call sites → `c.Resource(descriptor)` (Project, Secret, SandboxRunner, code-provider Connection/Repository).
- `clientFor` builds the scope from `X-Kedge-Cluster` + the caller token; `isProjectAPIInitializingError` recognises the gateway "schema not ready" shapes for the 503 path.

## Verification

- App Studio module **builds**, **vets**, and the **full test suite passes** (tests run through `c.Resource()` → dynamic fakes).
- Hub builds with the gateway re-pin (adds resolver methods only; backward compatible).

## Caveat

End-to-end against prod still needs the gateway confirmed serving a real query — raw `curl /graphql/{cluster}` 404'd token-less, though schemas *are* generated per the listener logs (`Schema file updated`), so it's likely an auth/ingress path detail, not coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)