### PR TITLE
feat(infra): template images as schema defaults + kro-acceptance e2e/CI

### DIFF
--- a/.github/workflows/infrastructure-templates-e2e.yaml
+++ b/.github/workflows/infrastructure-templates-e2e.yaml
@@ -1,0 +1,63 @@
+name: Infrastructure Template E2E
+
+# Every seeded infrastructure Template must author a kro ResourceGraphDefinition
+# that kro ACCEPTS. Unit tests only check buildRGD's output; this stands up a
+# real (standalone) kro on kind and asserts GraphAccepted=True for each template,
+# catching the failures unit tests miss (string-vs-int fields, non-standalone
+# includeWhen expressions, images that resolved to ""). See
+# providers/infrastructure/backend/kro/e2e_test.go.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'providers/infrastructure/install/templates/**'
+      - 'providers/infrastructure/backend/kro/**'
+      - 'providers/infrastructure/apis/**'
+      - '.github/workflows/infrastructure-templates-e2e.yaml'
+      - 'Makefile'
+  push:
+    branches: [main]
+    paths:
+      - 'providers/infrastructure/install/templates/**'
+      - 'providers/infrastructure/backend/kro/**'
+      - 'providers/infrastructure/apis/**'
+      - '.github/workflows/infrastructure-templates-e2e.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  template-rgd-acceptance:
+    name: Templates accepted by kro
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: v1.26.1
+
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The kro fork chart + image live in ghcr under this org; logging in lets
+      # helm/kind pull them whether they are public or org-private.
+      - name: Log in to GHCR for the kro chart
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Bring up kro + run the template e2e
+        run: make e2e-infrastructure
+
+      - name: Tear down the e2e cluster
+        if: always()
+        run: make e2e-infrastructure-down

--- a/.github/workflows/infrastructure-templates-e2e.yaml
+++ b/.github/workflows/infrastructure-templates-e2e.yaml
@@ -1,11 +1,13 @@
 name: Infrastructure Template E2E
 
 # Every seeded infrastructure Template must author a kro ResourceGraphDefinition
-# that kro ACCEPTS. Unit tests only check buildRGD's output; this stands up a
-# real (standalone) kro on kind and asserts GraphAccepted=True for each template,
-# catching the failures unit tests miss (string-vs-int fields, non-standalone
-# includeWhen expressions, images that resolved to ""). See
-# providers/infrastructure/backend/kro/e2e_test.go.
+# that kro ACCEPTS, and a sample instance of it must reconcile WITHOUT an apply
+# error. Unit tests only check buildRGD's output; this stands up a real
+# (standalone) kro on kind and, per template, asserts GraphAccepted=True and then
+# creates a sample instance that kro applies cleanly — catching the failures unit
+# tests miss (string-vs-int fields, non-standalone includeWhen expressions, an
+# image that resolved to "" surfacing as "Required value" only at apply time).
+# See providers/infrastructure/backend/kro/e2e_test.go.
 on:
   pull_request:
     branches: [main]
@@ -29,8 +31,8 @@ permissions:
   packages: read
 
 jobs:
-  template-rgd-acceptance:
-    name: Templates accepted by kro
+  template-e2e:
+    name: Templates accepted + instances apply
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,6 +390,14 @@ whole point.
   build/test and `go.work` awareness; they are not in the root `./...`.
 - Before merging: `make verify` is the full gate
   (boilerplate + codegen + vet + lint + build + test).
+- **Infrastructure templates declare configurable inputs (container images,
+  versions, sizes) as `spec.schema` fields with sane defaults** — never via
+  `${kedge.*}` env-substitution tokens. Fixed sidecar images (e.g. the
+  control-token `kubectl` job) are hardcoded literals. `${kedge.*}` tokens are
+  reserved for genuinely platform-global values with no universal default (only
+  the exposure Gateway parent today). A missing env must never be able to
+  produce an empty/invalid field. See
+  [`providers/infrastructure/docs/template-conventions.md`](providers/infrastructure/docs/template-conventions.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,6 +398,18 @@ whole point.
   the exposure Gateway parent today). A missing env must never be able to
   produce an empty/invalid field. See
   [`providers/infrastructure/docs/template-conventions.md`](providers/infrastructure/docs/template-conventions.md).
+- **Providers are isolated; never reach into another provider's backend.** A
+  provider's backend layer (its runtime/target clusters and their
+  credentials, databases, internal Services, controllers, kro RGDs) is
+  private to it. A provider must not hold a second credential into another
+  provider's cluster/DB/service, call its internal endpoints directly, or
+  hardcode its backend topology. Cross-provider access goes **only** through
+  the other provider's published `APIExport` resources + virtual-workspace
+  subresources, invoked **as the tenant user** and routed by binding (not by
+  a backend URL). This is what makes BYO compute work and bounds blast
+  radius. See [`docs/providers.md` §"Provider isolation"](docs/providers.md#provider-isolation-the-cross-provider-boundary)
+  and contract 3 in
+  [`docs/provider-connectivity-contract.md`](docs/provider-connectivity-contract.md).
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -678,7 +678,9 @@ KUERY_RUNTIME_KUBECONFIG ?= $(KCP_DATA_DIR)/kuery-runtime.kubeconfig
 # …) diverges from SQLite and passing on SQLite has shipped real query bugs.
 # kuery-db-up starts a throwaway container matching KUERY_DEV_DATABASE_URL.
 KUERY_POSTGRES_CONTAINER ?= kedge-kuery-postgres
-KUERY_POSTGRES_IMAGE ?= postgres:16-alpine
+# Pulled from Google's Docker Hub mirror (same official image, more reliable
+# pulls — Docker Hub has been dropping them with "unexpected EOF").
+KUERY_POSTGRES_IMAGE ?= mirror.gcr.io/library/postgres:16-alpine
 KUERY_POSTGRES_PORT ?= 55433
 KUERY_POSTGRES_DATA_DIR ?= $(KCP_DATA_DIR)/kuery-postgres
 KUERY_POSTGRES_USER ?= kuery
@@ -862,7 +864,7 @@ APP_STUDIO_SANDBOX_RUNNER_IMAGE ?= $(SANDBOX_RUNNER_IMAGE)
 APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE ?= $(SANDBOX_TOKEN_GENERATOR_IMAGE)
 APP_STUDIO_DEV_DATABASE_URL ?= postgres://appstudio:appstudio@localhost:55432/appstudio?sslmode=disable
 APP_STUDIO_POSTGRES_CONTAINER ?= kedge-app-studio-postgres
-APP_STUDIO_POSTGRES_IMAGE ?= postgres:16-alpine
+APP_STUDIO_POSTGRES_IMAGE ?= mirror.gcr.io/library/postgres:16-alpine
 APP_STUDIO_POSTGRES_PORT ?= 55432
 APP_STUDIO_POSTGRES_DATA_DIR ?= $(KCP_DATA_DIR)/app-studio-postgres
 APP_STUDIO_POSTGRES_USER ?= appstudio

--- a/Makefile
+++ b/Makefile
@@ -1324,6 +1324,14 @@ KRO_IMAGE_TAG ?= v0.0.1-mc.7
 KRO_NAMESPACE ?= kro-system
 KRO_SEED_DIR ?= providers/infrastructure/examples/rgds
 
+# --- Infrastructure template e2e (RGD acceptance against a real kro) ---
+# A throwaway kind cluster running STANDALONE kro (no kcp) — enough to validate
+# that every seeded Template authors a kro graph kro accepts. See
+# providers/infrastructure/backend/kro/e2e_test.go.
+E2E_KRO_KIND_NAME ?= kedge-kro-e2e
+E2E_KRO_KUBECONFIG ?= $(CURDIR)/.kedge-kro-e2e.kubeconfig
+GATEWAY_API_VERSION ?= v1.2.1
+
 ## Bring up the management kro cluster + install kro (fork w/ multicluster) +
 ## register the cluster as a self-member + seed RGDs. Idempotent: re-running
 ## just helm-upgrades the chart and re-applies the RGDs.
@@ -1429,6 +1437,33 @@ dev-kro-seed: ## Apply seed RGDs (providers/infrastructure/examples/rgds/) into 
 dev-kro-down: ## Delete the kedge-kro kind cluster + kubeconfig file
 	-kind delete cluster --name $(KRO_KIND_NAME)
 	-rm -f $(KRO_KIND_KUBECONFIG)
+
+e2e-infrastructure-up: ## Bring up a throwaway kind cluster with Gateway API CRDs + standalone kro for the template e2e
+	@command -v kind >/dev/null || { echo "kind not found; install: brew install kind"; exit 1; }
+	@command -v helm >/dev/null || { echo "helm not found; install: brew install helm"; exit 1; }
+	@if ! kind get clusters | grep -qx "$(E2E_KRO_KIND_NAME)"; then \
+		echo ">>> creating kind cluster $(E2E_KRO_KIND_NAME)"; \
+		kind create cluster --name $(E2E_KRO_KIND_NAME) --kubeconfig $(E2E_KRO_KUBECONFIG); \
+	else \
+		kind get kubeconfig --name $(E2E_KRO_KIND_NAME) > $(E2E_KRO_KUBECONFIG); \
+	fi
+	@echo ">>> installing Gateway API CRDs ($(GATEWAY_API_VERSION)) — templates declare HTTPRoute/ReferenceGrant"
+	KUBECONFIG=$(E2E_KRO_KUBECONFIG) kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
+	@echo ">>> installing standalone kro (no kcp) into $(KRO_NAMESPACE)"
+	KUBECONFIG=$(E2E_KRO_KUBECONFIG) helm upgrade --install kro $(KRO_CHART) \
+		--version $(KRO_CHART_VERSION) -n $(KRO_NAMESPACE) --create-namespace \
+		--set image.repository=$(KRO_IMAGE_REPO) --set image.tag=$(KRO_IMAGE_TAG) \
+		--set multicluster.enabled=false --wait --timeout 5m
+
+e2e-infrastructure-down: ## Delete the infra-template e2e kind cluster + kubeconfig
+	-kind delete cluster --name $(E2E_KRO_KIND_NAME)
+	-rm -f $(E2E_KRO_KUBECONFIG)
+
+e2e-infrastructure-run: ## Run the infra template RGD-acceptance e2e against $(E2E_KRO_KUBECONFIG)
+	cd providers/infrastructure && KUBECONFIG=$(E2E_KRO_KUBECONFIG) \
+		go test -tags e2e -count=1 -timeout 15m ./backend/kro/ -run TestE2E -v
+
+e2e-infrastructure: e2e-infrastructure-up e2e-infrastructure-run ## Bring up kro + run the infra template e2e (then `make e2e-infrastructure-down`)
 
 # --- In-cluster variants (no separate kind cluster) ---
 # Used by Tiltfile.cluster, which already manages a kind cluster for kcp.

--- a/docs/app-studio-runtime-decoupling.md
+++ b/docs/app-studio-runtime-decoupling.md
@@ -60,6 +60,14 @@ App Studio keeps the **product** concerns: the Project capability contract, the 
 
 ## 2. Design principles
 
+> This work is the reference implementation of the platform-wide
+> [provider-isolation rule](./providers.md#provider-isolation-the-cross-provider-boundary)
+> (contract 3 in [`provider-connectivity-contract.md`](./provider-connectivity-contract.md)):
+> App Studio's `APP_STUDIO_RUNTIME_KUBECONFIG` is a direct credential into
+> another provider's backend — exactly what the rule forbids — and this
+> design replaces it with calls to the infrastructure provider's published
+> subresources.
+
 1. **The runtime cluster has exactly one owner: the infrastructure provider.** Whoever materializes a workload also serves its data plane. No other component holds a runtime credential.
 2. **Data-plane verbs are subresources on the workload instance.** `sandboxrunners/{name}/log` is to a `SandboxRunner` what `pods/log` is to a Pod. This keeps the model k8s-native and routable by binding.
 3. **Routing is binding-driven, never URL-driven.** App Studio never resolves a provider backend URL. It calls a subresource on a resource it is already bound to; kcp routes to the provider that exports it. This is the BYO mechanism.

--- a/docs/app-studio-sandbox-runtime.md
+++ b/docs/app-studio-sandbox-runtime.md
@@ -50,7 +50,10 @@ is garbage-collected by the kro template when the `SandboxRunner` instance is
 deleted, and the preview `ReferenceGrant` is materialized by that template too.
 See [`app-studio-runtime-decoupling.md`](./app-studio-runtime-decoupling.md) for
 the full design (including BYO compute, where a workspace can be backed by a
-different infrastructure provider / runtime cluster).
+different infrastructure provider / runtime cluster). This is the platform
+[provider-isolation rule](./providers.md#provider-isolation-the-cross-provider-boundary):
+App Studio never reaches into the infrastructure provider's backend — only its
+published `SandboxRunner` CR and subresources.
 
 ## Capability Boundary
 

--- a/docs/infrastructure-architecture.md
+++ b/docs/infrastructure-architecture.md
@@ -42,6 +42,7 @@ Same user, same workspace, two different namespaces. The instance is real, the p
 3. **Backends implement a narrow interface, not a data model.** Each backend is responsible for taking a `Template` and serving instances of the corresponding per-template CRD. *How* it does that — RGDs, terraform modules, cloud SDK calls — is its own business.
 4. **kcp is the source of truth for identity.** Tenant = workspace logical-cluster name, embedded in the URL. No headers. No hashing.
 5. **The provider binary owns the platform layer + the backends it ships with.** Today that's one backend (kro). The binary stays small; complexity lives in backends behind the interface.
+6. **The backend layer is private to this provider; other providers reach it only through published APIs.** The runtime/target clusters a backend drives, the credentials to them, the kro RGDs, the internal Services — none of it is reachable by another provider. A consumer (e.g. App Studio) interacts with infrastructure-owned workloads **only** through the `Template`/instance CRs (control plane) and their VW subresources (data plane: `sandboxrunners/{name}/log`, `…/proxy/…`), as the tenant user. No other component holds a credential into the runtime cluster. This is the platform-wide [provider-isolation rule](./providers.md#provider-isolation-the-cross-provider-boundary); the worked example is [`app-studio-runtime-decoupling.md`](./app-studio-runtime-decoupling.md).
 
 ## 3. Architecture
 

--- a/docs/kuery-provider-architecture.md
+++ b/docs/kuery-provider-architecture.md
@@ -116,6 +116,12 @@ cluster-name prefix (`{tenantCluster}/…`) before forwarding to the engine. One
 isolation enforced at the single choke point. `KEDGE_DEV_ALLOW_TENANT_QUERY` mirrors the
 infrastructure provider's dev escape hatch.
 
+Kuery's relationship to the **edge providers** also follows the platform
+[provider-isolation rule](./providers.md#provider-isolation-the-cross-provider-boundary):
+it consumes `Edge` CRs (a tenant-scoped permission claim) and reaches the clusters
+through the hub's **edges-proxy** as the caller — it never holds a credential into an
+edge provider's backend.
+
 ### MCP tools (the primary consumer)
 
 The provider serves `/mcp` + `/mcp/sse` (proxied at `/services/providers/kuery/mcp`) and

--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -172,6 +172,11 @@ Two consequences:
   [`providers/infrastructure/tenant/client.go`](https://github.com/faroshq/kedge/blob/main/providers/infrastructure/tenant/client.go): the tenant client is
   built per-(tenant, caller) from the request token; the provider's own
   credentials are never used for tenant work.
+- **Federation routes to published endpoints, not backends.** The aggregator
+  reaches each provider through its registered `BackendURL`/`/mcp` surface
+  with the caller's identity forwarded — never into the provider's runtime
+  cluster, DB, or internal Services. This is the cross-provider half of the
+  platform [provider-isolation rule](./providers.md#provider-isolation-the-cross-provider-boundary).
 
 ## Adding a new integration
 

--- a/docs/provider-connectivity-contract.md
+++ b/docs/provider-connectivity-contract.md
@@ -1,10 +1,17 @@
 # Provider connectivity contract — how providers connect to the platform
 
-This doc pins down the two contracts every provider should follow for *how it
-reaches data*: the **UI data path** (contract 1) and the **API access path**
-(contract 2). It explains the hub plumbing that enforces them, how the portal
-authenticates, which providers conform today, and where the deliberate
-exceptions are.
+This doc pins down the contracts every provider should follow for *how it
+reaches data*: the **UI data path** (contract 1), the **platform API access
+path** (contract 2), and the **provider-to-provider path** (contract 3). It
+explains the hub plumbing that enforces them, how the portal authenticates,
+which providers conform today, and where the deliberate exceptions are.
+
+Contracts 1 and 2 are about a provider reaching the **platform** (kcp / the
+GraphQL gateway). Contract 3 is about a provider reaching **another
+provider** — and the rule there is that it does so *only* through that
+provider's published API, never into its backend. See
+[`providers.md` §"Provider isolation"](./providers.md#provider-isolation-the-cross-provider-boundary)
+for the principle in full; this doc gives the concrete access mechanics.
 
 It is the companion to [`providers.md`](./providers.md) (the provider plane
 overview), [`provider-scoping.md`](./provider-scoping.md) (Global/Org/Personal
@@ -14,11 +21,14 @@ scoping), and [`security.md`](./security.md) (auth setup).
 
 ## Restore-from-reboot summary
 
-- There are **two** legitimate data paths, not one. UI data flows through the
+- There are **three** legitimate data paths. UI data flows through the
   hub's **GraphQL gateway** (contract 1); backend/controller code reaches kcp
   either as a **non-privileged provider ServiceAccount via an
   APIExportEndpointSlice** *or* as the **caller using their forwarded bearer
-  token**, scoped to the tenant workspace (contract 2).
+  token**, scoped to the tenant workspace (contract 2); and one provider
+  reaches **another** provider only through that provider's **published
+  APIExport resources + VW subresources, as the caller** — never into its
+  backend (contract 3).
 - The hub exposes providers through **two different proxies** with **different
   token handling**: the UI proxy forwards **no token**, the backend proxy
   forwards the caller's `Authorization` header **as-is**.
@@ -57,6 +67,27 @@ API **without any admin/root client**. It uses one of two scoped mechanisms:
 Both 2a and 2b are admin-free. New providers should pick one (or use 2a for
 controllers and 2b for request-driven endpoints, like `code` and
 `infrastructure` do) and never construct a kcp-admin / root client.
+
+**Contract 3 — provider-to-provider path.** When provider A needs something
+provider B owns, A goes through **B's published API**, not B's backend:
+
+- **B's `APIExport` resources** — A binds B's `APIExport` (an `APIBinding`
+  in the tenant workspace) and reads/writes B's CRs over the normal
+  `/clusters/...` path. This is the control-plane channel (spec/status).
+- **B's VW subresources** on those resources (e.g.
+  `sandboxrunners/{name}/log`, `…/proxy/{path}`) — for data-plane verbs
+  (streams, proxies, shells) that aren't plain CRUD. B serves them against
+  *its* backend; A never sees it.
+
+Both are invoked **as the caller** (forwarded bearer token, scoped to the
+workspace — same identity as 2b) and **routed by binding, never by a
+backend URL**. A must never hold a credential into B's runtime cluster /
+database / internal Service, call B's internal endpoints directly, or encode
+B's backend topology in its own config. The owning provider is the single
+holder of its backend credential. This is the access mechanics behind
+[`providers.md` §"Provider isolation"](./providers.md#provider-isolation-the-cross-provider-boundary);
+the canonical example is the App Studio → infrastructure data-plane
+decoupling ([`app-studio-runtime-decoupling.md`](./app-studio-runtime-decoupling.md)).
 
 ---
 
@@ -215,6 +246,22 @@ keeps only the CA, and authenticates with the **caller's** bearer token against
 
 ---
 
+## Contract 3 conformance — provider-to-provider via published API only
+
+| Interaction | Mechanism | Verdict |
+|----------|-----------|---------|
+| `app-studio` → `infrastructure` (sandbox data plane) | **Target:** `SandboxRunner` CR (control plane) + `sandboxrunners/{name}/{log,proxy,sync,restart}` VW subresources (data plane), called as the tenant user | ✅ Conforms (after runtime-decoupling) |
+| `app-studio` → runtime cluster (legacy) | held `APP_STUDIO_RUNTIME_KUBECONFIG`, a direct second credential into infrastructure's runtime cluster | ❌ The violation being removed — see [`app-studio-runtime-decoupling.md`](./app-studio-runtime-decoupling.md) |
+| `kuery` → `Edge`s | reads bound `Edge` CRs / engages clusters through the hub's edges-proxy as the caller, never the edge provider's backend | ✅ Conforms |
+
+The shape that conforms: address a **bound resource** (or a subresource on
+it), authenticate as the **caller**, and let the binding decide which
+provider's backend answers. The shape that doesn't: a kubeconfig / DSN / URL
+in provider A's config that points straight at provider B's cluster, DB, or
+internal Service.
+
+---
+
 ## Known divergences (and why)
 
 1. **Built-ins are privileged by construction.** `mcp`, `kubernetesedges`, and
@@ -249,6 +296,10 @@ keeps only the CA, and authenticates with the **caller's** bearer token against
       drop the provider's own credential.
 - [ ] Never trust inbound `X-Kedge-*` headers in the provider — the backend
       proxy strips and re-injects them; treat them as hub-asserted only.
+- [ ] To reach **another provider**, bind its `APIExport` and call its CRs /
+      VW subresources as the caller (contract 3). Never hold a credential
+      into another provider's backend (runtime cluster, DB, internal
+      Service) or hardcode its backend URL.
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -164,6 +164,83 @@ provider's own custom HTTP backend (REST/GraphQL/WS), not for CR traffic.
 
 ---
 
+## Provider isolation (the cross-provider boundary)
+
+**A provider's backend layer is private. Another provider may never reach
+into it. All cross-provider interaction goes through the owning provider's
+*published* API surface.**
+
+This is the single rule that keeps the provider plane composable. State it
+as three parts:
+
+1. **Each provider owns a backend layer, and that layer is private to it.**
+   The "backend layer" is everything behind the provider's published API:
+   its controllers, its runtime/target clusters and the credentials to
+   them, its databases and object stores, its internal Services, its kro
+   RGDs / Terraform / cloud SDK calls — every implementation detail of
+   *how* it materializes and operates what it exports. No other component
+   holds a handle to any of it.
+
+2. **A provider must NOT touch another provider's backend layer.**
+   Concretely, a provider must never:
+   - hold a second credential (kubeconfig, DB DSN, API key) to another
+     provider's runtime cluster, database, or internal service;
+   - call another provider's internal Service / pod / REST endpoint
+     directly, or share its datastore;
+   - encode another provider's backend topology (cluster URLs, namespaces,
+     service names) in its own config.
+
+3. **Cross-provider interaction goes only through the other provider's
+   published interface, as the tenant/caller:**
+   - **kcp `APIExport` resources** — the other provider's CRDs, consumed by
+     binding to its `APIExport` (an `APIBinding` in the tenant workspace)
+     and reading/writing its CRs over the normal `/clusters/...` path.
+     Control-plane state (spec/status) flows this way.
+   - **Virtual-workspace subresources** on those resources — e.g.
+     `sandboxrunners/{name}/log`, `…/proxy/{path}`, `…/exec` — for
+     data-plane verbs (streams, proxies, shells) that aren't plain CRUD.
+     The owning provider serves them against *its* backend; the caller
+     never sees that backend.
+
+   Both are invoked **as the tenant user** (the caller's forwarded bearer
+   token, scoped to the workspace — see contract 2 in
+   [`provider-connectivity-contract.md`](./provider-connectivity-contract.md))
+   and **routed by binding, never by a hardcoded backend URL**. The calling
+   provider resolves *which* provider backs a workspace from the
+   binding/APIExport, not from its own configuration.
+
+**Why the rule pays off:**
+
+- **Substitutability / BYO.** Because the caller addresses a *bound
+  resource* and not a backend URL, the workspace can be backed by a
+  *different instance* of the owning provider — its own runtime cluster,
+  its own APIExport — with **zero change** in the caller. A provider that
+  reached a backend directly would be welded to one deployment.
+- **Single owner per backend.** Exactly one provider holds the credential
+  and the operational responsibility for a given runtime/datastore. No
+  duplicated clients, no two-writers-one-cluster ambiguity.
+- **Contained blast radius.** A provider's compromise or outage is bounded
+  by its published claims, not by who else happens to hold a key into its
+  cluster.
+
+**Reference implementation.** App Studio used to hold
+`APP_STUDIO_RUNTIME_KUBECONFIG` — a direct credential into the
+infrastructure provider's runtime cluster. That is exactly the violation
+this rule forbids. The fix moves the sandbox data plane to **subresources
+on the `SandboxRunner` instance**, served by the infrastructure provider's
+VW; App Studio now calls `sandboxrunners/{name}/{log,proxy,sync,restart}`
+as the tenant user and carries no runtime credential. See
+[`app-studio-runtime-decoupling.md`](./app-studio-runtime-decoupling.md).
+
+> Cross-provider *dependency resolution* (ordering, version-compatibility
+> matrices) remains out of scope for v1 (see Non-goals). The isolation rule
+> is about
+> the *access boundary*, not orchestration: a provider may consume another
+> provider's published API, but it owns the failure handling when a
+> prerequisite binding isn't present.
+
+---
+
 ## CRDs
 
 Two new CRDs, both in the kedge API group, both first-party (added to the
@@ -827,6 +904,12 @@ A provider's UI MUST:
 - **Provider→kcp isolation**: provider SAs are scoped to their own
   workspace. Cross-tenant access only via the APIExport mechanism, which
   kcp gates by `permissionClaims`.
+- **Provider→provider isolation**: a provider never holds a credential into
+  another provider's backend (runtime cluster, DB, internal Service). All
+  cross-provider access is through the other provider's published
+  `APIExport` resources + VW subresources, as the tenant user — see
+  §"Provider isolation". This contains blast radius (one owner per backend)
+  and is what makes BYO compute work.
 - **Permission claim gate**: the binding controller refuses any claim not
   marked `tenantScoped`. An override exists
   (`kedge.faros.sh/accept-untrusted-claims=true`) but is admin-only

--- a/providers/app-studio/README.md
+++ b/providers/app-studio/README.md
@@ -115,6 +115,14 @@ the infrastructure provider as subresources on the `SandboxRunner` instance,
 which App Studio calls through the hub as the requesting user. See
 [`docs/app-studio-runtime-decoupling.md`](../../docs/app-studio-runtime-decoupling.md).
 
+This is the platform
+[provider-isolation rule](../../docs/providers.md#provider-isolation-the-cross-provider-boundary)
+in practice: App Studio reaches infrastructure-owned workloads only through
+the `SandboxRunner` CR and its published subresources — never into the
+infrastructure provider's runtime cluster — which is what lets a tenant be
+backed by a different infrastructure provider (BYO compute) with no App
+Studio change.
+
 When `APP_STUDIO_PREVIEW_BASE_DOMAIN` is set, App Studio also creates a
 `SandboxPreviewHTTPRoute` infrastructure resource beside each `SandboxRunner`.
 That companion template creates a Gateway API `HTTPRoute` that attaches to the

--- a/providers/app-studio/README.md
+++ b/providers/app-studio/README.md
@@ -52,8 +52,6 @@ Environment variables consumed by the binary:
 | `KEDGE_HUB_TOKEN` | Bearer token for the heartbeat |
 | `KEDGE_PROVIDER_NAME` | CatalogEntry name (default `app-studio`) |
 | `KEDGE_PROVIDER_KUBECONFIG` | Provider kubeconfig (kcp front-proxy host + TLS only) |
-| `APP_STUDIO_SANDBOX_RUNNER_IMAGE` | Runner image passed to new `SandboxRunner` resources; use an immutable digest outside local development |
-| `APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE` | kubectl-capable token-generator image passed to new `SandboxRunner` resources; use an immutable digest outside local development |
 | `APP_STUDIO_PREVIEW_BASE_DOMAIN` | Optional DNS zone for companion Sandbox preview routing. |
 | `APP_STUDIO_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAME` | Gateway resource name to attach each preview `HTTPRoute` to. |
 | `APP_STUDIO_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAMESPACE` | Namespace of the parent Gateway (defaults to `kedge-preview`). |

--- a/providers/app-studio/api/deployment_defaults.go
+++ b/providers/app-studio/api/deployment_defaults.go
@@ -67,17 +67,15 @@ func defaultSandboxRunnerBinding(projectName string) aiv1alpha1.ProjectProviderB
 	}
 }
 
+// sandboxRunnerValues are the project-scoped fields App Studio supplies on a
+// SandboxRunner binding. The runner image is NOT one of them: the sandbox-runner
+// template declares spec.runnerImage as a schema field with a sane default (the
+// web-app convention), so App Studio doesn't pass it. See
+// providers/infrastructure/docs/template-conventions.md.
 func sandboxRunnerValues(projectName string) map[string]any {
-	values := map[string]any{
+	return map[string]any{
 		"projectRef": projectName,
 	}
-	if image := sandboxRunnerImage(); image != "" {
-		values["runnerImage"] = image
-	}
-	if image := sandboxTokenGeneratorImage(); image != "" {
-		values["tokenGeneratorImage"] = image
-	}
-	return values
 }
 
 func previewHTTPRouteEnabled() bool {
@@ -130,14 +128,6 @@ func previewBackendServicePort() int64 {
 		return 8080
 	}
 	return port
-}
-
-func sandboxRunnerImage() string {
-	return envValue("APP_STUDIO_SANDBOX_RUNNER_IMAGE")
-}
-
-func sandboxTokenGeneratorImage() string {
-	return envValue("APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE")
 }
 
 func envValue(key string) string {

--- a/providers/app-studio/api/deployment_defaults_test.go
+++ b/providers/app-studio/api/deployment_defaults_test.go
@@ -12,31 +12,19 @@ package api
 
 import "testing"
 
-func TestSandboxRunnerValuesOmitImagesWithoutConfiguration(t *testing.T) {
-	t.Setenv("APP_STUDIO_SANDBOX_RUNNER_IMAGE", "")
-	t.Setenv("APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE", "")
+// App Studio supplies only projectRef on a SandboxRunner binding. The runner
+// image is a schema field with a sane default on the sandbox-runner template
+// (the web-app convention), so App Studio never sets it — not even from the
+// legacy env.
+func TestSandboxRunnerValuesSuppliesOnlyProjectRef(t *testing.T) {
+	t.Setenv("APP_STUDIO_SANDBOX_RUNNER_IMAGE", "ghcr.io/faroshq/kedge-sandbox-runner@sha256:runner")
+	t.Setenv("APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE", "registry.example.com/kubectl@sha256:token")
 
 	values := sandboxRunnerValues("demo")
 	if got := values["projectRef"]; got != "demo" {
 		t.Fatalf("projectRef = %q, want demo", got)
 	}
-	if _, ok := values["runnerImage"]; ok {
-		t.Fatal("runnerImage must not default to a mutable development image")
-	}
-	if _, ok := values["tokenGeneratorImage"]; ok {
-		t.Fatal("tokenGeneratorImage must not default to a mutable development image")
-	}
-}
-
-func TestSandboxRunnerValuesUseConfiguredImages(t *testing.T) {
-	t.Setenv("APP_STUDIO_SANDBOX_RUNNER_IMAGE", " ghcr.io/faroshq/kedge-sandbox-runner@sha256:runner ")
-	t.Setenv("APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE", " registry.example.com/kubectl@sha256:token ")
-
-	values := sandboxRunnerValues("demo")
-	if got := values["runnerImage"]; got != "ghcr.io/faroshq/kedge-sandbox-runner@sha256:runner" {
-		t.Fatalf("runnerImage = %q, want configured digest", got)
-	}
-	if got := values["tokenGeneratorImage"]; got != "registry.example.com/kubectl@sha256:token" {
-		t.Fatalf("tokenGeneratorImage = %q, want configured digest", got)
+	if len(values) != 1 {
+		t.Fatalf("sandboxRunnerValues = %#v, want only projectRef (image is a template schema default)", values)
 	}
 }

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -1,25 +1,10 @@
 {{- $catalogEntryConfigMap := and .Values.catalogEntry.enabled .Values.catalogEntry.renderAsConfigMap -}}
-{{- $sandboxRunnerImage := .Values.sandboxRunner.runnerImage | default "" -}}
-{{- $sandboxTokenGeneratorImage := .Values.sandboxRunner.tokenGeneratorImage | default "" -}}
 {{- $previewGatewayEnabled := .Values.previewGateway.enabled | default false -}}
 {{- $previewGatewayBaseDomain := .Values.previewGateway.baseDomain | default "" -}}
 {{- $previewGatewayFeatureEnabled := and $previewGatewayEnabled (ne (trim $previewGatewayBaseDomain) "") -}}
 {{- $previewGatewayServiceName := printf "%s-preview-gateway" (include "appstudio.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- if and $previewGatewayFeatureEnabled (not .Values.previewTokenSecretRef.name) -}}
 {{- fail "previewGateway is enabled with baseDomain, but previewTokenSecretRef.name is required for shared preview tokens" -}}
-{{- end -}}
-{{- /*
-App Studio creates a SandboxRunner for every project's development environment,
-and the SandboxRunner spec requires both images. Require them unconditionally so
-a misconfigured install fails here instead of producing invalid SandboxRunner
-resources at runtime. (Image ownership moves to the infrastructure provider in a
-later phase; until then App Studio still passes them through.)
-*/ -}}
-{{- if not $sandboxRunnerImage -}}
-{{- fail "sandboxRunner.runnerImage is required; use an immutable digest reference" -}}
-{{- end -}}
-{{- if not $sandboxTokenGeneratorImage -}}
-{{- fail "sandboxRunner.tokenGeneratorImage is required; use an immutable digest reference" -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -106,12 +91,6 @@ spec:
             # calling user via the forwarded bearer token.
             - name: KEDGE_PROVIDER_KUBECONFIG
               value: /var/run/secrets/kedge/kedge-provider-kubeconfig
-            # Always set: the SandboxRunner spec requires both images, and the
-            # template above fails the install when either is unset.
-            - name: APP_STUDIO_SANDBOX_RUNNER_IMAGE
-              value: {{ $sandboxRunnerImage | quote }}
-            - name: APP_STUDIO_SANDBOX_TOKEN_GENERATOR_IMAGE
-              value: {{ $sandboxTokenGeneratorImage | quote }}
             {{- if $previewGatewayFeatureEnabled }}
             - name: APP_STUDIO_PREVIEW_BASE_DOMAIN
               value: {{ $previewGatewayBaseDomain | quote }}

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -39,14 +39,10 @@ providerKubeconfig:
 # infrastructure provider as subresources on the SandboxRunner instance, reached
 # through the hub as the calling user. See docs/app-studio-runtime-decoupling.md.
 
-# Images passed into infrastructure-backed SandboxRunner resources. App Studio
-# creates a SandboxRunner for every project, and its spec requires both images,
-# so the chart fails the install when either is unset (independent of the
-# runtime kubeconfig). They are empty by default so installs do not silently
-# trust mutable development tags — set both to immutable digest references.
-sandboxRunner:
-  runnerImage: ""
-  tokenGeneratorImage: ""
+# The SandboxRunner runner image is NOT configured here — the sandbox-runner
+# template declares it as a schema field with a sane default (the web-app
+# convention). App Studio passes only the project reference. See
+# providers/infrastructure/docs/template-conventions.md.
 
 # Optional preview route deployment settings and companion infrastructure binding.
 # If baseDomain is empty, App Studio does not add the SandboxPreviewHTTPRoute

--- a/providers/infrastructure/README.md
+++ b/providers/infrastructure/README.md
@@ -177,6 +177,16 @@ URL, watches instance CRs across every bound tenant workspace, and — with
 resources on the cluster kro runs in, while the instance object + status stay in
 the tenant workspace.
 
+**This provider is the sole owner of the runtime cluster.** The runtime
+kubeconfig (`/var/run/secrets/kro/kubeconfig`), the kro RGDs, and the
+workloads' internal Services are its private backend layer — no other
+provider holds a credential into them. Consumers (e.g. App Studio) operate
+infrastructure-owned workloads only through the instance CRs (control plane)
+and their VW subresources (data plane: `sandboxrunners/{name}/{log,proxy,…}`),
+as the tenant user. See the platform
+[provider-isolation rule](../../docs/providers.md#provider-isolation-the-cross-provider-boundary)
+and [`app-studio-runtime-decoupling.md`](../../docs/app-studio-runtime-decoupling.md).
+
 ## MCP integration
 
 Add the endpoint to a Claude / Cursor / Cline config separately from

--- a/providers/infrastructure/backend/kro/backend.go
+++ b/providers/infrastructure/backend/kro/backend.go
@@ -56,9 +56,10 @@ type Backend struct {
 	// tokens are the platform-config values substituted for reserved ${kedge.*}
 	// placeholders in a Template's backendConfig before the RGD is authored —
 	// platform-wide settings that belong on the backend, not in per-tenant data.
-	// See substituteTokens in rgd.go. Today: the exposure-layer Gateway parent
-	// (${kedge.gatewayName}/${kedge.gatewayNamespace}) and the sandbox runner
-	// images (${kedge.sandboxRunnerImage}/${kedge.sandboxTokenGeneratorImage}).
+	// See substituteTokens in rgd.go. The ONLY tokens are the exposure-layer
+	// Gateway parent (${kedge.gatewayName}/${kedge.gatewayNamespace}); per-instance
+	// inputs like container images are schema fields with defaults, not tokens
+	// (see providers/infrastructure/docs/template-conventions.md).
 	tokens map[string]string
 }
 
@@ -82,10 +83,11 @@ const (
 //
 //   - KEDGE_GATEWAY_NAME / KEDGE_GATEWAY_NAMESPACE — the exposure-layer Gateway
 //     parent (defaults "cloudflare-tunnel" / "cfgate-system").
-//   - KEDGE_SANDBOX_RUNNER_IMAGE / KEDGE_SANDBOX_TOKEN_GENERATOR_IMAGE — the
-//     images materialized into SandboxRunner workloads. The platform owns these
-//     (App Studio no longer injects them); deployments should pin immutable
-//     digests. Empty when unset — the chart guards against that at install.
+//
+// Per-instance inputs (container images, etc.) are NOT env tokens — templates
+// declare them as schema fields with sane defaults (e.g. SandboxRunner's
+// spec.runnerImage), the same convention every other template follows. See
+// providers/infrastructure/docs/template-conventions.md.
 func New(runtime dynamic.Interface) *Backend {
 	gatewayName := os.Getenv("KEDGE_GATEWAY_NAME")
 	if gatewayName == "" {
@@ -96,10 +98,8 @@ func New(runtime dynamic.Interface) *Backend {
 		gatewayNamespace = DefaultGatewayNamespace
 	}
 	tokens := map[string]string{
-		gatewayNameToken:           gatewayName,
-		gatewayNamespaceToken:      gatewayNamespace,
-		sandboxRunnerImageToken:    os.Getenv("KEDGE_SANDBOX_RUNNER_IMAGE"),
-		sandboxTokenGeneratorToken: os.Getenv("KEDGE_SANDBOX_TOKEN_GENERATOR_IMAGE"),
+		gatewayNameToken:      gatewayName,
+		gatewayNamespaceToken: gatewayNamespace,
 	}
 	return &Backend{runtime: runtime, tokens: tokens}
 }

--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -162,27 +162,12 @@ func TestSubstituteTokensLeavesKroRefs(t *testing.T) {
 	}
 }
 
-func TestSubstituteTokensSandboxImages(t *testing.T) {
-	in := []byte(`{"runner":"${kedge.sandboxRunnerImage}","token":"${kedge.sandboxTokenGeneratorImage}"}`)
-	tokens := map[string]string{
-		sandboxRunnerImageToken:    "ghcr.io/faroshq/kedge-sandbox-runner@sha256:abc",
-		sandboxTokenGeneratorToken: "docker.io/bitnami/kubectl@sha256:def",
-	}
-	out := string(substituteTokens(in, tokens))
-	want := `{"runner":"ghcr.io/faroshq/kedge-sandbox-runner@sha256:abc","token":"docker.io/bitnami/kubectl@sha256:def"}`
-	if out != want {
-		t.Errorf("substituteTokens = %s, want %s", out, want)
-	}
-}
-
-// testTokens is the platform-config token map the backend builds from env,
-// with the gateway defaults and placeholder sandbox images, for buildRGD tests.
+// testTokens is the platform-config token map the backend builds from env (the
+// exposure-layer Gateway parent), for buildRGD tests.
 func testTokens() map[string]string {
 	return map[string]string{
-		gatewayNameToken:           DefaultGatewayName,
-		gatewayNamespaceToken:      DefaultGatewayNamespace,
-		sandboxRunnerImageToken:    "ghcr.io/faroshq/kedge-sandbox-runner:test",
-		sandboxTokenGeneratorToken: "docker.io/bitnami/kubectl:test",
+		gatewayNameToken:      DefaultGatewayName,
+		gatewayNamespaceToken: DefaultGatewayNamespace,
 	}
 }
 

--- a/providers/infrastructure/backend/kro/e2e_test.go
+++ b/providers/infrastructure/backend/kro/e2e_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// E2E coverage for the seeded infrastructure Templates against a real kro
+// cluster. Build-tagged `e2e` so it never runs in the normal `go test ./...`
+// unit pass — it needs a running kro controller (see `make e2e-infrastructure`).
+//
+// What it proves: every Template the provider ships authors a kro
+// ResourceGraphDefinition that kro ACCEPTS (status GraphAccepted=True). This is
+// the exact class of failure that unit tests (which only check buildRGD output)
+// miss — e.g. an integer field fed a string, an includeWhen that isn't a
+// standalone CEL expression, or a container image that resolved to "". kro's
+// graph/schema validation is independent of its watch source, so this works
+// against any kro cluster (standalone kind in CI, or a kcp-wired dev cluster).
+package kro
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	e2eRGDPrefix  = "e2e-"
+	e2eAcceptWait = 90 * time.Second
+	e2ePollEvery  = 2 * time.Second
+)
+
+// TestE2ESeedTemplatesAcceptedByKro builds each seeded Template's RGD with the
+// real buildRGD path and asserts kro accepts the graph.
+func TestE2ESeedTemplatesAcceptedByKro(t *testing.T) {
+	dyn := e2eDynamicClient(t)
+	dir := filepath.Join("..", "..", "install", "templates")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read seed templates dir: %v", err)
+	}
+
+	var seen int
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		seen++
+		t.Run(entry.Name(), func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				t.Fatalf("read %s: %v", entry.Name(), err)
+			}
+			tmpl := decodeTemplate(t, raw)
+			rgd, err := buildRGD(tmpl, testTokens())
+			if err != nil {
+				t.Fatalf("buildRGD(%s): %v", tmpl.Name, err)
+			}
+			// Apply under a throwaway name so the test doesn't clobber any
+			// RGDs a dev cluster already seeded; GraphAccepted is name-
+			// independent. The per-template instance CRD it would create may
+			// collide with a seeded one (KindReady), which is fine — we only
+			// assert the graph is accepted.
+			name := e2eRGDPrefix + tmpl.Name
+			rgd.SetName(name)
+			applyRGDForTest(t, dyn, rgd)
+			t.Cleanup(func() { deleteRGDForTest(dyn, name) })
+
+			reason, msg := waitGraphAccepted(t, dyn, name)
+			if reason != "True" {
+				t.Fatalf("kro rejected RGD for template %q: GraphAccepted=%s: %s", tmpl.Name, reason, msg)
+			}
+			t.Logf("template %q: kro accepted the RGD", tmpl.Name)
+		})
+	}
+	if seen == 0 {
+		t.Fatal("no seed templates found")
+	}
+}
+
+func e2eDynamicClient(t *testing.T) dynamic.Interface {
+	t.Helper()
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("KUBECONFIG not set; this e2e needs a kro cluster (see make e2e-infrastructure)")
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("build rest config from %s: %v", kubeconfig, err)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("dynamic client: %v", err)
+	}
+	return dyn
+}
+
+func applyRGDForTest(t *testing.T, dyn dynamic.Interface, rgd *unstructured.Unstructured) {
+	t.Helper()
+	ctx := context.Background()
+	existing, err := dyn.Resource(rgdGVR).Get(ctx, rgd.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := dyn.Resource(rgdGVR).Create(ctx, rgd, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create RGD %q: %v", rgd.GetName(), err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("get RGD %q: %v", rgd.GetName(), err)
+	}
+	rgd.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := dyn.Resource(rgdGVR).Update(ctx, rgd, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update RGD %q: %v", rgd.GetName(), err)
+	}
+}
+
+func deleteRGDForTest(dyn dynamic.Interface, name string) {
+	_ = dyn.Resource(rgdGVR).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+// waitGraphAccepted polls the RGD until its GraphAccepted condition resolves to
+// True or False (Unknown/AwaitingReconciliation keeps waiting), returning the
+// final status + message.
+func waitGraphAccepted(t *testing.T, dyn dynamic.Interface, name string) (string, string) {
+	t.Helper()
+	deadline := time.Now().Add(e2eAcceptWait)
+	var lastStatus, lastMsg string
+	for time.Now().Before(deadline) {
+		obj, err := dyn.Resource(rgdGVR).Get(context.Background(), name, metav1.GetOptions{})
+		if err == nil {
+			lastStatus, lastMsg = graphAcceptedCondition(obj)
+			if lastStatus == "True" || lastStatus == "False" {
+				return lastStatus, lastMsg
+			}
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	t.Fatalf("timed out after %s waiting for RGD %q GraphAccepted (last=%q: %s)", e2eAcceptWait, name, lastStatus, lastMsg)
+	return lastStatus, lastMsg
+}
+
+func graphAcceptedCondition(obj *unstructured.Unstructured) (string, string) {
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, c := range conds {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _, _ := unstructured.NestedString(cond, "type"); t != "GraphAccepted" {
+			continue
+		}
+		status, _, _ := unstructured.NestedString(cond, "status")
+		msg, _, _ := unstructured.NestedString(cond, "message")
+		return status, msg
+	}
+	return "", ""
+}

--- a/providers/infrastructure/backend/kro/e2e_test.go
+++ b/providers/infrastructure/backend/kro/e2e_test.go
@@ -16,42 +16,69 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// E2E coverage for the seeded infrastructure Templates against a real kro
-// cluster. Build-tagged `e2e` so it never runs in the normal `go test ./...`
-// unit pass — it needs a running kro controller (see `make e2e-infrastructure`).
+// E2E coverage for the seeded infrastructure Templates against a real, CLEAN kro
+// cluster (one fresh cluster per run — see `make e2e-infrastructure`). Build-
+// tagged `e2e` so it never runs in the normal `go test ./...` unit pass.
 //
-// What it proves: every Template the provider ships authors a kro
-// ResourceGraphDefinition that kro ACCEPTS (status GraphAccepted=True). This is
-// the exact class of failure that unit tests (which only check buildRGD output)
-// miss — e.g. an integer field fed a string, an includeWhen that isn't a
-// standalone CEL expression, or a container image that resolved to "". kro's
-// graph/schema validation is independent of its watch source, so this works
-// against any kro cluster (standalone kind in CI, or a kcp-wired dev cluster).
+// For every Template the provider ships it proves two things unit tests can't
+// (they only check buildRGD's output):
+//
+//  1. kro ACCEPTS the authored ResourceGraphDefinition (status GraphAccepted=
+//     True) and establishes the per-template instance CRD. Catches malformed
+//     graphs — an integer field fed a string, an includeWhen that isn't a
+//     standalone CEL expression, etc.
+//  2. kro can CREATE an instance's objects: a sample instance reconciles WITHOUT
+//     an apply error. This is the exact failure that motivated the schema-default
+//     image convention ("apply results contain errors: ... image: Required
+//     value"). It does NOT require the images to pull — apply validates the spec.
 package kro
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
+
+	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
 )
 
 const (
-	e2eRGDPrefix  = "e2e-"
-	e2eAcceptWait = 90 * time.Second
-	e2ePollEvery  = 2 * time.Second
+	e2eGraphWait    = 90 * time.Second
+	e2eCRDWait      = 60 * time.Second
+	e2eInstanceWait = 120 * time.Second
+	e2ePollEvery    = 2 * time.Second
 )
 
-// TestE2ESeedTemplatesAcceptedByKro builds each seeded Template's RGD with the
-// real buildRGD path and asserts kro accepts the graph.
-func TestE2ESeedTemplatesAcceptedByKro(t *testing.T) {
+// e2eMinimalSpecs supplies a valid instance spec for templates that ship no
+// sampleValues (those that do — application, database — use them directly).
+var e2eMinimalSpecs = map[string]map[string]any{
+	"redis-cache":    {"name": "e2e-redis"},
+	"simple-webapp":  {"name": "e2e-web"},
+	"sandbox-runner": {"name": "kedge-sandbox-0000111122223333", "projectRef": "e2e"},
+}
+
+// e2eApplyErrorMarkers are substrings kro puts in an instance condition when it
+// FAILS to apply a child resource (the bug class we guard against). Readiness
+// waits (pods not up because an image can't pull in CI) do not contain these.
+var e2eApplyErrorMarkers = []string{
+	"apply results contain errors",
+	"is invalid",
+	"Required value",
+	"failed to apply",
+	"admission webhook",
+}
+
+func TestE2ESeedTemplates(t *testing.T) {
 	dyn := e2eDynamicClient(t)
 	dir := filepath.Join("..", "..", "install", "templates")
 	entries, err := os.ReadDir(dir)
@@ -71,25 +98,34 @@ func TestE2ESeedTemplatesAcceptedByKro(t *testing.T) {
 				t.Fatalf("read %s: %v", entry.Name(), err)
 			}
 			tmpl := decodeTemplate(t, raw)
+
 			rgd, err := buildRGD(tmpl, testTokens())
 			if err != nil {
 				t.Fatalf("buildRGD(%s): %v", tmpl.Name, err)
 			}
-			// Apply under a throwaway name so the test doesn't clobber any
-			// RGDs a dev cluster already seeded; GraphAccepted is name-
-			// independent. The per-template instance CRD it would create may
-			// collide with a seeded one (KindReady), which is fine — we only
-			// assert the graph is accepted.
-			name := e2eRGDPrefix + tmpl.Name
-			rgd.SetName(name)
-			applyRGDForTest(t, dyn, rgd)
-			t.Cleanup(func() { deleteRGDForTest(dyn, name) })
+			applyRGD(t, dyn, rgd)
+			t.Cleanup(func() { _ = dyn.Resource(rgdGVR).Delete(context.Background(), rgd.GetName(), metav1.DeleteOptions{}) })
 
-			reason, msg := waitGraphAccepted(t, dyn, name)
-			if reason != "True" {
-				t.Fatalf("kro rejected RGD for template %q: GraphAccepted=%s: %s", tmpl.Name, reason, msg)
+			// 1. kro accepts the graph.
+			if status, msg := waitGraphAccepted(t, dyn, rgd.GetName()); status != "True" {
+				t.Fatalf("kro rejected RGD for template %q: GraphAccepted=%s: %s", tmpl.Name, status, msg)
 			}
-			t.Logf("template %q: kro accepted the RGD", tmpl.Name)
+			t.Logf("template %q: RGD accepted", tmpl.Name)
+
+			// 2. kro creates an instance's objects without an apply error.
+			instGVR := schema.GroupVersionResource{
+				Group:    tmpl.Spec.InstanceCRD.Group,
+				Version:  tmpl.Spec.InstanceCRD.Version,
+				Resource: tmpl.Spec.InstanceCRD.Resource,
+			}
+			inst := e2eInstance(t, tmpl)
+			createInstance(t, dyn, instGVR, inst)
+			t.Cleanup(func() {
+				_ = dyn.Resource(instGVR).Delete(context.Background(), inst.GetName(), metav1.DeleteOptions{})
+			})
+
+			waitInstanceApplied(t, dyn, instGVR, inst.GetName(), tmpl.Name)
+			t.Logf("template %q: instance reconciled (objects applied)", tmpl.Name)
 		})
 	}
 	if seen == 0 {
@@ -101,7 +137,7 @@ func e2eDynamicClient(t *testing.T) dynamic.Interface {
 	t.Helper()
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
-		t.Skip("KUBECONFIG not set; this e2e needs a kro cluster (see make e2e-infrastructure)")
+		t.Skip("KUBECONFIG not set; this e2e needs a clean kro cluster (see make e2e-infrastructure)")
 	}
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -114,7 +150,7 @@ func e2eDynamicClient(t *testing.T) dynamic.Interface {
 	return dyn
 }
 
-func applyRGDForTest(t *testing.T, dyn dynamic.Interface, rgd *unstructured.Unstructured) {
+func applyRGD(t *testing.T, dyn dynamic.Interface, rgd *unstructured.Unstructured) {
 	t.Helper()
 	ctx := context.Background()
 	existing, err := dyn.Resource(rgdGVR).Get(ctx, rgd.GetName(), metav1.GetOptions{})
@@ -133,39 +169,118 @@ func applyRGDForTest(t *testing.T, dyn dynamic.Interface, rgd *unstructured.Unst
 	}
 }
 
-func deleteRGDForTest(dyn dynamic.Interface, name string) {
-	_ = dyn.Resource(rgdGVR).Delete(context.Background(), name, metav1.DeleteOptions{})
+// e2eInstance builds a sample instance: the template's sampleValues when present
+// (the curated working example), otherwise a minimal valid spec.
+func e2eInstance(t *testing.T, tmpl *infrav1alpha1.Template) *unstructured.Unstructured {
+	t.Helper()
+	spec := map[string]any{}
+	if sv := tmpl.Spec.SampleValues; sv != nil && len(sv.Raw) > 0 {
+		if err := json.Unmarshal(sv.Raw, &spec); err != nil {
+			t.Fatalf("template %q: decode sampleValues: %v", tmpl.Name, err)
+		}
+	} else if min, ok := e2eMinimalSpecs[tmpl.Name]; ok {
+		spec = min
+	} else {
+		t.Fatalf("template %q has no sampleValues and no e2eMinimalSpecs entry — add one", tmpl.Name)
+	}
+	name, _ := spec["name"].(string)
+	if name == "" {
+		name = "e2e-" + tmpl.Name
+		spec["name"] = name
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": tmpl.Spec.InstanceCRD.Group + "/" + tmpl.Spec.InstanceCRD.Version,
+		"kind":       tmpl.Spec.InstanceCRD.Kind,
+		"metadata":   map[string]any{"name": name},
+		"spec":       spec,
+	}}
 }
 
-// waitGraphAccepted polls the RGD until its GraphAccepted condition resolves to
-// True or False (Unknown/AwaitingReconciliation keeps waiting), returning the
-// final status + message.
+// createInstance retries Create until kro has established + served the
+// per-template CRD (a fresh RGD takes a few seconds to register the kind).
+func createInstance(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, inst *unstructured.Unstructured) {
+	t.Helper()
+	deadline := time.Now().Add(e2eCRDWait)
+	for {
+		_, err := dyn.Resource(gvr).Create(context.Background(), inst, metav1.CreateOptions{})
+		if err == nil || apierrors.IsAlreadyExists(err) {
+			return
+		}
+		// "no matches for kind" / NotFound while the CRD is still registering.
+		if time.Now().After(deadline) {
+			t.Fatalf("create %s instance %q: CRD never became servable: %v", gvr.Resource, inst.GetName(), err)
+		}
+		time.Sleep(e2ePollEvery)
+	}
+}
+
+// waitInstanceApplied waits until kro has reconciled the instance and asserts it
+// applied its objects without an apply error. A readiness wait (images not
+// pulled in CI) is success — apply succeeded. An apply-error marker is failure.
+func waitInstanceApplied(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, name, tmplName string) {
+	t.Helper()
+	deadline := time.Now().Add(e2eInstanceWait)
+	var sawConditions bool
+	for time.Now().Before(deadline) {
+		obj, err := dyn.Resource(gvr).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			time.Sleep(e2ePollEvery)
+			continue
+		}
+		conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+		for _, c := range conds {
+			cond, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			sawConditions = true
+			msg, _, _ := unstructured.NestedString(cond, "message")
+			for _, marker := range e2eApplyErrorMarkers {
+				if strings.Contains(msg, marker) {
+					ctype, _, _ := unstructured.NestedString(cond, "type")
+					t.Fatalf("template %q: kro failed to apply instance objects (%s): %s", tmplName, ctype, msg)
+				}
+			}
+		}
+		// kro reconciled it and recorded conditions, none of which are apply
+		// errors → the objects were applied. (Readiness is out of scope: the
+		// images may be unpullable in CI.)
+		if sawConditions {
+			return
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	if !sawConditions {
+		t.Fatalf("template %q: kro never reconciled instance %q within %s", tmplName, name, e2eInstanceWait)
+	}
+}
+
 func waitGraphAccepted(t *testing.T, dyn dynamic.Interface, name string) (string, string) {
 	t.Helper()
-	deadline := time.Now().Add(e2eAcceptWait)
+	deadline := time.Now().Add(e2eGraphWait)
 	var lastStatus, lastMsg string
 	for time.Now().Before(deadline) {
 		obj, err := dyn.Resource(rgdGVR).Get(context.Background(), name, metav1.GetOptions{})
 		if err == nil {
-			lastStatus, lastMsg = graphAcceptedCondition(obj)
+			lastStatus, lastMsg = conditionByType(obj, "GraphAccepted")
 			if lastStatus == "True" || lastStatus == "False" {
 				return lastStatus, lastMsg
 			}
 		}
 		time.Sleep(e2ePollEvery)
 	}
-	t.Fatalf("timed out after %s waiting for RGD %q GraphAccepted (last=%q: %s)", e2eAcceptWait, name, lastStatus, lastMsg)
+	t.Fatalf("timed out after %s waiting for RGD %q GraphAccepted (last=%q: %s)", e2eGraphWait, name, lastStatus, lastMsg)
 	return lastStatus, lastMsg
 }
 
-func graphAcceptedCondition(obj *unstructured.Unstructured) (string, string) {
+func conditionByType(obj *unstructured.Unstructured, condType string) (string, string) {
 	conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
 	for _, c := range conds {
 		cond, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
-		if t, _, _ := unstructured.NestedString(cond, "type"); t != "GraphAccepted" {
+		if tp, _, _ := unstructured.NestedString(cond, "type"); tp != condType {
 			continue
 		}
 		status, _, _ := unstructured.NestedString(cond, "status")

--- a/providers/infrastructure/backend/kro/e2e_test.go
+++ b/providers/infrastructure/backend/kro/e2e_test.go
@@ -31,25 +31,45 @@ limitations under the License.
 //     an apply error. This is the exact failure that motivated the schema-default
 //     image convention ("apply results contain errors: ... image: Required
 //     value"). It does NOT require the images to pull — apply validates the spec.
+//  3. The child objects the RGD declares actually EXIST in the runtime cluster
+//     (the Deployment, Service, StatefulSet, HTTPRoute, …), matched by kro's
+//     instance-id/node-id labels. Resources gated by includeWhen (e.g. the
+//     preview HTTPRoute) are verified only when present, never required.
 package kro
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 
 	infrav1alpha1 "github.com/faroshq/provider-infrastructure/apis/v1alpha1"
+)
+
+// kro stamps every child object it applies for an instance with these labels
+// (see the kro fork's pkg/metadata). instance-id is the instance UID; node-id is
+// the RGD resource's id. We use them to prove the actual Deployment/Service/
+// HTTPRoute/etc. landed in the runtime cluster, not just that the instance
+// reported no apply error.
+const (
+	kroInstanceIDLabel = "kro.run/instance-id"
+	kroNodeIDLabel     = "kro.run/node-id"
 )
 
 const (
@@ -67,6 +87,22 @@ var e2eMinimalSpecs = map[string]map[string]any{
 	"sandbox-runner": {"name": "kedge-sandbox-0000111122223333", "projectRef": "e2e"},
 }
 
+// e2ePlatformStamped are spec fields a platform component normally writes onto an
+// instance before kro reconciles it — values the user does NOT supply (the
+// sampleValues correctly omit them, marked "do NOT set"). With no controller
+// running in the standalone-kro e2e, the test stands in for the platform and
+// supplies them, so platform-stamped resources can render (e.g. application's
+// HTTPRoute needs spec.expose.fqdn — without it kro can't evaluate the route's
+// hostname and never creates it). Deep-merged onto the spec.
+var e2ePlatformStamped = map[string]map[string]any{
+	// The infra controller computes expose.fqdn and stamps credentialsSecretName
+	// (see the application template's "platform stamps …" note).
+	"application": {
+		"expose":                map[string]any{"fqdn": "demo.e2e.test"},
+		"credentialsSecretName": "demo-oidc",
+	},
+}
+
 // e2eApplyErrorMarkers are substrings kro puts in an instance condition when it
 // FAILS to apply a child resource (the bug class we guard against). Readiness
 // waits (pods not up because an image can't pull in CI) do not contain these.
@@ -79,7 +115,12 @@ var e2eApplyErrorMarkers = []string{
 }
 
 func TestE2ESeedTemplates(t *testing.T) {
-	dyn := e2eDynamicClient(t)
+	dyn, mapper := e2eClients(t)
+	// A per-run nonce makes every instance (and therefore every child object)
+	// uniquely named, so re-running against a reused cluster can't collide with a
+	// previous run's not-yet-garbage-collected objects. 16 hex digits because
+	// sandbox-runner's name must match ^kedge-sandbox-[a-f0-9]{16}$.
+	runID := fmt.Sprintf("%016x", time.Now().UnixNano())
 	dir := filepath.Join("..", "..", "install", "templates")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -118,14 +159,23 @@ func TestE2ESeedTemplates(t *testing.T) {
 				Version:  tmpl.Spec.InstanceCRD.Version,
 				Resource: tmpl.Spec.InstanceCRD.Resource,
 			}
-			inst := e2eInstance(t, tmpl)
+			inst := e2eInstance(t, tmpl, runID)
 			createInstance(t, dyn, instGVR, inst)
 			t.Cleanup(func() {
 				_ = dyn.Resource(instGVR).Delete(context.Background(), inst.GetName(), metav1.DeleteOptions{})
 			})
 
 			waitInstanceApplied(t, dyn, instGVR, inst.GetName(), tmpl.Name)
-			t.Logf("template %q: instance reconciled (objects applied)", tmpl.Name)
+			t.Logf("template %q: instance reconciled (no apply error)", tmpl.Name)
+
+			// 3. The child objects the RGD declares actually exist in the
+			// runtime cluster (the Deployment/Service/StatefulSet/HTTPRoute/…),
+			// not just a clean instance status.
+			created, err := dyn.Resource(instGVR).Get(context.Background(), inst.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("template %q: re-get instance for UID: %v", tmpl.Name, err)
+			}
+			verifyChildrenCreated(t, dyn, mapper, rgd, string(created.GetUID()), tmpl.Name)
 		})
 	}
 	if seen == 0 {
@@ -133,7 +183,11 @@ func TestE2ESeedTemplates(t *testing.T) {
 	}
 }
 
-func e2eDynamicClient(t *testing.T) dynamic.Interface {
+// e2eClients builds a dynamic client and a discovery-backed REST mapper against
+// the cluster in KUBECONFIG. The mapper turns each child kind the RGD declares
+// (Deployment, Service, HTTPRoute, …) into the resource we List to verify it was
+// created.
+func e2eClients(t *testing.T) (dynamic.Interface, meta.RESTMapper) {
 	t.Helper()
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
@@ -147,7 +201,15 @@ func e2eDynamicClient(t *testing.T) dynamic.Interface {
 	if err != nil {
 		t.Fatalf("dynamic client: %v", err)
 	}
-	return dyn
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		t.Fatalf("discovery client: %v", err)
+	}
+	groups, err := restmapper.GetAPIGroupResources(dc)
+	if err != nil {
+		t.Fatalf("discover API groups: %v", err)
+	}
+	return dyn, restmapper.NewDiscoveryRESTMapper(groups)
 }
 
 func applyRGD(t *testing.T, dyn dynamic.Interface, rgd *unstructured.Unstructured) {
@@ -171,7 +233,7 @@ func applyRGD(t *testing.T, dyn dynamic.Interface, rgd *unstructured.Unstructure
 
 // e2eInstance builds a sample instance: the template's sampleValues when present
 // (the curated working example), otherwise a minimal valid spec.
-func e2eInstance(t *testing.T, tmpl *infrav1alpha1.Template) *unstructured.Unstructured {
+func e2eInstance(t *testing.T, tmpl *infrav1alpha1.Template, runID string) *unstructured.Unstructured {
 	t.Helper()
 	spec := map[string]any{}
 	if sv := tmpl.Spec.SampleValues; sv != nil && len(sv.Raw) > 0 {
@@ -179,21 +241,53 @@ func e2eInstance(t *testing.T, tmpl *infrav1alpha1.Template) *unstructured.Unstr
 			t.Fatalf("template %q: decode sampleValues: %v", tmpl.Name, err)
 		}
 	} else if min, ok := e2eMinimalSpecs[tmpl.Name]; ok {
-		spec = min
+		// Copy so the per-run rename below never mutates the shared map.
+		spec = map[string]any{}
+		mergeSpec(spec, min)
 	} else {
 		t.Fatalf("template %q has no sampleValues and no e2eMinimalSpecs entry — add one", tmpl.Name)
 	}
-	name, _ := spec["name"].(string)
-	if name == "" {
-		name = "e2e-" + tmpl.Name
-		spec["name"] = name
+	if overlay, ok := e2ePlatformStamped[tmpl.Name]; ok {
+		mergeSpec(spec, overlay)
 	}
+	name := e2eInstanceName(tmpl.Name, spec, runID)
+	spec["name"] = name
 	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": tmpl.Spec.InstanceCRD.Group + "/" + tmpl.Spec.InstanceCRD.Version,
 		"kind":       tmpl.Spec.InstanceCRD.Kind,
 		"metadata":   map[string]any{"name": name},
 		"spec":       spec,
 	}}
+}
+
+// e2eInstanceName returns a per-run-unique instance name so child objects from
+// one run never collide with a prior run's on a reused cluster. sandbox-runner's
+// name is constrained to ^kedge-sandbox-[a-f0-9]{16}$, so it takes the 16-hex
+// runID verbatim; every other template suffixes its base name with a short slice
+// of it (still a valid DNS label).
+func e2eInstanceName(tmplName string, spec map[string]any, runID string) string {
+	if tmplName == "sandbox-runner" {
+		return "kedge-sandbox-" + runID
+	}
+	base, _ := spec["name"].(string)
+	if base == "" {
+		base = "e2e-" + tmplName
+	}
+	return base + "-" + runID[:8]
+}
+
+// mergeSpec deep-merges src into dst (nested maps recurse; other values
+// overwrite). Used to overlay platform-stamped fields onto a sample spec.
+func mergeSpec(dst, src map[string]any) {
+	for k, v := range src {
+		if vm, ok := v.(map[string]any); ok {
+			if dm, ok := dst[k].(map[string]any); ok {
+				mergeSpec(dm, vm)
+				continue
+			}
+		}
+		dst[k] = v
+	}
 }
 
 // createInstance retries Create until kro has established + served the
@@ -253,6 +347,102 @@ func waitInstanceApplied(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVe
 	if !sawConditions {
 		t.Fatalf("template %q: kro never reconciled instance %q within %s", tmplName, name, e2eInstanceWait)
 	}
+}
+
+// verifyChildrenCreated asserts kro actually created, in the runtime cluster,
+// the child objects the RGD declares for this instance — not merely that the
+// instance reported no apply error. The expected set comes straight from the
+// RGD: every resource with NO includeWhen is created unconditionally and must
+// be found; a resource gated by includeWhen (e.g. the preview HTTPRoute +
+// ReferenceGrant, off in the minimal specs) is verified only if it shows up,
+// never required. Children are matched by kro's own labels
+// (kro.run/instance-id = the instance UID, kro.run/node-id = the RGD resource
+// id), so this is fully template-driven: add a resource to a template and it is
+// automatically required here.
+func verifyChildrenCreated(t *testing.T, dyn dynamic.Interface, mapper meta.RESTMapper, rgd *unstructured.Unstructured, instanceUID, tmplName string) {
+	t.Helper()
+	type childNode struct {
+		id       string
+		gvk      schema.GroupVersionKind
+		required bool
+	}
+	resources, _, _ := unstructured.NestedSlice(rgd.Object, "spec", "resources")
+	var nodes []childNode
+	gvks := map[schema.GroupVersionKind]bool{}
+	for _, r := range resources {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _, _ := unstructured.NestedString(rm, "id")
+		apiVersion, _, _ := unstructured.NestedString(rm, "template", "apiVersion")
+		kind, _, _ := unstructured.NestedString(rm, "template", "kind")
+		if apiVersion == "" || kind == "" {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(apiVersion)
+		if err != nil {
+			t.Fatalf("template %q: resource %q has invalid apiVersion %q: %v", tmplName, id, apiVersion, err)
+		}
+		gvk := gv.WithKind(kind)
+		gvks[gvk] = true
+		includeWhen, hasInclude, _ := unstructured.NestedSlice(rm, "includeWhen")
+		nodes = append(nodes, childNode{id: id, gvk: gvk, required: !hasInclude || len(includeWhen) == 0})
+	}
+	if len(nodes) == 0 {
+		t.Fatalf("template %q: RGD declares no child resources to verify", tmplName)
+	}
+
+	// Resolve each declared kind to a listable resource once.
+	gvrByGVK := map[schema.GroupVersionKind]schema.GroupVersionResource{}
+	for gvk := range gvks {
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			t.Fatalf("template %q: cannot map child kind %s to a resource (is its CRD installed?): %v", tmplName, gvk, err)
+		}
+		gvrByGVK[gvk] = mapping.Resource
+	}
+
+	selector := kroInstanceIDLabel + "=" + instanceUID
+	deadline := time.Now().Add(e2eInstanceWait)
+	var missing []string
+	for {
+		present := map[string]bool{}    // node-id -> created
+		byKind := map[string][]string{} // kind -> object names (for the log)
+		for gvk, gvr := range gvrByGVK {
+			list, err := dyn.Resource(gvr).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+			if err != nil {
+				continue // transient; retried until the deadline
+			}
+			for i := range list.Items {
+				item := &list.Items[i]
+				present[item.GetLabels()[kroNodeIDLabel]] = true
+				byKind[gvk.Kind] = append(byKind[gvk.Kind], item.GetName())
+			}
+		}
+		missing = missing[:0]
+		for _, n := range nodes {
+			if n.required && !present[n.id] {
+				missing = append(missing, n.id+" ("+n.gvk.Kind+")")
+			}
+		}
+		if len(missing) == 0 {
+			summary := make([]string, 0, len(byKind))
+			for kind, names := range byKind {
+				summary = append(summary, kind+"×"+strconv.Itoa(len(names)))
+			}
+			sort.Strings(summary)
+			t.Logf("template %q: kro created child objects in the runtime cluster: %s", tmplName, strings.Join(summary, ", "))
+			return
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	sort.Strings(missing)
+	t.Fatalf("template %q: kro did not create these required child objects within %s: %s",
+		tmplName, e2eInstanceWait, strings.Join(missing, ", "))
 }
 
 func waitGraphAccepted(t *testing.T, dyn dynamic.Interface, name string) (string, string) {

--- a/providers/infrastructure/backend/kro/rgd.go
+++ b/providers/infrastructure/backend/kro/rgd.go
@@ -30,11 +30,6 @@ import (
 const (
 	gatewayNameToken      = "${kedge.gatewayName}"
 	gatewayNamespaceToken = "${kedge.gatewayNamespace}"
-	// sandboxRunnerImageToken / sandboxTokenGeneratorToken carry the images the
-	// SandboxRunner workload + its control-token Job run. The platform owns them
-	// (App Studio no longer injects them into the instance spec).
-	sandboxRunnerImageToken    = "${kedge.sandboxRunnerImage}"
-	sandboxTokenGeneratorToken = "${kedge.sandboxTokenGeneratorImage}"
 )
 
 const (

--- a/providers/infrastructure/backend/kro/seedtemplates_test.go
+++ b/providers/infrastructure/backend/kro/seedtemplates_test.go
@@ -393,17 +393,19 @@ func TestSandboxRunnerUsesManagedJobForControlToken(t *testing.T) {
 		t.Fatalf("runner container must not mount kube-api-access")
 	}
 
-	// The runner image is platform-owned: it comes from the ${kedge.*} token
-	// the backend substitutes, NOT from the instance spec.
-	if got, _, _ := unstructured.NestedString(runnerContainer, "image"); got != testTokens()[sandboxRunnerImageToken] {
-		t.Fatalf("runner image = %q, want the substituted ${kedge.sandboxRunnerImage} %q", got, testTokens()[sandboxRunnerImageToken])
+	// The runner image is a schema field with a sane default (the web-app
+	// convention) — kro resolves ${schema.spec.runnerImage} per instance.
+	if got, _, _ := unstructured.NestedString(runnerContainer, "image"); got != "${schema.spec.runnerImage}" {
+		t.Fatalf("runner image = %q, want ${schema.spec.runnerImage}", got)
 	}
+	// The control-token Job image is hardcoded (kubectl), like every other
+	// template's control job.
 	tokenContainers := mustNestedSlice(t, tokenGeneratorTemplate, "spec", "template", "spec", "containers")
 	if len(tokenContainers) != 1 {
 		t.Fatalf("tokenGenerator containers = %d, want 1", len(tokenContainers))
 	}
-	if got, _, _ := unstructured.NestedString(tokenContainers[0].(map[string]any), "image"); got != testTokens()[sandboxTokenGeneratorToken] {
-		t.Fatalf("token generator image = %q, want the substituted ${kedge.sandboxTokenGeneratorImage} %q", got, testTokens()[sandboxTokenGeneratorToken])
+	if got, _, _ := unstructured.NestedString(tokenContainers[0].(map[string]any), "image"); got != "bitnami/kubectl" {
+		t.Fatalf("token generator image = %q, want bitnami/kubectl", got)
 	}
 
 	runnerNetwork := findResource(t, rgd, "runnerNetwork")

--- a/providers/infrastructure/deploy/chart/templates/_helpers.tpl
+++ b/providers/infrastructure/deploy/chart/templates/_helpers.tpl
@@ -107,23 +107,3 @@ bootstrap.enabled=true. Two sources:
 kubeconfig
 {{- end -}}
 {{- end -}}
-
-{{/*
-Validate the SandboxRunner image config. Both images are platform-owned; an
-install that sets only one is a misconfiguration (the SandboxRunner workload or
-its control-token Job would reference an empty image). Fail fast at install in
-that case. Leaving BOTH empty is allowed — a provider deployment that does not
-run the App Studio sandbox runtime needs neither — but deployments that do run
-it MUST set both to immutable digests (see values.yaml). Invoked from both serve
-paths (chart Deployment and operator).
-*/}}
-{{- define "infrastructure.validateSandboxImages" -}}
-{{- $runner := .Values.sandboxRunner.runnerImage | default "" -}}
-{{- $token := .Values.sandboxRunner.tokenGeneratorImage | default "" -}}
-{{- if and (ne $runner "") (eq $token "") -}}
-{{- fail "sandboxRunner.runnerImage is set but sandboxRunner.tokenGeneratorImage is empty; set both (immutable digests) or neither" -}}
-{{- end -}}
-{{- if and (ne $token "") (eq $runner "") -}}
-{{- fail "sandboxRunner.tokenGeneratorImage is set but sandboxRunner.runnerImage is empty; set both (immutable digests) or neither" -}}
-{{- end -}}
-{{- end -}}

--- a/providers/infrastructure/deploy/chart/templates/deployment.yaml
+++ b/providers/infrastructure/deploy/chart/templates/deployment.yaml
@@ -141,17 +141,6 @@ spec:
             - name: KEDGE_GATEWAY_NAMESPACE
               value: {{ . | quote }}
             {{- end }}
-            {{- include "infrastructure.validateSandboxImages" . }}
-            {{- with .Values.sandboxRunner.runnerImage }}
-            # App Studio SandboxRunner workload image (${kedge.sandboxRunnerImage}).
-            - name: KEDGE_SANDBOX_RUNNER_IMAGE
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.sandboxRunner.tokenGeneratorImage }}
-            # Control-token Job image (${kedge.sandboxTokenGeneratorImage}).
-            - name: KEDGE_SANDBOX_TOKEN_GENERATOR_IMAGE
-              value: {{ . | quote }}
-            {{- end }}
           volumeMounts:
             - name: kedge-provider-kubeconfig
               mountPath: /var/run/secrets/kedge

--- a/providers/infrastructure/deploy/chart/templates/operator.yaml
+++ b/providers/infrastructure/deploy/chart/templates/operator.yaml
@@ -99,19 +99,6 @@ spec:
             # catalogentry.yaml's {{ "{{ .Chart.AppVersion }}" }}.
             - name: KEDGE_PROVIDER_VERSION
               value: {{ .Chart.AppVersion | quote }}
-            {{- include "infrastructure.validateSandboxImages" . }}
-            {{- with .Values.sandboxRunner.runnerImage }}
-            # Platform-owned SandboxRunner images. The operator forwards these to
-            # the serve container it manages (see operator/serve.go); the kro
-            # backend substitutes them for ${kedge.sandboxRunnerImage} /
-            # ${kedge.sandboxTokenGeneratorImage}.
-            - name: KEDGE_SANDBOX_RUNNER_IMAGE
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.sandboxRunner.tokenGeneratorImage }}
-            - name: KEDGE_SANDBOX_TOKEN_GENERATOR_IMAGE
-              value: {{ . | quote }}
-            {{- end }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
 {{- end }}

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -58,17 +58,11 @@ application:
     name: "cloudflare-tunnel"
     namespace: "cfgate-system"
 
-# Images materialized into App Studio SandboxRunner workloads. The platform owns
-# them (App Studio no longer injects them); the kro backend substitutes these
-# for ${kedge.sandboxRunnerImage} / ${kedge.sandboxTokenGeneratorImage} in the
-# sandbox-runner template. Empty by default so installs do not silently trust
-# mutable development tags. Deployments running the App Studio sandbox runtime
-# MUST set both to immutable digest references; leaving them empty makes
-# SandboxRunner pods reference an empty image and fail to start. Setting only one
-# is a misconfiguration the chart rejects at install (see _helpers.tpl).
-sandboxRunner:
-  runnerImage: ""
-  tokenGeneratorImage: ""
+# Container images are NOT configured here. Templates declare them as schema
+# fields with sane defaults (e.g. the sandbox-runner's spec.runnerImage defaults
+# to the standard kedge runner) — the same convention every template follows.
+# See providers/infrastructure/docs/template-conventions.md. Override per instance, or edit the
+# template default, to pin a digest.
 
 # Secret the provider mounts read-only at
 # /var/run/secrets/kedge/kedge-provider-kubeconfig to reach kcp. How it is

--- a/providers/infrastructure/docs/template-conventions.md
+++ b/providers/infrastructure/docs/template-conventions.md
@@ -1,0 +1,57 @@
+# Template authoring conventions
+
+How an infrastructure `Template` exposes the things its instances can configure —
+container images, versions, sizes, ports — and where platform-global values come
+from. The guiding rule:
+
+> **Configurable inputs are `spec.schema` fields with sane defaults. They are
+> never injected via `${kedge.*}` environment-substitution tokens.**
+
+A template must produce a valid workload out of the box, with no deployment-time
+env required. A missing env variable must never be able to bake an empty or
+invalid field into a materialized resource.
+
+## The three kinds of value
+
+| Kind | How to express it | Example |
+|---|---|---|
+| **Per-instance, configurable** (image, version, size, replicas) | `spec.schema` field **with a `default`**; the resource references `${schema.spec.<field>}` | `simple-webapp.spec.image` (`default: "nginx:latest"`); `sandbox-runner.spec.runnerImage` (`default: "ghcr.io/faroshq/kedge-sandbox-runner:dev"`); `postgres-database.spec.version` |
+| **Fixed sidecar / tooling image** (not user-facing) | **hardcoded literal** in the resource | the control-token `bitnami/kubectl` job (sandbox-runner, database, redis, application); `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` |
+| **Platform-global, no universal default** | a reserved `${kedge.*}` substitution token, resolved by the kro backend from env | the exposure Gateway parent: `${kedge.gatewayName}` / `${kedge.gatewayNamespace}` (the **only** tokens that exist) |
+
+## Why not `${kedge.*}` env tokens for images?
+
+They were tried for the sandbox runner and removed. The failure modes:
+
+- **Empty → invalid.** An unset `KEDGE_SANDBOX_RUNNER_IMAGE` substitutes to `""`,
+  and the kro backend bakes `image: ""` into the Deployment/Job — which the API
+  server rejects (`spec.template.spec.containers[0].image: Required value`). A
+  schema `default` cannot be empty.
+- **Substitution-type traps.** A token substitutes a *string* into the JSON, so
+  an integer field (`backendRefs[].port`) becomes `"8080"` and kro rejects the
+  graph (`expected integer type … got string`); and a value meant to be a CEL
+  expression (`includeWhen`) becomes a bare literal kro won't accept. Schema
+  refs (`${schema.spec.…}`) carry their type from the schema and dodge all of
+  this.
+- **Inconsistency.** Every other template uses schema fields + hardcoded sidecar
+  images; an env-token outlier is one more thing to wire (chart env, operator
+  passthrough, dev Makefile) and one more thing to forget.
+
+`${kedge.*}` tokens remain only for the exposure Gateway, which is genuinely one
+platform-wide value with no sane universal default and is referenced identically
+by every app's `HTTPRoute`.
+
+## Checklist for a new template
+
+- [ ] Each container image is either a `spec.schema` field with a sane `default`
+      (user-overridable) or a hardcoded literal (fixed tooling). Never an env
+      token.
+- [ ] Integer/boolean fields are schema fields (so their type is carried), not
+      string substitutions.
+- [ ] The template renders a valid graph with **zero** deployment env set —
+      verify with the `backend/kro` seed-template tests
+      (`buildRGD` + “no unsubstituted `${kedge.*}`”), and against a real kro
+      cluster (`GraphAccepted=True`).
+- [ ] A per-deployment platform value with no universal default? Reconsider —
+      if it truly has none, raise it for a new reserved `${kedge.*}` token
+      rather than reaching for an env override in one template.

--- a/providers/infrastructure/install/templates/sandbox-runner.yaml
+++ b/providers/infrastructure/install/templates/sandbox-runner.yaml
@@ -31,10 +31,8 @@ spec:
         default: "PORT_VALUE=\"$SANDBOX_PORT\"; if [ -z \"$PORT_VALUE\" ]; then PORT_VALUE=3000; fi; if [ -f package.json ]; then npm install --no-audit --no-fund && (npm run dev -- --host 0.0.0.0 --port \"$PORT_VALUE\" || npm start); else npx --yes vite --host 0.0.0.0 --port \"$PORT_VALUE\"; fi"
       runnerImage:
         type: string
-        description: "DEPRECATED and ignored: the runner image is platform-owned and injected by the infrastructure provider from KEDGE_SANDBOX_RUNNER_IMAGE. Retained as an optional field for backward compatibility; removed in a later release."
-      tokenGeneratorImage:
-        type: string
-        description: "DEPRECATED and ignored: the control-token Job image is platform-owned and injected by the infrastructure provider from KEDGE_SANDBOX_TOKEN_GENERATOR_IMAGE. Retained as an optional field for backward compatibility; removed in a later release."
+        description: "Container image for the live development runner. Defaults to the standard kedge runner; override per instance to pin a digest or use a custom runtime."
+        default: "ghcr.io/faroshq/kedge-sandbox-runner:dev"
       port:
         type: integer
         default: 3000
@@ -252,7 +250,7 @@ spec:
                 restartPolicy: OnFailure
                 containers:
                   - name: token
-                    image: ${kedge.sandboxTokenGeneratorImage}
+                    image: bitnami/kubectl
                     command:
                       - /bin/sh
                       - -c
@@ -307,7 +305,7 @@ spec:
                     type: RuntimeDefault
                 containers:
                   - name: runner
-                    image: ${kedge.sandboxRunnerImage}
+                    image: ${schema.spec.runnerImage}
                     env:
                       - name: SANDBOX_WORKDIR
                         value: ${schema.spec.workingDir}

--- a/providers/infrastructure/operator/serve.go
+++ b/providers/infrastructure/operator/serve.go
@@ -13,7 +13,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,17 +94,6 @@ func EnsureProviderServe(
 	}
 	if cr.Spec.Application.Gateway.Namespace != "" {
 		env = append(env, corev1.EnvVar{Name: "KEDGE_GATEWAY_NAMESPACE", Value: cr.Spec.Application.Gateway.Namespace})
-	}
-	// Sandbox runner images the kro backend materializes into SandboxRunner
-	// workloads (substituted for ${kedge.sandboxRunnerImage} /
-	// ${kedge.sandboxTokenGeneratorImage}). Platform-owned — App Studio no
-	// longer injects them. Forwarded from the operator's own environment so the
-	// chart sets them once on the operator; empty values are dropped (the chart
-	// guards that they are set when the sandbox runtime is in use).
-	for _, key := range []string{"KEDGE_SANDBOX_RUNNER_IMAGE", "KEDGE_SANDBOX_TOKEN_GENERATOR_IMAGE"} {
-		if v := os.Getenv(key); v != "" {
-			env = append(env, corev1.EnvVar{Name: key, Value: v})
-		}
 	}
 	volMounts := []corev1.VolumeMount{
 		{Name: "provider-kubeconfig", MountPath: "/var/run/secrets/kedge/provider", ReadOnly: true},


### PR DESCRIPTION
Two parts: (1) make sandbox-runner follow the **schema-default** image convention every other template uses, and (2) add an **e2e + CI gate** so template RGDs are validated against real kro — the check that would have caught the bugs hit while debugging this.

## 1. Sandbox-runner images → schema defaults (drop `${kedge.*}` tokens)
The sandbox-runner template was the lone outlier using `${kedge.*}` env-substitution tokens for its container images (Phase 2a). Every other template (`simple-webapp`, `database`, `redis`, `application`) declares configurable images as **`spec.schema` fields with sane defaults** and **hardcodes fixed sidecar images** (`bitnami/kubectl`). The outlier broke: an unset `KEDGE_SANDBOX_RUNNER_IMAGE` → `image: ""` → kro `Required value`.

- **`spec.runnerImage`** is now a schema field with a sane default (`ghcr.io/faroshq/kedge-sandbox-runner:dev`); the runner Deployment uses `${schema.spec.runnerImage}`.
- The **control-token Job image is hardcoded `bitnami/kubectl`** (`tokenGeneratorImage` field dropped).
- Removed all the dead image-token machinery (kro backend tokens, infra chart `KEDGE_SANDBOX_*` env / install guard / values / operator passthrough, App Studio image injection/helpers/chart guard).
- **Convention documented**: new [`providers/infrastructure/docs/template-conventions.md`](https://github.com/faroshq/kedge/blob/feat/infra-preview-routing/providers/infrastructure/docs/template-conventions.md) + an **AGENTS.md §9** guardrail.

## 2. E2E: every template's RGD must be accepted by kro
Unit tests only check `buildRGD`'s output — they miss whether kro *accepts* the graph (string-vs-int fields, non-standalone `includeWhen`, etc.).

- `providers/infrastructure/backend/kro/e2e_test.go` (build tag `e2e`): for each seeded template, build the real RGD and assert `GraphAccepted=True`. Skips when `KUBECONFIG` is unset, so it never runs in the unit pass.
- `make e2e-infrastructure`: throwaway kind + Gateway API CRDs + **standalone kro** (`multicluster.enabled=false`, no kcp) + the test. Split `-up`/`-run`/`-down`.
- `.github/workflows/infrastructure-templates-e2e.yaml`: runs on PRs touching the templates / kro backend / provider apis.

## Validated end to end
- `go build` + `go test` green (infra + app-studio); both charts render.
- The **actual built RGD for every template (application, database, redis-cache, sandbox-runner, simple-webapp) is accepted by a real kro** — confirmed both against a kcp-wired dev cluster and a **fresh standalone-kro kind cluster** (the CI path).

Also: dev postgres images default to `mirror.gcr.io/library/postgres:16-alpine` (Docker Hub has been dropping pulls with `unexpected EOF`). Preview routing is unchanged (already schema-based on main).

> [!NOTE]
> Supersedes the earlier "Phase 2b preview tokens" content on this branch — that env-token direction was wrong; this reverts to the schema-default convention and adds the CI gate to keep it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
