### PR TITLE
feat(code): portal condition summaries + in-app confirm modal

### DIFF
--- a/providers/code/portal/src/App.vue
+++ b/providers/code/portal/src/App.vue
@@ -7,6 +7,7 @@ import ConnectionDetailView from './views/ConnectionDetailView.vue'
 import RepositoriesView from './views/RepositoriesView.vue'
 import RepoDetailView from './views/RepoDetailView.vue'
 import PackagesView from './views/PackagesView.vue'
+import ConfirmDialog from './components/ConfirmDialog.vue'
 
 // Sub-path routing (the shell pushes the trailing /providers/code/<sub> segment):
 //   ''  | 'connections'        → Connections
@@ -74,5 +75,7 @@ function navigate(path: string) {
       <RepoDetailView v-else-if="route.repo" :name="route.repo" @back="navigate('repositories')" />
       <RepositoriesView v-else @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))" />
     </template>
+
+    <ConfirmDialog />
   </div>
 </template>

--- a/providers/code/portal/src/api.ts
+++ b/providers/code/portal/src/api.ts
@@ -16,6 +16,7 @@ import type {
   Package,
   PackageRow,
   Repository,
+  RepositoryDetail,
 } from './types'
 
 const GROUP = 'code.kedge.faros.sh'
@@ -151,6 +152,27 @@ function repoFromCR(cr: RawCR): Repository {
   }
 }
 
+// repoDetailFromCR is repoFromCR plus the raw status the detail view needs to
+// explain a pending repository: every condition verbatim and observed-vs-current
+// generation.
+function repoDetailFromCR(cr: RawCR): RepositoryDetail {
+  const status = cr.status ?? {}
+  return {
+    ...repoFromCR(cr),
+    repoID: status.repoID ? String(status.repoID) : undefined,
+    generation: typeof cr.metadata.generation === 'number' ? cr.metadata.generation : undefined,
+    observedGeneration: typeof status.observedGeneration === 'number' ? status.observedGeneration : undefined,
+    creationTimestamp: cr.metadata.creationTimestamp,
+    conditions: (status.conditions ?? []).map(c => ({
+      type: c.type,
+      status: c.status,
+      reason: c.reason,
+      message: c.message,
+      lastTransitionTime: (c as KCPCondition & { lastTransitionTime?: string }).lastTransitionTime,
+    })),
+  }
+}
+
 function keyFromCR(cr: RawCR): DeployKey {
   const spec = cr.spec ?? {}
   const status = cr.status ?? {}
@@ -177,6 +199,8 @@ function pkgFromCR(cr: RawCR): Package {
     htmlURL: status.htmlURL ? String(status.htmlURL) : undefined,
     versionCount: typeof status.versionCount === 'number' ? status.versionCount : undefined,
     updatedAt: status.updatedAt ? String(status.updatedAt) : undefined,
+    ready: condTrue(cr, 'Ready'),
+    message: condMsg(cr, 'Ready'),
   }
 }
 
@@ -251,6 +275,9 @@ const F_CONNECTION = `${GQL_META} spec { provider type owner secretRef { name na
 // lastTransitionTime so the detail view can explain why a connection is pending.
 const F_CONNECTION_DETAIL = `metadata { name uid resourceVersion generation creationTimestamp } spec { provider type owner secretRef { name namespace key } baseURL } status { login scopes observedGeneration conditions { type status reason message lastTransitionTime } }`
 const F_REPOSITORY = `${GQL_META} spec { connectionRef name owner visibility description defaultBranch autoInit } status { repoID htmlURL cloneURL sshURL ${GQL_COND} }`
+// Detail fragment: adds generation/observedGeneration and per-condition
+// lastTransitionTime so the detail view can explain why a repository is pending.
+const F_REPOSITORY_DETAIL = `metadata { name uid resourceVersion generation creationTimestamp } spec { connectionRef name owner visibility description defaultBranch autoInit } status { repoID htmlURL cloneURL sshURL observedGeneration conditions { type status reason message lastTransitionTime } }`
 const F_DEPLOYKEY = `${GQL_META} spec { repositoryRef title publicKey readOnly } status { keyID secretRef { name } ${GQL_COND} }`
 const F_COLLABORATOR = `${GQL_META} spec { repositoryRef username permission } status { invitationID ${GQL_COND} }`
 const F_PACKAGE = `${GQL_META} spec { repositoryRef } status { packageName type visibility htmlURL versionCount updatedAt ${GQL_COND} }`
@@ -370,8 +397,8 @@ export const api = {
     return (await gqlList('Repositories', F_REPOSITORY)).map(repoFromCR)
   },
 
-  async getRepository(name: string): Promise<Repository> {
-    return repoFromCR(await gqlGet('Repository', name, F_REPOSITORY))
+  async getRepository(name: string): Promise<RepositoryDetail> {
+    return repoDetailFromCR(await gqlGet('Repository', name, F_REPOSITORY_DETAIL))
   },
 
   async createRepository(input: {

--- a/providers/code/portal/src/components/ConditionsPanel.vue
+++ b/providers/code/portal/src/components/ConditionsPanel.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { ConditionInfo } from '../types'
+
+// ConditionsPanel renders a resource's status conditions verbatim so the
+// reason/message a controller recorded is visible for debugging — shared by the
+// Connection and Repository detail views. observed-vs-current generation, when
+// supplied, surfaces "controller has not caught up" independently of the
+// conditions themselves.
+const props = defineProps<{
+  conditions: ConditionInfo[]
+  generation?: number
+  observedGeneration?: number
+  emptyText?: string
+}>()
+
+function condClass(status: string): string {
+  if (status === 'True') return 'ok'
+  if (status === 'False') return 'warn'
+  return 'muted'
+}
+
+const reconciled = (): boolean =>
+  props.observedGeneration === undefined ||
+  props.generation === undefined ||
+  props.observedGeneration >= props.generation
+</script>
+
+<template>
+  <div class="panel">
+    <h3 class="panel-title">Conditions</h3>
+    <p v-if="observedGeneration !== undefined && !reconciled()" class="warn cond-lag">
+      Controller has not caught up — spec generation {{ generation }}, observed {{ observedGeneration }}.
+    </p>
+    <p v-if="!conditions.length" class="empty">
+      {{ emptyText || 'No conditions yet — the controller has not reconciled this resource.' }}
+    </p>
+    <table v-else class="table">
+      <thead>
+        <tr><th>Type</th><th>Status</th><th>Reason</th><th>Message</th><th>Since</th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="c in conditions" :key="c.type">
+          <td><strong>{{ c.type }}</strong></td>
+          <td><span :class="['badge', condClass(c.status)]">{{ c.status }}</span></td>
+          <td>{{ c.reason || '—' }}</td>
+          <td class="cond-msg">{{ c.message || '—' }}</td>
+          <td class="muted">{{ c.lastTransitionTime || '—' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.cond-lag { margin: 0 0 0.5rem; }
+.cond-msg { max-width: 40ch; word-break: break-word; }
+</style>

--- a/providers/code/portal/src/components/ConfirmDialog.vue
+++ b/providers/code/portal/src/components/ConfirmDialog.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { confirmState, resolveConfirm } from './confirm'
+
+// One instance is mounted at the app root; it renders whenever confirmDialog()
+// sets confirmState.open. Enter confirms, Escape/backdrop cancels.
+const confirmBtn = ref<HTMLButtonElement | null>(null)
+
+// Render the message as discrete paragraphs so a multi-line message (e.g. the
+// connection-switch warning) reads cleanly instead of as one run-on line.
+const paragraphs = computed(() =>
+  confirmState.message.split('\n').map(s => s.trim()).filter(Boolean),
+)
+
+function onConfirm() {
+  resolveConfirm(true)
+}
+function onCancel() {
+  resolveConfirm(false)
+}
+function onKeydown(e: KeyboardEvent) {
+  if (!confirmState.open) return
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    onCancel()
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    onConfirm()
+  }
+}
+
+// Focus the confirm button on open so keyboard users land inside the dialog;
+// bind the key handler only while open.
+watch(
+  () => confirmState.open,
+  open => {
+    if (open) {
+      window.addEventListener('keydown', onKeydown)
+      nextTick(() => confirmBtn.value?.focus())
+    } else {
+      window.removeEventListener('keydown', onKeydown)
+    }
+  },
+)
+</script>
+
+<template>
+  <div v-if="confirmState.open" class="modal-overlay" @click.self="onCancel">
+    <div class="modal" role="alertdialog" aria-modal="true" aria-labelledby="modal-title">
+      <h3 id="modal-title" class="modal-title">{{ confirmState.title }}</h3>
+      <p v-for="(line, i) in paragraphs" :key="i" class="modal-message">{{ line }}</p>
+      <div class="modal-actions">
+        <button class="secondary" @click="onCancel">{{ confirmState.cancelLabel }}</button>
+        <button
+          ref="confirmBtn"
+          :class="confirmState.danger ? 'danger-solid' : 'primary'"
+          @click="onConfirm"
+        >{{ confirmState.confirmLabel }}</button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/providers/code/portal/src/components/confirm.ts
+++ b/providers/code/portal/src/components/confirm.ts
@@ -1,0 +1,59 @@
+// Promise-based confirm dialog, replacing the browser's native window.confirm so
+// destructive actions use an in-app modal that matches the portal's styling.
+// A single <ConfirmDialog> (mounted once in App.vue) renders this shared state;
+// call sites await confirmDialog(...) and get true/false.
+import { reactive } from 'vue'
+
+export interface ConfirmOptions {
+  title: string
+  // message is optional supporting text shown under the title; it may contain
+  // newlines, which the dialog renders as paragraph breaks.
+  message?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  // danger styles the confirm button as a solid destructive action (delete/remove).
+  danger?: boolean
+}
+
+interface ConfirmState extends Required<Omit<ConfirmOptions, 'message'>> {
+  open: boolean
+  message: string
+  resolve: ((ok: boolean) => void) | null
+}
+
+export const confirmState = reactive<ConfirmState>({
+  open: false,
+  title: '',
+  message: '',
+  confirmLabel: 'Confirm',
+  cancelLabel: 'Cancel',
+  danger: false,
+  resolve: null,
+})
+
+// confirmDialog opens the modal and resolves true when the user confirms, false
+// on cancel/escape/backdrop. If a dialog is somehow already open, its promise is
+// resolved false before the new one replaces it.
+export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
+  if (confirmState.resolve) {
+    confirmState.resolve(false)
+    confirmState.resolve = null
+  }
+  confirmState.title = opts.title
+  confirmState.message = opts.message ?? ''
+  confirmState.confirmLabel = opts.confirmLabel ?? 'Confirm'
+  confirmState.cancelLabel = opts.cancelLabel ?? 'Cancel'
+  confirmState.danger = opts.danger ?? false
+  confirmState.open = true
+  return new Promise<boolean>(resolve => {
+    confirmState.resolve = resolve
+  })
+}
+
+// resolveConfirm closes the dialog and settles the pending promise.
+export function resolveConfirm(ok: boolean): void {
+  confirmState.open = false
+  const resolve = confirmState.resolve
+  confirmState.resolve = null
+  if (resolve) resolve(ok)
+}

--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -346,6 +346,66 @@ kedge-provider-code .badge.muted::before {
   display: none;
 }
 
+/* Solid destructive button — emphasis variant for confirm-dialog actions */
+kedge-provider-code button.danger-solid {
+  background: var(--color-danger, #f87171);
+  color: #fff;
+  border: 1px solid var(--color-danger, #f87171);
+  border-radius: 8px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+kedge-provider-code button.danger-solid:hover {
+  background: var(--color-danger-hover, #ef4444);
+}
+
+/* Confirm dialog (in-app modal replacing window.confirm) */
+kedge-provider-code .modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+kedge-provider-code .modal {
+  width: 100%;
+  max-width: 26rem;
+  background: var(--color-surface-raised, #0d0d14);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.08));
+  border-radius: 12px;
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+kedge-provider-code .modal-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary, inherit);
+}
+kedge-provider-code .modal-message {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-text-secondary, #7e7e96);
+}
+kedge-provider-code .modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 6px;
+}
+
 /* Misc text */
 kedge-provider-code .muted {
   color: var(--color-text-muted, #44445a);

--- a/providers/code/portal/src/types.ts
+++ b/providers/code/portal/src/types.ts
@@ -68,6 +68,17 @@ export interface Repository {
   message?: string
 }
 
+// RepositoryDetail is a Repository plus the full status needed to debug one that
+// is stuck "pending": every condition verbatim and observed-vs-current
+// generation (a lag means the controller has not reconciled the latest spec).
+export interface RepositoryDetail extends Repository {
+  repoID?: string
+  generation?: number
+  observedGeneration?: number
+  creationTimestamp?: string
+  conditions: ConditionInfo[]
+}
+
 export interface DeployKey {
   name: string
   repositoryRef: string
@@ -93,7 +104,8 @@ export interface Collaborator {
 // Package is a read-only view of an artifact published under a repository on the
 // host (container image, npm/maven package, …). The code provider's crawler
 // mirrors each into a Package CR (status subresource); the portal reads them via
-// the GraphQL gateway. Observed state only — no readiness/conditions.
+// the GraphQL gateway. Observed state — ready/message surface the crawler's
+// Ready condition so a failed mirror is debuggable from the UI.
 export interface Package {
   name: string
   type: string
@@ -101,6 +113,8 @@ export interface Package {
   htmlURL?: string
   versionCount?: number
   updatedAt?: string
+  ready: boolean
+  message?: string
 }
 
 // PackageRow is a Package plus its owning repository, for the workspace-wide

--- a/providers/code/portal/src/views/ConnectionDetailView.vue
+++ b/providers/code/portal/src/views/ConnectionDetailView.vue
@@ -2,6 +2,8 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { api } from '../api'
 import type { ConnectionDetail, ErrorResponse } from '../types'
+import ConditionsPanel from '../components/ConditionsPanel.vue'
+import { confirmDialog } from '../components/confirm'
 
 const props = defineProps<{ name: string }>()
 const emit = defineEmits<{ (e: 'back'): void }>()
@@ -63,19 +65,19 @@ async function load() {
 
 async function remove() {
   if (!conn.value) return
-  if (!confirm(`Delete connection "${conn.value.name}"? Repositories using it will stop reconciling.`)) return
+  const ok = await confirmDialog({
+    title: `Delete connection "${conn.value.name}"?`,
+    message: 'Repositories using it will stop reconciling.',
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
   try {
     await api.deleteConnection(conn.value.name)
     emit('back')
   } catch (e) {
     error.value = (e as ErrorResponse).message
   }
-}
-
-function condClass(status: string): string {
-  if (status === 'True') return 'ok'
-  if (status === 'False') return 'warn'
-  return 'muted'
 }
 
 onMounted(() => {
@@ -141,24 +143,12 @@ onUnmounted(() => window.clearInterval(timer))
       </div>
 
       <!-- Conditions -->
-      <div class="panel">
-        <h3 class="panel-title">Conditions</h3>
-        <p v-if="!conn.conditions.length" class="empty">No conditions yet — the controller has not reconciled this connection.</p>
-        <table v-else class="table">
-          <thead>
-            <tr><th>Type</th><th>Status</th><th>Reason</th><th>Message</th><th>Since</th></tr>
-          </thead>
-          <tbody>
-            <tr v-for="c in conn.conditions" :key="c.type">
-              <td><strong>{{ c.type }}</strong></td>
-              <td><span :class="['badge', condClass(c.status)]">{{ c.status }}</span></td>
-              <td>{{ c.reason || '—' }}</td>
-              <td>{{ c.message || '—' }}</td>
-              <td class="muted">{{ c.lastTransitionTime || '—' }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <ConditionsPanel
+        :conditions="conn.conditions"
+        :generation="conn.generation"
+        :observed-generation="conn.observedGeneration"
+        empty-text="No conditions yet — the controller has not reconciled this connection."
+      />
 
       <div class="actions">
         <button class="danger" @click="remove">Delete connection</button>

--- a/providers/code/portal/src/views/ConnectionsView.vue
+++ b/providers/code/portal/src/views/ConnectionsView.vue
@@ -2,6 +2,7 @@
 import { onMounted, onUnmounted, ref } from 'vue'
 import { api } from '../api'
 import type { Connection, ErrorResponse } from '../types'
+import { confirmDialog } from '../components/confirm'
 
 const emit = defineEmits<{ (e: 'open', name: string): void }>()
 
@@ -116,7 +117,13 @@ async function submit() {
 }
 
 async function remove(c: Connection) {
-  if (!confirm(`Delete connection "${c.name}"? Repositories using it will stop reconciling.`)) return
+  const ok = await confirmDialog({
+    title: `Delete connection "${c.name}"?`,
+    message: 'Repositories using it will stop reconciling.',
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
   try {
     await api.deleteConnection(c.name)
     await load()

--- a/providers/code/portal/src/views/PackagesView.vue
+++ b/providers/code/portal/src/views/PackagesView.vue
@@ -63,7 +63,7 @@ onUnmounted(() => window.clearInterval(timer))
     <div v-else class="panel">
       <table class="table">
         <thead>
-          <tr><th>Repository</th><th>Package</th><th>Type</th><th>Visibility</th><th>Versions</th><th class="right"></th></tr>
+          <tr><th>Repository</th><th>Package</th><th>Type</th><th>Visibility</th><th>Versions</th><th>Status</th><th class="right"></th></tr>
         </thead>
         <tbody>
           <template v-for="g in grouped" :key="g.repositoryRef">
@@ -79,6 +79,10 @@ onUnmounted(() => window.clearInterval(timer))
               <td><span class="badge muted">{{ p.type }}</span></td>
               <td><span class="muted">{{ p.visibility || '—' }}</span></td>
               <td><span class="muted">{{ p.versionCount || 0 }}</span></td>
+              <td>
+                <span v-if="p.ready" class="badge ok">synced</span>
+                <span v-else class="badge warn" :title="p.message">{{ p.message ? 'error' : 'pending' }}</span>
+              </td>
               <td class="right">
                 <a v-if="p.htmlURL" class="link" :href="p.htmlURL" target="_blank" rel="noopener">View ↗</a>
               </td>

--- a/providers/code/portal/src/views/RepoDetailView.vue
+++ b/providers/code/portal/src/views/RepoDetailView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { api } from '../api'
-import type { Collaborator, Connection, DeployKey, ErrorResponse, Package, Repository } from '../types'
+import type { Collaborator, Connection, DeployKey, ErrorResponse, Package, RepositoryDetail } from '../types'
+import ConditionsPanel from '../components/ConditionsPanel.vue'
+import { confirmDialog } from '../components/confirm'
 
 const props = defineProps<{ name: string }>()
 const emit = defineEmits<{ (e: 'back'): void }>()
 
-const repo = ref<Repository | null>(null)
+const repo = ref<RepositoryDetail | null>(null)
 const keys = ref<DeployKey[]>([])
 const collabs = ref<Collaborator[]>([])
 const error = ref<string | null>(null)
@@ -88,13 +90,18 @@ async function loadPackages() {
 
 async function changeConnection() {
   if (!repo.value || selectedConn.value === repo.value.connectionRef) return
-  const msg = ownerWillChange.value
-    ? `Change connection to "${selectedConn.value}"?\n\n` +
-      `Its owner (${newOwner.value}) differs from the current (${currentOwner.value}). ` +
+  const message = ownerWillChange.value
+    ? `Its owner (${newOwner.value}) differs from the current (${currentOwner.value}).\n` +
       `The repository will be re-targeted to that account — a new repo may be created there, ` +
       `and the existing repo on ${currentOwner.value} is left untouched.`
-    : `Change connection to "${selectedConn.value}"?`
-  if (!confirm(msg)) return
+    : 'Only the managing credential changes; the repository stays on the same account.'
+  const ok = await confirmDialog({
+    title: `Change connection to "${selectedConn.value}"?`,
+    message,
+    confirmLabel: 'Change',
+    danger: ownerWillChange.value,
+  })
+  if (!ok) return
   changingConn.value = true
   connError.value = null
   try {
@@ -129,7 +136,12 @@ async function addKey() {
 }
 
 async function removeKey(k: DeployKey) {
-  if (!confirm(`Delete deploy key "${k.title || k.name}"?`)) return
+  const ok = await confirmDialog({
+    title: `Delete deploy key "${k.title || k.name}"?`,
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
   try {
     await api.deleteDeployKey(k.name)
     await load()
@@ -158,7 +170,12 @@ async function addCollab() {
 }
 
 async function removeCollab(c: Collaborator) {
-  if (!confirm(`Remove collaborator "${c.username}"?`)) return
+  const ok = await confirmDialog({
+    title: `Remove collaborator "${c.username}"?`,
+    confirmLabel: 'Remove',
+    danger: true,
+  })
+  if (!ok) return
   try {
     await api.deleteCollaborator(c.name)
     await load()
@@ -219,6 +236,15 @@ onUnmounted(() => window.clearInterval(timer))
         <dt v-if="repo.sshURL">SSH URL</dt><dd v-if="repo.sshURL"><code>{{ repo.sshURL }}</code></dd>
       </dl>
     </div>
+
+    <!-- Conditions -->
+    <ConditionsPanel
+      v-if="repo"
+      :conditions="repo.conditions"
+      :generation="repo.generation"
+      :observed-generation="repo.observedGeneration"
+      empty-text="No conditions yet — the controller has not reconciled this repository."
+    />
 
     <div class="grid-2">
       <!-- Deploy keys -->
@@ -307,7 +333,7 @@ onUnmounted(() => window.clearInterval(timer))
       <p v-else-if="!packages.length" class="empty">No packages published to this repository yet.</p>
       <table v-else class="table">
         <thead>
-          <tr><th>Package</th><th>Type</th><th>Visibility</th><th>Versions</th><th></th></tr>
+          <tr><th>Package</th><th>Type</th><th>Visibility</th><th>Versions</th><th>Status</th><th></th></tr>
         </thead>
         <tbody>
           <tr v-for="p in packages" :key="p.type + '/' + p.name">
@@ -318,6 +344,10 @@ onUnmounted(() => window.clearInterval(timer))
             <td><span class="badge muted">{{ p.type }}</span></td>
             <td><span class="muted">{{ p.visibility || '—' }}</span></td>
             <td><span class="muted">{{ p.versionCount || 0 }}</span></td>
+            <td>
+              <span v-if="p.ready" class="badge ok">synced</span>
+              <span v-else class="badge warn" :title="p.message">{{ p.message ? 'error' : 'pending' }}</span>
+            </td>
             <td class="right">
               <a v-if="p.htmlURL" class="link" :href="p.htmlURL" target="_blank" rel="noopener">View ↗</a>
             </td>

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -2,6 +2,7 @@
 import { onMounted, onUnmounted, ref } from 'vue'
 import { api } from '../api'
 import type { Connection, ErrorResponse, Repository } from '../types'
+import { confirmDialog } from '../components/confirm'
 
 const emit = defineEmits<{ (e: 'open', name: string): void }>()
 
@@ -71,7 +72,13 @@ async function submit() {
 }
 
 async function remove(r: Repository) {
-  if (!confirm(`Delete repository "${r.repo}"? This removes it on the git host.`)) return
+  const ok = await confirmDialog({
+    title: `Delete repository "${r.repo}"?`,
+    message: 'This removes the repository on the git host. This cannot be undone.',
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
   try {
     await api.deleteRepository(r.name)
     await load()


### PR DESCRIPTION
Follow-up to #378 (which merged before this could be added).

## Conditions in the UI

All three resource kinds are now debuggable from the portal:

- **Shared `ConditionsPanel`** extracted from the connection detail view — Type/Status/Reason/Message/Since plus a "controller has not caught up" warning when `observedGeneration < generation`.
- **Repositories** gain a `RepositoryDetail` shape (conditions + observedGeneration) and render the panel on the detail page, so `EnsureFailed`/`DeleteFailed` reasons — e.g. the `403 Must have admin rights` delete error that motivated #378 — are visible without dropping to `kubectl`.
- **Packages** surface their `Ready` condition as a Status column (`synced`/`pending`/`error`, crawler message on hover) in both the repo and workspace-wide Packages views.

## In-app confirm modal (no more `window.confirm`)

- Promise-based `confirmDialog()` backed by a single `ConfirmDialog` mounted at the app root: Enter confirms, Escape/backdrop cancels, confirm button auto-focused, destructive actions styled `danger`.
- Every delete / remove / connection-switch call site converted. No UI component calls `alert()`/`confirm()`/`prompt()` anymore.
- Modal styles are namespaced under `kedge-provider-code` and use the existing `--color-*` tokens; the dialog renders inside the light-DOM element (no `body` teleport) so theme tokens and namespaced CSS still apply.

## Verification

- `npm run typecheck` — clean
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)