### PR TITLE
[codex] Gate App Studio creation on Git readiness

### DIFF
--- a/providers/app-studio/api/code_repository.go
+++ b/providers/app-studio/api/code_repository.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -68,6 +69,16 @@ type projectRepositoryPlan struct {
 	Description   string
 }
 
+type ProjectCreateReadinessView struct {
+	GitConnection ProjectCreateGitConnectionReadiness `json:"gitConnection"`
+}
+
+type ProjectCreateGitConnectionReadiness struct {
+	Ready         bool   `json:"ready"`
+	ConnectionRef string `json:"connectionRef,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
 type codeResourceGetter func(ctx context.Context, gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error)
 type codeResourceLister func(ctx context.Context, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
 
@@ -96,6 +107,28 @@ func (s *Server) prepareProjectRepository(ctx context.Context, c *asclient.Clien
 		Name:          repoName,
 		ConnectionRef: connectionRef,
 		Description:   description,
+	}, nil
+}
+
+func projectCreateReadiness(ctx context.Context, c *asclient.Client) (ProjectCreateReadinessView, error) {
+	connectionRef, err := selectCodeConnection(ctx, c, "")
+	if err != nil {
+		var validationErr *ValidationError
+		if errors.As(err, &validationErr) {
+			return ProjectCreateReadinessView{
+				GitConnection: ProjectCreateGitConnectionReadiness{
+					Ready:   false,
+					Message: err.Error(),
+				},
+			}, nil
+		}
+		return ProjectCreateReadinessView{}, err
+	}
+	return ProjectCreateReadinessView{
+		GitConnection: ProjectCreateGitConnectionReadiness{
+			Ready:         true,
+			ConnectionRef: connectionRef,
+		},
 	}, nil
 }
 

--- a/providers/app-studio/api/code_repository_test.go
+++ b/providers/app-studio/api/code_repository_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+
+	asclient "github.com/faroshq/provider-app-studio/client"
+)
+
+func TestProjectCreateReadinessRequiresValidatedGitConnection(t *testing.T) {
+	client := newCodeRepositoryTestClient()
+
+	readiness, err := projectCreateReadiness(context.Background(), client)
+	if err != nil {
+		t.Fatalf("projectCreateReadiness returned error: %v", err)
+	}
+	if readiness.GitConnection.Ready {
+		t.Fatalf("GitConnection.Ready = true, want false")
+	}
+	if readiness.GitConnection.ConnectionRef != "" {
+		t.Fatalf("GitConnection.ConnectionRef = %q, want empty", readiness.GitConnection.ConnectionRef)
+	}
+	if readiness.GitConnection.Message != "You need to connect to a Git account before you can continue" {
+		t.Fatalf("GitConnection.Message = %q, want missing connection guidance", readiness.GitConnection.Message)
+	}
+}
+
+func TestProjectCreateReadinessSelectsValidatedGitConnection(t *testing.T) {
+	client := newCodeRepositoryTestClient(
+		codeConnectionObjectWithValidated("github", metav1.ConditionTrue),
+	)
+
+	readiness, err := projectCreateReadiness(context.Background(), client)
+	if err != nil {
+		t.Fatalf("projectCreateReadiness returned error: %v", err)
+	}
+	if !readiness.GitConnection.Ready {
+		t.Fatalf("GitConnection.Ready = false, want true")
+	}
+	if readiness.GitConnection.ConnectionRef != "github" {
+		t.Fatalf("GitConnection.ConnectionRef = %q, want github", readiness.GitConnection.ConnectionRef)
+	}
+	if readiness.GitConnection.Message != "" {
+		t.Fatalf("GitConnection.Message = %q, want empty", readiness.GitConnection.Message)
+	}
+}
+
+func newCodeRepositoryTestClient(objects ...runtime.Object) *asclient.Client {
+	return asclient.NewFromDynamic(fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			codeConnectionsGVR: "ConnectionList",
+		},
+		objects...,
+	))
+}
+
+func codeConnectionObjectWithValidated(name string, status metav1.ConditionStatus) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": codeConditionValidated, "status": string(status)},
+				},
+			},
+		},
+	}
+	u.SetAPIVersion(codeSchemeGroupVersion.String())
+	u.SetKind("Connection")
+	u.SetName(name)
+	return u
+}

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -166,6 +166,19 @@ func writeProjectError(w http.ResponseWriter, err error) {
 	writeError(w, err)
 }
 
+func (s *Server) getProjectCreateReadiness(w http.ResponseWriter, r *http.Request) {
+	c, _, ok := s.requireProjectClient(w, r)
+	if !ok {
+		return
+	}
+	readiness, err := projectCreateReadiness(r.Context(), c)
+	if err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, readiness)
+}
+
 func isProjectAPIInitializingError(err error) bool {
 	if err == nil {
 		return false

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -144,6 +144,7 @@ func (s *Server) Register(r *mux.Router) {
 	r.HandleFunc("/api/projects", s.listProjects).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects", s.createProject).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/stream", s.createProjectStartStream).Methods(http.MethodPost)
+	r.HandleFunc("/api/projects/create-readiness", s.getProjectCreateReadiness).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/llm-settings", s.getProjectLLMSettings).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/llm-settings", s.patchProjectLLMSettings).Methods(http.MethodPatch)
 	r.HandleFunc("/api/projects/{project}", s.getProject).Methods(http.MethodGet)

--- a/providers/app-studio/portal/package.json
+++ b/providers/app-studio/portal/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "test:workbench": "node --test src/workbench.test.mjs",
     "test:preview-state": "node --test src/previewState.test.mjs",
+    "test:create-readiness": "node --test src/createReadiness.test.mjs",
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -32,7 +32,7 @@ import {
 import { api, isProjectAPIInitializingError } from './api'
 import {
   canSubmitCreatePrompt,
-  createPromptBlockedMessage,
+  createSetupItems,
   gitConnectionReady,
   type ProjectCreateReadiness,
 } from './createReadiness'
@@ -368,7 +368,8 @@ const isBuilderVisible = computed(() => !isAppStudioLandingRoute.value || select
 const showNewProjectComposer = computed(() => isCreateRoute.value)
 const chatPaneStyle = computed(() => ({ flexBasis: `${splitWidth.value}%` }))
 const assistantResumeBusy = computed(() => Object.keys(permissionBusy.value).length > 0 || Object.keys(followUpBusy.value).length > 0)
-const canStartProjectFromPrompt = computed(() => canSubmitCreatePrompt(prompt.value, createReadiness.value))
+const llmConfigured = computed(() => llmSettings.value?.configured ?? false)
+const canStartProjectFromPrompt = computed(() => canSubmitCreatePrompt(prompt.value, createReadiness.value) && llmConfigured.value)
 const canSendPrompt = computed(() => (llmSettings.value?.configured ?? false) && prompt.value.trim().length > 0 && !messageStreaming.value && !assistantResumeBusy.value)
 const settingsProject = computed(() => (isAppStudioLandingRoute.value ? null : selected.value))
 const settingsTitle = computed(() => (settingsProject.value ? 'Project settings' : 'LLM settings'))
@@ -386,26 +387,17 @@ const conversationWorkingLabel = computed(() => {
 })
 const gitConnectionCreateReady = computed(() => gitConnectionReady(createReadiness.value))
 const createReadinessChecking = computed(() => createReadinessLoading.value || (!!props.ctx?.token && createReadiness.value === null && !createReadinessError.value))
-const createReadinessBlockMessage = computed(() => {
-  if (createReadinessError.value) return createReadinessError.value
-  if (createReadinessChecking.value) return 'Checking Git connection...'
-  return createPromptBlockedMessage(createReadiness.value)
-})
+const createSetupItemsForPrompt = computed(() => createSetupItems({
+  readiness: createReadiness.value,
+  llmConfigured: llmConfigured.value,
+  checkingGit: createReadinessChecking.value,
+}))
 const createPromptSubmitTitle = computed(() => {
-  if (!gitConnectionCreateReady.value) return 'Connect Git before creating a durable project'
-  return llmSettings.value?.configured ? 'Create project and send prompt' : 'Configure LLM settings before creating a project'
+  if (createSetupItemsForPrompt.value.length > 0) return 'Complete setup before creating a project'
+  return prompt.value.trim() ? 'Create project and send prompt' : 'Describe what you want to build'
 })
-const createPromptSubmitLabel = computed(() => {
-  if (!gitConnectionCreateReady.value) return createReadinessChecking.value ? 'Checking Git' : 'Connect Git'
-  return llmSettings.value?.configured ? 'Create and send' : 'Set up and send'
-})
-const llmConfigured = computed(() => llmSettings.value?.configured ?? false)
-const workspaceSetupReady = computed(() => gitConnectionCreateReady.value && llmConfigured.value)
-const workspaceSetupLabel = computed(() => {
-  if (!gitConnectionCreateReady.value) return createReadinessChecking.value ? 'Checking Git' : 'Git setup needed'
-  if (!llmConfigured.value) return 'LLM setup needed'
-  return 'Workspace ready'
-})
+const createSetupVisible = computed(() => createSetupItemsForPrompt.value.length > 0 || !!createReadinessError.value)
+const createSetupErrorMessage = computed(() => createReadinessError.value || '')
 const deleteProjectMessage = computed(() => {
   const project = deleteProjectTarget.value
   if (!project) return ''
@@ -1260,20 +1252,16 @@ async function clearLLMKey() {
 async function createProjectFromPrompt() {
   const content = prompt.value.trim()
   if (!content) return
-  if (!await ensureGitConnectionReady()) return
-  if (!llmSettings.value?.configured) {
-    openSettings()
-    return
-  }
+  if (!await ensureCreateSetupReady()) return
   await createProjectAndStartConversation(content)
 }
 
-async function ensureGitConnectionReady(): Promise<boolean> {
+async function ensureCreateSetupReady(): Promise<boolean> {
   if (!gitConnectionCreateReady.value && !createReadinessLoading.value) {
     await loadCreateReadiness()
   }
-  if (gitConnectionCreateReady.value) return true
-  error.value = createReadinessError.value || createPromptBlockedMessage(createReadiness.value)
+  if (gitConnectionCreateReady.value && llmConfigured.value) return true
+  error.value = null
   return false
 }
 
@@ -2811,6 +2799,7 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
             Back to projects
           </button>
           <button
+            v-if="!showNewProjectComposer"
             type="button"
             class="flex h-9 items-center gap-2 rounded-md border border-border-subtle bg-surface-raised px-3 text-[13px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary"
             title="LLM settings"
@@ -2940,17 +2929,7 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
         <main class="flex min-h-0 flex-1 items-center justify-center py-4">
           <section class="w-full max-w-[1060px]">
             <div class="mx-auto flex max-w-[760px] flex-col items-center text-center">
-	              <span
-	                class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium"
-	                :class="workspaceSetupReady
-	                  ? 'border-success/30 bg-success-subtle text-success'
-	                  : 'border-warning/30 bg-warning-subtle text-warning'"
-	              >
-	                <Check v-if="workspaceSetupReady" class="h-3.5 w-3.5" :stroke-width="2" />
-	                <Settings2 v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
-	                {{ workspaceSetupLabel }}
-	              </span>
-              <h2 class="mt-5 text-[44px] font-semibold leading-[1.05] text-text-primary md:text-[56px]">
+              <h2 class="text-[44px] font-semibold leading-[1.05] text-text-primary md:text-[56px]">
                 What do you want to build?
               </h2>
               <p class="mt-4 max-w-[62ch] text-[14px] leading-6 text-text-muted">
@@ -2985,30 +2964,8 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
                         <X class="h-3.5 w-3.5" :stroke-width="2" />
                       </button>
                     </span>
-                    <button
-                      v-if="!llmSettings?.configured"
-                      type="button"
-                      class="inline-flex items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2.5 py-1.5 text-[12px] font-medium text-accent transition hover:bg-accent/20"
-                      @click="openSettings"
-                    >
-                      <Settings2 class="h-3.5 w-3.5" :stroke-width="1.75" />
-                      Set up LLM
-                    </button>
-                    <span v-else class="text-[12px] text-text-muted">
+                    <span v-if="!createSetupVisible" class="text-[12px] text-text-muted">
                       The first message will create the project and start the conversation.
-                    </span>
-                    <span
-                      v-if="createReadinessBlockMessage"
-                      class="inline-flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning-subtle px-2.5 py-1.5 text-[12px] font-medium text-warning"
-                    >
-                      <GitBranch class="h-3.5 w-3.5" :stroke-width="1.75" />
-                      <template v-if="isMissingCodeConnectionError(createReadinessBlockMessage)">
-                        <a :href="CODE_CONNECTIONS_URL" class="underline underline-offset-2 hover:text-warning/80">
-                          Connect Git
-                        </a>
-                        <span>to create a durable project.</span>
-                      </template>
-                      <template v-else>{{ createReadinessBlockMessage }}</template>
                     </span>
                   </div>
                   <button
@@ -3017,10 +2974,62 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
                     :disabled="busy || !canStartProjectFromPrompt"
                     :title="createPromptSubmitTitle"
                   >
-                    <Plus v-if="gitConnectionCreateReady && llmSettings?.configured" class="h-4 w-4" :stroke-width="2" />
-                    <Settings2 v-else class="h-4 w-4" :stroke-width="1.75" />
-                    {{ createPromptSubmitLabel }}
+                    <Plus class="h-4 w-4" :stroke-width="2" />
+                    Create and send
                   </button>
+                </div>
+              </div>
+              <div
+                v-if="createSetupVisible"
+                class="mt-3 rounded-lg border border-border-subtle bg-surface-raised/70 p-3 text-left"
+              >
+                <div class="mb-2 flex items-center gap-2 text-[12px] font-semibold text-text-primary">
+                  <Settings2 class="h-3.5 w-3.5 text-accent" :stroke-width="1.75" />
+                  Complete setup before creating
+                </div>
+                <div v-if="createSetupErrorMessage" class="mb-2 text-[12px] text-danger">{{ createSetupErrorMessage }}</div>
+                <div class="grid gap-2">
+                  <div
+                    v-for="item in createSetupItemsForPrompt"
+                    :key="item.id"
+                    class="flex min-h-10 flex-wrap items-center justify-between gap-2 rounded-md border border-border-subtle bg-surface px-3 py-2"
+                  >
+                    <div class="flex min-w-0 items-center gap-2">
+                      <span
+                        class="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border"
+                        :class="item.status === 'ready'
+                          ? 'border-success/30 bg-success-subtle text-success'
+                          : item.status === 'checking'
+                            ? 'border-warning/30 bg-warning-subtle text-warning'
+                            : 'border-border-subtle bg-surface-raised text-text-muted'"
+                      >
+                        <Check v-if="item.status === 'ready'" class="h-3.5 w-3.5" :stroke-width="2" />
+                        <Loader2 v-else-if="item.status === 'checking'" class="h-3.5 w-3.5 animate-spin" :stroke-width="1.75" />
+                        <GitBranch v-else-if="item.id === 'git'" class="h-3.5 w-3.5" :stroke-width="1.75" />
+                        <Settings2 v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+                      </span>
+                      <span class="truncate text-[13px] font-medium text-text-primary">{{ item.label }}</span>
+                    </div>
+                    <span v-if="item.status === 'ready'" class="text-[12px] font-medium text-success">Ready</span>
+                    <span v-else-if="item.status === 'checking'" class="text-[12px] font-medium text-warning">Checking</span>
+                    <a
+                      v-else-if="item.action === 'connect-git'"
+                      :href="CODE_CONNECTIONS_URL"
+                      class="inline-flex h-8 items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2.5 text-[12px] font-medium text-accent transition hover:bg-accent/20"
+                    >
+                      <GitBranch class="h-3.5 w-3.5" :stroke-width="1.75" />
+                      {{ item.actionLabel }}
+                    </a>
+                    <button
+                      v-else-if="item.action === 'setup-llm'"
+                      type="button"
+                      class="inline-flex h-8 items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2.5 text-[12px] font-medium text-accent transition hover:bg-accent/20"
+                      @click="openSettings"
+                    >
+                      <Settings2 class="h-3.5 w-3.5" :stroke-width="1.75" />
+                      {{ item.actionLabel }}
+                    </button>
+                  </div>
                 </div>
               </div>
             </form>

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -30,6 +30,12 @@ import {
   X,
 } from 'lucide-vue-next'
 import { api, isProjectAPIInitializingError } from './api'
+import {
+  canSubmitCreatePrompt,
+  createPromptBlockedMessage,
+  gitConnectionReady,
+  type ProjectCreateReadiness,
+} from './createReadiness'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
 import { useEscapeKey } from '@/composables/useEscapeKey'
@@ -313,6 +319,9 @@ const followUpAnswers = ref<Record<string, string>>({})
 const followUpBusy = ref<Record<string, boolean>>({})
 const followUpErrors = ref<Record<string, string>>({})
 const toolState = ref<'idle' | 'loading' | 'ready' | 'error'>('idle')
+const createReadiness = ref<ProjectCreateReadiness | null>(null)
+const createReadinessLoading = ref(false)
+const createReadinessError = ref<string | null>(null)
 const workbench = ref(createDefaultWorkbenchState())
 const draggedWorkbenchTabID = ref<string | null>(null)
 const dragOverWorkbenchTabID = ref<string | null>(null)
@@ -359,7 +368,7 @@ const isBuilderVisible = computed(() => !isAppStudioLandingRoute.value || select
 const showNewProjectComposer = computed(() => isCreateRoute.value)
 const chatPaneStyle = computed(() => ({ flexBasis: `${splitWidth.value}%` }))
 const assistantResumeBusy = computed(() => Object.keys(permissionBusy.value).length > 0 || Object.keys(followUpBusy.value).length > 0)
-const canStartProjectFromPrompt = computed(() => prompt.value.trim().length > 0)
+const canStartProjectFromPrompt = computed(() => canSubmitCreatePrompt(prompt.value, createReadiness.value))
 const canSendPrompt = computed(() => (llmSettings.value?.configured ?? false) && prompt.value.trim().length > 0 && !messageStreaming.value && !assistantResumeBusy.value)
 const settingsProject = computed(() => (isAppStudioLandingRoute.value ? null : selected.value))
 const settingsTitle = computed(() => (settingsProject.value ? 'Project settings' : 'LLM settings'))
@@ -374,6 +383,28 @@ const conversationWorkingLabel = computed(() => {
   const lastAssistant = [...messages.value].reverse().find((message) => message.role === 'assistant')
   if (lastAssistant?.content.trim()) return 'Working'
   return 'Working'
+})
+const gitConnectionCreateReady = computed(() => gitConnectionReady(createReadiness.value))
+const createReadinessChecking = computed(() => createReadinessLoading.value || (!!props.ctx?.token && createReadiness.value === null && !createReadinessError.value))
+const createReadinessBlockMessage = computed(() => {
+  if (createReadinessError.value) return createReadinessError.value
+  if (createReadinessChecking.value) return 'Checking Git connection...'
+  return createPromptBlockedMessage(createReadiness.value)
+})
+const createPromptSubmitTitle = computed(() => {
+  if (!gitConnectionCreateReady.value) return 'Connect Git before creating a durable project'
+  return llmSettings.value?.configured ? 'Create project and send prompt' : 'Configure LLM settings before creating a project'
+})
+const createPromptSubmitLabel = computed(() => {
+  if (!gitConnectionCreateReady.value) return createReadinessChecking.value ? 'Checking Git' : 'Connect Git'
+  return llmSettings.value?.configured ? 'Create and send' : 'Set up and send'
+})
+const llmConfigured = computed(() => llmSettings.value?.configured ?? false)
+const workspaceSetupReady = computed(() => gitConnectionCreateReady.value && llmConfigured.value)
+const workspaceSetupLabel = computed(() => {
+  if (!gitConnectionCreateReady.value) return createReadinessChecking.value ? 'Checking Git' : 'Git setup needed'
+  if (!llmConfigured.value) return 'LLM setup needed'
+  return 'Workspace ready'
 })
 const deleteProjectMessage = computed(() => {
   const project = deleteProjectTarget.value
@@ -723,6 +754,7 @@ const developmentPreviewUnavailableMessage = computed(() => {
 onMounted(() => {
   void load()
   void loadProviders()
+  void loadCreateReadiness()
   void loadLLMSettings()
   startLandingPlaceholderRotation()
   window.addEventListener('focus', handleDevelopmentPreviewAuthorizationWake)
@@ -742,6 +774,7 @@ watch(
   () => props.ctx?.token,
   () => {
     void loadProviders()
+    void loadCreateReadiness()
     void loadLLMSettings()
   },
 )
@@ -903,6 +936,7 @@ function handleProjectAPIInitializing(err: unknown): boolean {
   initializationRetryTimer = window.setTimeout(() => {
     initializationRetryTimer = undefined
     void load()
+    void loadCreateReadiness()
     void loadLLMSettings()
   }, 2000)
   return true
@@ -935,6 +969,21 @@ async function loadProviders() {
     toolError.value = e instanceof Error ? e.message : String(e)
   } finally {
     providersLoading.value = false
+  }
+}
+
+async function loadCreateReadiness() {
+  if (!props.ctx?.token) return
+  createReadinessLoading.value = true
+  createReadinessError.value = null
+  try {
+    createReadiness.value = await api.getProjectCreateReadiness(props.ctx)
+  } catch (e) {
+    if (handleProjectAPIInitializing(e)) return
+    createReadiness.value = null
+    createReadinessError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    createReadinessLoading.value = false
   }
 }
 
@@ -1211,11 +1260,21 @@ async function clearLLMKey() {
 async function createProjectFromPrompt() {
   const content = prompt.value.trim()
   if (!content) return
+  if (!await ensureGitConnectionReady()) return
   if (!llmSettings.value?.configured) {
     openSettings()
     return
   }
   await createProjectAndStartConversation(content)
+}
+
+async function ensureGitConnectionReady(): Promise<boolean> {
+  if (!gitConnectionCreateReady.value && !createReadinessLoading.value) {
+    await loadCreateReadiness()
+  }
+  if (gitConnectionCreateReady.value) return true
+  error.value = createReadinessError.value || createPromptBlockedMessage(createReadiness.value)
+  return false
 }
 
 async function createProjectAndStartConversation(content: string) {
@@ -2881,16 +2940,16 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
         <main class="flex min-h-0 flex-1 items-center justify-center py-4">
           <section class="w-full max-w-[1060px]">
             <div class="mx-auto flex max-w-[760px] flex-col items-center text-center">
-              <span
-                class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium"
-                :class="llmSettings?.configured
-                  ? 'border-success/30 bg-success-subtle text-success'
-                  : 'border-warning/30 bg-warning-subtle text-warning'"
-              >
-                <Check v-if="llmSettings?.configured" class="h-3.5 w-3.5" :stroke-width="2" />
-                <Settings2 v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
-                {{ llmSettings?.configured ? 'Workspace ready' : 'LLM setup needed' }}
-              </span>
+	              <span
+	                class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium"
+	                :class="workspaceSetupReady
+	                  ? 'border-success/30 bg-success-subtle text-success'
+	                  : 'border-warning/30 bg-warning-subtle text-warning'"
+	              >
+	                <Check v-if="workspaceSetupReady" class="h-3.5 w-3.5" :stroke-width="2" />
+	                <Settings2 v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+	                {{ workspaceSetupLabel }}
+	              </span>
               <h2 class="mt-5 text-[44px] font-semibold leading-[1.05] text-text-primary md:text-[56px]">
                 What do you want to build?
               </h2>
@@ -2938,16 +2997,29 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
                     <span v-else class="text-[12px] text-text-muted">
                       The first message will create the project and start the conversation.
                     </span>
+                    <span
+                      v-if="createReadinessBlockMessage"
+                      class="inline-flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning-subtle px-2.5 py-1.5 text-[12px] font-medium text-warning"
+                    >
+                      <GitBranch class="h-3.5 w-3.5" :stroke-width="1.75" />
+                      <template v-if="isMissingCodeConnectionError(createReadinessBlockMessage)">
+                        <a :href="CODE_CONNECTIONS_URL" class="underline underline-offset-2 hover:text-warning/80">
+                          Connect Git
+                        </a>
+                        <span>to create a durable project.</span>
+                      </template>
+                      <template v-else>{{ createReadinessBlockMessage }}</template>
+                    </span>
                   </div>
                   <button
                     class="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-accent/30 bg-accent/10 px-3 text-[13px] font-medium text-accent transition hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-60"
                     type="submit"
                     :disabled="busy || !canStartProjectFromPrompt"
-                    :title="llmSettings?.configured ? 'Create project and send prompt' : 'Configure LLM settings before creating a project'"
+                    :title="createPromptSubmitTitle"
                   >
-                    <Plus v-if="llmSettings?.configured" class="h-4 w-4" :stroke-width="2" />
+                    <Plus v-if="gitConnectionCreateReady && llmSettings?.configured" class="h-4 w-4" :stroke-width="2" />
                     <Settings2 v-else class="h-4 w-4" :stroke-width="1.75" />
-                    {{ llmSettings?.configured ? 'Create and send' : 'Set up and send' }}
+                    {{ createPromptSubmitLabel }}
                   </button>
                 </div>
               </div>

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -13,6 +13,7 @@ import type {
   ProjectMessagesPage,
   ProviderItem,
 } from './types'
+import type { ProjectCreateReadiness } from './createReadiness'
 
 interface TenantSelection {
   orgUUID: string | null
@@ -591,6 +592,10 @@ export const api = {
     signal?: AbortSignal,
   ): Promise<void> {
     return requestStream(ctx, 'POST', `${baseURL(ctx)}/stream`, body, onEvent, signal)
+  },
+
+  async getProjectCreateReadiness(ctx: KedgeContext | null): Promise<ProjectCreateReadiness> {
+    return request<ProjectCreateReadiness>(ctx, 'GET', `${baseURL(ctx)}/create-readiness`)
   },
 
   async getLLMSettings(ctx: KedgeContext | null): Promise<ProjectLLMSettings> {

--- a/providers/app-studio/portal/src/createReadiness.test.mjs
+++ b/providers/app-studio/portal/src/createReadiness.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import ts from 'typescript'
+
+const source = await readFile(new URL('./createReadiness.ts', import.meta.url), 'utf8')
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+})
+const moduleURL = `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
+const {
+  canSubmitCreatePrompt,
+  createPromptBlockedMessage,
+} = await import(moduleURL)
+
+test('blocks project creation when no validated Git connection is ready', () => {
+  const readiness = {
+    gitConnection: {
+      ready: false,
+      message: 'You need to connect to a Git account before you can continue',
+    },
+  }
+
+  assert.equal(canSubmitCreatePrompt('build a dashboard', readiness), false)
+  assert.equal(
+    createPromptBlockedMessage(readiness),
+    'You need to connect to a Git account before you can continue',
+  )
+})
+
+test('allows the a-ha prompt only after Git durability is ready', () => {
+  const readiness = {
+    gitConnection: {
+      ready: true,
+      connectionRef: 'github',
+    },
+  }
+
+  assert.equal(canSubmitCreatePrompt('build a dashboard', readiness), true)
+  assert.equal(createPromptBlockedMessage(readiness), '')
+})
+
+test('still requires the user to type a prompt before submitting', () => {
+  const readiness = {
+    gitConnection: {
+      ready: true,
+      connectionRef: 'github',
+    },
+  }
+
+  assert.equal(canSubmitCreatePrompt('   ', readiness), false)
+})

--- a/providers/app-studio/portal/src/createReadiness.test.mjs
+++ b/providers/app-studio/portal/src/createReadiness.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test'
 import ts from 'typescript'
 
 const source = await readFile(new URL('./createReadiness.ts', import.meta.url), 'utf8')
+const appSource = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
 const { outputText } = ts.transpileModule(source, {
   compilerOptions: {
     module: ts.ModuleKind.ES2022,
@@ -14,6 +15,7 @@ const { outputText } = ts.transpileModule(source, {
 const moduleURL = `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
 const {
   canSubmitCreatePrompt,
+  createSetupItems,
   createPromptBlockedMessage,
 } = await import(moduleURL)
 
@@ -53,4 +55,87 @@ test('still requires the user to type a prompt before submitting', () => {
   }
 
   assert.equal(canSubmitCreatePrompt('   ', readiness), false)
+})
+
+test('summarizes Git and LLM setup as one checklist', () => {
+  const items = createSetupItems({
+    readiness: {
+      gitConnection: {
+        ready: false,
+        message: 'You need to connect to a Git account before you can continue',
+      },
+    },
+    llmConfigured: false,
+    checkingGit: false,
+  })
+
+  assert.deepEqual(items, [
+    {
+      id: 'git',
+      label: 'Git connection',
+      status: 'missing',
+      actionLabel: 'Connect Git',
+      action: 'connect-git',
+    },
+    {
+      id: 'llm',
+      label: 'LLM credentials',
+      status: 'missing',
+      actionLabel: 'Set up LLM',
+      action: 'setup-llm',
+    },
+  ])
+})
+
+test('collapses the setup checklist once all prerequisites are ready', () => {
+  const items = createSetupItems({
+    readiness: {
+      gitConnection: {
+        ready: true,
+        connectionRef: 'github',
+      },
+    },
+    llmConfigured: true,
+    checkingGit: false,
+  })
+
+  assert.deepEqual(items, [])
+})
+
+test('keeps ready setup rows visible while another prerequisite is missing', () => {
+  const items = createSetupItems({
+    readiness: {
+      gitConnection: {
+        ready: true,
+        connectionRef: 'github',
+      },
+    },
+    llmConfigured: false,
+    checkingGit: false,
+  })
+
+  assert.deepEqual(items, [
+    {
+      id: 'git',
+      label: 'Git connection',
+      status: 'ready',
+    },
+    {
+      id: 'llm',
+      label: 'LLM credentials',
+      status: 'missing',
+      actionLabel: 'Set up LLM',
+      action: 'setup-llm',
+    },
+  ])
+})
+
+test('new-project route has one setup surface and a stable create button label', () => {
+  assert.equal(appSource.includes('workspaceSetupLabel'), false)
+  assert.equal(appSource.includes('createPromptSubmitLabel'), false)
+  assert.equal(appSource.includes('to create a durable project.'), false)
+  assert.match(appSource, /<button\s+v-if="!showNewProjectComposer"[\s\S]*title="LLM settings"/)
+  assert.equal(appSource.includes('error.value = gitConnectionCreateReady.value ? null : createReadinessError.value || createPromptBlockedMessage(createReadiness.value)'), false)
+  assert.match(appSource, /if \(gitConnectionCreateReady\.value && llmConfigured\.value\) return true\s+error\.value = null\s+return false/)
+  assert.match(appSource, />\s*Create and send\s*</)
 })

--- a/providers/app-studio/portal/src/createReadiness.ts
+++ b/providers/app-studio/portal/src/createReadiness.ts
@@ -1,0 +1,22 @@
+export interface ProjectCreateReadiness {
+  gitConnection: {
+    ready: boolean
+    connectionRef?: string
+    message?: string
+  }
+}
+
+const defaultGitConnectionMessage = 'You need to connect to a Git account before you can continue'
+
+export function gitConnectionReady(readiness: ProjectCreateReadiness | null): boolean {
+  return readiness?.gitConnection.ready === true
+}
+
+export function createPromptBlockedMessage(readiness: ProjectCreateReadiness | null): string {
+  if (gitConnectionReady(readiness)) return ''
+  return readiness?.gitConnection.message?.trim() || defaultGitConnectionMessage
+}
+
+export function canSubmitCreatePrompt(prompt: string, readiness: ProjectCreateReadiness | null): boolean {
+  return prompt.trim().length > 0 && gitConnectionReady(readiness)
+}

--- a/providers/app-studio/portal/src/createReadiness.ts
+++ b/providers/app-studio/portal/src/createReadiness.ts
@@ -6,6 +6,20 @@ export interface ProjectCreateReadiness {
   }
 }
 
+export interface CreateSetupItemsInput {
+  readiness: ProjectCreateReadiness | null
+  llmConfigured: boolean
+  checkingGit: boolean
+}
+
+export interface CreateSetupItem {
+  id: 'git' | 'llm'
+  label: string
+  status: 'checking' | 'ready' | 'missing'
+  actionLabel?: string
+  action?: 'connect-git' | 'setup-llm'
+}
+
 const defaultGitConnectionMessage = 'You need to connect to a Git account before you can continue'
 
 export function gitConnectionReady(readiness: ProjectCreateReadiness | null): boolean {
@@ -19,4 +33,53 @@ export function createPromptBlockedMessage(readiness: ProjectCreateReadiness | n
 
 export function canSubmitCreatePrompt(prompt: string, readiness: ProjectCreateReadiness | null): boolean {
   return prompt.trim().length > 0 && gitConnectionReady(readiness)
+}
+
+export function createSetupItems(input: CreateSetupItemsInput): CreateSetupItem[] {
+  const gitReady = gitConnectionReady(input.readiness)
+  if (gitReady && input.llmConfigured) return []
+
+  const items: CreateSetupItem[] = [gitSetupItem(gitReady, input.checkingGit)]
+
+  items.push(
+    input.llmConfigured
+      ? {
+        id: 'llm',
+        label: 'LLM credentials',
+        status: 'ready',
+      }
+      : {
+        id: 'llm',
+        label: 'LLM credentials',
+        status: 'missing',
+        actionLabel: 'Set up LLM',
+        action: 'setup-llm',
+      },
+  )
+
+  return items
+}
+
+function gitSetupItem(gitReady: boolean, checkingGit: boolean): CreateSetupItem {
+  if (checkingGit) {
+    return {
+      id: 'git',
+      label: 'Git connection',
+      status: 'checking',
+    }
+  }
+  if (gitReady) {
+    return {
+      id: 'git',
+      label: 'Git connection',
+      status: 'ready',
+    }
+  }
+  return {
+    id: 'git',
+    label: 'Git connection',
+    status: 'missing',
+    actionLabel: 'Connect Git',
+    action: 'connect-git',
+  }
 }


### PR DESCRIPTION
## Summary

- Add an App Studio create-readiness endpoint that reuses the existing Code connection validation path.
- Gate the prompt composer submit action until a validated Git connection is ready, while still letting users type and refine their prompt.
- Show an inline Connect Git CTA and make the setup pill reflect both Git durability and LLM readiness.

## Why

Trying to create an App Studio project without a configured provider-code connection could enter the optimistic draft/create flow and then abruptly bounce back when repository setup failed. This keeps repository creation mandatory for durable projects, but moves the failure to an early, visible readiness gate.

## Validation

- `go test -count=1 ./api` from `providers/app-studio`
- `npm run test:create-readiness` from `providers/app-studio/portal`
- `npm run test:preview-state` from `providers/app-studio/portal`
- `npm run test:workbench` from `providers/app-studio/portal`
- `npm run typecheck` from `providers/app-studio/portal`
- `npm run build` from `providers/app-studio/portal`
- `git diff --check`