### PR TITLE
fix(code): request delete_repo scope so the provider can delete repos

### DIFF
--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -95,8 +95,9 @@ lets `?tenant=` / `?token=` stand in for the hub-injected identity headers.
 ## Connecting an account
 
 - **Personal Access Token (default):** paste a PAT in the portal's Connections
-  view. A classic PAT needs `repo` (+ `admin:public_key` for deploy keys,
-  `read:org` for org repos, and **`read:packages`** for the repo Packages panel).
+  view. A classic PAT needs `repo` (+ `delete_repo` to remove provider-created
+  repositories, `admin:public_key` for deploy keys, `read:org` for org repos,
+  and **`read:packages`** for the repo Packages panel).
 - **Connect with GitHub (OAuth):** enable the OAuth App (below) and the portal
   shows a one-click button — no copy-paste. OAuth tokens are requested with
   `read:packages` by default so the Packages panel works out of the box.
@@ -306,7 +307,7 @@ the connection token's `read:packages` scope.
 | `GITHUB_OAUTH_CLIENT_SECRET` | (unset) | GitHub OAuth App client secret |
 | `GITHUB_OAUTH_REDIRECT_URL` | (unset) | Absolute callback URL (must end in `/callback`); either the hub `/services/providers/code/oauth/github/callback` proxy route or the provider's own host. `/start` is derived from it |
 | `GITHUB_OAUTH_PORTAL_ORIGIN` | `*` | postMessage target origin (set to the hub origin in prod) |
-| `GITHUB_OAUTH_SCOPES` | `repo,read:org,admin:public_key,read:packages` | Requested OAuth scopes |
+| `GITHUB_OAUTH_SCOPES` | `repo,delete_repo,read:org,admin:public_key,read:packages` | Requested OAuth scopes |
 
 ### `init` subcommand
 

--- a/providers/code/deploy/chart/values.yaml
+++ b/providers/code/deploy/chart/values.yaml
@@ -66,7 +66,8 @@ githubOAuth:
   # origin). Empty broadcasts to "*" — set this in production.
   portalOrigin: ""
   # Comma-separated scopes. Empty → provider default
-  # (repo,read:org,admin:public_key,read:packages).
+  # (repo,delete_repo,read:org,admin:public_key,read:packages). delete_repo is
+  # required for the provider to remove repositories it created.
   scopes: ""
 
 # Tenant credential resolution. Empty → the provider default ("default"), the

--- a/providers/code/oauthgithub/oauth.go
+++ b/providers/code/oauthgithub/oauth.go
@@ -100,7 +100,9 @@ func FromEnv() (cfg Config, enabled bool, err error) {
 	scopes := os.Getenv("GITHUB_OAUTH_SCOPES")
 	if scopes == "" {
 		// read:packages lets the portal list the packages published under a repo.
-		scopes = "repo,read:org,admin:public_key,read:packages"
+		// delete_repo is required to remove repositories the provider created;
+		// the `repo` scope alone grants full control but NOT deletion.
+		scopes = "repo,delete_repo,read:org,admin:public_key,read:packages"
 	}
 	for _, s := range strings.Split(scopes, ",") {
 		if s = strings.TrimSpace(s); s != "" {


### PR DESCRIPTION
## Problem

The code provider can create GitHub repositories but cannot delete them. Repository CRs get stuck on their finalizer with:

```
github: forbidden — token lacks scope or rate-limited (403): DELETE
https://api.github.com/repos/<owner>/<repo>: 403 Must have admin rights to Repository.
```

## Root cause

GitHub's `repo` OAuth scope grants full control of private repositories but **specifically excludes repository deletion** — that requires the separate `delete_repo` scope. The default scope set (`repo,read:org,admin:public_key,read:packages`) never included it, so every DELETE was rejected. The provider's delete code was fine; the token simply never had permission.

## Fix

Add `delete_repo` to the default scope set:
- `oauthgithub/oauth.go` — default `GITHUB_OAUTH_SCOPES`
- `deploy/chart/values.yaml` — documented default
- `README.md` — PAT requirements and env var default

## Note for existing connections

Tokens are minted at authorization time, so existing connections keep their old (narrower) scope. To pick up `delete_repo`:
- **OAuth:** re-run "Connect with GitHub" (may require revoking the prior grant so GitHub re-prompts).
- **PAT:** replace with a classic PAT that includes `delete_repo`.

## Follow-up (not in this PR)

A permission-denied host delete currently pins the finalizer forever, so a user who revokes access can never GC their CRs. Worth deciding whether to release the finalizer after unrecoverable permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)