### PR TITLE
fix(app-studio): persist write approval until the next commit

### DIFF
--- a/providers/app-studio/api/assistant_approved_plan.go
+++ b/providers/app-studio/api/assistant_approved_plan.go
@@ -109,5 +109,6 @@ func mergeProjectAssistantApprovedPlans(existing, next projectAssistantApprovedP
 	merged := next
 	merged.TargetPaths = normalizeProjectAssistantStringList(append(append([]string(nil), existing.TargetPaths...), next.TargetPaths...))
 	merged.Operations = normalizeProjectAssistantStringList(append(append([]string(nil), existing.Operations...), next.Operations...))
+	merged.AllowAllWrites = existing.AllowAllWrites || next.AllowAllWrites
 	return merged
 }

--- a/providers/app-studio/api/assistant_eino_state.go
+++ b/providers/app-studio/api/assistant_eino_state.go
@@ -30,6 +30,11 @@ type projectAssistantApprovedPlan struct {
 	AcceptanceCriteria []string  `json:"acceptanceCriteria,omitempty"`
 	ApprovedAt         time.Time `json:"approvedAt,omitempty"`
 	ApprovalTool       string    `json:"approvalTool,omitempty"`
+	// AllowAllWrites grants every workspace write tool, on any path, until the
+	// next commit. It is set when the user approves a write prompt directly (as
+	// opposed to a model-supplied plan envelope), so a single "Allow" does not
+	// re-prompt for each subsequent edit.
+	AllowAllWrites bool `json:"allowAllWrites,omitempty"`
 }
 
 type projectEinoAssistantRunState struct {

--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -382,6 +382,32 @@ func (t projectEinoAssistantTool) invokeApprovedPlanTool(ctx context.Context, ca
 	return result
 }
 
+// grantAllWritesUntilCommit records a blanket write grant after the user
+// approves a write prompt directly, so subsequent edits do not re-prompt until
+// the next commit retires the grant. It merges with any active plan envelope
+// and persists best effort: a failed write only means the user is re-prompted.
+func (t projectEinoAssistantTool) grantAllWritesUntilCommit(ctx context.Context) {
+	plan := normalizeProjectAssistantApprovedPlan(projectAssistantApprovedPlan{
+		Summary:        "User approved workspace writes until the next commit.",
+		Operations:     []string{projectToolWriteFile, projectToolApplyPatch, projectToolMkdir},
+		AllowAllWrites: true,
+		ApprovalTool:   "permission_allow_write",
+	})
+	if existing := t.runState.ApprovedPlan(); existing != nil {
+		plan = mergeProjectAssistantApprovedPlans(*existing, plan)
+	}
+	t.runState.ApprovePlan(plan)
+	stored := t.runState.ApprovedPlan()
+	if stored == nil {
+		return
+	}
+	persistCtx, cancelPersist := detachedProjectPersistenceContext(ctx)
+	defer cancelPersist()
+	if err := t.server.saveProjectAssistantApprovedPlan(persistCtx, t.req.MessageScope, stored); err != nil {
+		klog.FromContext(ctx).Error(err, "persist App Studio write grant", "project", t.req.MessageScope.ProjectName)
+	}
+}
+
 func (t projectEinoAssistantTool) appendBuilderEvent(eventType string) {
 	emitProjectAssistantBuilderEvent(t.req.StreamCallbacks, projectAssistantBuilderEventView(eventType))
 }
@@ -439,6 +465,11 @@ func (t projectEinoAssistantTool) resumePermission(ctx context.Context, callID s
 	case projectAssistantPermissionAllow:
 		if data.EditedArguments != nil {
 			args = cloneProjectAssistantToolArguments(data.EditedArguments)
+		}
+		if spec.Risk == projectAssistantToolRiskWrite {
+			// The user approved a write directly. Remember it as a blanket write
+			// grant until the next commit so each later edit does not re-prompt.
+			t.grantAllWritesUntilCommit(ctx)
 		}
 		return t.invokeAllowedTool(ctx, callID, spec, args)
 	case projectAssistantPermissionDeny:

--- a/providers/app-studio/api/assistant_permission.go
+++ b/providers/app-studio/api/assistant_permission.go
@@ -65,7 +65,7 @@ func projectAssistantPermissionForToolWithRunState(spec projectAssistantToolSpec
 }
 
 func projectAssistantApprovedPlanActive(plan *projectAssistantApprovedPlan) bool {
-	return plan != nil && len(plan.Operations) > 0
+	return plan != nil && (len(plan.Operations) > 0 || plan.AllowAllWrites)
 }
 
 func projectAssistantApprovedPlanAllowsWrite(plan *projectAssistantApprovedPlan, toolName string, args map[string]any) bool {
@@ -77,6 +77,11 @@ func projectAssistantApprovedPlanAllowsWrite(plan *projectAssistantApprovedPlan,
 	case projectToolWriteFile, projectToolApplyPatch, projectToolMkdir:
 	default:
 		return false
+	}
+	// A direct user approval of a write prompt grants every write tool on any
+	// path until the next commit, so subsequent edits do not re-prompt.
+	if plan.AllowAllWrites {
+		return true
 	}
 	if !projectAssistantApprovedPlanAllowsOperation(plan, toolName) {
 		return false

--- a/providers/app-studio/api/assistant_permission_test.go
+++ b/providers/app-studio/api/assistant_permission_test.go
@@ -108,6 +108,39 @@ func TestProjectAssistantPlanApprovalAllowsScopedWritesButNotCommit(t *testing.T
 	}
 }
 
+func TestProjectAssistantAllowAllWritesGrantAuthorizesAnyPath(t *testing.T) {
+	state := newProjectEinoAssistantRunState()
+	state.ApprovePlan(projectAssistantApprovedPlan{
+		Summary:        "User approved workspace writes until the next commit.",
+		Operations:     []string{projectToolWriteFile, projectToolApplyPatch, projectToolMkdir},
+		AllowAllWrites: true,
+		ApprovedAt:     testProjectAssistantApprovalTime(),
+		ApprovalTool:   "permission_allow_write",
+	})
+
+	for _, path := range []string{"src/App.tsx", "README.md", "deploy/values.yaml"} {
+		decision := projectAssistantPermissionForToolWithRunState(projectAssistantToolSpec{
+			Name: projectToolWriteFile,
+			Risk: projectAssistantToolRiskWrite,
+		}, false, state, map[string]any{
+			"path": path,
+		})
+		if decision != projectAssistantPermissionAllow {
+			t.Fatalf("write permission for %q = %q, want %q", path, decision, projectAssistantPermissionAllow)
+		}
+	}
+
+	commitDecision := projectAssistantPermissionForToolWithRunState(projectAssistantToolSpec{
+		Name: projectToolCommitProjectFiles,
+		Risk: projectAssistantToolRiskCommit,
+	}, false, state, map[string]any{
+		"paths": []any{"src/App.tsx"},
+	})
+	if commitDecision != projectAssistantPermissionAsk {
+		t.Fatalf("commit permission = %q, want %q", commitDecision, projectAssistantPermissionAsk)
+	}
+}
+
 func TestProjectAssistantPlanApprovalWithoutOperationsDoesNotAuthorizeWrites(t *testing.T) {
 	state := newProjectEinoAssistantRunState()
 	state.ApprovePlan(projectAssistantApprovedPlan{

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -2068,9 +2068,11 @@ func TestResumeProjectAssistantRunPersistsAssistantTextBeforeNextPause(t *testin
 			firstCall := chatStreamingCall{Index: 0, ID: "call-first-write", Type: "function"}
 			firstCall.Function.Name = projectToolWriteFile
 			firstCall.Function.Arguments = `{"path":"src/App.tsx","content":"first\n"}`
-			secondCall := chatStreamingCall{Index: 0, ID: "call-second-write", Type: "function"}
-			secondCall.Function.Name = projectToolWriteFile
-			secondCall.Function.Arguments = `{"path":"src/Other.tsx","content":"second\n"}`
+			// Approving the first write grants every write until the next commit,
+			// so the next pause has to come from a tool that still always asks.
+			secondCall := chatStreamingCall{Index: 0, ID: "call-second-runtime", Type: "function"}
+			secondCall.Function.Name = projectToolDeployProjectRuntime
+			secondCall.Function.Arguments = `{"targetRef":"runtime-a","image":"ghcr.io/demo/app:latest","port":8080,"intent":"preview"}`
 			model := &repositoryFlowEinoChatModel{Steps: []repositoryFlowEinoModelStep{
 				{Message: einoschema.AssistantMessage("", projectEinoToolCallsFromStreamingForTest([]chatStreamingCall{firstCall}))},
 				{Message: einoschema.AssistantMessage("First change applied. ", projectEinoToolCallsFromStreamingForTest([]chatStreamingCall{secondCall}))},
@@ -2160,6 +2162,79 @@ func TestResumeProjectAssistantRunPersistsAssistantTextBeforeNextPause(t *testin
 				t.Fatalf("assistant interrupt = %#v, want pending next approval", interrupt)
 			}
 		})
+	}
+}
+
+func TestResumeProjectAssistantRunAllowingWriteDoesNotRePromptLaterWrites(t *testing.T) {
+	messages := store.NewMemoryStore()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	server := NewWithWorkspace(nil, messages, workspaces, "", false)
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo"
+	id := identity{tenantPath: "root:org-a:ws-1", orgUUID: "org-a", workspaceUUID: "ws-1"}
+	messageScope := projectMessageScope(id.orgUUID, id.workspaceUUID, project.Name)
+	workspaceScope := projectWorkspaceScope(id, project.Name)
+
+	firstCall := chatStreamingCall{Index: 0, ID: "call-first-write", Type: "function"}
+	firstCall.Function.Name = projectToolWriteFile
+	firstCall.Function.Arguments = `{"path":"src/App.tsx","content":"first\n"}`
+	secondCall := chatStreamingCall{Index: 0, ID: "call-second-write", Type: "function"}
+	secondCall.Function.Name = projectToolWriteFile
+	secondCall.Function.Arguments = `{"path":"src/Other.tsx","content":"second\n"}`
+	model := &repositoryFlowEinoChatModel{Steps: []repositoryFlowEinoModelStep{
+		{Message: einoschema.AssistantMessage("", projectEinoToolCallsFromStreamingForTest([]chatStreamingCall{firstCall}))},
+		{Message: einoschema.AssistantMessage("Applied both changes. ", projectEinoToolCallsFromStreamingForTest([]chatStreamingCall{secondCall}))},
+		{Message: einoschema.AssistantMessage("All done.", nil)},
+	}}
+	setProjectAssistantModelForTest(server, model)
+	settings := projectLLMSettings{Provider: defaultProjectLLMProvider, BaseURL: defaultProjectLLMBaseURL, Model: "test-model", APIKey: "test-key"}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: projectLLMSettingsSecret(settings)})
+	if err := appendProjectUserMessage(context.Background(), messages, messageScope, "write files"); err != nil {
+		t.Fatalf("appendProjectUserMessage returned error: %v", err)
+	}
+
+	_, err := server.generateProjectAssistantStream(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		projectAssistantStreamCallbacks{},
+	)
+	var permissionErr *projectAssistantPermissionRequiredError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("generateProjectAssistantStream error = %v, want permission required", err)
+	}
+
+	resp, err := server.resumeProjectAssistantRunWithRepositoryAndClient(
+		context.Background(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		id,
+		client,
+		project,
+		&ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady},
+		permissionErr.RunID,
+		projectAssistantResumeRequest{
+			RequestID: permissionErr.RequestID,
+			Decision:  string(projectAssistantPermissionAllow),
+		},
+	)
+	if err != nil {
+		t.Fatalf("resumeProjectAssistantRun returned error: %v", err)
+	}
+	if resp.Status != store.AssistantRunStatusCompleted {
+		t.Fatalf("resume status = %q, want %q (second write should auto-approve)", resp.Status, store.AssistantRunStatusCompleted)
+	}
+
+	files, err := workspaces.ListFiles(context.Background(), workspaceScope, workspace.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListFiles returned error: %v", err)
+	}
+	written := map[string]bool{}
+	for _, f := range files.Files {
+		written[f.Path] = true
+	}
+	if !written["src/App.tsx"] || !written["src/Other.tsx"] {
+		t.Fatalf("written files = %v, want both src/App.tsx and src/Other.tsx", written)
 	}
 }
 


### PR DESCRIPTION
## Problem

In App Studio's project assistant, approving a write prompt ("This action will modify files in the App Studio workspace.") did not persist — every subsequent edit re-prompted, even for the same file.

**Root cause:** write tools (`write_file`, `apply_patch`, `mkdir`) only auto-approve when an active approved-plan grant covers them. Clicking **Allow** just ran that one tool call (`resumePermission` → `invokeAllowedTool`) and recorded nothing. The only durable grant was the one the *model* creates via `request_project_plan_approval`, which direct writes bypass — so the user's answer never stuck.

## Fix

A direct write approval now records a blanket write grant (`AllowAllWrites`) that authorizes every workspace write on any path **until the next commit**, persisted across turns via the existing approved-plan store.

- `assistant_eino_state.go` — `AllowAllWrites` field on the grant struct.
- `assistant_permission.go` — grant with `AllowAllWrites` authorizes any write path and counts as active.
- `assistant_approved_plan.go` — merge unions the flag (re-stating a plan can only widen).
- `assistant_eino_tool.go` — `grantAllWritesUntilCommit`, invoked when the user approves a write; merges + persists.

Existing teardown already fits: `commit_project_files` clears the grant and new turns reload it, so one approval covers the whole edit cycle and the user re-confirms only at commit.

## Tests

- Unit: blanket grant authorizes any path but still asks for commit.
- Integration: approving the first write lets a second write (different file) complete with no second prompt; both files land.
- Updated `TestResumeProjectAssistantRunPersistsAssistantTextBeforeNextPause` — its old "next write re-prompts" assumption no longer holds, so the next pausing action is now a runtime deploy (still always prompts).

Full `./providers/app-studio/...` suite is green.

## Note

This is intentionally broad: one click authorizes edits to any path until commit (the chosen scope). A per-file variant is a small follow-up if it ever feels too loose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)