### PR TITLE
feat(infra): publish kedge-sandbox-runner image and point the template at it

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -121,6 +121,32 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  # PR-only validation that the sandbox runner Dockerfile + build context still
+  # builds. The runner ships with app-studio (built from its ./runner) and is
+  # PUBLISHED — with the app-studio version tags + :latest — by
+  # provider-release.yaml on a `providers/app-studio/v*` tag, not here. Its
+  # Dockerfile.runner COPYs provider-sdk + providers/app-studio, so the context
+  # is the repo root (unlike the provider matrix above).
+  build-sandbox-runner-image:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build sandbox runner image (validation only)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./providers/app-studio/Dockerfile.runner
+          platforms: linux/amd64
+          push: false
+
   build-and-push-agent-image:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -78,6 +78,25 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.semver }}
 
+      # The sandbox runner image is part of app-studio: it is built from
+      # app-studio's ./runner and is what the infrastructure SandboxRunner
+      # template runs. Publish it on every app-studio release with the SAME
+      # version tags as the provider image, plus :latest (the tag the template
+      # defaults to). Dockerfile.runner COPYs provider-sdk + providers/app-studio,
+      # so its build context is the repo root, not ./providers/app-studio.
+      - name: Build and push sandbox runner image
+        if: steps.tag.outputs.provider == 'app-studio'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./providers/app-studio/Dockerfile.runner
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-sandbox-runner:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-sandbox-runner:${{ steps.tag.outputs.semver }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-sandbox-runner:latest
+
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -1112,7 +1112,7 @@ uninstall-provider-app-studio: ## Delete App Studio CatalogEntry
 		delete -f $(APP_STUDIO_MANIFEST) -f $(APP_STUDIO_PROVIDER_MANIFEST)
 
 # --- App Studio sandbox runner image (live development runtimes) ---
-SANDBOX_RUNNER_IMAGE ?= ghcr.io/faroshq/kedge-sandbox-runner:dev
+SANDBOX_RUNNER_IMAGE ?= ghcr.io/faroshq/kedge-sandbox-runner:latest
 SANDBOX_TOKEN_GENERATOR_IMAGE ?= docker.io/bitnami/kubectl@sha256:b9f4412e53f09d76b0991cdd29c0feff4c1d1e112b307e0ab155e5b050a9f4ec
 SANDBOX_RUNNER_PLATFORM ?= linux/$(ARCH)
 

--- a/providers/infrastructure/docs/template-conventions.md
+++ b/providers/infrastructure/docs/template-conventions.md
@@ -15,7 +15,7 @@ invalid field into a materialized resource.
 
 | Kind | How to express it | Example |
 |---|---|---|
-| **Per-instance, configurable** (image, version, size, replicas) | `spec.schema` field **with a `default`**; the resource references `${schema.spec.<field>}` | `simple-webapp.spec.image` (`default: "nginx:latest"`); `sandbox-runner.spec.runnerImage` (`default: "ghcr.io/faroshq/kedge-sandbox-runner:dev"`); `postgres-database.spec.version` |
+| **Per-instance, configurable** (image, version, size, replicas) | `spec.schema` field **with a `default`**; the resource references `${schema.spec.<field>}` | `simple-webapp.spec.image` (`default: "nginx:latest"`); `sandbox-runner.spec.runnerImage` (`default: "ghcr.io/faroshq/kedge-sandbox-runner:latest"`); `postgres-database.spec.version` |
 | **Fixed sidecar / tooling image** (not user-facing) | **hardcoded literal** in the resource | the control-token `bitnami/kubectl` job (sandbox-runner, database, redis, application); `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` |
 | **Platform-global, no universal default** | a reserved `${kedge.*}` substitution token, resolved by the kro backend from env | the exposure Gateway parent: `${kedge.gatewayName}` / `${kedge.gatewayNamespace}` (the **only** tokens that exist) |
 

--- a/providers/infrastructure/install/templates/sandbox-runner.yaml
+++ b/providers/infrastructure/install/templates/sandbox-runner.yaml
@@ -31,8 +31,8 @@ spec:
         default: "PORT_VALUE=\"$SANDBOX_PORT\"; if [ -z \"$PORT_VALUE\" ]; then PORT_VALUE=3000; fi; if [ -f package.json ]; then npm install --no-audit --no-fund && (npm run dev -- --host 0.0.0.0 --port \"$PORT_VALUE\" || npm start); else npx --yes vite --host 0.0.0.0 --port \"$PORT_VALUE\"; fi"
       runnerImage:
         type: string
-        description: "Container image for the live development runner. Defaults to the standard kedge runner; override per instance to pin a digest or use a custom runtime."
-        default: "ghcr.io/faroshq/kedge-sandbox-runner:dev"
+        description: "Container image for the live development runner. Defaults to the standard kedge runner (published with app-studio releases); override per instance to pin a digest or use a custom runtime."
+        default: "ghcr.io/faroshq/kedge-sandbox-runner:latest"
       port:
         type: integer
         default: 3000


### PR DESCRIPTION
## Problem

The infrastructure `sandbox-runner` Template defaulted `spec.runnerImage` to `ghcr.io/faroshq/kedge-sandbox-runner:dev`, but **nothing ever built and pushed that image**:

- the Makefile only `kind load`s it into a local cluster (`load-sandbox-runner-image`) — no push;
- no CI workflow targets `providers/app-studio/Dockerfile.runner` (`images.yaml` builds the hub, the 5 provider `Dockerfile`s, and the agent — never the runner).

So on any cluster that pulls from ghcr, the runner pod `ImagePullBackOff`s. Observed live on the home cluster:

```
kedge-sandbox-…  0/1  ImagePullBackOff
runner: ErrImagePull … ghcr.io/faroshq/kedge-sandbox-runner:dev: … 403 Forbidden
```

The package never existed.

## Change

Publish the runner and point the template at the published tag.

- **`provider-release.yaml`** — on every `providers/app-studio/v*` release, additionally build `Dockerfile.runner` and push `ghcr.io/<owner>/kedge-sandbox-runner` with the **same version tags as the app-studio provider image** (`vX.Y.Z` and `X.Y.Z`) **plus `:latest`**. Multi-arch (amd64+arm64). The runner ships with app-studio (built from its `./runner`), so it releases on the same tag. Build context is the repo root because `Dockerfile.runner` `COPY`s `provider-sdk` + `providers/app-studio` (so it can't reuse the provider matrix's `./providers/<name>` context).
- **`images.yaml`** — PR-only build validation of `Dockerfile.runner` so a broken runner build is caught before a release tag.
- **`sandbox-runner.yaml`** — default `runnerImage` `:dev` → `:latest`. Left at the default pull policy (`Always` for a `:latest` tag) so every sandbox pod gets the newest published runner.
- **`Makefile`** + **`template-conventions.md`** — align the `:dev` → `:latest` references.

## ⚠️ Follow-up required after first release

The ghcr package `kedge-sandbox-runner` is created **private** on first push. It must be made **public** (or the runtime cluster given an image pull secret), otherwise pods keep `403`ing — with `imagePullPolicy: Always` there is no local fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
