### PR TITLE
fix(app-studio): unlock infra + repo MCP tools for instance/git turns

### DIFF
--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -135,7 +135,9 @@ func projectAssistantTurnNeedsInfrastructureMCP(history []store.Message) bool {
 		}
 		content := strings.ToLower(strings.TrimSpace(history[i].Content))
 		return containsProjectAssistantTurnKeyword(content, []string{
-			"infrastructure", "infra", "template", "templates", "provision", "database", "postgres", "redis", "supporting resource", "provider",
+			"infrastructure", "infra", "template", "templates", "provision",
+			"instance", "instances", "database", "postgres", "redis",
+			"supporting resource", "provider", "platform", "mcp",
 		})
 	}
 	return false

--- a/providers/app-studio/api/assistant_eino_tool_test.go
+++ b/providers/app-studio/api/assistant_eino_tool_test.go
@@ -22,8 +22,34 @@ import (
 	"testing"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	"github.com/faroshq/provider-app-studio/store"
 	"github.com/faroshq/provider-app-studio/workspace"
 )
+
+func TestProjectAssistantTurnNeedsInfrastructureMCP(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"list instances", "list instances via mcp", true},
+		{"single instance", "show me the status of my instance", true},
+		{"platform vocabulary", "what platform resources do I have?", true},
+		{"mcp mention", "call mcp to enumerate things", true},
+		{"templates", "what templates are available?", true},
+		{"unrelated", "fix the button styling in app.js", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			history := []store.Message{{
+				Role:    aiv1alpha1.ProjectMessageRoleUser,
+				Content: tc.content,
+			}}
+			if got := projectAssistantTurnNeedsInfrastructureMCP(history); got != tc.want {
+				t.Fatalf("projectAssistantTurnNeedsInfrastructureMCP(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestEinoApprovePlanToolRejectsMissingAllowedOperations(t *testing.T) {
 	runState := newProjectEinoAssistantRunState()

--- a/providers/app-studio/api/assistant_turn_profile.go
+++ b/providers/app-studio/api/assistant_turn_profile.go
@@ -166,6 +166,7 @@ func fallbackProjectAssistantTurnDecisionForMessage(content string) projectAssis
 	}
 	if containsProjectAssistantTurnKeyword(normalized, []string{
 		"build", "add", "change", "update", "implement", "write", "make the app", "create", "remove", "delete", "ship", "commit", "deploy", "provision",
+		"git", "push", "pull request", "branch", "merge",
 	}) {
 		return fallbackProjectAssistantTurnDecisionWithProfile(projectAssistantTurnProfileImplementation)
 	}

--- a/providers/app-studio/api/assistant_turn_profile_test.go
+++ b/providers/app-studio/api/assistant_turn_profile_test.go
@@ -43,6 +43,9 @@ func TestProjectAssistantTurnProfileClassifier(t *testing.T) {
 		{name: "debug fix", message: "Fix the failed fetch error and make it work", want: projectAssistantTurnProfileDebugFix},
 		{name: "fix only fallback", message: "Please fix the login form", want: projectAssistantTurnProfileDebugFix},
 		{name: "implementation", message: "Add a search field to the todo app", want: projectAssistantTurnProfileImplementation},
+		{name: "git push", message: "push my changes to git", want: projectAssistantTurnProfileImplementation},
+		{name: "pull request", message: "open a pull request for this branch", want: projectAssistantTurnProfileImplementation},
+		{name: "merge", message: "merge the feature branch", want: projectAssistantTurnProfileImplementation},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

After the app-studio / infrastructure split, the assistant could not list instances. Asking *"list instances via mcp"* returned a reply that it had "no MCP instance list available."

## Root cause

The assistant only fetches the aggregated infrastructure MCP tools when the **last user message** matches a hardcoded keyword gate (`projectAssistantTurnNeedsInfrastructureMCP`, added in #350). The keyword list covered *template/provisioning* vocabulary but omitted the *instance* lifecycle — so prompts about instances never tripped the gate, `infrastructure__list_instances` was never loaded for the turn, and the model truthfully said it had no instance list.

This is not a data-path regression from the runtime-kubeconfig decoupling (#368) — the federated `infrastructure__list_instances` tool is intact; it simply wasn't being offered for these turns.

## Fix

Add `instance`, `instances`, `platform`, and `mcp` to the keyword list, plus a test asserting the gate trips on instance/platform/mcp phrasing and still ignores unrelated turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)