### PR TITLE
fix(infrastructure): dev-agent image — IfNotPresent pull + CI publish

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -91,6 +91,11 @@ jobs:
             image: ${{ github.repository_owner }}/kedge/app-studio-provider
           - name: databricks
             image: ${{ github.repository_owner }}/kedge-databricks-provider
+          # Companion image of the infrastructure provider (the dev-agent its
+          # kro backend injects into development-mode pods); published by
+          # provider-release.yaml on the infrastructure provider's tag.
+          - name: infrastructure/dev-agent
+            image: ${{ github.repository_owner }}/kedge-dev-agent
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -78,6 +78,25 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.semver }}
 
+      # The infrastructure provider ships a companion image: the dev-agent its
+      # kro backend injects into development-mode pods (providers/infrastructure/
+      # dev-agent, a scratch image carrying one static binary). It versions with
+      # the provider — publish it on the same tag so deployments can pin
+      # KEDGE_DEV_AGENT_IMAGE / development.agentImage to vX.Y.Z, and refresh
+      # :latest, which backs the in-binary default for stock deployments.
+      - name: Build and push dev-agent image
+        if: steps.tag.outputs.provider == 'infrastructure'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./providers/infrastructure/dev-agent
+          file: ./providers/infrastructure/dev-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:${{ steps.tag.outputs.semver }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:latest
+
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:

--- a/providers/infrastructure/backend/kro/devoverlay.go
+++ b/providers/infrastructure/backend/kro/devoverlay.go
@@ -355,9 +355,14 @@ func synthesizeDevDeployment(name string, comp infrav1alpha1.TemplateDevelopment
 
 	initContainers, _ := podSpec["initContainers"].([]any)
 	initContainers = append(initContainers, map[string]any{
-		"name":    "kedge-dev-agent",
-		"image":   agentImage,
-		"command": []any{"/kedge-dev-agent", "--install", devAgentBinDir},
+		"name":  "kedge-dev-agent",
+		"image": agentImage,
+		// The default-for-:latest Always policy would force a registry pull
+		// even when the image is side-loaded (kind/local dev) and fail the pod
+		// if the registry copy is missing. Production pins digests via
+		// KEDGE_DEV_AGENT_IMAGE, where IfNotPresent is equivalent.
+		"imagePullPolicy": "IfNotPresent",
+		"command":         []any{"/kedge-dev-agent", "--install", devAgentBinDir},
 		"volumeMounts": []any{
 			map[string]any{"name": "kedge-dev-agent-bin", "mountPath": devAgentBinDir},
 		},


### PR DESCRIPTION
Follow-up to #394 — these two commits were pushed to `appstudio.catalog` after it merged, so they never landed.

## Problem
Development-mode pods failed with `ImagePullBackOff`: the injected dev-agent init container had no `imagePullPolicy`, so the `:latest` default (`Always`) forced a registry pull of `ghcr.io/faroshq/kedge-dev-agent` — which nothing has ever published (ghcr 403) — even when the image was side-loaded into the local kind runtime by tilt.

## Fixes
- **`imagePullPolicy: IfNotPresent`** on the injected init container. Local side-loaded images are used as-is; production pins digests via `KEDGE_DEV_AGENT_IMAGE` / `development.agentImage`, where the policy change is behaviorally equivalent.
- **CI publish**: `provider-release.yaml` now builds `providers/infrastructure/dev-agent` on a `providers/infrastructure/v*` tag and pushes `kedge-dev-agent:vX.Y.Z` / `:X.Y.Z` / `:latest` (the `latest` tag backs the in-binary and chart defaults). `images.yaml` adds the Dockerfile to the PR-only build-validation matrix.

The image first publishes when the next infrastructure provider tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)