### PR TITLE
feat(app-studio): drop runtime kubeconfig; call infra data-plane (Phase 3)

### DIFF
--- a/docs/app-studio-runtime-decoupling.md
+++ b/docs/app-studio-runtime-decoupling.md
@@ -131,7 +131,7 @@ POST …/sandboxrunners/{name}/restart
 
 Today the runtime-cluster client lives in the kro backend / operator. The data-plane handler runs in the provider **serve** process, which already gets the runtime kubeconfig mounted (the operator wires it). Add the runtime client to the server `Deps` so the handler can read the control Secret and reach the service-proxy. No new credential is introduced — it is the credential the provider already owns.
 
-## 5. App Studio after cutover
+## 5. App Studio after cutover — **DONE (Phase 3)**
 
 - **Delete** `runtimeConfig` / `runtimeClient` / `runtimeDynamic`, `loadRuntimeConfig`, `APP_STUDIO_RUNTIME_KUBECONFIG`, and the `runtimeKubeconfig` chart wiring.
 - **Rewrite** `api/development_runtime.go` / `api/development_sync.go` handlers to call the VW subresources as the tenant user (forwarding the caller's bearer token over App Studio's existing tenant kcp client) instead of the runtime cluster.

--- a/docs/app-studio-sandbox-runtime.md
+++ b/docs/app-studio-sandbox-runtime.md
@@ -38,24 +38,19 @@ Known limitations:
 Before promoting this beyond local/dev use, add explicit runtime isolation,
 quota defaults, image provenance controls, and network policy hardening.
 
-## Runtime kubeconfig RBAC
+## Runtime data plane (no App Studio runtime kubeconfig)
 
-`APP_STUDIO_RUNTIME_KUBECONFIG` must be scoped to only the runtime data-plane
-operations App Studio performs after validating deterministic `SandboxRunner`
-refs. The credential should not be cluster-admin. A minimal role needs:
-
-```yaml
-rules:
-  - apiGroups: [""]
-    resources: ["secrets", "endpoints"]
-    verbs: ["get"]
-  - apiGroups: [""]
-    resources: ["services/proxy"]
-    verbs: ["get", "create"]
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["delete"]
-```
+App Studio no longer holds a kubeconfig to the runtime cluster. The live
+data-plane operations (sync, restart, logs, preview readiness) are served by the
+**infrastructure provider** as subresources on the `SandboxRunner` instance —
+the provider owns the runtime-cluster credential and the control-token
+injection. App Studio calls those subresources through the hub as the requesting
+user, who is authorized by their own RBAC on the instance. The runtime namespace
+is garbage-collected by the kro template when the `SandboxRunner` instance is
+deleted, and the preview `ReferenceGrant` is materialized by that template too.
+See [`app-studio-runtime-decoupling.md`](./app-studio-runtime-decoupling.md) for
+the full design (including BYO compute, where a workspace can be backed by a
+different infrastructure provider / runtime cluster).
 
 ## Capability Boundary
 

--- a/providers/app-studio/README.md
+++ b/providers/app-studio/README.md
@@ -52,7 +52,6 @@ Environment variables consumed by the binary:
 | `KEDGE_HUB_TOKEN` | Bearer token for the heartbeat |
 | `KEDGE_PROVIDER_NAME` | CatalogEntry name (default `app-studio`) |
 | `KEDGE_PROVIDER_KUBECONFIG` | Provider kubeconfig (kcp front-proxy host + TLS only) |
-| `APP_STUDIO_RUNTIME_KUBECONFIG` | Kubernetes kubeconfig for the runtime cluster that runs `SandboxRunner` pods |
 | `APP_STUDIO_SANDBOX_RUNNER_IMAGE` | Runner image passed to new `SandboxRunner` resources; use an immutable digest outside local development |
 | `APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE` | kubectl-capable token-generator image passed to new `SandboxRunner` resources; use an immutable digest outside local development |
 | `APP_STUDIO_PREVIEW_BASE_DOMAIN` | Optional DNS zone for companion Sandbox preview routing. |
@@ -112,9 +111,11 @@ preview URLs by minting signed, host-based URLs from the companion
 
 Infrastructure owns the resource composition: the `sandbox-runner` Template uses
 KRO to create the runtime namespace, PVC, Deployment, Service, control Secret,
-and network policy. App Studio uses `APP_STUDIO_RUNTIME_KUBECONFIG` only for
-runtime data-plane calls after validating that `SandboxRunner` status refs still
-point at the deterministic runner-owned namespace, Service, and Secret.
+and network policy. App Studio holds **no** kubeconfig to the runtime cluster:
+the live data plane (logs, file sync, restart, preview readiness) is served by
+the infrastructure provider as subresources on the `SandboxRunner` instance,
+which App Studio calls through the hub as the requesting user. See
+[`docs/app-studio-runtime-decoupling.md`](../../docs/app-studio-runtime-decoupling.md).
 
 When `APP_STUDIO_PREVIEW_BASE_DOMAIN` is set, App Studio also creates a
 `SandboxPreviewHTTPRoute` infrastructure resource beside each `SandboxRunner`.

--- a/providers/app-studio/api/dataplane_client.go
+++ b/providers/app-studio/api/dataplane_client.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// App Studio no longer holds a kubeconfig to the runtime cluster. The live
+// development data plane (logs, file sync, restart, preview readiness) is now
+// served by the infrastructure provider as subresources on the SandboxRunner
+// instance, reached through the hub backend proxy:
+//
+//	{hub}/services/providers/infrastructure/dataplane/clusters/{cluster}/sandboxrunners/{name}/{verb}
+//
+// The caller's bearer token is forwarded as-is; the infra provider authorizes
+// the request as that caller (a tenant-scoped GET on the instance) and owns the
+// runtime-cluster credential. See docs/app-studio-runtime-decoupling.md.
+const (
+	infraDataPlaneProvider = "infrastructure"
+	sandboxRunnersResource = "sandboxrunners"
+
+	dataPlaneVerbLog     = "log"
+	dataPlaneVerbSync    = "sync"
+	dataPlaneVerbRestart = "restart"
+	dataPlaneVerbProxy   = "proxy"
+
+	dataPlaneCallTimeout = 30 * time.Second
+)
+
+// sandboxDataPlaneURL composes the hub URL for a SandboxRunner data-plane verb.
+// tail (with leading slash) is appended after the verb — used only by the open
+// "proxy" verb; the control verbs leave it empty.
+func (s *Server) sandboxDataPlaneURL(clusterID, runnerName, verb, tail string) string {
+	u := strings.TrimRight(s.hubBase, "/") +
+		fmt.Sprintf("/services/providers/%s/dataplane/clusters/%s/%s/%s/%s",
+			infraDataPlaneProvider, clusterID, sandboxRunnersResource, runnerName, verb)
+	if tail != "" {
+		u += tail
+	}
+	return u
+}
+
+// newSandboxDataPlaneRequest builds a data-plane request authenticated as the
+// caller (the same bearer token the caller authenticated to App Studio with).
+func (s *Server) newSandboxDataPlaneRequest(ctx context.Context, method string, id identity, runnerName, verb, tail string, body io.Reader) (*http.Request, error) {
+	if strings.TrimSpace(s.hubBase) == "" {
+		return nil, fmt.Errorf("hub URL is not configured; cannot reach the infrastructure data plane")
+	}
+	if strings.TrimSpace(id.clusterID) == "" {
+		return nil, fmt.Errorf("no workspace cluster on request; cannot address the sandbox runner")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, s.sandboxDataPlaneURL(id.clusterID, runnerName, verb, tail), body)
+	if err != nil {
+		return nil, err
+	}
+	if token := strings.TrimSpace(id.token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req, nil
+}
+
+// sandboxDataPlaneClient returns an HTTP client for data-plane calls, honoring
+// the same TLS-skip knob the MCP client uses for hub-internal addressing.
+func (s *Server) sandboxDataPlaneClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout, Transport: projectMCPTransport(s.mcpInsecureSkipTLSVerify)}
+}
+
+// sandboxDataPlanePost sends a POST verb (sync, restart) and returns the body +
+// status code. The caller maps non-2xx to an error so the runner's own response
+// surfaces to the UI.
+func (s *Server) sandboxDataPlanePost(ctx context.Context, id identity, runnerName, verb string, payload []byte) ([]byte, int, error) {
+	callCtx, cancel := context.WithTimeout(ctx, dataPlaneCallTimeout)
+	defer cancel()
+	req, err := s.newSandboxDataPlaneRequest(callCtx, http.MethodPost, id, runnerName, verb, "", strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.sandboxDataPlaneClient(dataPlaneCallTimeout).Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("sandbox data plane %s: %w", verb, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return body, resp.StatusCode, nil
+}
+
+// sandboxDataPlaneStream proxies a streaming GET verb (logs) straight to w,
+// copying the upstream status and content type.
+func (s *Server) sandboxDataPlaneStream(ctx context.Context, id identity, runnerName, verb string, w http.ResponseWriter) error {
+	req, err := s.newSandboxDataPlaneRequest(ctx, http.MethodGet, id, runnerName, verb, "", nil)
+	if err != nil {
+		return err
+	}
+	// No client timeout: log streams are long-lived; ctx cancellation (request
+	// close) ends them.
+	resp, err := s.sandboxDataPlaneClient(0).Do(req)
+	if err != nil {
+		return fmt.Errorf("sandbox data plane %s: %w", verb, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	}
+	w.WriteHeader(resp.StatusCode)
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 32<<10)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				return writeErr
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+// sandboxDataPlaneProbe performs a GET against the open proxy verb (path tail)
+// and returns the upstream status + a bounded body, for preview readiness.
+func (s *Server) sandboxDataPlaneProbe(ctx context.Context, id identity, runnerName, tail string) (int, []byte, error) {
+	callCtx, cancel := context.WithTimeout(ctx, previewReadinessProbeTimeout)
+	defer cancel()
+	req, err := s.newSandboxDataPlaneRequest(callCtx, http.MethodGet, id, runnerName, dataPlaneVerbProxy, tail, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := s.sandboxDataPlaneClient(previewReadinessProbeTimeout).Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, body, nil
+}

--- a/providers/app-studio/api/dataplane_client_test.go
+++ b/providers/app-studio/api/dataplane_client_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestSandboxDataPlaneURL(t *testing.T) {
+	s := &Server{hubBase: "https://hub.example/"}
+	got := s.sandboxDataPlaneURL("root:kedge:orgs:acme", "kedge-sandbox-abc", dataPlaneVerbLog, "")
+	want := "https://hub.example/services/providers/infrastructure/dataplane/clusters/root:kedge:orgs:acme/sandboxrunners/kedge-sandbox-abc/log"
+	if got != want {
+		t.Fatalf("sandboxDataPlaneURL = %q, want %q", got, want)
+	}
+	// The open proxy verb appends the caller tail after the verb.
+	gotProxy := s.sandboxDataPlaneURL("c1", "r1", dataPlaneVerbProxy, "/assets/app.js")
+	wantProxy := "https://hub.example/services/providers/infrastructure/dataplane/clusters/c1/sandboxrunners/r1/proxy/assets/app.js"
+	if gotProxy != wantProxy {
+		t.Fatalf("proxy URL = %q, want %q", gotProxy, wantProxy)
+	}
+}
+
+func TestNewSandboxDataPlaneRequestRequiresHubAndCluster(t *testing.T) {
+	id := identity{clusterID: "c1", token: "tok"}
+	// No hub base configured.
+	if _, err := (&Server{}).newSandboxDataPlaneRequest(context.Background(), http.MethodGet, id, "r1", dataPlaneVerbLog, "", nil); err == nil {
+		t.Fatal("expected error when hubBase is unset")
+	}
+	// No cluster on the request.
+	s := &Server{hubBase: "https://hub.example"}
+	if _, err := s.newSandboxDataPlaneRequest(context.Background(), http.MethodGet, identity{token: "tok"}, "r1", dataPlaneVerbLog, "", nil); err == nil {
+		t.Fatal("expected error when clusterID is empty")
+	}
+	// Happy path forwards the caller's bearer token.
+	req, err := s.newSandboxDataPlaneRequest(context.Background(), http.MethodGet, id, "r1", dataPlaneVerbLog, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("Authorization = %q, want Bearer tok", got)
+	}
+}

--- a/providers/app-studio/api/development_environment_test.go
+++ b/providers/app-studio/api/development_environment_test.go
@@ -21,15 +21,12 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
-	kubernetesfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 	asclient "github.com/faroshq/provider-app-studio/client"
@@ -409,16 +406,49 @@ func TestProjectAssistantPreviewRefreshNeededUsesSuccessfulMutatingToolCalls(t *
 	}
 }
 
-func TestSyncProjectDevelopmentTargetPostsWorkspaceFilesToRuntime(t *testing.T) {
-	var gotControlToken string
-	var gotFiles []map[string]string
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", token: "caller-token"}
-	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
-	runtimeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.URL.Path, "/api/v1/namespaces/"+runnerName+"/services/"+runnerName+"-control:control/proxy/sync"; got != want {
-			t.Fatalf("path = %q, want %q", got, want)
+// newSandboxDataPlaneHub stands up a fake hub backend-proxy endpoint for the
+// infrastructure provider's SandboxRunner data plane. The handler is invoked
+// with the verb parsed from the path (.../sandboxrunners/<name>/<verb>[/tail]).
+// Returns the base URL to set as the server's hubBase.
+func newSandboxDataPlaneHub(t *testing.T, handler func(verb string, w http.ResponseWriter, r *http.Request)) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		verb := ""
+		for i, p := range parts {
+			if p == sandboxRunnersResource && i+2 < len(parts) {
+				verb = parts[i+2]
+				break
+			}
 		}
-		gotControlToken = r.Header.Get("X-Sandbox-Control-Token")
+		handler(verb, w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// readyDataPlaneHub returns a hub whose proxy verb answers 200 (preview ready).
+func readyDataPlaneHub(t *testing.T) string {
+	return newSandboxDataPlaneHub(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// notFoundDataPlaneHub returns a hub whose proxy verb answers 404 (no service).
+func notFoundDataPlaneHub(t *testing.T) string {
+	return newSandboxDataPlaneHub(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+}
+
+func TestSyncProjectDevelopmentTargetPostsWorkspaceFilesToRuntime(t *testing.T) {
+	var gotVerb, gotAuth string
+	var gotFiles []map[string]string
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", clusterID: "cluster-a", token: "caller-token"}
+	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
+	hub := newSandboxDataPlaneHub(t, func(verb string, w http.ResponseWriter, r *http.Request) {
+		gotVerb = verb
+		gotAuth = r.Header.Get("Authorization")
 		var body struct {
 			Files   []map[string]string `json:"files"`
 			Restart string              `json:"restart"`
@@ -431,8 +461,7 @@ func TestSyncProjectDevelopmentTargetPostsWorkspaceFilesToRuntime(t *testing.T) 
 		}
 		gotFiles = body.Files
 		fmt.Fprint(w, `{"phase":"Synced","changed":["src/App.tsx"]}`)
-	}))
-	defer runtimeAPI.Close()
+	})
 
 	workspaces := workspace.NewFileStore(t.TempDir())
 	project := &aiv1alpha1.Project{
@@ -447,9 +476,7 @@ func TestSyncProjectDevelopmentTargetPostsWorkspaceFilesToRuntime(t *testing.T) 
 	}
 
 	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), testSandboxRunner(runnerName, project.Name)))
-	server := NewWithWorkspace(nil, nil, workspaces, "http://hub.example", false)
-	server.runtimeConfig = &rest.Config{Host: runtimeAPI.URL}
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testRuntimeControlSecret(runnerName, "runtime-token"))
+	server := NewWithWorkspace(nil, nil, workspaces, hub, false)
 	target, ok := projectDevelopmentSyncTarget(project, id)
 	if !ok {
 		t.Fatal("projectDevelopmentSyncTarget returned !ok")
@@ -458,8 +485,11 @@ func TestSyncProjectDevelopmentTargetPostsWorkspaceFilesToRuntime(t *testing.T) 
 	if err != nil {
 		t.Fatalf("syncProjectDevelopmentTarget returned error: %v", err)
 	}
-	if got, want := gotControlToken, "runtime-token"; got != want {
-		t.Fatalf("X-Sandbox-Control-Token = %q, want %q", got, want)
+	if gotVerb != dataPlaneVerbSync {
+		t.Fatalf("data-plane verb = %q, want %q", gotVerb, dataPlaneVerbSync)
+	}
+	if gotAuth != "Bearer caller-token" {
+		t.Fatalf("forwarded Authorization = %q, want the caller's bearer token", gotAuth)
 	}
 	if len(gotFiles) != 1 || gotFiles[0]["path"] != "src/App.tsx" || gotFiles[0]["content"] != "hello\n" {
 		t.Fatalf("files = %#v, want src/App.tsx content", gotFiles)
@@ -481,7 +511,7 @@ func TestSyncProjectDevelopmentTargetPostsWorkspaceFilesToRuntime(t *testing.T) 
 
 func TestAuthorizeProjectDevelopmentPreviewTargetGetsSignedHTTPRouteHostURL(t *testing.T) {
 	setPreviewHTTPRouteEnv(t)
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", clusterID: "cluster-a", user: "user@example.com", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
 	project := &aiv1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
@@ -493,9 +523,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetGetsSignedHTTPRouteHostURL(t *t
 		runtime.NewScheme(),
 		testSandboxRunnerWithPreviewRoute(runnerName, project.Name, "https://"+runnerName+".preview.example.com/"),
 	))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
-	server.runtimeDynamic = fake.NewSimpleDynamicClient(runtime.NewScheme())
+	server := NewWithWorkspace(nil, nil, nil, readyDataPlaneHub(t), false)
 	server.previewSigner = previewtoken.NewSigner([]byte("test-secret"))
 	got, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
 	if err != nil {
@@ -557,121 +585,10 @@ func TestAuthorizeProjectDevelopmentPreviewTargetGetsSignedHTTPRouteHostURL(t *t
 	}
 }
 
-func TestAuthorizeProjectDevelopmentPreviewTargetEnsuresBackendReferenceGrant(t *testing.T) {
-	setPreviewHTTPRouteEnv(t)
-	ctx := context.Background()
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com", token: "caller-token"}
-	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
-	project := &aiv1alpha1.Project{
-		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
-		Spec: aiv1alpha1.ProjectSpec{
-			Environments: []aiv1alpha1.ProjectEnvironmentSpec{defaultProjectDevelopmentEnvironment("todo")},
-		},
-	}
-	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(
-		runtime.NewScheme(),
-		testSandboxRunnerWithPreviewRoute(runnerName, project.Name, "https://"+runnerName+".preview.example.com/"),
-	))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
-	server.runtimeDynamic = fake.NewSimpleDynamicClient(runtime.NewScheme())
-	server.previewSigner = previewtoken.NewSigner([]byte("test-secret"))
-
-	got, err := server.authorizeProjectDevelopmentPreviewTarget(ctx, client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
-	if err != nil {
-		t.Fatalf("authorizeProjectDevelopmentPreviewTarget returned error: %v", err)
-	}
-	if !got.Ready {
-		t.Fatalf("ready = false, want true: %#v", got)
-	}
-	grant, err := server.runtimeDynamic.Resource(gatewayReferenceGrantGVR).Namespace("preview-system").Get(ctx, runnerName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get ReferenceGrant: %v", err)
-	}
-	from := mustNestedSlice(t, grant.Object, "spec", "from")
-	if len(from) != 1 {
-		t.Fatalf("ReferenceGrant from entries = %d, want 1", len(from))
-	}
-	fromEntry, ok := from[0].(map[string]any)
-	if !ok {
-		t.Fatalf("ReferenceGrant from entry type = %T, want map[string]any", from[0])
-	}
-	if got, want := fromEntry["group"], "gateway.networking.k8s.io"; got != want {
-		t.Fatalf("ReferenceGrant from.group = %q, want %q", got, want)
-	}
-	if got, want := fromEntry["kind"], "HTTPRoute"; got != want {
-		t.Fatalf("ReferenceGrant from.kind = %q, want %q", got, want)
-	}
-	if got, want := fromEntry["namespace"], "default"; got != want {
-		t.Fatalf("ReferenceGrant from.namespace = %q, want %q", got, want)
-	}
-	to := mustNestedSlice(t, grant.Object, "spec", "to")
-	if len(to) != 1 {
-		t.Fatalf("ReferenceGrant to entries = %d, want 1", len(to))
-	}
-	toEntry, ok := to[0].(map[string]any)
-	if !ok {
-		t.Fatalf("ReferenceGrant to entry type = %T, want map[string]any", to[0])
-	}
-	if got, want := toEntry["group"], ""; got != want {
-		t.Fatalf("ReferenceGrant to.group = %q, want empty core group", got)
-	}
-	if got, want := toEntry["kind"], "Service"; got != want {
-		t.Fatalf("ReferenceGrant to.kind = %q, want %q", got, want)
-	}
-	if got, want := toEntry["name"], "preview-gateway"; got != want {
-		t.Fatalf("ReferenceGrant to.name = %q, want %q", got, want)
-	}
-}
-
-func TestAuthorizeProjectDevelopmentPreviewTargetAllowsKROPrefixedHTTPRouteNamespace(t *testing.T) {
-	setPreviewHTTPRouteEnv(t)
-	ctx := context.Background()
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com", token: "caller-token"}
-	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
-	clusterID := "5n0g2q17plwnurrz"
-	project := &aiv1alpha1.Project{
-		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
-		Spec: aiv1alpha1.ProjectSpec{
-			Environments: []aiv1alpha1.ProjectEnvironmentSpec{defaultProjectDevelopmentEnvironment("todo")},
-		},
-	}
-	runner := testSandboxRunnerWithPreviewRoute(runnerName, project.Name, "https://"+runnerName+".preview.example.com/")
-	runner.SetAnnotations(map[string]string{kcpClusterAnnotation: clusterID})
-	if err := unstructured.SetNestedField(runner.Object, clusterID+"-default", "status", "previewRoute", "httpRouteRef", "namespace"); err != nil {
-		t.Fatalf("set prefixed route namespace: %v", err)
-	}
-	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), runner))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
-	server.runtimeDynamic = fake.NewSimpleDynamicClient(runtime.NewScheme())
-	server.previewSigner = previewtoken.NewSigner([]byte("test-secret"))
-
-	got, err := server.authorizeProjectDevelopmentPreviewTarget(ctx, client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
-	if err != nil {
-		t.Fatalf("authorizeProjectDevelopmentPreviewTarget returned error: %v", err)
-	}
-	if !got.Ready {
-		t.Fatalf("ready = false, want true: %#v", got)
-	}
-	grant, err := server.runtimeDynamic.Resource(gatewayReferenceGrantGVR).Namespace("preview-system").Get(ctx, runnerName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get ReferenceGrant: %v", err)
-	}
-	from := mustNestedSlice(t, grant.Object, "spec", "from")
-	fromEntry, ok := from[0].(map[string]any)
-	if !ok {
-		t.Fatalf("ReferenceGrant from entry type = %T, want map[string]any", from[0])
-	}
-	if got, want := fromEntry["namespace"], clusterID+"-default"; got != want {
-		t.Fatalf("ReferenceGrant from.namespace = %q, want %q", got, want)
-	}
-}
-
 func TestAuthorizeProjectDevelopmentPreviewTargetAddsConfiguredPublicPort(t *testing.T) {
 	setPreviewHTTPRouteEnv(t)
 	t.Setenv("APP_STUDIO_PREVIEW_PUBLIC_PORT", "10443")
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", user: "user@example.com", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1", clusterID: "cluster-a", user: "user@example.com", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
 	project := &aiv1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
@@ -683,9 +600,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetAddsConfiguredPublicPort(t *tes
 		runtime.NewScheme(),
 		testSandboxRunnerWithPreviewRoute(runnerName, project.Name, "https://"+runnerName+".preview.example.com/"),
 	))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
-	server.runtimeDynamic = fake.NewSimpleDynamicClient(runtime.NewScheme())
+	server := NewWithWorkspace(nil, nil, nil, readyDataPlaneHub(t), false)
 	server.previewSigner = previewtoken.NewSigner([]byte("test-secret"))
 
 	got, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
@@ -710,7 +625,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetAddsConfiguredPublicPort(t *tes
 
 func TestAuthorizeProjectDevelopmentPreviewTargetRejectsForgedSandboxRunnerPreviewRouteHost(t *testing.T) {
 	setPreviewHTTPRouteEnv(t)
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", clusterID: "cluster-a", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
 	project := &aiv1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
@@ -722,9 +637,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetRejectsForgedSandboxRunnerPrevi
 		runtime.NewScheme(),
 		testSandboxRunnerWithPreviewRoute(runnerName, project.Name, "https://evil.example.net/"),
 	))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
-	server.runtimeDynamic = fake.NewSimpleDynamicClient(runtime.NewScheme())
+	server := NewWithWorkspace(nil, nil, nil, readyDataPlaneHub(t), false)
 	server.previewSigner = previewtoken.NewSigner([]byte("test-secret"))
 
 	if _, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName}); err == nil || !strings.Contains(err.Error(), "does not match expected host") {
@@ -734,7 +647,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetRejectsForgedSandboxRunnerPrevi
 
 func TestAuthorizeProjectDevelopmentPreviewTargetRejectsForgedSandboxRunnerPreviewRouteNamespace(t *testing.T) {
 	setPreviewHTTPRouteEnv(t)
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", clusterID: "cluster-a", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
 	project := &aiv1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
@@ -747,9 +660,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetRejectsForgedSandboxRunnerPrevi
 		t.Fatalf("set forged route namespace: %v", err)
 	}
 	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), runner))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
-	server.runtimeDynamic = fake.NewSimpleDynamicClient(runtime.NewScheme())
+	server := NewWithWorkspace(nil, nil, nil, readyDataPlaneHub(t), false)
 	server.previewSigner = previewtoken.NewSigner([]byte("test-secret"))
 
 	if _, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName}); err == nil || !strings.Contains(err.Error(), "does not match expected namespace") {
@@ -759,7 +670,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetRejectsForgedSandboxRunnerPrevi
 
 func TestAuthorizeProjectDevelopmentPreviewTargetRequiresSandboxRunnerPreviewRouteURL(t *testing.T) {
 	setPreviewHTTPRouteEnv(t)
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", clusterID: "cluster-a", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
 	project := &aiv1alpha1.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
@@ -771,8 +682,7 @@ func TestAuthorizeProjectDevelopmentPreviewTargetRequiresSandboxRunnerPreviewRou
 		runtime.NewScheme(),
 		testSandboxRunnerWithPreviewRoute(runnerName, project.Name, ""),
 	))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
+	server := NewWithWorkspace(nil, nil, nil, readyDataPlaneHub(t), false)
 	got, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
 	if err != nil {
 		t.Fatalf("authorizeProjectDevelopmentPreviewTarget returned error: %v", err)
@@ -789,12 +699,11 @@ func TestAuthorizeProjectDevelopmentPreviewTargetRequiresSandboxRunnerPreviewRou
 }
 
 func TestAuthorizeProjectDevelopmentPreviewTargetReturnsNotReady(t *testing.T) {
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", clusterID: "cluster-a", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
 	project := &aiv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "todo"}}
 	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), testSandboxRunner(runnerName, project.Name)))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset()
+	server := NewWithWorkspace(nil, nil, nil, notFoundDataPlaneHub(t), false)
 	got, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
 	if err != nil {
 		t.Fatalf("authorizeProjectDevelopmentPreviewTarget returned error: %v", err)
@@ -811,23 +720,22 @@ func TestAuthorizeProjectDevelopmentPreviewTargetReturnsNotReady(t *testing.T) {
 }
 
 func TestAuthorizeProjectDevelopmentPreviewTargetWaitsForRuntimeServiceProxy(t *testing.T) {
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", token: "caller-token"}
+	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1", clusterID: "cluster-a", token: "caller-token"}
 	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
-	runtimeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.URL.Path, "/api/v1/namespaces/"+runnerName+"/services/"+runnerName+"-preview:preview/proxy/"; got != want {
-			t.Fatalf("runtime proxy path = %q, want %q", got, want)
+	hub := newSandboxDataPlaneHub(t, func(verb string, w http.ResponseWriter, _ *http.Request) {
+		if verb != dataPlaneVerbProxy {
+			t.Fatalf("readiness verb = %q, want %q", verb, dataPlaneVerbProxy)
 		}
+		// The infra data-plane proxy surfaces the runtime service-proxy's own
+		// 503 + Kubernetes Status body while the runner is still starting.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"error trying to reach service: dial tcp 10.244.0.55:3000: connect: connection refused","reason":"ServiceUnavailable","code":503}`)
-	}))
-	defer runtimeAPI.Close()
+	})
 
 	project := &aiv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "todo"}}
 	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), testSandboxRunner(runnerName, project.Name)))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeConfig = &rest.Config{Host: runtimeAPI.URL}
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(testReadyPreviewEndpoints(runnerName))
+	server := NewWithWorkspace(nil, nil, nil, hub, false)
 	got, err := server.authorizeProjectDevelopmentPreviewTarget(context.Background(), client, id, project, projectDevelopmentSyncTargetInfo{ResourceName: runnerName})
 	if err != nil {
 		t.Fatalf("authorizeProjectDevelopmentPreviewTarget returned error: %v", err)
@@ -865,67 +773,6 @@ func TestDeleteProjectProviderResourcesRemovesInfrastructureSandboxRunner(t *tes
 	}
 	if _, err := client.Dynamic().Resource(infrastructureSandboxRunnerGVR()).Get(context.Background(), runnerName, metav1.GetOptions{}); err == nil {
 		t.Fatal("infrastructure SandboxRunner still exists after project provider cleanup")
-	}
-}
-
-func TestDeleteProjectProviderResourcesRemovesSandboxRuntimeNamespace(t *testing.T) {
-	project := &aiv1alpha1.Project{
-		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
-		Spec:       defaultProjectSpec("todo", "Todo", "", nil),
-	}
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1"}
-	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
-	runtimeNamespace := "cluster-a-" + runnerName
-	runner := testSandboxRunner(runnerName, "todo")
-	runner.SetAnnotations(map[string]string{kcpClusterAnnotation: "cluster-a"})
-	if err := unstructured.SetNestedField(runner.Object, runtimeNamespace, "status", "runtimeNamespace"); err != nil {
-		t.Fatalf("set runtime namespace: %v", err)
-	}
-	for _, field := range []string{"previewServiceRef", "controlServiceRef", "controlSecretRef"} {
-		if err := unstructured.SetNestedField(runner.Object, runtimeNamespace, "status", field, "namespace"); err != nil {
-			t.Fatalf("set %s namespace: %v", field, err)
-		}
-	}
-	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), runner))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: runtimeNamespace},
-	})
-
-	if err := server.deleteProjectProviderResources(context.Background(), client, project, id); err != nil {
-		t.Fatalf("deleteProjectProviderResources returned error: %v", err)
-	}
-	if _, err := client.Dynamic().Resource(infrastructureSandboxRunnerGVR()).Get(context.Background(), runnerName, metav1.GetOptions{}); err == nil {
-		t.Fatal("infrastructure SandboxRunner still exists after project provider cleanup")
-	}
-	if _, err := server.runtimeClient.CoreV1().Namespaces().Get(context.Background(), runtimeNamespace, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("runtime namespace get error = %v, want not found", err)
-	}
-}
-
-func TestDeleteProjectProviderResourcesRejectsForgedSandboxRuntimeNamespace(t *testing.T) {
-	project := &aiv1alpha1.Project{
-		ObjectMeta: metav1.ObjectMeta{Name: "todo"},
-		Spec:       defaultProjectSpec("todo", "Todo", "", nil),
-	}
-	id := identity{tenantPath: "root:kedge:tenants:org-a:ws-1"}
-	runnerName := sandboxRunnerResourceName(id.tenantPath, "todo")
-	runner := testSandboxRunner(runnerName, "todo")
-	runner.SetAnnotations(map[string]string{kcpClusterAnnotation: "cluster-a"})
-	if err := unstructured.SetNestedField(runner.Object, "kube-system", "status", "runtimeNamespace"); err != nil {
-		t.Fatalf("set forged runtime namespace: %v", err)
-	}
-	client := asclient.NewFromDynamic(fake.NewSimpleDynamicClient(runtime.NewScheme(), runner))
-	server := NewWithWorkspace(nil, nil, nil, "http://hub.example", false)
-	server.runtimeClient = kubernetesfake.NewSimpleClientset(&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: "kube-system"},
-	})
-
-	if err := server.deleteProjectProviderResources(context.Background(), client, project, id); err == nil {
-		t.Fatal("deleteProjectProviderResources returned nil for forged runtime namespace")
-	}
-	if _, err := server.runtimeClient.CoreV1().Namespaces().Get(context.Background(), "kube-system", metav1.GetOptions{}); err != nil {
-		t.Fatalf("forged namespace was deleted or unreadable: %v", err)
 	}
 }
 
@@ -1186,29 +1033,6 @@ func setPreviewHTTPRouteEnv(t *testing.T) {
 	t.Setenv("APP_STUDIO_PREVIEW_BACKEND_SERVICE_PORT", "9443")
 }
 
-func testRuntimeControlSecret(name, token string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: name,
-			Name:      name + "-control",
-		},
-		Data: map[string][]byte{"token": []byte(token)},
-	}
-}
-
-func testReadyPreviewEndpoints(name string) *corev1.Endpoints {
-	return &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: name,
-			Name:      name + "-preview",
-		},
-		Subsets: []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{IP: "10.0.0.10"}},
-			Ports:     []corev1.EndpointPort{{Name: "preview", Port: 3000}},
-		}},
-	}
-}
-
 type previewOverlayProbeEngine struct {
 	previewURL string
 }
@@ -1236,16 +1060,4 @@ func infrastructureSandboxPreviewHTTPRouteGVR() k8sschema.GroupVersionResource {
 		Version:  "v1alpha1",
 		Resource: "sandboxpreviewhttproutes",
 	}
-}
-
-func mustNestedSlice(t *testing.T, obj map[string]any, fields ...string) []any {
-	t.Helper()
-	got, found, err := unstructured.NestedSlice(obj, fields...)
-	if err != nil {
-		t.Fatalf("read nested slice %v: %v", fields, err)
-	}
-	if !found {
-		t.Fatalf("nested slice %v not found", fields)
-	}
-	return got
 }

--- a/providers/app-studio/api/development_runtime.go
+++ b/providers/app-studio/api/development_runtime.go
@@ -11,24 +11,17 @@ You may obtain a copy of the License at
 package api
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"path"
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 
 	asclient "github.com/faroshq/provider-app-studio/client"
 )
@@ -200,12 +193,13 @@ func (s *Server) restartProjectDevelopment(w http.ResponseWriter, r *http.Reques
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "project has no sandbox runner binding")
 		return
 	}
-	runtimeTarget, _, err := s.runtimeTargetForProject(r.Context(), c, target.ResourceName)
-	if err != nil {
+	// Validate the runner exists in the workspace before reaching the data
+	// plane, so a missing runner surfaces as 404 rather than a proxy error.
+	if _, _, err := s.runtimeTargetForProject(r.Context(), c, target.ResourceName); err != nil {
 		writeRuntimeTargetError(w, err)
 		return
 	}
-	respBody, status, err := s.postRuntimeService(r.Context(), runtimeTarget, "restart", []byte(`{}`))
+	respBody, status, err := s.sandboxDataPlanePost(r.Context(), id, target.ResourceName, dataPlaneVerbRestart, []byte(`{}`))
 	if err != nil {
 		writeStatus(w, http.StatusBadGateway, "BadGateway", err.Error())
 		return
@@ -225,41 +219,19 @@ func (s *Server) logsProjectDevelopment(w http.ResponseWriter, r *http.Request) 
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "project has no sandbox runner binding")
 		return
 	}
-	runtimeTarget, _, err := s.runtimeTargetForProject(r.Context(), c, target.ResourceName)
-	if err != nil {
+	// Validate the runner exists in the workspace first (404 vs proxy error).
+	if _, _, err := s.runtimeTargetForProject(r.Context(), c, target.ResourceName); err != nil {
 		writeRuntimeTargetError(w, err)
 		return
 	}
-	if s.runtimeConfig == nil {
-		writeStatus(w, http.StatusNotImplemented, "NotImplemented", "runtime kubeconfig not configured")
-		return
-	}
-	upstream := s.runtimeConfig.Host + runtimeServicePath(runtimeTarget.Control, "logs")
-	transport, err := restTransport(s.runtimeConfig)
-	if err != nil {
-		writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())
-		return
-	}
-	token, err := s.runtimeControlToken(r.Context(), runtimeTarget.ControlSecret)
-	if err != nil {
+	// Stream logs from the infrastructure provider's data-plane subresource;
+	// it owns the runtime credential and the control-token injection.
+	if err := s.sandboxDataPlaneStream(r.Context(), id, target.ResourceName, dataPlaneVerbLog, w); err != nil {
+		// Headers may already be sent on a mid-stream failure; only safe to
+		// write a status when nothing has been flushed yet.
 		writeStatus(w, http.StatusBadGateway, "BadGateway", err.Error())
 		return
 	}
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstream, nil)
-	if err != nil {
-		writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())
-		return
-	}
-	req.Header.Set("X-Sandbox-Control-Token", token)
-	resp, err := (&http.Client{Transport: transport}).Do(req)
-	if err != nil {
-		writeStatus(w, http.StatusBadGateway, "BadGateway", err.Error())
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
-	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
 }
 
 func (s *Server) statusProjectDevelopment(w http.ResponseWriter, r *http.Request) {
@@ -281,53 +253,6 @@ func (s *Server) statusProjectDevelopment(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, status)
 }
 
-func (s *Server) postRuntimeService(ctx context.Context, target runtimeTarget, op string, body []byte) ([]byte, int, error) {
-	if s.runtimeConfig == nil {
-		return nil, 0, fmt.Errorf("runtime kubeconfig not configured")
-	}
-	upstream := s.runtimeConfig.Host + runtimeServicePath(target.Control, op)
-	transport, err := restTransport(s.runtimeConfig)
-	if err != nil {
-		return nil, 0, err
-	}
-	token, err := s.runtimeControlToken(ctx, target.ControlSecret)
-	if err != nil {
-		return nil, 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstream, bytes.NewReader(body))
-	if err != nil {
-		return nil, 0, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Sandbox-Control-Token", token)
-	client := &http.Client{Transport: transport}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("POST runtime service %s: %w", op, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
-	if err != nil {
-		return nil, 0, err
-	}
-	return raw, resp.StatusCode, nil
-}
-
-func (s *Server) runtimeControlToken(ctx context.Context, ref runtimeSecretRef) (string, error) {
-	if s.runtimeClient == nil {
-		return "", fmt.Errorf("runtime client is not configured")
-	}
-	secret, err := s.runtimeClient.CoreV1().Secrets(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	token := string(secret.Data["token"])
-	if token == "" {
-		return "", fmt.Errorf("runtime control token is empty")
-	}
-	return token, nil
-}
-
 func patchLastSync(ctx context.Context, c *asclient.Client, name string, t metav1.Time) error {
 	if c == nil {
 		return nil
@@ -346,109 +271,29 @@ func patchLastSync(ctx context.Context, c *asclient.Client, name string, t metav
 	return err
 }
 
-func (s *Server) previewReadiness(ctx context.Context, target runtimeTarget) projectSandboxPreviewURLResponse {
-	if s.runtimeClient == nil {
-		return projectSandboxPreviewURLResponse{
-			Ready:   false,
-			Reason:  "runtime_not_configured",
-			Message: "Preview is getting ready. The sandbox runtime is still being configured.",
-		}
+// previewReadiness probes the sandbox preview through the infrastructure
+// provider's data-plane proxy subresource (App Studio no longer reaches the
+// runtime cluster directly). The proxy returns the runtime service-proxy
+// response, so a 503 carrying a Kubernetes "Status" body means the runtime is
+// still starting / has no ready endpoints; any normal response means ready.
+func (s *Server) previewReadiness(ctx context.Context, id identity, runnerName string) projectSandboxPreviewURLResponse {
+	notReady := func(reason, message string) projectSandboxPreviewURLResponse {
+		return projectSandboxPreviewURLResponse{Ready: false, Reason: reason, Message: message}
 	}
-	endpoints, err := s.runtimeClient.CoreV1().Endpoints(target.Preview.Namespace).Get(ctx, target.Preview.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return projectSandboxPreviewURLResponse{
-			Ready:   false,
-			Reason:  "service_not_found",
-			Message: "Preview is getting ready. The preview service has not been created yet.",
-		}
-	}
+	status, body, err := s.sandboxDataPlaneProbe(ctx, id, runnerName, "/")
 	if err != nil {
-		return projectSandboxPreviewURLResponse{
-			Ready:   false,
-			Reason:  "service_unavailable",
-			Message: "Preview is getting ready. The sandbox runtime is not reachable yet.",
-		}
+		return notReady("service_unavailable", "Preview is getting ready. The sandbox runtime is not reachable yet.")
 	}
-	if !hasReadyEndpoint(endpoints) {
-		return projectSandboxPreviewURLResponse{
-			Ready:   false,
-			Reason:  "no_ready_endpoints",
-			Message: "Preview is getting ready. The sandbox runtime is not serving traffic yet.",
-		}
+	switch {
+	case status == http.StatusServiceUnavailable && isPreviewRuntimeStartingStatus(body):
+		return notReady("runtime_starting", "Preview is getting ready. The sandbox runtime is not serving traffic yet.")
+	case status == http.StatusNotFound:
+		return notReady("service_not_found", "Preview is getting ready. The preview service has not been created yet.")
+	case status == http.StatusBadGateway, status == http.StatusGatewayTimeout, status == http.StatusServiceUnavailable:
+		return notReady("service_unavailable", "Preview is getting ready. The sandbox runtime is not reachable yet.")
+	default:
+		return projectSandboxPreviewURLResponse{Ready: true}
 	}
-	if ok, err := s.previewServiceResponding(ctx, target.Preview); err != nil {
-		return projectSandboxPreviewURLResponse{
-			Ready:   false,
-			Reason:  "service_unavailable",
-			Message: "Preview is getting ready. The sandbox runtime is not reachable yet.",
-		}
-	} else if !ok {
-		return projectSandboxPreviewURLResponse{
-			Ready:   false,
-			Reason:  "runtime_starting",
-			Message: "Preview is getting ready. The sandbox runtime is not serving traffic yet.",
-		}
-	}
-	return projectSandboxPreviewURLResponse{Ready: true}
-}
-
-func (s *Server) previewServiceResponding(ctx context.Context, ref runtimeServiceRef) (bool, error) {
-	if s.runtimeConfig == nil {
-		return true, nil
-	}
-	target, err := url.Parse(s.runtimeConfig.Host)
-	if err != nil {
-		return false, err
-	}
-	transport, err := restTransport(s.runtimeConfig)
-	if err != nil {
-		return false, err
-	}
-	probeCtx, cancel := context.WithTimeout(ctx, previewReadinessProbeTimeout)
-	defer cancel()
-	reqURL := *target
-	reqURL.Path = runtimeServicePath(ref, "")
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, reqURL.String(), nil)
-	if err != nil {
-		return false, err
-	}
-	req.Host = target.Host
-	stripPreviewForwardedCredentials(req.Header)
-	resp, err := (&http.Client{Transport: transport}).Do(req)
-	if err != nil {
-		if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
-			return false, nil
-		}
-		return false, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode == http.StatusServiceUnavailable && previewStatusContentType(resp.Header.Get("Content-Type")) {
-		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		if err != nil {
-			return false, err
-		}
-		if isPreviewRuntimeStartingStatus(raw) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-func hasReadyEndpoint(endpoints *corev1.Endpoints) bool {
-	if endpoints == nil {
-		return false
-	}
-	for _, subset := range endpoints.Subsets {
-		if len(subset.Addresses) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func previewStatusContentType(contentType string) bool {
-	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
-	return mediaType == "application/json" || mediaType == "application/status+json"
 }
 
 func isPreviewRuntimeStartingStatus(raw []byte) bool {
@@ -472,32 +317,6 @@ func isPreviewRuntimeStartingStatus(raw []byte) bool {
 	return strings.Contains(message, "error trying to reach service") ||
 		strings.Contains(message, "no endpoints available") ||
 		strings.Contains(message, "connection refused")
-}
-
-func stripPreviewForwardedCredentials(header http.Header) {
-	header.Del("Authorization")
-	header.Del("Cookie")
-	header.Del("X-Kedge-Tenant")
-	header.Del("X-Kedge-User")
-	header.Del("X-Sandbox-Control-Token")
-	for key := range header {
-		if strings.HasPrefix(strings.ToLower(key), "x-kedge-") {
-			header.Del(key)
-		}
-	}
-}
-
-func runtimeServicePath(ref runtimeServiceRef, suffix string) string {
-	cleanSuffix := strings.TrimPrefix(path.Clean("/"+suffix), "/")
-	base := "/api/v1/namespaces/" + ref.Namespace + "/services/" + ref.Name + ":" + ref.PortName + "/proxy"
-	if cleanSuffix == "" || cleanSuffix == "." {
-		return base + "/"
-	}
-	return base + "/" + cleanSuffix
-}
-
-func restTransport(cfg *rest.Config) (http.RoundTripper, error) {
-	return rest.TransportFor(cfg)
 }
 
 func writeRuntimeTargetError(w http.ResponseWriter, err error) {

--- a/providers/app-studio/api/development_sync.go
+++ b/providers/app-studio/api/development_sync.go
@@ -24,7 +24,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
@@ -41,12 +40,6 @@ const (
 	sandboxPreviewHTTPRouteNamespace    = "default"
 	projectSandboxSyncTimeout           = 20 * time.Second
 )
-
-var gatewayReferenceGrantGVR = schema.GroupVersionResource{
-	Group:    "gateway.networking.k8s.io",
-	Version:  "v1beta1",
-	Resource: "referencegrants",
-}
 
 type projectDevelopmentSyncTargetInfo struct {
 	EnvironmentName string
@@ -187,11 +180,11 @@ func (s *Server) syncProjectDevelopmentTarget(ctx context.Context, c *asclient.C
 	if err != nil {
 		return nil, fmt.Errorf("encode sandbox sync payload: %w", err)
 	}
-	runtimeTarget, _, err := s.runtimeTargetForProject(ctx, c, target.ResourceName)
-	if err != nil {
+	// Validate the runner exists in the workspace first (clear 404 vs proxy err).
+	if _, _, err := s.runtimeTargetForProject(ctx, c, target.ResourceName); err != nil {
 		return nil, err
 	}
-	body, status, err := s.postRuntimeService(ctx, runtimeTarget, "sync", payload)
+	body, status, err := s.sandboxDataPlanePost(ctx, id, target.ResourceName, dataPlaneVerbSync, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +207,7 @@ func (s *Server) authorizeProjectDevelopmentPreviewTarget(ctx context.Context, c
 		}
 		return projectSandboxPreviewURLResponse{}, err
 	}
-	preview := s.previewReadiness(ctx, runtimeTarget)
+	preview := s.previewReadiness(ctx, id, target.ResourceName)
 	if !preview.Ready {
 		return preview, nil
 	}
@@ -229,9 +222,11 @@ func (s *Server) authorizeProjectDevelopmentPreviewTarget(ctx context.Context, c
 			Message: "Preview is getting ready. The sandbox preview route does not have a URL yet.",
 		}, nil
 	}
-	if err := s.ensureSandboxPreviewReferenceGrant(ctx, p.Name, route); err != nil {
-		return projectSandboxPreviewURLResponse{}, err
-	}
+	// The cross-namespace ReferenceGrant that lets the preview HTTPRoute target
+	// the shared preview-gateway Service is now materialized by the
+	// sandbox-runner kro template on the runtime cluster (App Studio no longer
+	// writes to that cluster). See providers/infrastructure/install/templates/
+	// sandbox-runner.yaml.
 	preview.PreviewURL, preview.PreviewTokenExpiresAt = s.signedProjectPreviewURLAndExpiry(p.Name, id, target, runtimeTarget, route.URL, aiv1alpha1.ProjectSharingModePrivate)
 	return preview, nil
 }
@@ -284,76 +279,6 @@ func isExpectedSandboxPreviewHTTPRouteNamespace(obj *unstructured.Unstructured, 
 		return true
 	}
 	return namespace != "" && namespace == expectedKROPrefixedNamespace(obj, sandboxPreviewHTTPRouteNamespace)
-}
-
-func (s *Server) ensureSandboxPreviewReferenceGrant(ctx context.Context, projectName string, route sandboxPreviewHTTPRouteInfo) error {
-	if s.runtimeDynamic == nil {
-		return fmt.Errorf("sandbox preview reference grant requires runtime dynamic client")
-	}
-	if route.ReferenceGrantName == "" {
-		return fmt.Errorf("sandbox preview reference grant name is empty")
-	}
-	if route.HTTPRouteNamespace == "" {
-		return fmt.Errorf("sandbox preview HTTPRoute namespace is empty")
-	}
-	if route.BackendNamespace == "" || route.BackendServiceName == "" {
-		return fmt.Errorf("sandbox preview backend service reference is incomplete")
-	}
-	res := s.runtimeDynamic.Resource(gatewayReferenceGrantGVR).Namespace(route.BackendNamespace)
-	wantSpec := map[string]any{
-		"from": []any{
-			map[string]any{
-				"group":     "gateway.networking.k8s.io",
-				"kind":      "HTTPRoute",
-				"namespace": route.HTTPRouteNamespace,
-			},
-		},
-		"to": []any{
-			map[string]any{
-				"group": "",
-				"kind":  "Service",
-				"name":  route.BackendServiceName,
-			},
-		},
-	}
-	labels := map[string]string{
-		"app-studio.kedge.faros.sh/project":    projectName,
-		"app-studio.kedge.faros.sh/managed-by": "app-studio",
-	}
-	existing, err := res.Get(ctx, route.ReferenceGrantName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		grant := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "gateway.networking.k8s.io/v1beta1",
-			"kind":       "ReferenceGrant",
-			"metadata": map[string]any{
-				"name":      route.ReferenceGrantName,
-				"namespace": route.BackendNamespace,
-				"labels": map[string]any{
-					"app-studio.kedge.faros.sh/project":    projectName,
-					"app-studio.kedge.faros.sh/managed-by": "app-studio",
-				},
-			},
-			"spec": wantSpec,
-		}}
-		_, err = res.Create(ctx, grant, metav1.CreateOptions{})
-		return err
-	}
-	if err != nil {
-		return err
-	}
-	existing.SetAPIVersion("gateway.networking.k8s.io/v1beta1")
-	existing.SetKind("ReferenceGrant")
-	existing.Object["spec"] = wantSpec
-	existingLabels := existing.GetLabels()
-	if existingLabels == nil {
-		existingLabels = map[string]string{}
-	}
-	for key, value := range labels {
-		existingLabels[key] = value
-	}
-	existing.SetLabels(existingLabels)
-	_, err = res.Update(ctx, existing, metav1.UpdateOptions{})
-	return err
 }
 
 func previewPublicURL(raw string) string {

--- a/providers/app-studio/api/provider_resources.go
+++ b/providers/app-studio/api/provider_resources.go
@@ -136,60 +136,18 @@ func (s *Server) deleteProjectProviderResources(ctx context.Context, c *asclient
 			if name == "" {
 				return fmt.Errorf("provider binding %q has no resource name", binding.Name)
 			}
-			runtimeNamespace := ""
-			if isSandboxRunnerBinding(binding) && s != nil && s.runtimeClient != nil {
-				obj, err := c.Resource(providerBindingResource(gvr, binding.ResourceRef.Kind), "").Get(ctx, name, metav1.GetOptions{})
-				if err != nil && !apierrors.IsNotFound(err) {
-					return err
-				}
-				if err == nil {
-					runtimeNamespace, err = sandboxRunnerRuntimeNamespaceForCleanup(obj)
-					if err != nil {
-						return err
-					}
-				}
-			}
+			// Deleting the SandboxRunner instance is enough: the
+			// infrastructure provider's kro template owns the runtime
+			// namespace and garbage-collects it (and every materialized
+			// workload) when the instance goes away. App Studio no longer
+			// holds a runtime-cluster client to delete it directly.
 			err = c.Resource(providerBindingResource(gvr, binding.ResourceRef.Kind), "").Delete(ctx, name, metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
-			if runtimeNamespace != "" {
-				if err := s.deleteSandboxRuntimeNamespace(ctx, runtimeNamespace); err != nil {
-					return err
-				}
-			}
 		}
 	}
 	return nil
-}
-
-func sandboxRunnerRuntimeNamespaceForCleanup(obj *unstructured.Unstructured) (string, error) {
-	name, err := sandboxRunnerInstanceName(obj)
-	if err != nil {
-		return "", err
-	}
-	if statusNamespace, ok, err := sandboxRunnerStatusRuntimeNamespace(obj, name); err != nil || ok {
-		return statusNamespace, err
-	}
-	if prefixed := expectedKROPrefixedRuntimeNamespace(obj, name); prefixed != "" {
-		return prefixed, nil
-	}
-	return name, nil
-}
-
-func (s *Server) deleteSandboxRuntimeNamespace(ctx context.Context, namespace string) error {
-	if s == nil || s.runtimeClient == nil {
-		return nil
-	}
-	namespace = strings.TrimSpace(namespace)
-	if namespace == "" {
-		return nil
-	}
-	err := s.runtimeClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	return err
 }
 
 func projectProviderResourceOwnerRef(p *aiv1alpha1.Project) *metav1.OwnerReference {

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -28,9 +28,6 @@ import (
 
 	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 	asclient "github.com/faroshq/provider-app-studio/client"
@@ -51,9 +48,6 @@ type Server struct {
 	workspaces                   *workspace.FileStore
 	hubBase                      string
 	mcpInsecureSkipTLSVerify     bool
-	runtimeConfig                *rest.Config
-	runtimeClient                kubernetes.Interface
-	runtimeDynamic               dynamic.Interface
 	previewSigner                *previewtoken.Signer
 	autoApproveActions           bool
 	assistantEngine              projectAssistantEngine
@@ -82,28 +76,6 @@ func NewWithWorkspace(gql *tenant.GraphQLClient, msgStore store.Store, workspace
 	s.assistantEngine = NewEinoAssistantEngine(s)
 	s.assistantRunManager = newProjectAssistantRunManager()
 	return s
-}
-
-func (s *Server) SetRuntimeConfig(cfg *rest.Config) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.runtimeConfig = cfg
-	if cfg == nil {
-		s.runtimeClient = nil
-		s.runtimeDynamic = nil
-		return nil
-	}
-	client, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return err
-	}
-	dyn, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return err
-	}
-	s.runtimeClient = client
-	s.runtimeDynamic = dyn
-	return nil
 }
 
 func (s *Server) SetPreviewTokenSecret(secret []byte) {

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -1,5 +1,4 @@
 {{- $catalogEntryConfigMap := and .Values.catalogEntry.enabled .Values.catalogEntry.renderAsConfigMap -}}
-{{- $runtimeKubeconfigSecret := .Values.runtimeKubeconfig.secretName | default "" -}}
 {{- $sandboxRunnerImage := .Values.sandboxRunner.runnerImage | default "" -}}
 {{- $sandboxTokenGeneratorImage := .Values.sandboxRunner.tokenGeneratorImage | default "" -}}
 {{- $previewGatewayEnabled := .Values.previewGateway.enabled | default false -}}
@@ -11,10 +10,10 @@
 {{- end -}}
 {{- /*
 App Studio creates a SandboxRunner for every project's development environment,
-and the SandboxRunner spec requires both images regardless of whether the
-runtime data plane (runtimeKubeconfig) is enabled. Require them unconditionally
-so a misconfigured install fails here instead of producing invalid SandboxRunner
-resources at runtime.
+and the SandboxRunner spec requires both images. Require them unconditionally so
+a misconfigured install fails here instead of producing invalid SandboxRunner
+resources at runtime. (Image ownership moves to the infrastructure provider in a
+later phase; until then App Studio still passes them through.)
 */ -}}
 {{- if not $sandboxRunnerImage -}}
 {{- fail "sandboxRunner.runnerImage is required; use an immutable digest reference" -}}
@@ -107,10 +106,6 @@ spec:
             # calling user via the forwarded bearer token.
             - name: KEDGE_PROVIDER_KUBECONFIG
               value: /var/run/secrets/kedge/kedge-provider-kubeconfig
-            {{- if $runtimeKubeconfigSecret }}
-            - name: APP_STUDIO_RUNTIME_KUBECONFIG
-              value: /var/run/secrets/kedge/runtime/kubeconfig
-            {{- end }}
             # Always set: the SandboxRunner spec requires both images, and the
             # template above fails the install when either is unset.
             - name: APP_STUDIO_SANDBOX_RUNNER_IMAGE
@@ -184,11 +179,6 @@ spec:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge
               readOnly: true
-            {{- if $runtimeKubeconfigSecret }}
-            - name: runtime-kubeconfig
-              mountPath: /var/run/secrets/kedge/runtime
-              readOnly: true
-            {{- end }}
             - name: project-workspaces
               mountPath: {{ .Values.workspace.path | quote }}
           resources:
@@ -204,14 +194,6 @@ spec:
             items:
               - key: kubeconfig
                 path: kedge-provider-kubeconfig
-        {{- if $runtimeKubeconfigSecret }}
-        - name: runtime-kubeconfig
-          secret:
-            secretName: {{ $runtimeKubeconfigSecret }}
-            items:
-              - key: kubeconfig
-                path: kubeconfig
-        {{- end }}
         {{- if $catalogEntryConfigMap }}
         - name: catalogentry
           configMap:

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -34,12 +34,10 @@ catalogEntry:
 providerKubeconfig:
   secretName: kedge-provider-kubeconfig
 
-# Optional Secret holding a kubeconfig for the Kubernetes cluster that runs
-# SandboxRunner workloads. App Studio uses it only for project-scoped runtime
-# data-plane operations (sync, logs, restart, and preview proxying). Leave empty
-# to start App Studio with sandbox runtime APIs disabled.
-runtimeKubeconfig:
-  secretName: ""
+# App Studio no longer holds a kubeconfig to the runtime cluster. The sandbox
+# data plane (sync, logs, restart, preview readiness) is served by the
+# infrastructure provider as subresources on the SandboxRunner instance, reached
+# through the hub as the calling user. See docs/app-studio-runtime-decoupling.md.
 
 # Images passed into infrastructure-backed SandboxRunner resources. App Studio
 # creates a SandboxRunner for every project, and its spec requires both images,

--- a/providers/app-studio/main.go
+++ b/providers/app-studio/main.go
@@ -79,30 +79,6 @@ func loadProviderConfig() (*rest.Config, error) {
 	return nil, fmt.Errorf("no kubeconfig found (set KEDGE_PROVIDER_KUBECONFIG)")
 }
 
-// loadRuntimeConfig loads the kubeconfig used for the sandbox runtime data
-// plane. This must be distinct from the provider kubeconfig: it points at the
-// Kubernetes cluster where SandboxRunner workloads run.
-func loadRuntimeConfig() (*rest.Config, error) {
-	candidates := []string{
-		os.Getenv("APP_STUDIO_RUNTIME_KUBECONFIG"),
-		"/var/run/secrets/kedge/runtime/kubeconfig",
-	}
-	for _, path := range candidates {
-		if path == "" {
-			continue
-		}
-		if _, err := os.Stat(path); err != nil {
-			continue
-		}
-		cfg, err := clientcmd.BuildConfigFromFlags("", path)
-		if err != nil {
-			return nil, fmt.Errorf("loading runtime kubeconfig %s: %w", path, err)
-		}
-		return cfg, nil
-	}
-	return nil, fmt.Errorf("no runtime kubeconfig found (set APP_STUDIO_RUNTIME_KUBECONFIG)")
-}
-
 func loadPreviewGatewayConfig() (*rest.Config, error) {
 	if path := strings.TrimSpace(os.Getenv("APP_STUDIO_PREVIEW_GATEWAY_KUBECONFIG")); path != "" {
 		cfg, err := clientcmd.BuildConfigFromFlags("", path)
@@ -192,11 +168,10 @@ func runServe() {
 	if secret := os.Getenv("APP_STUDIO_PREVIEW_TOKEN_SECRET"); secret != "" {
 		apiServer.SetPreviewTokenSecret([]byte(secret))
 	}
-	if cfg, err := loadRuntimeConfig(); err != nil {
-		log.Printf("WARNING sandbox runtime API disabled (no runtime kubeconfig): %v", err)
-	} else if err := apiServer.SetRuntimeConfig(cfg); err != nil {
-		log.Printf("WARNING sandbox runtime API disabled (invalid runtime kubeconfig): %v", err)
-	}
+	// App Studio no longer holds a runtime-cluster kubeconfig: the sandbox data
+	// plane (logs/sync/restart/preview) is served by the infrastructure provider
+	// as subresources on the SandboxRunner instance, reached through the hub as
+	// the calling user. See docs/app-studio-runtime-decoupling.md.
 
 	handler, err := newHandler(apiServer)
 	if err != nil {

--- a/providers/infrastructure/install/templates/sandbox-runner.yaml
+++ b/providers/infrastructure/install/templates/sandbox-runner.yaml
@@ -428,6 +428,33 @@ spec:
                     namespace: ${schema.spec.previewRoute.backend.namespace}
                     port: ${schema.spec.previewRoute.backend.servicePort}
                     kind: Service
+      # Allow the preview HTTPRoute (in the "default" namespace) to reference the
+      # shared preview-gateway Service in the backend namespace across the
+      # namespace boundary. Previously App Studio created this ReferenceGrant
+      # imperatively against the runtime cluster; it is now owned by this
+      # template so App Studio no longer needs a runtime-cluster credential.
+      - id: previewReferenceGrant
+        includeWhen:
+          - ${schema.spec.previewRouteEnabled}
+        template:
+          apiVersion: gateway.networking.k8s.io/v1beta1
+          kind: ReferenceGrant
+          metadata:
+            name: ${schema.spec.name}
+            namespace: ${schema.spec.previewRoute.backend.namespace}
+            labels:
+              app.kubernetes.io/name: sandbox-runner
+              app.kubernetes.io/instance: ${schema.spec.name}
+              app.kubernetes.io/managed-by: kedge-infrastructure
+          spec:
+            from:
+              - group: gateway.networking.k8s.io
+                kind: HTTPRoute
+                namespace: default
+            to:
+              - group: ""
+                kind: Service
+                name: ${schema.spec.previewRoute.backend.serviceName}
       - id: runnerNetwork
         template:
           apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
**Phase 3 — the payoff** of decoupling App Studio from the runtime cluster. App Studio **no longer holds a kubeconfig to the runtime cluster**: the live development data plane is served by the infrastructure provider as subresources on the `SandboxRunner` instance (Phase 1), reached through the hub as the requesting user.

Design doc: [`docs/app-studio-runtime-decoupling.md`](https://github.com/faroshq/kedge/blob/feat/appstudio-dataplane-cutover/docs/app-studio-runtime-decoupling.md) §5.

### What this does
New `api/dataplane_client.go` calls `{hub}/services/providers/infrastructure/dataplane/clusters/{cluster}/sandboxrunners/{name}/{verb}`, forwarding the caller's bearer token. The infra provider authorizes as that user and owns the runtime credential + control-token injection. Handlers rewritten:

| Op | Before (direct to runtime cluster) | After |
|---|---|---|
| sync / restart | service-proxy POST + control token | `POST .../{sync,restart}` |
| logs | service-proxy GET + control token | `GET .../log` (streamed) |
| preview readiness | read Endpoints + probe service-proxy | `GET .../proxy/` (503 + k8s Status ⇒ starting) |
| status | reads the CR status | unchanged (control plane) |

**Removed from App Studio:** `runtimeConfig`/`runtimeClient`/`runtimeDynamic` + `SetRuntimeConfig`, `loadRuntimeConfig` + `APP_STUDIO_RUNTIME_KUBECONFIG` + chart wiring, the per-instance control-token Secret read, the explicit runtime Namespace delete (kro GCs it on CR delete), and the imperative preview `ReferenceGrant` create — now materialized by the sandbox-runner template (new `previewReferenceGrant` RGD resource).

**Kept:** `runtimeTargetForProject` (reads the CR to resolve refs — control plane) and signed preview-URL minting (product logic). App Studio still passes the runner images through (removing that waits on #366 to avoid an ordering trap).

### Testing
`go build ./...` + `go test ./...` green; both provider charts render. New `dataplane_client` tests (URL shape, token forwarding, hub/cluster guards). The sync + preview-readiness tests were rewritten to drive a **fake hub data-plane endpoint**; obsolete runtime-namespace and ReferenceGrant tests removed.

> [!IMPORTANT]
> **Deploy ordering.** This needs Phase 1 (#367) live for the data plane and Phase 2a (#366) for runner-image ownership. The `ReferenceGrant` RGD resource ships **here** so preview routing has no gap when App Studio stops writing it. No live integration test against a running hub+infra in this PR (unit + chart-render only) — that belongs in the pre-rollout e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
