### PR TITLE
fix(kuery): stop a recursive output schema from EOF-ing the whole MCP endpoint

### DIFF
--- a/providers/app-studio/api/assistant_approved_plan.go
+++ b/providers/app-studio/api/assistant_approved_plan.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/faroshq/provider-app-studio/store"
+)
+
+// projectAssistantApprovedPlanGrantRunID is a reserved AssistantRun id that
+// holds the active plan-approval grant for a project. Real assistant runs use
+// "run-<uuid>" ids, so this fixed id never collides. Reusing the AssistantRun
+// blob keeps the grant encrypted at rest and persisted per project without a
+// new store method or schema migration. The grant lives until the next commit,
+// which matches the approval prompt's promise to the user.
+const projectAssistantApprovedPlanGrantRunID = "approved-plan-grant"
+
+func projectAssistantApprovedPlanScopeReady(scope store.Scope) bool {
+	return scope.OrgUUID != "" && scope.WorkspaceUUID != "" && scope.ProjectName != ""
+}
+
+// loadProjectAssistantApprovedPlan returns the active cross-turn plan grant for
+// a project, or nil when none is active. It is best effort: any load failure is
+// logged and treated as "no grant" so a single bad read never blocks a turn.
+func (s *Server) loadProjectAssistantApprovedPlan(ctx context.Context, scope store.Scope) *projectAssistantApprovedPlan {
+	if s == nil || s.store == nil || !projectAssistantApprovedPlanScopeReady(scope) {
+		return nil
+	}
+	run, err := s.store.GetAssistantRun(ctx, scope, projectAssistantApprovedPlanGrantRunID)
+	if err != nil {
+		// Missing grant is the common case (returned as an error); only note
+		// it at high verbosity so genuine store errors remain discoverable.
+		klog.FromContext(ctx).V(4).Info("no active App Studio plan grant", "project", scope.ProjectName, "reason", err.Error())
+		return nil
+	}
+	if len(run.Checkpoint) == 0 {
+		return nil
+	}
+	var plan projectAssistantApprovedPlan
+	if err := json.Unmarshal(run.Checkpoint, &plan); err != nil {
+		klog.FromContext(ctx).Error(err, "decode App Studio plan grant", "project", scope.ProjectName)
+		return nil
+	}
+	if len(plan.Operations) == 0 {
+		// A cleared grant is persisted as an empty object; treat it as none.
+		return nil
+	}
+	normalized := normalizeProjectAssistantApprovedPlan(plan)
+	return &normalized
+}
+
+func (s *Server) saveProjectAssistantApprovedPlan(ctx context.Context, scope store.Scope, plan *projectAssistantApprovedPlan) error {
+	if s == nil || s.store == nil || plan == nil || !projectAssistantApprovedPlanScopeReady(scope) {
+		return nil
+	}
+	raw, err := json.Marshal(plan)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	return s.store.SaveAssistantRun(ctx, scope, store.AssistantRun{
+		ID:         projectAssistantApprovedPlanGrantRunID,
+		Status:     store.AssistantRunStatusCompleted,
+		Checkpoint: raw,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+}
+
+// clearProjectAssistantApprovedPlan retires the active grant by persisting an
+// empty payload, so the next edit turn prompts for plan approval again.
+func (s *Server) clearProjectAssistantApprovedPlan(ctx context.Context, scope store.Scope) error {
+	if s == nil || s.store == nil || !projectAssistantApprovedPlanScopeReady(scope) {
+		return nil
+	}
+	now := time.Now().UTC()
+	return s.store.SaveAssistantRun(ctx, scope, store.AssistantRun{
+		ID:         projectAssistantApprovedPlanGrantRunID,
+		Status:     store.AssistantRunStatusCompleted,
+		Checkpoint: json.RawMessage(`{}`),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	})
+}
+
+// mergeProjectAssistantApprovedPlans keeps the latest plan's narrative while
+// unioning the approved path/operation envelope, so a re-stated plan can only
+// widen what is already allowed, never silently shrink it mid-session.
+func mergeProjectAssistantApprovedPlans(existing, next projectAssistantApprovedPlan) projectAssistantApprovedPlan {
+	merged := next
+	merged.TargetPaths = normalizeProjectAssistantStringList(append(append([]string(nil), existing.TargetPaths...), next.TargetPaths...))
+	merged.Operations = normalizeProjectAssistantStringList(append(append([]string(nil), existing.Operations...), next.Operations...))
+	return merged
+}

--- a/providers/app-studio/api/assistant_eino_engine.go
+++ b/providers/app-studio/api/assistant_eino_engine.go
@@ -92,6 +92,14 @@ func (e projectEinoAssistantEngine) StreamProjectAssistant(
 	runState := newProjectEinoAssistantRunState()
 	runState.SetTurnPolicy(req.TurnPolicy)
 	runState.SetProjectRepositoryRef(projectEinoAssistantProjectRepositoryRef(req))
+	// A new chat message starts a fresh run, so seed the plan-approval grant
+	// that a previous turn earned. Without this the model re-requests approval
+	// every turn even though the grant is meant to last until the next commit.
+	if e.server != nil {
+		if grant := e.server.loadProjectAssistantApprovedPlan(ctx, req.MessageScope); grant != nil {
+			runState.ApprovePlan(*grant)
+		}
+	}
 
 	checkpointID := newProjectAssistantRunID()
 	checkpointStore := newProjectEinoAssistantCheckpointStore()

--- a/providers/app-studio/api/assistant_eino_engine_test.go
+++ b/providers/app-studio/api/assistant_eino_engine_test.go
@@ -1249,6 +1249,73 @@ func TestEinoAssistantEnginePlanApprovalAllowsScopedWriteOnResume(t *testing.T) 
 	}
 }
 
+func TestEinoAssistantEnginePersistedPlanGrantSkipsApprovalOnNewTurn(t *testing.T) {
+	messages := &countingAssistantRunStore{MemoryStore: store.NewMemoryStore()}
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	registry := server.projectAssistantToolRegistry()
+	planTool, ok := registry.Get(projectToolRequestProjectPlanApproval)
+	if !ok {
+		t.Fatal("request_project_plan_approval tool missing")
+	}
+	writeTool, ok := registry.Get(projectToolWriteFile)
+	if !ok {
+		t.Fatal("write_file tool missing")
+	}
+	chatModel := &planThenWriteEinoChatModel{}
+	engine := projectEinoAssistantEngine{
+		server: server,
+		newModel: func(context.Context, projectAssistantRunRequest, *projectEinoAssistantRunState) (einomodel.BaseChatModel, error) {
+			return chatModel, nil
+		},
+		newTools: func(_ context.Context, req projectAssistantRunRequest, state *projectEinoAssistantRunState) ([]einotool.BaseTool, error) {
+			return []einotool.BaseTool{
+				newProjectEinoAssistantServerTool(server, planTool, req, state),
+				newProjectEinoAssistantServerTool(server, writeTool, req, state),
+			}, nil
+		},
+	}
+	id := identity{orgUUID: "org-a", workspaceUUID: "ws-1", tenantPath: "root:org-a:ws-1"}
+	project := &aiv1alpha1.Project{}
+	project.Name = "demo"
+	req := projectAssistantRunRequest{
+		Identity:       id,
+		HTTPRequest:    httptest.NewRequest(http.MethodPost, "/", nil),
+		Project:        project,
+		WorkspaceScope: projectWorkspaceScope(id, project.Name),
+		MessageScope:   projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name),
+		Workspace:      workspaces,
+	}
+
+	// Seed a grant as if a previous turn already earned plan approval.
+	grant := normalizeProjectAssistantApprovedPlan(projectAssistantApprovedPlan{
+		Summary:     "Build app shell",
+		TargetPaths: []string{"src/"},
+		Operations:  []string{projectToolWriteFile},
+	})
+	if err := server.saveProjectAssistantApprovedPlan(context.Background(), req.MessageScope, &grant); err != nil {
+		t.Fatalf("saveProjectAssistantApprovedPlan returned error: %v", err)
+	}
+
+	result, err := engine.StreamProjectAssistant(context.Background(), req)
+	if err != nil {
+		t.Fatalf("StreamProjectAssistant returned error: %v, want no plan permission prompt with an active grant", err)
+	}
+	if result.Content != "workspace ready" {
+		t.Fatalf("content = %q, want resumed model response", result.Content)
+	}
+	read, err := workspaces.ReadFile(context.Background(), req.WorkspaceScope, workspace.ReadOptions{Path: "src/App.tsx"})
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if read.Content != "approved plan write\n" {
+		t.Fatalf("content = %q, want approved plan write", read.Content)
+	}
+	if messages.saveAssistantRunCount != 0 {
+		t.Fatalf("permission checkpoints = %d, want none while a plan grant is active", messages.saveAssistantRunCount)
+	}
+}
+
 func TestEinoAssistantEngineCommitRequestConsumesApprovedPlan(t *testing.T) {
 	messages := &countingAssistantRunStore{MemoryStore: store.NewMemoryStore()}
 	workspaces := workspace.NewFileStore(t.TempDir())
@@ -2211,7 +2278,11 @@ type countingAssistantRunStore struct {
 }
 
 func (s *countingAssistantRunStore) SaveAssistantRun(ctx context.Context, scope store.Scope, run store.AssistantRun) error {
-	s.saveAssistantRunCount++
+	// Only count real run checkpoints. The reserved plan-grant run is
+	// cross-turn approval bookkeeping, not a permission/follow-up checkpoint.
+	if run.ID != projectAssistantApprovedPlanGrantRunID {
+		s.saveAssistantRunCount++
+	}
 	return s.MemoryStore.SaveAssistantRun(ctx, scope, run)
 }
 

--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 	"github.com/eino-contrib/jsonschema"
+	"k8s.io/klog/v2"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 	"github.com/faroshq/provider-app-studio/store"
@@ -273,6 +274,16 @@ func (t projectEinoAssistantTool) invokeAllowedTool(ctx context.Context, callID 
 	if spec.Risk == projectAssistantToolRiskWrite {
 		t.appendBuilderEvent(projectBuilderEventWorkspaceChanged)
 	}
+	if spec.Risk == projectAssistantToolRiskCommit {
+		// The grant ends at the commit it promised; retire it in-memory and in
+		// the store so the next edit cycle prompts for plan approval again.
+		t.runState.ClearApprovedPlan()
+		persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+		defer cancelPersist()
+		if err := t.server.clearProjectAssistantApprovedPlan(persistCtx, t.req.MessageScope); err != nil {
+			klog.FromContext(ctx).Error(err, "clear App Studio plan grant", "project", t.req.MessageScope.ProjectName)
+		}
+	}
 	return result, nil
 }
 
@@ -335,7 +346,19 @@ func (t projectEinoAssistantTool) invokeApprovedPlanTool(ctx context.Context, ca
 	if len(plan.Operations) == 0 {
 		return t.finishFailedToolCall(callID, spec.Name, projectEinoToolArgumentsString(args), "allowedOperations is required")
 	}
+	if existing := t.runState.ApprovedPlan(); existing != nil {
+		plan = mergeProjectAssistantApprovedPlans(*existing, plan)
+	}
 	t.runState.ApprovePlan(plan)
+	// Persist the grant so it survives into later turns until the next commit.
+	// Best effort: a failed write only means the user is re-prompted next turn.
+	if stored := t.runState.ApprovedPlan(); stored != nil {
+		persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+		defer cancelPersist()
+		if err := t.server.saveProjectAssistantApprovedPlan(persistCtx, t.req.MessageScope, stored); err != nil {
+			klog.FromContext(ctx).Error(err, "persist App Studio plan grant", "project", t.req.MessageScope.ProjectName)
+		}
+	}
 	resultPayload := map[string]any{
 		"status":      "approved",
 		"summary":     plan.Summary,

--- a/providers/app-studio/api/assistant_permission.go
+++ b/providers/app-studio/api/assistant_permission.go
@@ -43,7 +43,10 @@ func projectAssistantPermissionForToolWithRunState(spec projectAssistantToolSpec
 	case projectAssistantToolRiskRead, projectAssistantToolRiskInput:
 		return projectAssistantPermissionAllow
 	case projectAssistantToolRiskPlan:
-		if autoApprove {
+		// The first plan in a commit cycle prompts the user. Once a grant is
+		// active it stays active until the next commit, so re-stating the plan
+		// on later turns must not re-prompt — it only widens the envelope.
+		if autoApprove || projectAssistantApprovedPlanActive(runState.ApprovedPlan()) {
 			return projectAssistantPermissionAllow
 		}
 		return projectAssistantPermissionAsk
@@ -59,6 +62,10 @@ func projectAssistantPermissionForToolWithRunState(spec projectAssistantToolSpec
 	default:
 		return projectAssistantPermissionDeny
 	}
+}
+
+func projectAssistantApprovedPlanActive(plan *projectAssistantApprovedPlan) bool {
+	return plan != nil && len(plan.Operations) > 0
 }
 
 func projectAssistantApprovedPlanAllowsWrite(plan *projectAssistantApprovedPlan, toolName string, args map[string]any) bool {

--- a/providers/kuery/mcpserver/server.go
+++ b/providers/kuery/mcpserver/server.go
@@ -20,9 +20,12 @@
 package mcpserver
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"k8s.io/klog/v2"
 
 	"github.com/faroshq/kuery/pkg/engine"
 )
@@ -67,4 +70,20 @@ func newPerRequestServer(deps Deps, r *http.Request) *mcp.Server {
 
 	registerTools(srv, deps, r)
 	return srv
+}
+
+// safeRegister runs one tool's registration in isolation. mcp.AddTool panics
+// on bad tool definitions (most notably the SDK's schema reflector choking on
+// a recursive Go type) — and because the server is built per request inside
+// the streamable-HTTP handler, that panic propagates out of ServeHTTP and the
+// caller just sees a dropped connection (EOF), losing EVERY kuery tool. Wrap
+// each AddTool so a single misbehaving tool degrades to "that one tool is
+// missing" while the rest of kuery's tools keep serving.
+func safeRegister(name string, register func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Background().Error(fmt.Errorf("%v", r), "kuery MCP: tool registration panicked; tool skipped", "tool", name)
+		}
+	}()
+	register()
 }

--- a/providers/kuery/mcpserver/server_test.go
+++ b/providers/kuery/mcpserver/server_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package mcpserver
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestHandlerListsToolsWithoutPanic is the regression guard for the kuery
+// federation EOF: registerTools used to register kuery_query with a typed Out
+// (queryOutput, whose status is the self-recursive v1alpha1.ObjectResult). The
+// SDK's schema reflector panics with "cycle detected" on recursive types, and
+// because the server is built per request, that panic propagated out of
+// ServeHTTP and every /mcp request died mid-flight — the aggregator's tools/list
+// saw an EOF and dropped kuery entirely.
+//
+// This drives the real streamable-HTTP handler the exact way the aggregator
+// does (initialize + tools/list) and asserts both tools come back. Deps.Engine
+// is nil on purpose: registration must not touch it (the engine is only used
+// inside the tool handlers at call time), so a tools/list never dereferences it.
+func TestHandlerListsToolsWithoutPanic(t *testing.T) {
+	srv := httptest.NewServer(NewHandler(Deps{}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: srv.URL + "/mcp"}, nil)
+	if err != nil {
+		t.Fatalf("connect to kuery MCP handler: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	res, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list against kuery MCP handler: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, tool := range res.Tools {
+		got[tool.Name] = true
+	}
+	for _, want := range []string{"kuery_query", "kuery_impact"} {
+		if !got[want] {
+			t.Errorf("tools/list missing %q; got %v", want, keys(got))
+		}
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/providers/kuery/mcpserver/tools.go
+++ b/providers/kuery/mcpserver/tools.go
@@ -32,6 +32,14 @@ type queryInput struct {
 	Spec json.RawMessage `json:"spec" jsonschema:"kuery QuerySpec JSON. Key fields: filter.objects[] (groupKind{group,kind}, namespace, name, labels, categories), cluster.name (an EDGE name to restrict to one edge; omit for the whole fleet), limit, objects.object (sparse projection, e.g. {metadata:{name:true},spec:{replicas:true}}), objects.relations{} (owners, owners+, descendants, descendants+, references, selects, selected-by, linked, linked+, grouped), maxDepth."`
 }
 
+// queryOutput is the kuery_query result. It is returned as the handler's
+// structured output, but the tool is registered with Out=any (see the handler
+// signature in registerTools) so the SDK does NOT infer a JSON output schema
+// from this type. v1alpha1.ObjectResult is self-recursive (its Relations field
+// is map[string][]ObjectResult), and the SDK's schema reflector panics with
+// "cycle detected for type v1alpha1.ObjectResult" on recursive types — which
+// previously crashed every kuery /mcp request. With Out=any the schema is
+// omitted while StructuredOutput and JSON content are still populated.
 type queryOutput struct {
 	Status *v1alpha1.QueryStatus `json:"status"`
 }
@@ -138,108 +146,116 @@ func classifyImpact(anchor *v1alpha1.ObjectResult) (impactedBy, impacts, associa
 func registerTools(srv *mcp.Server, deps Deps, r *http.Request) {
 	ident := queryapi.IdentityFromRequest(r)
 
-	mcp.AddTool(srv, &mcp.Tool{
-		Name:        "kuery_query",
-		Title:       "Query objects across the edge fleet",
-		Description: "Run one kuery query over every edge cluster connected to this workspace: filter by kind/namespace/labels, project sparse fields, and expand relations. Use instead of per-edge kubectl when the question spans edges.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in queryInput) (*mcp.CallToolResult, queryOutput, error) {
-		if ident.Tenant == "" {
-			return nil, queryOutput{}, fmt.Errorf("missing tenant identity")
-		}
-		var spec v1alpha1.QuerySpec
-		if len(in.Spec) > 0 {
-			if err := json.Unmarshal(in.Spec, &spec); err != nil {
-				return nil, queryOutput{}, fmt.Errorf("invalid QuerySpec: %w", err)
+	safeRegister("kuery_query", func() {
+		mcp.AddTool(srv, &mcp.Tool{
+			Name:        "kuery_query",
+			Title:       "Query objects across the edge fleet",
+			Description: "Run one kuery query over every edge cluster connected to this workspace: filter by kind/namespace/labels, project sparse fields, and expand relations. Use instead of per-edge kubectl when the question spans edges.",
+			Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
+			// Out is 'any', not queryOutput, on purpose — see the queryOutput doc
+			// comment: a typed Out makes the SDK infer an output schema from the
+			// recursive v1alpha1.ObjectResult and panic. 'any' keeps the structured
+			// output without the schema.
+		}, func(ctx context.Context, _ *mcp.CallToolRequest, in queryInput) (*mcp.CallToolResult, any, error) {
+			if ident.Tenant == "" {
+				return nil, nil, fmt.Errorf("missing tenant identity")
 			}
-		}
-		queryapi.ScopeToTenant(&spec, ident.Tenant)
-		status, err := deps.Engine.Execute(ctx, &spec)
-		if err != nil {
-			return nil, queryOutput{}, fmt.Errorf("query failed: %w", err)
-		}
-		return nil, queryOutput{Status: status}, nil
+			var spec v1alpha1.QuerySpec
+			if len(in.Spec) > 0 {
+				if err := json.Unmarshal(in.Spec, &spec); err != nil {
+					return nil, nil, fmt.Errorf("invalid QuerySpec: %w", err)
+				}
+			}
+			queryapi.ScopeToTenant(&spec, ident.Tenant)
+			status, err := deps.Engine.Execute(ctx, &spec)
+			if err != nil {
+				return nil, nil, fmt.Errorf("query failed: %w", err)
+			}
+			return nil, queryOutput{Status: status}, nil
+		})
 	})
 
-	mcp.AddTool(srv, &mcp.Tool{
-		Name:  "kuery_impact",
-		Title: "Impact of one object (upstream deps + downstream blast radius)",
-		Description: "Map one object's DECLARED coupling across the edge fleet, split by impact direction so you query the right list:\n" +
-			"- impactedBy (UPSTREAM dependencies): deleting/breaking any of these breaks the target — its owners, the ConfigMaps/Secrets/ServiceAccounts it references, the Namespace it lives in, the selectors that target it. Use for 'why is X failing?' or 'what does X depend on?'.\n" +
-			"- impacts (DOWNSTREAM blast radius): what breaks if you change/delete the target — objects it owns (transitively), Services/endpoints that select it, and (for a Namespace) every object inside it. Use for 'is it safe to change/delete X?'.\n" +
-			"- associated: lateral peers (kuery.io/relates-to links, shared group label).\n" +
-			"Coupling is DECLARED — ownerRefs, spec field references, label selectors, namespace membership — NOT runtime traffic or network policy, so a clean result is not proof nothing else depends on it at runtime. Each related object is returned with its kind/namespace/name/edge and the relation that linked it. Prefer this over per-edge kubectl for change-safety and root-cause questions that span edges.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in impactInput) (*mcp.CallToolResult, impactOutput, error) {
-		if ident.Tenant == "" {
-			return nil, impactOutput{}, fmt.Errorf("missing tenant identity")
-		}
-		if in.Kind == "" || in.Name == "" {
-			return nil, impactOutput{}, fmt.Errorf("kind and name are required")
-		}
-		maxDepth := in.MaxDepth
-		if maxDepth == 0 {
-			maxDepth = 5
-		}
-
-		// Project just enough on related objects to identify them.
-		relProj, _ := json.Marshal(map[string]any{
-			"kind":       true,
-			"apiVersion": true,
-			"metadata":   map[string]any{"name": true, "namespace": true},
-		})
-		relObjects := &v1alpha1.ObjectsSpec{Cluster: true, Object: &runtime.RawExtension{Raw: relProj}}
-		relations := map[string]v1alpha1.RelationSpec{}
-		for _, rel := range impactRelations {
-			rs := v1alpha1.RelationSpec{Objects: relObjects}
-			if rel == "namespaced" {
-				rs.Limit = 200 // a Namespace's membership can be large
+	safeRegister("kuery_impact", func() {
+		mcp.AddTool(srv, &mcp.Tool{
+			Name:  "kuery_impact",
+			Title: "Impact of one object (upstream deps + downstream blast radius)",
+			Description: "Map one object's DECLARED coupling across the edge fleet, split by impact direction so you query the right list:\n" +
+				"- impactedBy (UPSTREAM dependencies): deleting/breaking any of these breaks the target — its owners, the ConfigMaps/Secrets/ServiceAccounts it references, the Namespace it lives in, the selectors that target it. Use for 'why is X failing?' or 'what does X depend on?'.\n" +
+				"- impacts (DOWNSTREAM blast radius): what breaks if you change/delete the target — objects it owns (transitively), Services/endpoints that select it, and (for a Namespace) every object inside it. Use for 'is it safe to change/delete X?'.\n" +
+				"- associated: lateral peers (kuery.io/relates-to links, shared group label).\n" +
+				"Coupling is DECLARED — ownerRefs, spec field references, label selectors, namespace membership — NOT runtime traffic or network policy, so a clean result is not proof nothing else depends on it at runtime. Each related object is returned with its kind/namespace/name/edge and the relation that linked it. Prefer this over per-edge kubectl for change-safety and root-cause questions that span edges.",
+			Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true},
+		}, func(ctx context.Context, _ *mcp.CallToolRequest, in impactInput) (*mcp.CallToolResult, impactOutput, error) {
+			if ident.Tenant == "" {
+				return nil, impactOutput{}, fmt.Errorf("missing tenant identity")
 			}
-			relations[rel] = rs
-		}
-		spec := v1alpha1.QuerySpec{
-			Cluster:  &v1alpha1.ClusterFilter{Name: in.Edge},
-			MaxDepth: maxDepth,
-			Filter: &v1alpha1.QueryFilter{
-				Objects: []v1alpha1.ObjectFilter{{
-					GroupKind: &v1alpha1.GroupKindFilter{APIGroup: in.Group, Kind: in.Kind},
-					Namespace: in.Namespace,
-					Name:      in.Name,
-				}},
-			},
-			Objects: &v1alpha1.ObjectsSpec{
-				ID:        true,
-				Cluster:   true,
-				Relations: relations,
-			},
-		}
-		if in.Edge == "" {
-			spec.Cluster = nil
-		}
-		queryapi.ScopeToTenant(&spec, ident.Tenant)
-		status, err := deps.Engine.Execute(ctx, &spec)
-		if err != nil {
-			return nil, impactOutput{}, fmt.Errorf("impact query failed: %w", err)
-		}
+			if in.Kind == "" || in.Name == "" {
+				return nil, impactOutput{}, fmt.Errorf("kind and name are required")
+			}
+			maxDepth := in.MaxDepth
+			if maxDepth == 0 {
+				maxDepth = 5
+			}
 
-		target := impactRef{Edge: in.Edge, Group: in.Group, Kind: in.Kind, Namespace: in.Namespace, Name: in.Name}
-		if len(status.Objects) == 0 {
-			return nil, impactOutput{
-				Object:  target,
-				Found:   false,
-				Summary: fmt.Sprintf("%s/%s not found in the kuery store (sync may be catching up)", in.Kind, in.Name),
-			}, nil
-		}
-		impactedBy, impacts, associated := classifyImpact(&status.Objects[0])
-		out := impactOutput{
-			Object:     target,
-			Found:      true,
-			ImpactedBy: impactedBy,
-			Impacts:    impacts,
-			Associated: associated,
-			Summary: fmt.Sprintf("%s %s/%s: %d upstream dependency(ies) that can break it, %d downstream object(s) in its blast radius, %d associated.",
-				in.Kind, in.Namespace, in.Name, len(impactedBy), len(impacts), len(associated)),
-		}
-		return nil, out, nil
+			// Project just enough on related objects to identify them.
+			relProj, _ := json.Marshal(map[string]any{
+				"kind":       true,
+				"apiVersion": true,
+				"metadata":   map[string]any{"name": true, "namespace": true},
+			})
+			relObjects := &v1alpha1.ObjectsSpec{Cluster: true, Object: &runtime.RawExtension{Raw: relProj}}
+			relations := map[string]v1alpha1.RelationSpec{}
+			for _, rel := range impactRelations {
+				rs := v1alpha1.RelationSpec{Objects: relObjects}
+				if rel == "namespaced" {
+					rs.Limit = 200 // a Namespace's membership can be large
+				}
+				relations[rel] = rs
+			}
+			spec := v1alpha1.QuerySpec{
+				Cluster:  &v1alpha1.ClusterFilter{Name: in.Edge},
+				MaxDepth: maxDepth,
+				Filter: &v1alpha1.QueryFilter{
+					Objects: []v1alpha1.ObjectFilter{{
+						GroupKind: &v1alpha1.GroupKindFilter{APIGroup: in.Group, Kind: in.Kind},
+						Namespace: in.Namespace,
+						Name:      in.Name,
+					}},
+				},
+				Objects: &v1alpha1.ObjectsSpec{
+					ID:        true,
+					Cluster:   true,
+					Relations: relations,
+				},
+			}
+			if in.Edge == "" {
+				spec.Cluster = nil
+			}
+			queryapi.ScopeToTenant(&spec, ident.Tenant)
+			status, err := deps.Engine.Execute(ctx, &spec)
+			if err != nil {
+				return nil, impactOutput{}, fmt.Errorf("impact query failed: %w", err)
+			}
+
+			target := impactRef{Edge: in.Edge, Group: in.Group, Kind: in.Kind, Namespace: in.Namespace, Name: in.Name}
+			if len(status.Objects) == 0 {
+				return nil, impactOutput{
+					Object:  target,
+					Found:   false,
+					Summary: fmt.Sprintf("%s/%s not found in the kuery store (sync may be catching up)", in.Kind, in.Name),
+				}, nil
+			}
+			impactedBy, impacts, associated := classifyImpact(&status.Objects[0])
+			out := impactOutput{
+				Object:     target,
+				Found:      true,
+				ImpactedBy: impactedBy,
+				Impacts:    impacts,
+				Associated: associated,
+				Summary: fmt.Sprintf("%s %s/%s: %d upstream dependency(ies) that can break it, %d downstream object(s) in its blast radius, %d associated.",
+					in.Kind, in.Namespace, in.Name, len(impactedBy), len(impacts), len(associated)),
+			}
+			return nil, out, nil
+		})
 	})
 }


### PR DESCRIPTION
## Problem

A misbehaving provider was taking down MCP tooling for the whole aggregate. Observed in the hub logs as the kuery provider being silently dropped from federation:

```
provider federation: tools/list failed (skipping) provider="kuery" err="POST .../mcp: EOF"
```

Root cause: the kuery provider's `/mcp` handler **panicked on every request**. `kuery_query` was registered with a typed `Out` (`queryOutput` → `v1alpha1.QueryStatus` → `[]ObjectResult`), and `ObjectResult` is **self-recursive** (`Relations map[string][]ObjectResult`). The go-sdk schema reflector panics with `cycle detected for type v1alpha1.ObjectResult` on recursive types. Because the MCP server is built per request, that panic propagated out of `ServeHTTP` and the connection dropped mid-flight — the aggregator saw an `EOF` and dropped **all** of kuery's tools (`kuery_query` *and* `kuery_impact`).

## Fix

Two layers, so one bad tool can never take down a provider's whole MCP surface:

1. **Fix the actual bug** — register `kuery_query` with `Out=any`. The SDK documents this as the escape hatch: with `Out=any` it omits output-schema inference (no cycle) while still populating structured output + JSON content from the returned value.
2. **Defense in depth** — wrap each tool registration in `safeRegister()`. A panic in any single `AddTool` is now recovered and logged, so one bad tool degrades to "that tool is missing" instead of crashing the per-request server and EOF-ing the caller.

## Test

Adds `TestHandlerListsToolsWithoutPanic`, which drives the **real** streamable-HTTP handler the same way the aggregator does (`initialize` + `tools/list`) and asserts both tools are listed. Verified it fails (panic/EOF) on the pre-fix code and passes after.

## Notes / out of scope

- Bundles in-progress **app-studio assistant** (eino / approved-plan) changes that were already in the working tree, per request.
- Two *other* federation symptoms seen in the same logs are **not** addressed here (separate concerns): app-studio returning `405` to `POST /mcp` (it doesn't expose a provider MCP server, so it shouldn't be in the federation list), and the hub's `SandboxRunner not found` poll spam (a stale development environment referencing a deleted sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
