### PR TITLE
fix(app-studio): GPT-5 temperature limits + unconditional sandbox images

### DIFF
--- a/providers/app-studio/api/assistant_eino_model.go
+++ b/providers/app-studio/api/assistant_eino_model.go
@@ -59,18 +59,55 @@ func newProjectEinoChatModel(ctx context.Context, settings projectLLMSettings) (
 }
 
 func newProjectEinoOpenAIChatModel(ctx context.Context, settings projectLLMSettings) (einomodel.BaseChatModel, error) {
-	temperature := float32(0.2)
-	model, err := openaimodel.NewChatModel(ctx, &openaimodel.ChatModelConfig{
-		APIKey:      strings.TrimSpace(settings.APIKey),
-		BaseURL:     strings.TrimRight(strings.TrimSpace(settings.BaseURL), "/"),
-		Model:       strings.TrimSpace(settings.Model),
-		Temperature: &temperature,
-		HTTPClient:  &http.Client{},
-	})
+	config := &openaimodel.ChatModelConfig{
+		APIKey:     strings.TrimSpace(settings.APIKey),
+		BaseURL:    strings.TrimRight(strings.TrimSpace(settings.BaseURL), "/"),
+		Model:      strings.TrimSpace(settings.Model),
+		HTTPClient: &http.Client{},
+	}
+	// GPT-5 and the o-series reasoning models reject any temperature other than
+	// the fixed default of 1, so only request a custom temperature when the
+	// configured model supports it.
+	if projectModelSupportsTemperature(settings.Model) {
+		temperature := float32(0.2)
+		config.Temperature = &temperature
+	}
+	model, err := openaimodel.NewChatModel(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("create native Eino OpenAI chat model: %w", err)
 	}
 	return model, nil
+}
+
+// projectModelSupportsTemperature reports whether the given model accepts a
+// custom sampling temperature. OpenAI's GPT-5 family and the o-series reasoning
+// models (o1/o3/o4) fix temperature, top_p, and the penalties, and return an
+// error if a non-default value is sent.
+func projectModelSupportsTemperature(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return true
+	}
+	// Drop any provider prefix such as "openai/".
+	if idx := strings.LastIndex(m, "/"); idx >= 0 {
+		m = m[idx+1:]
+	}
+	switch {
+	case strings.HasPrefix(m, "gpt-5"), strings.HasPrefix(m, "gpt5"):
+		return false
+	case strings.HasPrefix(m, "o1"), strings.HasPrefix(m, "o3"), strings.HasPrefix(m, "o4"):
+		return false
+	}
+	return true
+}
+
+// projectTemperatureOptions returns the per-call temperature option for the
+// given model, or nil when the model does not accept a custom temperature.
+func projectTemperatureOptions(model string, temperature float32) []einomodel.Option {
+	if !projectModelSupportsTemperature(model) {
+		return nil
+	}
+	return []einomodel.Option{einomodel.WithTemperature(temperature)}
 }
 
 func newProjectEinoGeminiChatModel(ctx context.Context, settings projectLLMSettings) (einomodel.BaseChatModel, error) {

--- a/providers/app-studio/api/assistant_turn_profile.go
+++ b/providers/app-studio/api/assistant_turn_profile.go
@@ -88,15 +88,16 @@ func classifyProjectAssistantTurnProfile(history []store.Message) projectAssista
 	return fallbackProjectAssistantTurnDecision(history).Profile
 }
 
-func classifyProjectAssistantTurnWithModel(ctx context.Context, model einomodel.BaseChatModel, history []store.Message) (projectAssistantTurnDecision, error) {
+func classifyProjectAssistantTurnWithModel(ctx context.Context, model einomodel.BaseChatModel, history []store.Message, extraOpts ...einomodel.Option) (projectAssistantTurnDecision, error) {
 	fallback := fallbackProjectAssistantTurnDecision(history)
 	if model == nil {
 		return fallback, nil
 	}
+	opts := append([]einomodel.Option{einomodel.WithToolChoice(einoschema.ToolChoiceForbidden)}, extraOpts...)
 	msg, err := model.Generate(ctx, []*einoschema.Message{
 		einoschema.SystemMessage(projectAssistantTurnClassifierSystemPrompt),
 		einoschema.UserMessage(projectAssistantTurnClassifierUserPrompt(history)),
-	}, einomodel.WithTemperature(0), einomodel.WithToolChoice(einoschema.ToolChoiceForbidden))
+	}, opts...)
 	if err != nil || msg == nil || len(msg.ToolCalls) > 0 {
 		return fallback, nil
 	}
@@ -117,7 +118,7 @@ func projectAssistantSemanticTurnRouter(ctx context.Context, req projectAssistan
 	if err != nil {
 		return fallbackProjectAssistantTurnDecision(req.History), nil
 	}
-	return classifyProjectAssistantTurnWithModel(ctx, model, req.History)
+	return classifyProjectAssistantTurnWithModel(ctx, model, req.History, projectTemperatureOptions(req.LLM.Model, 0)...)
 }
 
 func projectAssistantFallbackTurnRouter(_ context.Context, req projectAssistantTurnRouteRequest) (projectAssistantTurnDecision, error) {

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 	"time"
 
-	einomodel "github.com/cloudwego/eino/components/model"
 	einoschema "github.com/cloudwego/eino/schema"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -415,13 +414,12 @@ func (s *Server) generateProjectNaming(ctx context.Context, c *asclient.Client, 
 	if err != nil {
 		return projectNamingResult{}, err
 	}
-	temperature := float32(0.1)
 	reply, err := model.Generate(ctx, []*einoschema.Message{
 		einoschema.SystemMessage("Generate concise app project names. Return only JSON with string fields displayName and repositoryName. " +
 			"displayName should be 2-5 words, human-readable, and no longer than 64 characters. " +
 			"repositoryName must be derived from displayName and must already satisfy DNS-1123 label rules: lowercase a-z, 0-9, hyphen only; starts and ends with alphanumeric; max 63 characters."),
 		einoschema.UserMessage("Prompt:\n" + prompt),
-	}, einomodel.WithTemperature(temperature))
+	}, projectTemperatureOptions(settings.Model, 0.1)...)
 	if err != nil {
 		return projectNamingResult{}, err
 	}

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -9,11 +9,18 @@
 {{- if and $previewGatewayFeatureEnabled (not .Values.previewTokenSecretRef.name) -}}
 {{- fail "previewGateway is enabled with baseDomain, but previewTokenSecretRef.name is required for shared preview tokens" -}}
 {{- end -}}
-{{- if and $runtimeKubeconfigSecret (not $sandboxRunnerImage) -}}
-{{- fail "sandboxRunner.runnerImage is required when runtimeKubeconfig.secretName is set; use an immutable digest reference" -}}
+{{- /*
+App Studio creates a SandboxRunner for every project's development environment,
+and the SandboxRunner spec requires both images regardless of whether the
+runtime data plane (runtimeKubeconfig) is enabled. Require them unconditionally
+so a misconfigured install fails here instead of producing invalid SandboxRunner
+resources at runtime.
+*/ -}}
+{{- if not $sandboxRunnerImage -}}
+{{- fail "sandboxRunner.runnerImage is required; use an immutable digest reference" -}}
 {{- end -}}
-{{- if and $runtimeKubeconfigSecret (not $sandboxTokenGeneratorImage) -}}
-{{- fail "sandboxRunner.tokenGeneratorImage is required when runtimeKubeconfig.secretName is set; use an immutable digest reference" -}}
+{{- if not $sandboxTokenGeneratorImage -}}
+{{- fail "sandboxRunner.tokenGeneratorImage is required; use an immutable digest reference" -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -104,14 +111,12 @@ spec:
             - name: APP_STUDIO_RUNTIME_KUBECONFIG
               value: /var/run/secrets/kedge/runtime/kubeconfig
             {{- end }}
-            {{- if $sandboxRunnerImage }}
+            # Always set: the SandboxRunner spec requires both images, and the
+            # template above fails the install when either is unset.
             - name: APP_STUDIO_SANDBOX_RUNNER_IMAGE
               value: {{ $sandboxRunnerImage | quote }}
-            {{- end }}
-            {{- if $sandboxTokenGeneratorImage }}
             - name: APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE
               value: {{ $sandboxTokenGeneratorImage | quote }}
-            {{- end }}
             {{- if $previewGatewayFeatureEnabled }}
             - name: APP_STUDIO_PREVIEW_BASE_DOMAIN
               value: {{ $previewGatewayBaseDomain | quote }}

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -41,10 +41,11 @@ providerKubeconfig:
 runtimeKubeconfig:
   secretName: ""
 
-# Images passed into infrastructure-backed SandboxRunner resources. They are
-# intentionally empty by default so installs do not silently trust mutable
-# development tags. Set both to immutable digest references before enabling the
-# sandbox runtime kubeconfig.
+# Images passed into infrastructure-backed SandboxRunner resources. App Studio
+# creates a SandboxRunner for every project, and its spec requires both images,
+# so the chart fails the install when either is unset (independent of the
+# runtime kubeconfig). They are empty by default so installs do not silently
+# trust mutable development tags — set both to immutable digest references.
 sandboxRunner:
   runnerImage: ""
   tokenGeneratorImage: ""


### PR DESCRIPTION
Two independent App Studio production fixes.

## 1. Omit `temperature` for models that fix it (GPT-5, o-series)

OpenAI's GPT-5 family and the o1/o3/o4 reasoning models reject any sampling temperature other than the fixed default of `1`:

> this model has beta-limitations, temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0

App Studio hard-coded a custom temperature at three call sites, so any project configured with one of these models failed **every** chat completion.

- New helpers `projectModelSupportsTemperature` / `projectTemperatureOptions` in `assistant_eino_model.go`.
- Temperature is now gated on model support in the OpenAI model constructor, project naming (`llm.go`), and the turn classifier (`assistant_turn_profile.go`).
- No behavior change for models that accept a custom temperature (e.g. `gpt-4o-mini`).

## 2. Require sandbox images independent of `runtimeKubeconfig`

App Studio creates a `SandboxRunner` for every project's development environment, and the `SandboxRunner` spec requires `runnerImage` and `tokenGeneratorImage`. The chart only emitted (and validated) the image env vars when `runtimeKubeconfig.secretName` was set — coupling a **control-plane** concern (the runner resource always created) to the unrelated **runtime data plane**. With the runtime kubeconfig disabled in prod, the images were never passed and every project create failed:

```
SandboxRunner ... is invalid: [spec.runnerImage: Required value, spec.tokenGeneratorImage: Required value]
```

The chart now requires both images **unconditionally**, so a misconfigured install fails at `helm` time instead of producing invalid `SandboxRunner` resources at runtime.

> [!IMPORTANT]
> This changes chart validation: any deploy that does not set `sandboxRunner.runnerImage` and `sandboxRunner.tokenGeneratorImage` will now fail at install. **Prod values must set both** (immutable digests) before rolling this out — that is also the actual remedy for the current incident.

## Testing
- `go build ./...` and `go test ./api/` pass.
- `helm template` fails as expected when images are unset, and renders both env vars when they are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
