### PR TITLE
feat(infra): data-plane subresource proxy handler (Phase 1, re-land)

### DIFF
--- a/docs/app-studio-runtime-decoupling.md
+++ b/docs/app-studio-runtime-decoupling.md
@@ -110,14 +110,14 @@ A generic resolver turns `(instance, endpointName) → {serviceNamespace, servic
 ### 4.1 Request shape
 
 ```
-GET  /services/providers/infrastructure/vw/clusters/{ws}/
-       apis/infrastructure.kedge.faros.sh/v1alpha1/sandboxrunners/{name}/log
+GET  /services/providers/infrastructure/dataplane/clusters/{ws}/sandboxrunners/{name}/log
 GET  …/sandboxrunners/{name}/proxy/{path...}
 POST …/sandboxrunners/{name}/sync
 POST …/sandboxrunners/{name}/restart
+     …/sandboxrunners/{name}/status     (served from the instance status; no runtime hop)
 ```
 
-(The exact prefix depends on the transport vehicle chosen in §6; the handler logic is identical either way.)
+The `/services/providers/infrastructure` prefix is the hub backend proxy; the provider's serve mux sees `/dataplane/clusters/{ws}/{resource}/{name}/{verb}[/{tail}]` (§6.1). The `{ws}` segment carries colons (`root:kedge:orgs:acme`) and is a single path segment.
 
 ### 4.2 Per-request flow
 
@@ -148,16 +148,17 @@ After this, App Studio's `SandboxRunner` values shrink to roughly `{projectRef}`
 
 ## 6. Open decisions
 
-### 6.1 VW transport vehicle — **spike in Phase 1**
+### 6.1 VW transport vehicle — **decided in Phase 1**
 
 The "subresource on the instance" semantics can be realized two ways:
 
 | Vehicle | Pros | Cons |
 |---|---|---|
 | **kcp APIExport subresource** on the instance kind | Purest model; reachable via the normal bound-resource API path App Studio already uses; no per-workspace URL mapping | Unproven that kcp APIExport supports arbitrary custom subresources on CRD-backed resources |
-| **Dedicated VW builder** (`spec.virtualWorkspace` → `/services/providers/infrastructure/vw/…`) | **Proven in-repo** by `edges_proxy_builder.go` (proxy + upgrades + WebSocket through the hub) | Hub must map workspace → provider (the binding supplies this); slightly more wiring |
+| **Provider serve mux behind the hub backend proxy** (`/services/providers/infrastructure/dataplane/…`, workspace in the path) | **Proven in-repo** — the provider already serves `/mcp` this way, and `edges_proxy_builder.go` shows proxy + upgrades + WebSocket through the hub; no kcp-VW machinery | Workspace addressed explicitly in the URL rather than implied by the bound resource; the handler re-authorizes against the instance itself |
 
-Recommendation: budget for the **dedicated VW builder**; it is the de-risked path and the handler logic is identical. Confirm the APIExport-subresource option early — if kcp supports it, prefer it.
+**Decision (Phase 1):** the **provider serve mux** vehicle. The handler mounts at `dataplane.PathPrefix` (`/dataplane/`) on the provider's existing HTTP server and is reached through the hub backend proxy with the caller's bearer token forwarded as-is. The URL carries the workspace explicitly —
+`/dataplane/clusters/<ws>/<resource>/<name>/<verb>[/<tail>]` — and the handler authorizes by fetching the instance **as the caller** (a tenant-scoped GET; 403/404 is the gate). This keeps the k8s-native subresource *semantics* while avoiding the unproven kcp-APIExport-subresource path. BYO compute still falls out of the binding: App Studio resolves which provider backs a workspace and routes there; a future migration to a true APIExport subresource can swap the transport without touching the resolver or the handler logic.
 
 ### 6.2 Move runner config ownership to infra
 

--- a/providers/infrastructure/dataplane/contract.go
+++ b/providers/infrastructure/dataplane/contract.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+)
+
+// ContractGetter returns the data-plane contract for an instance resource
+// (the lowercase plural, e.g. "sandboxrunners"). Returns a nil contract with no
+// error when the template declares no data plane, and an error when no template
+// owns the resource.
+type ContractGetter interface {
+	For(ctx context.Context, resource string) (*infrav1alpha1.TemplateDataPlane, error)
+}
+
+var templateGVR = schema.GroupVersionResource{
+	Group:    "infrastructure.kedge.faros.sh",
+	Version:  "v1alpha1",
+	Resource: "templates",
+}
+
+// TemplateContractGetter resolves a resource's data-plane contract by reading
+// Templates from the provider workspace with the provider's own (platform)
+// kcp client. Templates are platform-owned and cluster-scoped, so reading them
+// with the provider credential is correct — the caller's RBAC is enforced
+// separately, on the instance (see handler.go).
+type TemplateContractGetter struct {
+	templates dynamic.NamespaceableResourceInterface
+}
+
+// NewTemplateContractGetter builds a getter over the provider's dynamic client.
+// Returns nil when client is nil (REST-only/dev serve), which the handler
+// surfaces as "data plane unavailable".
+func NewTemplateContractGetter(client dynamic.Interface) *TemplateContractGetter {
+	if client == nil {
+		return nil
+	}
+	return &TemplateContractGetter{templates: client.Resource(templateGVR)}
+}
+
+// For lists Templates and returns the dataPlane of the one whose
+// spec.instanceCRD.resource matches. Not cached: the Template set is tiny and a
+// stale contract would silently mis-route a proxy, so we always read fresh.
+func (g *TemplateContractGetter) For(ctx context.Context, resource string) (*infrav1alpha1.TemplateDataPlane, error) {
+	resource = strings.TrimSpace(resource)
+	if resource == "" {
+		return nil, fmt.Errorf("empty instance resource")
+	}
+	list, err := g.templates.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing templates: %w", err)
+	}
+	for i := range list.Items {
+		tmpl := &list.Items[i]
+		got, _, _ := unstructured.NestedString(tmpl.Object, "spec", "instanceCRD", "resource")
+		if strings.TrimSpace(got) != resource {
+			continue
+		}
+		return dataPlaneFromTemplate(tmpl)
+	}
+	return nil, fmt.Errorf("no template owns resource %q", resource)
+}
+
+// dataPlaneFromTemplate extracts and decodes spec.dataPlane from a Template's
+// unstructured form. Returns (nil, nil) when the template declares no data
+// plane.
+func dataPlaneFromTemplate(tmpl *unstructured.Unstructured) (*infrav1alpha1.TemplateDataPlane, error) {
+	raw, found, err := unstructured.NestedMap(tmpl.Object, "spec", "dataPlane")
+	if err != nil {
+		return nil, fmt.Errorf("template %q spec.dataPlane is malformed: %w", tmpl.GetName(), err)
+	}
+	if !found || len(raw) == 0 {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("template %q spec.dataPlane re-encode: %w", tmpl.GetName(), err)
+	}
+	var contract infrav1alpha1.TemplateDataPlane
+	if err := json.Unmarshal(encoded, &contract); err != nil {
+		return nil, fmt.Errorf("template %q spec.dataPlane decode: %w", tmpl.GetName(), err)
+	}
+	return &contract, nil
+}

--- a/providers/infrastructure/dataplane/handler.go
+++ b/providers/infrastructure/dataplane/handler.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// PathPrefix is where the handler is mounted on the provider's serve mux. It is
+// reached through the hub backend proxy at
+// /services/providers/infrastructure/dataplane/... with the caller's bearer
+// token forwarded as-is and X-Kedge-* identity headers injected.
+const PathPrefix = "/dataplane/"
+
+// InstanceGetter authorizes and fetches a workload instance AS THE CALLER. The
+// implementation builds a tenant-scoped client from (workspace, token) and does
+// a GET — so a 403/404 from the caller's RBAC is the access gate for the whole
+// data plane. No provider-wide credential is consulted here.
+type InstanceGetter interface {
+	Get(ctx context.Context, workspace, token, resource, name string) (*unstructured.Unstructured, error)
+}
+
+// Handler serves a template's declared data-plane verbs as subresources on a
+// workload instance:
+//
+//	/dataplane/clusters/<ws>/<resource>/<name>/<verb>[/<caller-path...>]
+//
+// e.g. /dataplane/clusters/root:kedge:orgs:acme/sandboxrunners/kedge-sandbox-…/log
+//
+// It authorizes the caller against the instance, resolves the verb to a runtime
+// target via the template contract, and reverse-proxies to the runtime cluster
+// the provider owns. Consumers therefore never hold a runtime credential.
+type Handler struct {
+	instances InstanceGetter
+	contracts ContractGetter
+	runtime   Runtime
+}
+
+// NewHandler wires the handler. Any nil dependency makes the data plane report
+// 503 (the serve process runs without a runtime/kcp config in dev).
+func NewHandler(instances InstanceGetter, contracts ContractGetter, runtime Runtime) *Handler {
+	return &Handler{instances: instances, contracts: contracts, runtime: runtime}
+}
+
+// request is the parsed addressing of a data-plane call.
+type request struct {
+	workspace  string
+	resource   string
+	name       string
+	verb       string
+	callerPath string // remaining path beyond the verb (open-proxy tail)
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.instances == nil || h.contracts == nil || h.runtime == nil {
+		http.Error(w, "data plane unavailable on this provider", http.StatusServiceUnavailable)
+		return
+	}
+
+	id := identityFromRequest(r)
+	if id.token == "" {
+		http.Error(w, "no bearer token — cannot act on the caller's behalf", http.StatusUnauthorized)
+		return
+	}
+
+	req, ok := parsePath(r.URL.Path)
+	if !ok {
+		http.Error(w, "bad data-plane path; want /dataplane/clusters/<ws>/<resource>/<name>/<verb>", http.StatusBadRequest)
+		return
+	}
+
+	// 1. Authorize + fetch the instance as the caller. RBAC is the gate.
+	instance, err := h.instances.Get(r.Context(), req.workspace, id.token, req.resource, req.name)
+	if err != nil {
+		writeKubeError(w, err)
+		return
+	}
+
+	// 2. Resolve the template's data-plane contract for this resource.
+	contract, err := h.contracts.For(r.Context(), req.resource)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	if contract == nil {
+		http.Error(w, "resource "+req.resource+" exposes no data plane", http.StatusNotFound)
+		return
+	}
+
+	// 3. Method allowlist for the verb.
+	if !MethodAllowed(contract, req.verb, r.Method) {
+		http.Error(w, "method "+r.Method+" not allowed for verb "+req.verb, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// 4. Resolve the verb to a concrete runtime target (namespace-confined).
+	target, err := Resolve(contract, instance, req.verb)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+
+	// 5a. A status verb is served straight from the instance status — no hop.
+	if target.FromStatus {
+		writeInstanceStatus(w, instance)
+		return
+	}
+
+	// 5b. Reverse-proxy to the runtime Service the provider owns.
+	serveProxy(w, r, h.runtime, target, req.callerPath)
+}
+
+// parsePath parses /dataplane/clusters/<ws>/<resource>/<name>/<verb>[/<tail...>].
+// The workspace segment may itself contain colons (root:kedge:orgs:acme); it is
+// a single path segment, so no escaping is needed.
+func parsePath(p string) (request, bool) {
+	rest := strings.TrimPrefix(p, PathPrefix)
+	if rest == p {
+		return request{}, false
+	}
+	rest = strings.TrimPrefix(rest, "clusters/")
+	parts := strings.SplitN(rest, "/", 5)
+	// parts: [ws, resource, name, verb, tail?]
+	if len(parts) < 4 {
+		return request{}, false
+	}
+	req := request{
+		workspace: strings.TrimSpace(parts[0]),
+		resource:  strings.TrimSpace(parts[1]),
+		name:      strings.TrimSpace(parts[2]),
+		verb:      strings.TrimSpace(parts[3]),
+	}
+	if req.workspace == "" || req.resource == "" || req.name == "" || req.verb == "" {
+		return request{}, false
+	}
+	if len(parts) == 5 {
+		req.callerPath = "/" + parts[4]
+	}
+	return req, true
+}
+
+// writeInstanceStatus returns the instance's status subobject as JSON.
+func writeInstanceStatus(w http.ResponseWriter, instance *unstructured.Unstructured) {
+	status, _, _ := unstructured.NestedMap(instance.Object, "status")
+	if status == nil {
+		status = map[string]any{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status)
+}
+
+// writeKubeError maps a Kubernetes API error from the authorize/fetch step to
+// an HTTP status, so a caller's 403/404 surfaces faithfully rather than as 500.
+func writeKubeError(w http.ResponseWriter, err error) {
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		code := int(statusErr.ErrStatus.Code)
+		if code == 0 {
+			code = http.StatusBadGateway
+		}
+		http.Error(w, statusErr.ErrStatus.Message, code)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusBadGateway)
+}

--- a/providers/infrastructure/dataplane/handler_test.go
+++ b/providers/infrastructure/dataplane/handler_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+)
+
+const testNamespace = "kedge-sandbox-a1c31ddaaaa007d4"
+
+type fakeInstanceGetter struct {
+	instance *unstructured.Unstructured
+	err      error
+
+	gotWorkspace string
+	gotToken     string
+	gotResource  string
+	gotName      string
+}
+
+func (f *fakeInstanceGetter) Get(_ context.Context, ws, token, resource, name string) (*unstructured.Unstructured, error) {
+	f.gotWorkspace, f.gotToken, f.gotResource, f.gotName = ws, token, resource, name
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.instance, nil
+}
+
+type fakeContractGetter struct {
+	contract *infrav1alpha1.TemplateDataPlane
+	err      error
+}
+
+func (f *fakeContractGetter) For(context.Context, string) (*infrav1alpha1.TemplateDataPlane, error) {
+	return f.contract, f.err
+}
+
+type fakeRuntime struct {
+	host  string
+	token string
+
+	gotTokenNamespace string
+	gotTokenName      string
+}
+
+func (f *fakeRuntime) Host() string { return f.host }
+func (f *fakeRuntime) Transport() (http.RoundTripper, error) {
+	return http.DefaultTransport, nil
+}
+func (f *fakeRuntime) ControlToken(_ context.Context, namespace, name string) (string, error) {
+	f.gotTokenNamespace, f.gotTokenName = namespace, name
+	return f.token, nil
+}
+
+func newTestHandler(t *testing.T, ig *fakeInstanceGetter, rt *fakeRuntime) *Handler {
+	t.Helper()
+	return NewHandler(ig, &fakeContractGetter{contract: sandboxRunnerContract()}, rt)
+}
+
+func doRequest(h *Handler, method, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, target, nil)
+	req.Header.Set("Authorization", "Bearer caller-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func dataplaneURL(verb string) string {
+	return PathPrefix + "clusters/root:kedge:orgs:acme/sandboxrunners/" + testNamespace + "/" + verb
+}
+
+func TestHandlerProxiesControlVerb(t *testing.T) {
+	var gotPath, gotControlToken, gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotControlToken = r.Header.Get(controlTokenHeader)
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, "log line\n")
+	}))
+	defer upstream.Close()
+
+	ig := &fakeInstanceGetter{instance: runnerInstance(testNamespace)}
+	rt := &fakeRuntime{host: upstream.URL, token: "control-secret-token"}
+	rec := doRequest(newTestHandler(t, ig, rt), http.MethodGet, dataplaneURL("log"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "log line\n" {
+		t.Errorf("body = %q, want %q", rec.Body.String(), "log line\n")
+	}
+	wantPath := "/api/v1/namespaces/" + testNamespace + "/services/" + testNamespace + "-control:control/proxy/logs"
+	if gotPath != wantPath {
+		t.Errorf("upstream path = %q, want %q", gotPath, wantPath)
+	}
+	if gotControlToken != "control-secret-token" {
+		t.Errorf("control token header = %q, want injected token", gotControlToken)
+	}
+	if gotAuth != "" {
+		t.Errorf("caller Authorization leaked to runtime: %q", gotAuth)
+	}
+	// Authz used the path workspace + caller token.
+	if ig.gotWorkspace != "root:kedge:orgs:acme" || ig.gotToken != "caller-token" {
+		t.Errorf("authz used ws=%q token=%q, want acme/caller-token", ig.gotWorkspace, ig.gotToken)
+	}
+	if ig.gotResource != "sandboxrunners" || ig.gotName != testNamespace {
+		t.Errorf("authz used resource=%q name=%q", ig.gotResource, ig.gotName)
+	}
+	if rt.gotTokenName != testNamespace+"-control" || rt.gotTokenNamespace != testNamespace {
+		t.Errorf("control token read from %s/%s, want %s/%s-control", rt.gotTokenNamespace, rt.gotTokenName, testNamespace, testNamespace)
+	}
+}
+
+func TestHandlerProxyVerbAppendsCallerPath(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+	}))
+	defer upstream.Close()
+
+	h := newTestHandler(t, &fakeInstanceGetter{instance: runnerInstance(testNamespace)}, &fakeRuntime{host: upstream.URL})
+	rec := doRequest(h, http.MethodGet, dataplaneURL("proxy")+"/assets/app.js")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	wantPath := "/api/v1/namespaces/" + testNamespace + "/services/" + testNamespace + "-preview:preview/proxy/assets/app.js"
+	if gotPath != wantPath {
+		t.Errorf("upstream path = %q, want %q", gotPath, wantPath)
+	}
+}
+
+func TestHandlerStatusVerbServedFromCR(t *testing.T) {
+	h := newTestHandler(t, &fakeInstanceGetter{instance: runnerInstance(testNamespace)}, &fakeRuntime{host: "http://unused"})
+	rec := doRequest(h, http.MethodGet, dataplaneURL("status"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "runtimeNamespace") {
+		t.Errorf("status body missing runtimeNamespace: %s", rec.Body.String())
+	}
+}
+
+func TestHandlerRejectsMissingToken(t *testing.T) {
+	h := newTestHandler(t, &fakeInstanceGetter{instance: runnerInstance(testNamespace)}, &fakeRuntime{host: "http://unused"})
+	req := httptest.NewRequest(http.MethodGet, dataplaneURL("log"), nil) // no Authorization
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandlerForwardsAuthzDenial(t *testing.T) {
+	denied := apierrors.NewForbidden(schema.GroupResource{Group: "infrastructure.kedge.faros.sh", Resource: "sandboxrunners"}, testNamespace, nil)
+	h := newTestHandler(t, &fakeInstanceGetter{err: denied}, &fakeRuntime{host: "http://unused"})
+	rec := doRequest(h, http.MethodGet, dataplaneURL("log"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHandlerForwardsNotFound(t *testing.T) {
+	missing := apierrors.NewNotFound(schema.GroupResource{Group: "infrastructure.kedge.faros.sh", Resource: "sandboxrunners"}, testNamespace)
+	h := newTestHandler(t, &fakeInstanceGetter{err: missing}, &fakeRuntime{host: "http://unused"})
+	rec := doRequest(h, http.MethodGet, dataplaneURL("log"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandlerMethodNotAllowed(t *testing.T) {
+	h := newTestHandler(t, &fakeInstanceGetter{instance: runnerInstance(testNamespace)}, &fakeRuntime{host: "http://unused"})
+	rec := doRequest(h, http.MethodPost, dataplaneURL("log")) // log is GET-only
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandlerNamespaceEscapeIsConflict(t *testing.T) {
+	instance := runnerInstance(testNamespace)
+	unstructured.SetNestedField(instance.Object, "kube-system", "status", "controlServiceRef", "namespace") //nolint:errcheck
+	h := newTestHandler(t, &fakeInstanceGetter{instance: instance}, &fakeRuntime{host: "http://unused"})
+	rec := doRequest(h, http.MethodGet, dataplaneURL("log"))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestHandlerUnknownVerb(t *testing.T) {
+	h := newTestHandler(t, &fakeInstanceGetter{instance: runnerInstance(testNamespace)}, &fakeRuntime{host: "http://unused"})
+	rec := doRequest(h, http.MethodGet, dataplaneURL("exec"))
+	// exec is undeclared: MethodAllowed returns false => 405.
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandlerUnavailableWhenDepsNil(t *testing.T) {
+	h := NewHandler(nil, nil, nil)
+	rec := doRequest(h, http.MethodGet, dataplaneURL("log"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestParsePath(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want request
+		ok   bool
+	}{
+		{
+			path: PathPrefix + "clusters/root:kedge:orgs:acme/sandboxrunners/r1/log",
+			want: request{workspace: "root:kedge:orgs:acme", resource: "sandboxrunners", name: "r1", verb: "log"},
+			ok:   true,
+		},
+		{
+			path: PathPrefix + "clusters/ws/sandboxrunners/r1/proxy/assets/app.js",
+			want: request{workspace: "ws", resource: "sandboxrunners", name: "r1", verb: "proxy", callerPath: "/assets/app.js"},
+			ok:   true,
+		},
+		{path: PathPrefix + "clusters/ws/sandboxrunners/r1", ok: false},   // no verb
+		{path: "/other/clusters/ws/sandboxrunners/r1/log", ok: false},     // wrong prefix
+		{path: PathPrefix + "clusters//sandboxrunners/r1/log", ok: false}, // empty ws
+	} {
+		got, ok := parsePath(tc.path)
+		if ok != tc.ok {
+			t.Errorf("parsePath(%q) ok = %v, want %v", tc.path, ok, tc.ok)
+			continue
+		}
+		if ok && got != tc.want {
+			t.Errorf("parsePath(%q) = %+v, want %+v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestDataPlaneFromTemplate(t *testing.T) {
+	tmpl := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "sandbox-runner"},
+		"spec": map[string]any{
+			"instanceCRD": map[string]any{"resource": "sandboxrunners"},
+			"dataPlane": map[string]any{
+				"runtimeNamespacePath": "status.runtimeNamespace",
+				"tokenSecretPath":      "status.controlSecretRef",
+				"endpoints": map[string]any{
+					"log":    map[string]any{"servicePath": "status.controlServiceRef", "port": "control", "upstreamPath": "/logs", "methods": []any{"GET"}, "stream": true},
+					"status": map[string]any{"fromStatus": true},
+				},
+			},
+		},
+	}}
+	got, err := dataPlaneFromTemplate(tmpl)
+	if err != nil {
+		t.Fatalf("dataPlaneFromTemplate error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("dataPlaneFromTemplate returned nil contract")
+	}
+	if got.RuntimeNamespacePath != "status.runtimeNamespace" || got.TokenSecretPath != "status.controlSecretRef" {
+		t.Errorf("contract paths = %q / %q", got.RuntimeNamespacePath, got.TokenSecretPath)
+	}
+	logEp, ok := got.Endpoints["log"]
+	if !ok || logEp.Port != "control" || !logEp.Stream || logEp.UpstreamPath != "/logs" {
+		t.Errorf("log endpoint decoded wrong: %+v", logEp)
+	}
+	if st, ok := got.Endpoints["status"]; !ok || !st.FromStatus {
+		t.Errorf("status endpoint decoded wrong: %+v", st)
+	}
+}
+
+func TestDataPlaneFromTemplateAbsent(t *testing.T) {
+	tmpl := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "redis"},
+		"spec":     map[string]any{"instanceCRD": map[string]any{"resource": "redises"}},
+	}}
+	got, err := dataPlaneFromTemplate(tmpl)
+	if err != nil {
+		t.Fatalf("dataPlaneFromTemplate error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil contract for a template with no dataPlane, got %+v", got)
+	}
+}

--- a/providers/infrastructure/dataplane/identity.go
+++ b/providers/infrastructure/dataplane/identity.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// identity is the caller on whose behalf a data-plane request runs. token is
+// the caller's own bearer token (forwarded as-is by the hub backend proxy);
+// every runtime action is gated by the caller's RBAC on the instance, so there
+// is no provider-wide identity. Mirrors mcpserver.identityFromRequest but kept
+// local to avoid a package dependency.
+type identity struct {
+	tenantPath string
+	user       string
+	token      string
+}
+
+func identityFromRequest(r *http.Request) identity {
+	id := identity{
+		tenantPath: r.Header.Get("X-Kedge-Tenant"),
+		user:       r.Header.Get("X-Kedge-User"),
+		token:      bearerToken(r),
+	}
+	if os.Getenv("KEDGE_DEV_ALLOW_TENANT_QUERY") == "true" && id.token == "" {
+		id.token = r.URL.Query().Get("token")
+	}
+	return id
+}
+
+// bearerToken extracts the caller's token from the Authorization header.
+func bearerToken(r *http.Request) string {
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return ""
+}

--- a/providers/infrastructure/dataplane/proxy.go
+++ b/providers/infrastructure/dataplane/proxy.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// Runtime is the provider's handle to the cluster where workloads run. It is
+// the only component that holds a runtime-cluster credential — the whole point
+// of this work is that consumers (App Studio) no longer do. Implementations
+// wrap the runtime rest.Config the serve process already resolves from
+// KRO_KUBECONFIG / in-cluster.
+type Runtime interface {
+	// Host is the runtime API server base URL (scheme://host[:port]).
+	Host() string
+	// Transport authenticates to the runtime API server (client cert / token +
+	// CA from the runtime kubeconfig).
+	Transport() (http.RoundTripper, error)
+	// ControlToken reads the "token" key of the named Secret in the runtime
+	// cluster. Used to mint the X-Sandbox-Control-Token header the runner's
+	// control sidecar expects.
+	ControlToken(ctx context.Context, namespace, name string) (string, error)
+}
+
+// controlTokenHeader is the header the sandbox runner's control sidecar checks.
+// Kept identical to App Studio's today so the runner image is unchanged.
+const controlTokenHeader = "X-Sandbox-Control-Token"
+
+// serveProxy reverse-proxies the request to the resolved runtime Service via
+// the runtime API server's services/proxy subresource. callerPath is the
+// remaining path the caller addressed beyond the verb (only meaningful for an
+// open proxy verb like "proxy"; the control verbs carry a fixed UpstreamPath
+// and an empty callerPath).
+//
+// httputil.ReverseProxy handles both plain requests and connection upgrades
+// (WebSocket / SPDY) when the upstream answers 101, so a single path covers
+// preview WebSockets and log streaming alike; FlushInterval=-1 disables
+// response buffering for streamed/upgraded responses.
+func serveProxy(w http.ResponseWriter, r *http.Request, rt Runtime, target ResolvedTarget, callerPath string) {
+	transport, err := rt.Transport()
+	if err != nil {
+		http.Error(w, "runtime transport unavailable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	base, err := url.Parse(rt.Host())
+	if err != nil {
+		http.Error(w, "invalid runtime host: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	var token string
+	if target.TokenSecretName != "" {
+		token, err = rt.ControlToken(r.Context(), target.TokenSecretNamespace, target.TokenSecretName)
+		if err != nil {
+			http.Error(w, "control token unavailable: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+	}
+
+	upstreamPath := serviceProxyPath(target, callerPath)
+
+	// Buffer plain responses; disable buffering for streamed or upgraded ones so
+	// log follow and preview WebSockets flush immediately.
+	flush := time.Duration(0)
+	if target.Stream || target.Upgrade {
+		flush = -1
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Transport:     transport,
+		FlushInterval: flush,
+		Director: func(req *http.Request) {
+			req.URL.Scheme = base.Scheme
+			req.URL.Host = base.Host
+			req.URL.Path = upstreamPath
+			req.Host = base.Host
+			// The runtime credential is supplied by Transport; never forward the
+			// caller's bearer token to the runtime cluster.
+			req.Header.Del("Authorization")
+			if token != "" {
+				req.Header.Set(controlTokenHeader, token)
+			} else {
+				// Defense in depth: a caller cannot smuggle its own control token.
+				req.Header.Del(controlTokenHeader)
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			http.Error(w, "runtime proxy error: "+err.Error(), http.StatusBadGateway)
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// serviceProxyPath composes the runtime API path that reverse-proxies to the
+// target Service's named port:
+//
+//	/api/v1/namespaces/<ns>/services/<name>:<port>/proxy<upstream><caller>
+func serviceProxyPath(target ResolvedTarget, callerPath string) string {
+	svc := fmt.Sprintf("%s:%s", target.ServiceName, target.ServicePort)
+	base := fmt.Sprintf("/api/v1/namespaces/%s/services/%s/proxy", target.ServiceNamespace, svc)
+	tail := joinPaths(target.UpstreamPath, callerPath)
+	if tail == "" || tail == "/" {
+		// services/proxy requires a trailing slash to hit the service root.
+		return base + "/"
+	}
+	return base + tail
+}
+
+// joinPaths joins the configured upstream path with the caller-supplied tail,
+// preserving a single leading slash and avoiding duplicate separators. Returns
+// "/" when both are effectively empty.
+func joinPaths(upstream, caller string) string {
+	upstream = strings.TrimSpace(upstream)
+	caller = strings.TrimSpace(strings.TrimPrefix(caller, "/"))
+	switch {
+	case upstream == "" && caller == "":
+		return "/"
+	case caller == "":
+		return ensureLeadingSlash(upstream)
+	case upstream == "" || upstream == "/":
+		return "/" + caller
+	default:
+		joined := path.Join(upstream, caller)
+		return ensureLeadingSlash(joined)
+	}
+}
+
+func ensureLeadingSlash(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
+}

--- a/providers/infrastructure/dataplane/resolver_test.go
+++ b/providers/infrastructure/dataplane/resolver_test.go
@@ -191,7 +191,7 @@ func TestMethodAllowed(t *testing.T) {
 		{"sync", http.MethodPost, true},
 		{"sync", http.MethodGet, false},
 		{"proxy", http.MethodHead, true},
-		{"status", http.MethodGet, true},  // FromStatus, empty Methods => GET
+		{"status", http.MethodGet, true}, // FromStatus, empty Methods => GET
 		{"status", http.MethodPost, false},
 		{"unknown", http.MethodGet, false},
 	} {

--- a/providers/infrastructure/dataplane/runtime.go
+++ b/providers/infrastructure/dataplane/runtime.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// restRuntime is the production Runtime: it wraps the runtime cluster's
+// rest.Config (resolved from KRO_KUBECONFIG / in-cluster) and a clientset for
+// reading the per-instance control-token Secret. It is the single holder of a
+// runtime-cluster credential in the request path.
+type restRuntime struct {
+	config *rest.Config
+	client kubernetes.Interface
+}
+
+// NewRuntime builds a Runtime from the runtime cluster config. Returns nil when
+// config is nil, which the handler reports as "data plane unavailable".
+func NewRuntime(config *rest.Config) (Runtime, error) {
+	if config == nil {
+		return nil, nil
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("runtime clientset: %w", err)
+	}
+	return &restRuntime{config: config, client: client}, nil
+}
+
+func (r *restRuntime) Host() string {
+	return strings.TrimRight(r.config.Host, "/")
+}
+
+func (r *restRuntime) Transport() (http.RoundTripper, error) {
+	return rest.TransportFor(r.config)
+}
+
+func (r *restRuntime) ControlToken(ctx context.Context, namespace, name string) (string, error) {
+	secret, err := r.client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("read control secret %s/%s: %w", namespace, name, err)
+	}
+	token := strings.TrimSpace(string(secret.Data["token"]))
+	if token == "" {
+		return "", fmt.Errorf("control secret %s/%s has no token", namespace, name)
+	}
+	return token, nil
+}

--- a/providers/infrastructure/main.go
+++ b/providers/infrastructure/main.go
@@ -145,8 +145,17 @@ func serveWithConfig(ctx context.Context, kcpConfig *rest.Config) {
 		log.Fatalf("portal embed: %v", err)
 	}
 
+	// Data-plane subresource proxy (logs/sync/restart/preview proxy/status).
+	// nil in REST-only/dev (no kcp or runtime cluster); the handler then reports
+	// 503 so the route exists but is clearly unavailable.
+	var dataPlaneHandler http.Handler
+	if h := buildDataPlaneHandler(kcpConfig); h != nil {
+		dataPlaneHandler = h
+	}
+
 	srv := server.New(server.Deps{
 		MCP:              mcpHandler,
+		DataPlane:        dataPlaneHandler,
 		PortalFileServer: fileServer,
 		PortalFS:         distFS,
 		ServePortalAsset: servePortalAsset,

--- a/providers/infrastructure/serve_dataplane.go
+++ b/providers/infrastructure/serve_dataplane.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/faroshq/provider-infrastructure/dataplane"
+	"github.com/faroshq/provider-infrastructure/tenant"
+)
+
+// instanceGroupVersion is the group/version of every per-template instance CRD;
+// the resource (plural) comes from the request path.
+var instanceGroupVersion = schema.GroupVersion{Group: "infrastructure.kedge.faros.sh", Version: "v1alpha1"}
+
+// buildDataPlaneHandler wires the data-plane subresource handler for serve.
+// Returns nil (the handler then reports 503) when the provider has no kcp config
+// or no runtime cluster — the dev/REST-only flow.
+//
+//   - InstanceGetter authorizes + fetches the instance AS THE CALLER via the
+//     tenant client factory (caller RBAC is the access gate).
+//   - ContractGetter reads Templates with the provider's own kcp client
+//     (platform-owned, cluster-scoped) to find the dataPlane contract.
+//   - Runtime holds the only runtime-cluster credential in the request path.
+func buildDataPlaneHandler(kcpConfig *rest.Config) *dataplane.Handler {
+	if kcpConfig == nil {
+		log.Printf("data plane: disabled (no kcp config)")
+		return nil
+	}
+
+	providerDyn, err := dynamic.NewForConfig(kcpConfig)
+	if err != nil {
+		log.Printf("data plane: disabled (provider dynamic client: %v)", err)
+		return nil
+	}
+
+	runtimeCfg, src := loadDataPlaneRuntimeConfig()
+	runtime, err := dataplane.NewRuntime(runtimeCfg)
+	if err != nil {
+		log.Printf("data plane: disabled (runtime client: %v)", err)
+		return nil
+	}
+	if runtime == nil {
+		log.Printf("data plane: disabled (no runtime cluster config: KRO_KUBECONFIG unset, not in a pod)")
+		return nil
+	}
+
+	log.Printf("data plane: enabled (runtime cluster: %s)", src)
+	return dataplane.NewHandler(
+		&tenantInstanceGetter{factory: tenant.NewClientFactory(kcpConfig)},
+		dataplane.NewTemplateContractGetter(providerDyn),
+		runtime,
+	)
+}
+
+// loadDataPlaneRuntimeConfig resolves the cluster where workloads run, matching
+// the controller manager's kro runtime resolution: explicit KRO_KUBECONFIG,
+// else the pod's in-cluster config. Returns (nil, "") when neither is present.
+func loadDataPlaneRuntimeConfig() (*rest.Config, string) {
+	if p := os.Getenv("KRO_KUBECONFIG"); p != "" {
+		cfg, err := clientcmd.BuildConfigFromFlags("", p)
+		if err != nil {
+			log.Printf("data plane: KRO_KUBECONFIG set but unloadable: %v", err)
+			return nil, ""
+		}
+		return cfg, "KRO_KUBECONFIG=" + p
+	}
+	if cfg, err := rest.InClusterConfig(); err == nil {
+		return cfg, "in-cluster"
+	}
+	return nil, ""
+}
+
+// tenantInstanceGetter authorizes and fetches a workload instance as the caller.
+// The instance CRs are cluster-scoped in the tenant's kcp workspace, so the GET
+// is namespaceless. A 403/404 from the caller's RBAC is the data-plane gate.
+type tenantInstanceGetter struct {
+	factory *tenant.ClientFactory
+}
+
+func (g *tenantInstanceGetter) Get(ctx context.Context, workspace, token, resource, name string) (*unstructured.Unstructured, error) {
+	dyn, err := g.factory.For(workspace, token)
+	if err != nil {
+		return nil, err
+	}
+	gvr := instanceGroupVersion.WithResource(resource)
+	return dyn.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+}

--- a/providers/infrastructure/server/server.go
+++ b/providers/infrastructure/server/server.go
@@ -31,6 +31,7 @@ type AssetServer func(w http.ResponseWriter, r *http.Request, distFS fs.FS, name
 // in the smoke test only.
 type Deps struct {
 	MCP              http.Handler // /mcp + /mcp/sse handler; may be nil
+	DataPlane        http.Handler // /dataplane/* subresource proxy; may be nil
 	PortalFileServer http.Handler
 	PortalFS         fs.FS
 	ServePortalAsset AssetServer
@@ -63,6 +64,14 @@ func New(d Deps) *Server {
 		// streamable-HTTP handler dispatches on method internally.
 		s.mux.Handle("/mcp", d.MCP)
 		s.mux.Handle("/mcp/sse", d.MCP)
+	}
+
+	// Data-plane subresource proxy: /dataplane/clusters/<ws>/<resource>/<name>/<verb>.
+	// Reached via the hub backend proxy at
+	// /services/providers/infrastructure/dataplane/... — see the dataplane
+	// package and docs/app-studio-runtime-decoupling.md.
+	if d.DataPlane != nil {
+		s.mux.Handle("/dataplane/", d.DataPlane)
 	}
 
 	// Portal fallback — last so all explicit routes above take


### PR DESCRIPTION
**Corrective re-land of Phase 1.** #364 was merged before GitHub retargeted it from the Phase 0 branch to `main`, so it landed Phase 1 onto `feat/infra-dataplane-contract` (a dead-end branch) instead of `main` — Phase 1 never reached `main`. The original phase branches were also forked from a pre-#360/#362 `main`, so merging them now would additionally revert those PRs.

This branch is the **Phase 1 commit cleanly cherry-picked onto current `main`**. Diff is Phase-1-only (no #360/#362 reverts).

Content is identical to #364 — the data-plane subresource proxy handler:
- `dataplane/{handler,proxy,contract,runtime,identity}.go` + wiring in `serve_dataplane.go`, `server/server.go`, `main.go`.
- Serves `/dataplane/clusters/<ws>/<resource>/<name>/<verb>` behind the hub backend proxy; authorizes as the caller (tenant-scoped GET on the instance), resolves the Phase 0 contract, reverse-proxies to the runtime cluster injecting `X-Sandbox-Control-Token` and stripping the caller's Authorization; `status` served from the CR.
- Unit-tested with fakes + httptest runtime backend (`go test ./dataplane/...` green).

See #364 for the full Phase 1 discussion. Builds on Phase 0 (#363, already in `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
