### PR TITLE
[codex] Reconcile sandbox preview ReferenceGrants in infrastructure

### DIFF
--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -931,8 +931,20 @@ local_resource(
     # KRO_KUBECONFIG points at the kind cluster's host kubeconfig (where kro is).
     serve_cmd=('KRO_KUBECONFIG={kro} INFRASTRUCTURE_KUBECONFIG={kc} ' +
                'INFRASTRUCTURE_WORKSPACE_PATH=root:kedge:providers:infrastructure ' +
+               'KEDGE_SANDBOX_PREVIEW_BASE_DOMAIN={preview_domain} ' +
+               'KEDGE_SANDBOX_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAME={preview_gateway} ' +
+               'KEDGE_SANDBOX_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAMESPACE=envoy-gateway-system ' +
+               'KEDGE_SANDBOX_PREVIEW_HTTPROUTE_PARENT_GATEWAY_SECTION_NAME={preview_listener} ' +
+               'KEDGE_SANDBOX_PREVIEW_BACKEND_NAMESPACE={preview_namespace} ' +
+               'KEDGE_SANDBOX_PREVIEW_BACKEND_SERVICE_NAME={preview_backend} ' +
+               'KEDGE_SANDBOX_PREVIEW_BACKEND_SERVICE_PORT=8080 ' +
                'make run-provider-infrastructure').format(
-                   kro=KIND_HOST_KUBECONFIG, kc=KCP_ADMIN_KUBECONFIG),
+                   kro=KIND_HOST_KUBECONFIG, kc=KCP_ADMIN_KUBECONFIG,
+                   preview_domain=app_studio_preview_base_domain,
+                   preview_gateway=app_studio_preview_parent_gateway_name,
+                   preview_listener=app_studio_preview_listener,
+                   preview_namespace=app_studio_preview_namespace,
+                   preview_backend=app_studio_preview_gateway_name),
     deps=[
         'providers/infrastructure/main.go',
         'providers/infrastructure/heartbeat.go',

--- a/providers/infrastructure/dataplane/handler.go
+++ b/providers/infrastructure/dataplane/handler.go
@@ -52,15 +52,31 @@ type InstanceGetter interface {
 // target via the template contract, and reverse-proxies to the runtime cluster
 // the provider owns. Consumers therefore never hold a runtime credential.
 type Handler struct {
-	instances InstanceGetter
-	contracts ContractGetter
-	runtime   Runtime
+	instances     InstanceGetter
+	contracts     ContractGetter
+	runtime       Runtime
+	previewRoutes PreviewRouteEnsurer
+}
+
+// HandlerOption customizes the data-plane handler.
+type HandlerOption func(*Handler)
+
+// WithPreviewRouteManager installs the infrastructure-owned preview route
+// reconciler. It is only used for SandboxRunner proxy requests.
+func WithPreviewRouteManager(manager PreviewRouteEnsurer) HandlerOption {
+	return func(h *Handler) {
+		h.previewRoutes = manager
+	}
 }
 
 // NewHandler wires the handler. Any nil dependency makes the data plane report
 // 503 (the serve process runs without a runtime/kcp config in dev).
-func NewHandler(instances InstanceGetter, contracts ContractGetter, runtime Runtime) *Handler {
-	return &Handler{instances: instances, contracts: contracts, runtime: runtime}
+func NewHandler(instances InstanceGetter, contracts ContractGetter, runtime Runtime, opts ...HandlerOption) *Handler {
+	h := &Handler{instances: instances, contracts: contracts, runtime: runtime}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
 // request is the parsed addressing of a data-plane call.
@@ -125,6 +141,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if target.FromStatus {
 		writeInstanceStatus(w, instance)
 		return
+	}
+
+	if h.previewRoutes != nil && req.resource == "sandboxrunners" && req.verb == "proxy" {
+		if err := h.previewRoutes.Ensure(r.Context(), instance); err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
 	}
 
 	// 5b. Reverse-proxy to the runtime Service the provider owns.

--- a/providers/infrastructure/dataplane/handler_test.go
+++ b/providers/infrastructure/dataplane/handler_test.go
@@ -18,6 +18,7 @@ package dataplane
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -75,6 +76,19 @@ func (f *fakeRuntime) Transport() (http.RoundTripper, error) {
 func (f *fakeRuntime) ControlToken(_ context.Context, namespace, name string) (string, error) {
 	f.gotTokenNamespace, f.gotTokenName = namespace, name
 	return f.token, nil
+}
+
+type fakePreviewRouteManager struct {
+	err error
+
+	calls int
+	got   *unstructured.Unstructured
+}
+
+func (f *fakePreviewRouteManager) Ensure(_ context.Context, instance *unstructured.Unstructured) error {
+	f.calls++
+	f.got = instance
+	return f.err
 }
 
 func newTestHandler(t *testing.T, ig *fakeInstanceGetter, rt *fakeRuntime) *Handler {
@@ -151,6 +165,61 @@ func TestHandlerProxyVerbAppendsCallerPath(t *testing.T) {
 	wantPath := "/api/v1/namespaces/" + testNamespace + "/services/" + testNamespace + "-preview:preview/proxy/assets/app.js"
 	if gotPath != wantPath {
 		t.Errorf("upstream path = %q, want %q", gotPath, wantPath)
+	}
+}
+
+func TestHandlerEnsuresPreviewRouteBeforeProxyingSandboxPreview(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+	}))
+	defer upstream.Close()
+
+	manager := &fakePreviewRouteManager{}
+	h := NewHandler(
+		&fakeInstanceGetter{instance: runnerInstance(testNamespace)},
+		&fakeContractGetter{contract: sandboxRunnerContract()},
+		&fakeRuntime{host: upstream.URL},
+		WithPreviewRouteManager(manager),
+	)
+	rec := doRequest(h, http.MethodGet, dataplaneURL("proxy")+"/assets/app.js")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if manager.calls != 1 {
+		t.Fatalf("preview route ensure calls = %d, want 1", manager.calls)
+	}
+	if manager.got == nil || manager.got.GetName() != "kedge-sandbox-a1c31ddaaaa007d4" {
+		t.Fatalf("preview route manager got instance %#v", manager.got)
+	}
+	if gotPath == "" {
+		t.Fatal("request was not proxied after preview route ensure")
+	}
+}
+
+func TestHandlerReportsPreviewRouteNotReady(t *testing.T) {
+	h := NewHandler(
+		&fakeInstanceGetter{instance: runnerInstance(testNamespace)},
+		&fakeContractGetter{contract: sandboxRunnerContract()},
+		&fakeRuntime{host: "http://unused"},
+		WithPreviewRouteManager(&fakePreviewRouteManager{err: previewRouteNotReady("waiting for ResolvedRefs")}),
+	)
+	rec := doRequest(h, http.MethodGet, dataplaneURL("proxy"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestHandlerFailsClosedWhenPreviewRouteValidationFails(t *testing.T) {
+	h := NewHandler(
+		&fakeInstanceGetter{instance: runnerInstance(testNamespace)},
+		&fakeContractGetter{contract: sandboxRunnerContract()},
+		&fakeRuntime{host: "http://unused"},
+		WithPreviewRouteManager(&fakePreviewRouteManager{err: errors.New("unexpected backend")}),
+	)
+	rec := doRequest(h, http.MethodGet, dataplaneURL("proxy"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
 	}
 }
 

--- a/providers/infrastructure/dataplane/preview_route.go
+++ b/providers/infrastructure/dataplane/preview_route.go
@@ -1,0 +1,447 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	defaultPreviewBackendNamespace = "kedge-preview"
+	defaultPreviewBackendService   = "sandbox-preview-gateway"
+	defaultPreviewBackendPort      = 8080
+)
+
+var (
+	httpRouteGVR = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1",
+		Resource: "httproutes",
+	}
+	referenceGrantGVR = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1beta1",
+		Resource: "referencegrants",
+	}
+)
+
+// PreviewRouteEnsurer verifies and reconciles the Gateway API grant required by
+// a SandboxRunner preview route. The caller has already been authorized against
+// the SandboxRunner instance before this runs.
+type PreviewRouteEnsurer interface {
+	Ensure(ctx context.Context, instance *unstructured.Unstructured) error
+}
+
+// GatewayParentRef is the platform Gateway parent a sandbox preview route is
+// allowed to attach to. Empty fields mean "do not enforce this field".
+type GatewayParentRef struct {
+	Name        string
+	Namespace   string
+	SectionName string
+}
+
+// PreviewRouteConfig is the platform allowlist for sandbox preview routing.
+type PreviewRouteConfig struct {
+	BaseDomain       string
+	ParentGateway    GatewayParentRef
+	BackendNamespace string
+	BackendService   string
+	BackendPort      int64
+}
+
+// PreviewRouteConfigFromEnv reads infrastructure-owned preview routing config.
+// APP_STUDIO_* fallbacks keep local/dev deployments working while ownership is
+// moving out of App Studio.
+func PreviewRouteConfigFromEnv() PreviewRouteConfig {
+	return normalizePreviewRouteConfig(PreviewRouteConfig{
+		BaseDomain: envAny("KEDGE_SANDBOX_PREVIEW_BASE_DOMAIN", "APP_STUDIO_PREVIEW_BASE_DOMAIN"),
+		ParentGateway: GatewayParentRef{
+			Name:        envAny("KEDGE_SANDBOX_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAME", "APP_STUDIO_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAME"),
+			Namespace:   envAny("KEDGE_SANDBOX_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAMESPACE", "APP_STUDIO_PREVIEW_HTTPROUTE_PARENT_GATEWAY_NAMESPACE"),
+			SectionName: envAny("KEDGE_SANDBOX_PREVIEW_HTTPROUTE_PARENT_GATEWAY_SECTION_NAME", "APP_STUDIO_PREVIEW_HTTPROUTE_PARENT_GATEWAY_SECTION_NAME"),
+		},
+		BackendNamespace: envAny("KEDGE_SANDBOX_PREVIEW_BACKEND_NAMESPACE", "APP_STUDIO_PREVIEW_BACKEND_NAMESPACE"),
+		BackendService:   envAny("KEDGE_SANDBOX_PREVIEW_BACKEND_SERVICE_NAME", "APP_STUDIO_PREVIEW_BACKEND_SERVICE_NAME"),
+		BackendPort:      envAnyInt64(defaultPreviewBackendPort, "KEDGE_SANDBOX_PREVIEW_BACKEND_SERVICE_PORT", "APP_STUDIO_PREVIEW_BACKEND_SERVICE_PORT"),
+	})
+}
+
+type PreviewRouteManager struct {
+	client dynamic.Interface
+	config PreviewRouteConfig
+}
+
+func NewPreviewRouteManager(client dynamic.Interface, config PreviewRouteConfig) *PreviewRouteManager {
+	if client == nil {
+		return nil
+	}
+	return &PreviewRouteManager{
+		client: client,
+		config: normalizePreviewRouteConfig(config),
+	}
+}
+
+func (m *PreviewRouteManager) Ensure(ctx context.Context, instance *unstructured.Unstructured) error {
+	if m == nil || m.client == nil {
+		return nil
+	}
+	info, err := previewRouteInfoFromInstance(instance, m.config)
+	if err != nil {
+		return err
+	}
+
+	route, err := m.client.Resource(httpRouteGVR).Namespace(info.RouteNamespace).Get(ctx, info.RouteName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return previewRouteNotReady(fmt.Sprintf("preview HTTPRoute %s/%s has not been created yet", info.RouteNamespace, info.RouteName))
+	}
+	if err != nil {
+		return fmt.Errorf("get preview HTTPRoute %s/%s: %w", info.RouteNamespace, info.RouteName, err)
+	}
+	if err := validatePreviewHTTPRoute(route, info, m.config); err != nil {
+		return err
+	}
+	if err := m.ensureReferenceGrant(ctx, info); err != nil {
+		return err
+	}
+	if !httpRouteReady(route) {
+		return previewRouteNotReady(fmt.Sprintf("preview HTTPRoute %s/%s has not been accepted with resolved backend references yet", info.RouteNamespace, info.RouteName))
+	}
+	return nil
+}
+
+type previewRouteInfo struct {
+	RunnerName     string
+	Host           string
+	RouteName      string
+	RouteNamespace string
+	Gateway        GatewayParentRef
+}
+
+func previewRouteInfoFromInstance(instance *unstructured.Unstructured, config PreviewRouteConfig) (previewRouteInfo, error) {
+	if instance == nil {
+		return previewRouteInfo{}, fmt.Errorf("sandbox runner is nil")
+	}
+	name := strings.TrimSpace(instance.GetName())
+	if name == "" {
+		return previewRouteInfo{}, fmt.Errorf("sandbox runner has no name")
+	}
+	host, _, _ := unstructured.NestedString(instance.Object, "status", "previewRoute", "host")
+	routeName, _, _ := unstructured.NestedString(instance.Object, "status", "previewRoute", "httpRouteRef", "name")
+	routeNamespace, _, _ := unstructured.NestedString(instance.Object, "status", "previewRoute", "httpRouteRef", "namespace")
+	gatewayName, _, _ := unstructured.NestedString(instance.Object, "status", "previewRoute", "gatewayRef", "name")
+	gatewayNamespace, _, _ := unstructured.NestedString(instance.Object, "status", "previewRoute", "gatewayRef", "namespace")
+	info := previewRouteInfo{
+		RunnerName:     name,
+		Host:           strings.TrimSpace(host),
+		RouteName:      strings.TrimSpace(routeName),
+		RouteNamespace: strings.TrimSpace(routeNamespace),
+		Gateway: GatewayParentRef{
+			Name:      strings.TrimSpace(gatewayName),
+			Namespace: strings.TrimSpace(gatewayNamespace),
+		},
+	}
+	if info.RouteName == "" || info.RouteNamespace == "" {
+		return previewRouteInfo{}, previewRouteNotReady("sandbox preview HTTPRoute status is not populated yet")
+	}
+	if info.RouteName != info.RunnerName {
+		return previewRouteInfo{}, fmt.Errorf("sandbox preview HTTPRoute name %q does not match runner %q", info.RouteName, info.RunnerName)
+	}
+	if config.BaseDomain != "" {
+		wantHost := info.RunnerName + "." + strings.Trim(strings.TrimSpace(config.BaseDomain), ".")
+		if info.Host != wantHost {
+			return previewRouteInfo{}, fmt.Errorf("sandbox preview host %q does not match expected host %q", info.Host, wantHost)
+		}
+	}
+	return info, nil
+}
+
+func validatePreviewHTTPRoute(route *unstructured.Unstructured, info previewRouteInfo, config PreviewRouteConfig) error {
+	if route.GetName() != info.RouteName || route.GetNamespace() != info.RouteNamespace {
+		return fmt.Errorf("preview HTTPRoute identity changed from %s/%s to %s/%s", info.RouteNamespace, info.RouteName, route.GetNamespace(), route.GetName())
+	}
+	if err := validateRouteHost(route, info, config); err != nil {
+		return err
+	}
+	if err := validateRouteParent(route, info, config); err != nil {
+		return err
+	}
+	return validateRouteBackend(route, config)
+}
+
+func validateRouteHost(route *unstructured.Unstructured, info previewRouteInfo, config PreviewRouteConfig) error {
+	hosts, _, _ := unstructured.NestedStringSlice(route.Object, "spec", "hostnames")
+	want := info.Host
+	if config.BaseDomain != "" {
+		want = info.RunnerName + "." + strings.Trim(strings.TrimSpace(config.BaseDomain), ".")
+	}
+	if want == "" {
+		return nil
+	}
+	if len(hosts) != 1 || hosts[0] != want {
+		return fmt.Errorf("preview HTTPRoute hostnames %v do not match expected host %q", hosts, want)
+	}
+	return nil
+}
+
+func validateRouteParent(route *unstructured.Unstructured, info previewRouteInfo, config PreviewRouteConfig) error {
+	parents, _, _ := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
+	if len(parents) != 1 {
+		return fmt.Errorf("preview HTTPRoute must have exactly one parentRef, got %d", len(parents))
+	}
+	parent, ok := parents[0].(map[string]any)
+	if !ok {
+		return fmt.Errorf("preview HTTPRoute parentRef is malformed")
+	}
+	got := GatewayParentRef{
+		Name:        stringField(parent, "name"),
+		Namespace:   stringField(parent, "namespace"),
+		SectionName: stringField(parent, "sectionName"),
+	}
+	want := config.ParentGateway
+	if want.Name == "" {
+		want.Name = info.Gateway.Name
+	}
+	if want.Namespace == "" {
+		want.Namespace = info.Gateway.Namespace
+	}
+	if want.SectionName != "" && got.SectionName != want.SectionName {
+		return fmt.Errorf("preview HTTPRoute parent section %q does not match expected section %q", got.SectionName, want.SectionName)
+	}
+	if want.Name != "" && got.Name != want.Name {
+		return fmt.Errorf("preview HTTPRoute parent name %q does not match expected name %q", got.Name, want.Name)
+	}
+	if want.Namespace != "" && got.Namespace != want.Namespace {
+		return fmt.Errorf("preview HTTPRoute parent namespace %q does not match expected namespace %q", got.Namespace, want.Namespace)
+	}
+	return nil
+}
+
+func validateRouteBackend(route *unstructured.Unstructured, config PreviewRouteConfig) error {
+	rules, _, _ := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if len(rules) != 1 {
+		return fmt.Errorf("preview HTTPRoute must have exactly one rule, got %d", len(rules))
+	}
+	rule, ok := rules[0].(map[string]any)
+	if !ok {
+		return fmt.Errorf("preview HTTPRoute rule is malformed")
+	}
+	refs, ok := rule["backendRefs"].([]any)
+	if !ok || len(refs) != 1 {
+		return fmt.Errorf("preview HTTPRoute must have exactly one backendRef")
+	}
+	ref, ok := refs[0].(map[string]any)
+	if !ok {
+		return fmt.Errorf("preview HTTPRoute backendRef is malformed")
+	}
+	group := stringField(ref, "group")
+	kind := stringField(ref, "kind")
+	if group != "" || (kind != "" && kind != "Service") {
+		return fmt.Errorf("preview HTTPRoute backend must be a core Service, got group=%q kind=%q", group, kind)
+	}
+	gotNamespace := stringField(ref, "namespace")
+	gotName := stringField(ref, "name")
+	gotPort, ok := int64Field(ref, "port")
+	if gotNamespace != config.BackendNamespace || gotName != config.BackendService || !ok || gotPort != config.BackendPort {
+		return fmt.Errorf("preview HTTPRoute has unexpected backend %s/%s:%d", gotNamespace, gotName, gotPort)
+	}
+	return nil
+}
+
+func (m *PreviewRouteManager) ensureReferenceGrant(ctx context.Context, info previewRouteInfo) error {
+	grant := referenceGrantFor(info, m.config)
+	client := m.client.Resource(referenceGrantGVR).Namespace(m.config.BackendNamespace)
+	existing, err := client.Get(ctx, grant.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := client.Create(ctx, grant, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create preview ReferenceGrant %s/%s: %w", m.config.BackendNamespace, grant.GetName(), err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get preview ReferenceGrant %s/%s: %w", m.config.BackendNamespace, grant.GetName(), err)
+	}
+	if referenceGrantMatches(existing, grant) {
+		return nil
+	}
+	grant.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := client.Update(ctx, grant, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update preview ReferenceGrant %s/%s: %w", m.config.BackendNamespace, grant.GetName(), err)
+	}
+	return nil
+}
+
+func referenceGrantFor(info previewRouteInfo, config PreviewRouteConfig) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1beta1",
+		"kind":       "ReferenceGrant",
+		"metadata": map[string]any{
+			"name":      info.RunnerName,
+			"namespace": config.BackendNamespace,
+			"labels": map[string]any{
+				"app.kubernetes.io/name":         "sandbox-runner",
+				"app.kubernetes.io/instance":     info.RunnerName,
+				"app.kubernetes.io/managed-by":   "kedge-infrastructure",
+				"kedge.faros.sh/route-name":      info.RouteName,
+				"kedge.faros.sh/route-namespace": info.RouteNamespace,
+			},
+		},
+		"spec": map[string]any{
+			"from": []any{
+				map[string]any{
+					"group":     "gateway.networking.k8s.io",
+					"kind":      "HTTPRoute",
+					"namespace": info.RouteNamespace,
+				},
+			},
+			"to": []any{
+				map[string]any{
+					"group": "",
+					"kind":  "Service",
+					"name":  config.BackendService,
+				},
+			},
+		},
+	}}
+}
+
+func referenceGrantMatches(existing, desired *unstructured.Unstructured) bool {
+	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	return reflect.DeepEqual(existingSpec, desiredSpec) &&
+		reflect.DeepEqual(existing.GetLabels(), desired.GetLabels())
+}
+
+func httpRouteReady(route *unstructured.Unstructured) bool {
+	accepted := false
+	resolvedRefs := false
+	parents, _, _ := unstructured.NestedSlice(route.Object, "status", "parents")
+	for _, rawParent := range parents {
+		parent, ok := rawParent.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawConditions, ok := parent["conditions"].([]any)
+		if !ok {
+			continue
+		}
+		for _, rawCondition := range rawConditions {
+			condition, ok := rawCondition.(map[string]any)
+			if !ok {
+				continue
+			}
+			if stringField(condition, "status") != "True" {
+				continue
+			}
+			switch stringField(condition, "type") {
+			case "Accepted":
+				accepted = true
+			case "ResolvedRefs":
+				resolvedRefs = true
+			}
+		}
+	}
+	return accepted && resolvedRefs
+}
+
+type previewRouteNotReadyError struct {
+	message string
+}
+
+func previewRouteNotReady(message string) error {
+	return previewRouteNotReadyError{message: message}
+}
+
+func (e previewRouteNotReadyError) Error() string {
+	return "preview route not ready: " + e.message
+}
+
+func IsPreviewRouteNotReady(err error) bool {
+	var target previewRouteNotReadyError
+	return errors.As(err, &target)
+}
+
+func normalizePreviewRouteConfig(config PreviewRouteConfig) PreviewRouteConfig {
+	config.BaseDomain = strings.Trim(strings.TrimSpace(config.BaseDomain), ".")
+	config.ParentGateway.Name = strings.TrimSpace(config.ParentGateway.Name)
+	config.ParentGateway.Namespace = strings.TrimSpace(config.ParentGateway.Namespace)
+	config.ParentGateway.SectionName = strings.TrimSpace(config.ParentGateway.SectionName)
+	config.BackendNamespace = strings.TrimSpace(config.BackendNamespace)
+	if config.BackendNamespace == "" {
+		config.BackendNamespace = defaultPreviewBackendNamespace
+	}
+	config.BackendService = strings.TrimSpace(config.BackendService)
+	if config.BackendService == "" {
+		config.BackendService = defaultPreviewBackendService
+	}
+	if config.BackendPort == 0 {
+		config.BackendPort = defaultPreviewBackendPort
+	}
+	return config
+}
+
+func envAny(names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func envAnyInt64(fallback int64, names ...string) int64 {
+	for _, name := range names {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			parsed, err := strconv.ParseInt(value, 10, 32)
+			if err == nil && parsed > 0 {
+				return parsed
+			}
+		}
+	}
+	return fallback
+}
+
+func stringField(m map[string]any, field string) string {
+	value, _ := m[field].(string)
+	return strings.TrimSpace(value)
+}
+
+func int64Field(m map[string]any, field string) (int64, bool) {
+	switch value := m[field].(type) {
+	case int:
+		return int64(value), true
+	case int32:
+		return int64(value), true
+	case int64:
+		return value, true
+	case float64:
+		return int64(value), value == float64(int64(value))
+	default:
+		return 0, false
+	}
+}

--- a/providers/infrastructure/dataplane/preview_route_test.go
+++ b/providers/infrastructure/dataplane/preview_route_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func TestPreviewRouteManagerCreatesGrantFromRealizedRouteNamespace(t *testing.T) {
+	runnerName := "kedge-sandbox-1e81e471f80f99ed"
+	routeNamespace := "2bul5qspgunhky27-default"
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme(),
+		testHTTPRoute(runnerName, routeNamespace, "kedge-preview", "sandbox-preview-gateway", 8080, "True"),
+	)
+	manager := NewPreviewRouteManager(client, PreviewRouteConfig{
+		BaseDomain:       "preview.localhost",
+		ParentGateway:    GatewayParentRef{Name: "app-studio-preview", Namespace: "envoy-gateway-system", SectionName: "https"},
+		BackendNamespace: "kedge-preview",
+		BackendService:   "sandbox-preview-gateway",
+		BackendPort:      8080,
+	})
+
+	if err := manager.Ensure(context.Background(), testPreviewRouteInstance(runnerName, routeNamespace)); err != nil {
+		t.Fatalf("Ensure returned error: %v", err)
+	}
+
+	grant, err := client.Resource(referenceGrantGVR).Namespace("kedge-preview").Get(context.Background(), runnerName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ReferenceGrant: %v", err)
+	}
+	from, _, _ := unstructured.NestedSlice(grant.Object, "spec", "from")
+	gotFrom := from[0].(map[string]any)
+	if gotFrom["namespace"] != routeNamespace {
+		t.Fatalf("grant from namespace = %q, want %q", gotFrom["namespace"], routeNamespace)
+	}
+	to, _, _ := unstructured.NestedSlice(grant.Object, "spec", "to")
+	gotTo := to[0].(map[string]any)
+	if gotTo["name"] != "sandbox-preview-gateway" {
+		t.Fatalf("grant to service = %q, want sandbox-preview-gateway", gotTo["name"])
+	}
+}
+
+func TestPreviewRouteManagerRejectsUnexpectedBackend(t *testing.T) {
+	runnerName := "kedge-sandbox-1e81e471f80f99ed"
+	routeNamespace := "2bul5qspgunhky27-default"
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme(),
+		testHTTPRoute(runnerName, routeNamespace, "kube-system", "kube-dns", 53, "True"),
+	)
+	manager := NewPreviewRouteManager(client, PreviewRouteConfig{
+		BaseDomain:       "preview.localhost",
+		ParentGateway:    GatewayParentRef{Name: "app-studio-preview", Namespace: "envoy-gateway-system", SectionName: "https"},
+		BackendNamespace: "kedge-preview",
+		BackendService:   "sandbox-preview-gateway",
+		BackendPort:      8080,
+	})
+
+	err := manager.Ensure(context.Background(), testPreviewRouteInstance(runnerName, routeNamespace))
+	if err == nil || !strings.Contains(err.Error(), "unexpected backend") {
+		t.Fatalf("Ensure error = %v, want unexpected backend", err)
+	}
+	if _, err := client.Resource(referenceGrantGVR).Namespace("kedge-preview").Get(context.Background(), runnerName, metav1.GetOptions{}); err == nil {
+		t.Fatal("ReferenceGrant was created for an unexpected backend")
+	}
+}
+
+func TestPreviewRouteManagerReportsUnresolvedRouteAsNotReady(t *testing.T) {
+	runnerName := "kedge-sandbox-1e81e471f80f99ed"
+	routeNamespace := "2bul5qspgunhky27-default"
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme(),
+		testHTTPRoute(runnerName, routeNamespace, "kedge-preview", "sandbox-preview-gateway", 8080, "False"),
+	)
+	manager := NewPreviewRouteManager(client, PreviewRouteConfig{
+		BaseDomain:       "preview.localhost",
+		ParentGateway:    GatewayParentRef{Name: "app-studio-preview", Namespace: "envoy-gateway-system", SectionName: "https"},
+		BackendNamespace: "kedge-preview",
+		BackendService:   "sandbox-preview-gateway",
+		BackendPort:      8080,
+	})
+
+	err := manager.Ensure(context.Background(), testPreviewRouteInstance(runnerName, routeNamespace))
+	if !IsPreviewRouteNotReady(err) {
+		t.Fatalf("Ensure error = %v, want preview route not ready", err)
+	}
+}
+
+func TestPreviewRouteManagerReportsUnacceptedRouteAsNotReady(t *testing.T) {
+	runnerName := "kedge-sandbox-1e81e471f80f99ed"
+	routeNamespace := "2bul5qspgunhky27-default"
+	route := testHTTPRoute(runnerName, routeNamespace, "kedge-preview", "sandbox-preview-gateway", 8080, "True")
+	route.Object["status"].(map[string]any)["parents"] = []any{
+		map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Accepted", "status": "False"},
+				map[string]any{"type": "ResolvedRefs", "status": "True"},
+			},
+		},
+	}
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme(), route)
+	manager := NewPreviewRouteManager(client, PreviewRouteConfig{
+		BaseDomain:       "preview.localhost",
+		ParentGateway:    GatewayParentRef{Name: "app-studio-preview", Namespace: "envoy-gateway-system", SectionName: "https"},
+		BackendNamespace: "kedge-preview",
+		BackendService:   "sandbox-preview-gateway",
+		BackendPort:      8080,
+	})
+
+	err := manager.Ensure(context.Background(), testPreviewRouteInstance(runnerName, routeNamespace))
+	if !IsPreviewRouteNotReady(err) {
+		t.Fatalf("Ensure error = %v, want preview route not ready", err)
+	}
+}
+
+func testPreviewRouteInstance(name, routeNamespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "infrastructure.kedge.faros.sh/v1alpha1",
+		"kind":       "SandboxRunner",
+		"metadata":   map[string]any{"name": name},
+		"status": map[string]any{
+			"previewRoute": map[string]any{
+				"host": name + ".preview.localhost",
+				"httpRouteRef": map[string]any{
+					"name":      name,
+					"namespace": routeNamespace,
+				},
+				"gatewayRef": map[string]any{
+					"name":      "app-studio-preview",
+					"namespace": "envoy-gateway-system",
+				},
+			},
+		},
+	}}
+}
+
+func testHTTPRoute(name, namespace, backendNamespace, backendName string, backendPort int64, resolvedRefs string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"parentRefs": []any{
+				map[string]any{
+					"name":        "app-studio-preview",
+					"namespace":   "envoy-gateway-system",
+					"sectionName": "https",
+				},
+			},
+			"hostnames": []any{name + ".preview.localhost"},
+			"rules": []any{
+				map[string]any{
+					"backendRefs": []any{
+						map[string]any{
+							"name":      backendName,
+							"namespace": backendNamespace,
+							"port":      backendPort,
+							"kind":      "Service",
+						},
+					},
+				},
+			},
+		},
+		"status": map[string]any{
+			"parents": []any{
+				map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":   "Accepted",
+							"status": "True",
+						},
+						map[string]any{
+							"type":   "ResolvedRefs",
+							"status": resolvedRefs,
+						},
+					},
+				},
+			},
+		},
+	}}
+}

--- a/providers/infrastructure/sandbox-runner/main.go
+++ b/providers/infrastructure/sandbox-runner/main.go
@@ -26,10 +26,10 @@ You may obtain a copy of the License at
 //
 //     GET  /healthz  liveness; no auth.
 //     POST /sync     write/delete workspace files and optionally restart. Body:
-//                    {files:[{path,content}], deletePaths:[], restart:"auto"|"always"|""}.
-//                    "auto" restarts only when a startup-affecting file
-//                    (package.json, a lockfile, vite.config.*, server.js)
-//                    actually changed, or the process isn't running.
+//     {files:[{path,content}], deletePaths:[], restart:"auto"|"always"|""}.
+//     "auto" restarts only when a startup-affecting file
+//     (package.json, a lockfile, vite.config.*, server.js)
+//     actually changed, or the process isn't running.
 //     POST /restart  stop + start the dev process.
 //     GET  /logs     the buffered dev-process output (text/plain).
 //
@@ -199,7 +199,11 @@ func (s *runnerServer) handleSync(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		content := []byte(f.Content)
-		if isStartupAffectingPath(clean) && workspaceFileContentChanged(root, clean, content) {
+		fileChanged := workspaceFileContentChanged(root, clean, content)
+		if !fileChanged {
+			continue
+		}
+		if isStartupAffectingPath(clean) {
 			startupChanged = true
 		}
 		if err := writeWorkspaceFile(root, clean, content); err != nil {

--- a/providers/infrastructure/sandbox-runner/main_test.go
+++ b/providers/infrastructure/sandbox-runner/main_test.go
@@ -47,6 +47,39 @@ func TestSyncWritesAndDeletesOnlyWorkspaceRelativePaths(t *testing.T) {
 	}
 }
 
+func TestSyncSkipsUnchangedFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "src.ts"), []byte("same"), 0o644); err != nil {
+		t.Fatalf("write initial file: %v", err)
+	}
+	before, err := os.Stat(filepath.Join(root, "src.ts"))
+	if err != nil {
+		t.Fatalf("stat initial file: %v", err)
+	}
+
+	s := newRunnerServer(&runnerConfig{WorkDir: root, ControlToken: "test-token"})
+	resp := postJSON(t, s, "/sync", syncRequest{
+		Files: []syncFile{{Path: "src.ts", Content: "same"}},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("sync status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body syncResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode sync response: %v", err)
+	}
+	if len(body.Changed) != 0 {
+		t.Fatalf("changed = %#v, want empty for unchanged content", body.Changed)
+	}
+	after, err := os.Stat(filepath.Join(root, "src.ts"))
+	if err != nil {
+		t.Fatalf("stat after sync: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Fatalf("mtime changed for unchanged file: before=%s after=%s", before.ModTime(), after.ModTime())
+	}
+}
+
 func TestSyncRejectsPathTraversal(t *testing.T) {
 	root := t.TempDir()
 	s := newRunnerServer(&runnerConfig{WorkDir: root, ControlToken: "test-token"})

--- a/providers/infrastructure/serve_dataplane.go
+++ b/providers/infrastructure/serve_dataplane.go
@@ -59,12 +59,18 @@ func buildDataPlaneHandler(kcpConfig *rest.Config) *dataplane.Handler {
 		log.Printf("data plane: disabled (no runtime cluster config: KRO_KUBECONFIG unset, not in a pod)")
 		return nil
 	}
+	runtimeDyn, err := dynamic.NewForConfig(runtimeCfg)
+	if err != nil {
+		log.Printf("data plane: disabled (runtime dynamic client: %v)", err)
+		return nil
+	}
 
 	log.Printf("data plane: enabled (runtime cluster: %s)", src)
 	return dataplane.NewHandler(
 		&tenantInstanceGetter{factory: tenant.NewClientFactory(kcpConfig)},
 		dataplane.NewTemplateContractGetter(providerDyn),
 		runtime,
+		dataplane.WithPreviewRouteManager(dataplane.NewPreviewRouteManager(runtimeDyn, dataplane.PreviewRouteConfigFromEnv())),
 	)
 }
 


### PR DESCRIPTION
## Summary

Moves sandbox preview ReferenceGrant reconciliation into the infrastructure data-plane path, after the caller is authorized against the SandboxRunner instance. The reconciler verifies the realized HTTPRoute against infra-owned preview config before creating/updating the grant, then requires the route to be Accepted and ResolvedRefs before preview readiness can proceed.

Also makes sandbox-runner sync idempotent for unchanged file contents so repeated workspace snapshots do not touch mtimes or trigger unnecessary dev-server restarts.

## Root Cause

After the runtime/data-plane refactor, App Studio stopped imperatively creating the runtime ReferenceGrant. The KRO template-created ReferenceGrant used logical namespaces, but KCP/KRO materialized the HTTPRoute in a prefixed runtime namespace, so Envoy rejected the backend ref with RefNotPermitted.

## Security Notes

- App Studio does not regain a runtime kubeconfig.
- The grant is reconciled only after tenant-user authorization against the SandboxRunner.
- The backend Service, backend namespace, backend port, route host, and parent Gateway are verified against infrastructure preview config before any grant is written.
- Preview-route validation errors fail closed as 503 so App Studio does not sign a preview URL prematurely.

## Validation

- `go test ./... -count=1` in `providers/infrastructure`
- `go test ./... -count=1` in `providers/infrastructure/sandbox-runner`
- `go test ./api -count=1` in `providers/app-studio`
- `git diff --cached --check`
