### PR TITLE
fix(app-studio,infra): local dev preview reachability + assistant fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,9 +394,12 @@ whole point.
   versions, sizes) as `spec.schema` fields with sane defaults** — never via
   `${kedge.*}` env-substitution tokens. Fixed sidecar images (e.g. the
   control-token `kubectl` job) are hardcoded literals. `${kedge.*}` tokens are
-  reserved for genuinely platform-global values with no universal default (only
-  the exposure Gateway parent today). A missing env must never be able to
-  produce an empty/invalid field. See
+  reserved for the handful of genuinely platform-global values with no universal
+  default: the exposure Gateway parent (`${kedge.gatewayName}` /
+  `${kedge.gatewayNamespace}`), the dev-overlay images
+  (`${kedge.devImage.<toolchain>}` / `${kedge.devAgentImage}`), and the
+  exposure-URL port suffix (`${kedge.appPublicPort}`). A missing env must never
+  be able to produce an empty/invalid field. See
   [`providers/infrastructure/docs/template-conventions.md`](providers/infrastructure/docs/template-conventions.md).
 - **Providers are isolated; never reach into another provider's backend.** A
   provider's backend layer (its runtime/target clusters and their

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -422,7 +422,10 @@ k8s_yaml(helm(
         # /bonkers admin access for the dev static token (resolves to
         # static-dev-toke@kedge.local — see proxy.ensureStaticTokenUserOnce).
         'hub.adminUsers={static-dev-toke@kedge.local}',
-        'hub.portalFrameSources={https://*.%s:%s}' % (app_studio_preview_base_domain, app_studio_preview_public_port),
+        # Development previews render the app's own exposure URL (status.url)
+        # in the portal iframe — allow the local apps domain on the envoy
+        # port-forward. (preview.localhost was the deleted preview-gateway.)
+        'hub.portalFrameSources={https://*.%s:%s}' % (app_base_domain, app_studio_preview_public_port),
         # Make *.kcp.localhost resolve to the Envoy gateway from the hub pod,
         # so the operator-issued kubeconfigs work in-cluster unchanged.
         'hostAliases[0].ip=%s' % gateway_ip,
@@ -824,10 +827,15 @@ local_resource(
                # cloudflare-tunnel (the in-binary default).
                'KEDGE_GATEWAY_NAME={gateway} ' +
                'KEDGE_GATEWAY_NAMESPACE=envoy-gateway-system ' +
+               # Locally the Gateway is only reachable via the envoy
+               # port-forward — templates append this to status.url
+               # (${kedge.appPublicPort}); prod leaves it unset (443).
+               'KEDGE_APP_PUBLIC_PORT={port} ' +
                'make run-provider-infrastructure').format(
                    kro=KIND_HOST_KUBECONFIG, kc=KCP_ADMIN_KUBECONFIG,
                    apps_domain=app_base_domain,
-                   gateway=app_studio_preview_parent_gateway_name),
+                   gateway=app_studio_preview_parent_gateway_name,
+                   port=app_studio_preview_public_port),
     deps=[
         'providers/infrastructure/main.go',
         'providers/infrastructure/heartbeat.go',

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -622,6 +622,9 @@ local_resource(
     # instance's own public URL (docs/app-studio-template-sandboxes.md) — no
     # preview-gateway env.
     serve_cmd=('KEDGE_PROVIDER_KUBECONFIG={kc} ' +
+               # Opaque chat disclosures (generic labels, no tool names /
+               # summarized output) — drop this to get full summary disclosure.
+               'APP_STUDIO_TOOL_DISCLOSURE=minimal ' +
                'make run-provider-app-studio').format(
                    kc=KCP_ADMIN_KUBECONFIG),
     deps=[

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -21,12 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"k8s.io/klog/v2"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 	asclient "github.com/faroshq/provider-app-studio/client"
@@ -602,12 +602,13 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 		if history, histErr := s.store.LoadRecentMessages(ctx, messageScope, 24); histErr == nil {
 			// The answer is not persisted as a message yet — append it so the
 			// router classifies the instruction, not the stale history.
-			history = append(history, store.Message{Role: "user", Content: answer})
+			history = append(history, store.Message{Role: aiv1alpha1.ProjectMessageRoleUser, Content: answer})
 			if turnDecision, routeErr := s.projectAssistantTurnRouter()(ctx, projectAssistantTurnRouteRequest{LLM: settings, History: history}); routeErr == nil {
 				engineReq.TurnPolicy = projectAssistantTurnPolicyForDecision(turnDecision)
 				engineReq.TurnProfile = engineReq.TurnPolicy.profile
-				log.Printf("assistant resume re-route: project=%s profile=%s confidence=%s mutation=%v",
-					p.Name, turnDecision.Profile, turnDecision.Confidence, turnDecision.RequestsMutation)
+				klog.FromContext(ctx).V(2).Info("assistant resume re-route",
+					"project", p.Name, "profile", turnDecision.Profile, "confidence", turnDecision.Confidence,
+					"mutation", turnDecision.RequestsMutation)
 			}
 		}
 	}

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -591,6 +591,23 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 			OnAssistantEvent: emitAssistantEvent,
 		},
 	}
+	// A free-text resume answer is a fresh user instruction ("go for it",
+	// "fix the login") — re-route it so the engine can escalate the run's
+	// tool policy. Without this, a run that began as a discussion question
+	// restores its toolless policy from the checkpoint on every resume, and
+	// the model can only keep asking for access it will never get. Routing
+	// failures fall through to the checkpoint policy (no escalation).
+	if answer := strings.TrimSpace(resumeReq.Answer); answer != "" {
+		if history, histErr := s.store.LoadRecentMessages(ctx, messageScope, 24); histErr == nil {
+			// The answer is not persisted as a message yet — append it so the
+			// router classifies the instruction, not the stale history.
+			history = append(history, store.Message{Role: "user", Content: answer})
+			if turnDecision, routeErr := s.projectAssistantTurnRouter()(ctx, projectAssistantTurnRouteRequest{LLM: settings, History: history}); routeErr == nil {
+				engineReq.TurnPolicy = projectAssistantTurnPolicyForDecision(turnDecision)
+				engineReq.TurnProfile = engineReq.TurnPolicy.profile
+			}
+		}
+	}
 	currentRequestID := run.RequestID
 	currentToolCallID := strings.TrimSpace(state.Eino.ToolCallID)
 	result, err := s.projectAssistantEngine().ResumeProjectAssistant(ctx, engineReq, resumeReq, state)

--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -605,6 +606,8 @@ func (s *Server) resumeClaimedProjectAssistantRunWithEinoCheckpoint(
 			if turnDecision, routeErr := s.projectAssistantTurnRouter()(ctx, projectAssistantTurnRouteRequest{LLM: settings, History: history}); routeErr == nil {
 				engineReq.TurnPolicy = projectAssistantTurnPolicyForDecision(turnDecision)
 				engineReq.TurnProfile = engineReq.TurnPolicy.profile
+				log.Printf("assistant resume re-route: project=%s profile=%s confidence=%s mutation=%v",
+					p.Name, turnDecision.Profile, turnDecision.Confidence, turnDecision.RequestsMutation)
 			}
 		}
 	}

--- a/providers/app-studio/api/assistant_eino_engine.go
+++ b/providers/app-studio/api/assistant_eino_engine.go
@@ -134,8 +134,13 @@ func (e projectEinoAssistantEngine) ResumeProjectAssistant(
 	}))
 	resumeRunReq := req
 	resumeRunReq.Continuation = &state
-	resumeRunReq.TurnPolicy = runState.TurnPolicy()
+	// The checkpoint restores the policy the run STARTED with; req.TurnPolicy
+	// carries the (optional) re-routed decision for this resume. Escalate-only
+	// merge: a "go for it" follow-up gains implementation tools, but an
+	// in-flight fix never loses tools to a chatty-looking reply.
+	resumeRunReq.TurnPolicy = escalateProjectAssistantTurnPolicy(runState.TurnPolicy(), req.TurnPolicy)
 	resumeRunReq.TurnProfile = resumeRunReq.TurnPolicy.profile
+	runState.SetTurnPolicy(resumeRunReq.TurnPolicy)
 	checkpointStore := newProjectEinoAssistantCheckpointStoreWithCheckpoint(state.Eino.CheckpointID, state.Eino.Checkpoint)
 	turn := newProjectAssistantTurnItem(projectAssistantTurnResume, req.Identity, req.Project.Name)
 	turn.RequestID = strings.TrimSpace(resumeReq.RequestID)

--- a/providers/app-studio/api/assistant_events.go
+++ b/providers/app-studio/api/assistant_events.go
@@ -247,10 +247,18 @@ func (w *projectAssistantStreamWriter) nextMessageComponentIDs() (string, string
 }
 
 func projectAssistantUIToolCardText(action projectAssistantUIAction) string {
-	if action.Summary != "" {
-		return action.Label + "\n" + action.Summary
+	header := action.Label
+	if action.Tool != "" {
+		header += " · " + action.Tool
 	}
-	return action.Label
+	body := action.Detail
+	if body == "" {
+		body = action.Summary
+	}
+	if body != "" {
+		return header + "\n" + body
+	}
+	return header
 }
 
 func projectAssistantUIEventIsEmpty(ui projectAssistantUIEvent) bool {

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -205,6 +205,35 @@ func TestProjectAssistantStreamWriterMapsStatusToUIDataModelUpdate(t *testing.T)
 	}
 }
 
+// Minimal disclosure mode (APP_STUDIO_TOOL_DISCLOSURE=minimal) restores the
+// fully opaque contract from #322: generic labels only — no tool names,
+// paths, or error text anywhere in the streamed UI.
+func TestProjectAssistantStreamWriterMinimalDisclosureHidesToolDetail(t *testing.T) {
+	prev := projectAssistantToolDisclosureMinimal
+	projectAssistantToolDisclosureMinimal = true
+	t.Cleanup(func() { projectAssistantToolDisclosureMinimal = prev })
+
+	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
+		Type: projectAssistantEventToolCallFinished,
+		ToolCall: &projectAssistantToolCall{
+			ID:        "tool-1",
+			Name:      "write_file",
+			Status:    "succeeded",
+			Summary:   "Wrote src/App.tsx",
+			Arguments: `{"path":"src/App.tsx"}`,
+			Error:     "warning only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("events = %#v, want beginRendering and opaque tool result card", got)
+	}
+	assertA2UICard(t, got[1], "tool result", "Edited files")
+	assertNoRawAssistantTrace(t, got, "src/App.tsx", "write_file", "warning only")
+}
+
 // Tool disclosure contract: the chat shows WHICH tool ran and its summarized
 // arguments/result (summarizers emit paths/counts, never file contents or
 // secrets); raw error text stays hidden when a result summary exists.

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -265,6 +265,25 @@ func TestProjectAssistantStreamWriterMapsToolCallToSafeDisclosure(t *testing.T) 
 	assertNoRawAssistantTrace(t, got, "warning only")
 }
 
+// Disclosure boundary: an unknown/MCP tool has no bespoke argument summary, so
+// the summarizer falls back to marshaling the whole arg map — which could carry
+// file contents or secrets. That raw-JSON fallback must be dropped, not shown.
+func TestProjectAssistantUIActionToolArgumentsDropsRawJSONFallback(t *testing.T) {
+	// A tool with a dedicated summarizer yields a safe, non-JSON summary.
+	if got := projectAssistantUIActionToolArguments(projectToolReadProjectFile, `{"path":"src/App.tsx"}`); !strings.Contains(got, "src/App.tsx") || looksLikeRawJSON(got) {
+		t.Errorf("read_project_file arguments = %q, want a non-JSON path summary", got)
+	}
+	// An unknown tool falls through to json.Marshal(args); the guard must drop
+	// the raw payload rather than leak content/secrets.
+	if got := projectAssistantUIActionToolArguments("some__mcp_tool", `{"content":"secret file body","token":"abc123"}`); got != "" {
+		t.Errorf("unknown-tool arguments = %q, want empty (raw JSON fallback dropped)", got)
+	}
+	// Already-summarized (non-JSON) input passes through untouched.
+	if got := projectAssistantUIActionToolArguments("some__mcp_tool", "path api/server.js; 12 bytes"); got != "path api/server.js; 12 bytes" {
+		t.Errorf("pre-summarized arguments = %q, want passthrough", got)
+	}
+}
+
 func TestProjectAssistantStreamWriterSkipsLowValueFinishedInspectionProgress(t *testing.T) {
 	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
 		Type: projectAssistantEventToolCallFinished,

--- a/providers/app-studio/api/assistant_events_test.go
+++ b/providers/app-studio/api/assistant_events_test.go
@@ -205,6 +205,9 @@ func TestProjectAssistantStreamWriterMapsStatusToUIDataModelUpdate(t *testing.T)
 	}
 }
 
+// Tool disclosure contract: the chat shows WHICH tool ran and its summarized
+// arguments/result (summarizers emit paths/counts, never file contents or
+// secrets); raw error text stays hidden when a result summary exists.
 func TestProjectAssistantStreamWriterMapsToolCallToSafeDisclosure(t *testing.T) {
 	got, err := collectProjectAssistantStreamEvents(projectAssistantEvent{
 		Type: projectAssistantEventToolCallFinished,
@@ -221,14 +224,16 @@ func TestProjectAssistantStreamWriterMapsToolCallToSafeDisclosure(t *testing.T) 
 		t.Fatalf("EmitProjectAssistantEvent returned error: %v", err)
 	}
 	if len(got) != 2 {
-		t.Fatalf("events = %#v, want beginRendering and safe tool result card", got)
+		t.Fatalf("events = %#v, want beginRendering and tool result card", got)
 	}
 	event := got[1]
 	if event.Type != "" || event.SurfaceUpdate == nil {
-		t.Fatalf("event = %#v, want safe surfaceUpdate UI event", event)
+		t.Fatalf("event = %#v, want surfaceUpdate UI event", event)
 	}
 	assertA2UICard(t, event, "tool result", "Edited files")
-	assertNoRawAssistantTrace(t, got, "src/App.tsx", "warning only", "write_file")
+	assertA2UICard(t, event, "tool result", "write_file")
+	assertA2UICard(t, event, "tool result", "Wrote src/App.tsx")
+	assertNoRawAssistantTrace(t, got, "warning only")
 }
 
 func TestProjectAssistantStreamWriterSkipsLowValueFinishedInspectionProgress(t *testing.T) {
@@ -252,7 +257,8 @@ func TestProjectAssistantStreamWriterSkipsLowValueFinishedInspectionProgress(t *
 		t.Fatalf("event = %#v, want safe surfaceUpdate UI event", event)
 	}
 	assertA2UICard(t, event, "tool result", "Inspected project")
-	assertNoRawAssistantTrace(t, got, "src/App.tsx", "read_project_file")
+	assertA2UICard(t, event, "tool result", "read_project_file")
+	assertA2UICard(t, event, "tool result", "Read src/App.tsx")
 }
 
 func TestProjectAssistantStreamWriterMapsPermissionCheckpointToInterruptRequest(t *testing.T) {
@@ -320,7 +326,10 @@ func TestProjectAssistantMessageMetadataStoresSafeUIModel(t *testing.T) {
 		t.Fatalf("marshal metadata: %v", err)
 	}
 	payload := string(raw)
-	for _, value := range []string{"src/App.tsx", "secret", "raw tool failure", "waiting_for_permission", "permission_required"} {
+	// Tool name and summarized arguments/result are disclosed by design; the
+	// permission Input payload (raw file contents / secrets), raw error text
+	// behind a summary, and checkpoint internals must never leak.
+	for _, value := range []string{"secret", "raw tool failure", "waiting_for_permission", "permission_required"} {
 		if strings.Contains(payload, value) {
 			t.Fatalf("metadata leaked %q in %s", value, payload)
 		}

--- a/providers/app-studio/api/assistant_runtime_tools.go
+++ b/providers/app-studio/api/assistant_runtime_tools.go
@@ -194,15 +194,19 @@ func boundedRuntimeLogLines(raw string, tail int) []string {
 	return lines
 }
 
+type projectAssistantRuntimeRestartToolInput struct {
+	Component string `json:"component,omitempty" jsonschema_description:"Restart only this development component (e.g. \"api\" or \"web\"). Omit to restart every component."`
+}
+
 func newProjectAssistantRestartRuntimeGraphTool(runCtx projectAssistantWorkflowRunContext) (einotool.BaseTool, error) {
-	workflow := compose.NewWorkflow[*projectAssistantRuntimeStatusToolInput, *projectAssistantRuntimeWorkflowResult]()
+	workflow := compose.NewWorkflow[*projectAssistantRuntimeRestartToolInput, *projectAssistantRuntimeWorkflowResult]()
 	workflow.AddLambdaNode("restart-runtime", compose.InvokableLambda(restartProjectAssistantRuntime(runCtx))).
 		AddInput(compose.START)
 	workflow.End().AddInput("restart-runtime")
 	innerTool, err := graphtool.NewInvokableGraphTool(
 		workflow,
 		projectToolRestartRuntime,
-		"Restart the development runtime's dev process so it picks up new files or configuration. Use this to recover a sandbox that is stuck or crash-looping.",
+		"Restart the development runtime's dev process so it picks up new files or configuration. Use this to recover a sandbox that is stuck or crash-looping. Pass component to restart a single component of a multi-component app.",
 		compose.WithGraphName("app-studio-restart-runtime"),
 	)
 	if err != nil {
@@ -211,8 +215,8 @@ func newProjectAssistantRestartRuntimeGraphTool(runCtx projectAssistantWorkflowR
 	return approvaltool.InvokableApprovableTool{InvokableTool: innerTool}, nil
 }
 
-func restartProjectAssistantRuntime(runCtx projectAssistantWorkflowRunContext) func(context.Context, *projectAssistantRuntimeStatusToolInput) (*projectAssistantRuntimeWorkflowResult, error) {
-	return func(ctx context.Context, _ *projectAssistantRuntimeStatusToolInput) (*projectAssistantRuntimeWorkflowResult, error) {
+func restartProjectAssistantRuntime(runCtx projectAssistantWorkflowRunContext) func(context.Context, *projectAssistantRuntimeRestartToolInput) (*projectAssistantRuntimeWorkflowResult, error) {
+	return func(ctx context.Context, input *projectAssistantRuntimeRestartToolInput) (*projectAssistantRuntimeWorkflowResult, error) {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -220,7 +224,19 @@ func restartProjectAssistantRuntime(runCtx projectAssistantWorkflowRunContext) f
 		if blocked != nil {
 			return blocked, nil
 		}
-		for component, ref := range runtimeComponentRefs(target) {
+		refs := runtimeComponentRefs(target)
+		if input != nil && strings.TrimSpace(input.Component) != "" {
+			component := strings.TrimSpace(input.Component)
+			ref, ok := refs[component]
+			if !ok {
+				return &projectAssistantRuntimeWorkflowResult{
+					Status:  "error",
+					Summary: fmt.Sprintf("Unknown component %q; this app's components are: %s.", component, strings.Join(target.sortedComponents(), ", ")),
+				}, nil
+			}
+			refs = map[string]dataPlaneRef{component: ref}
+		}
+		for component, ref := range refs {
 			body, status, err := server.dataPlanePost(ctx, id, ref, dataPlaneVerbRestart, []byte(`{}`))
 			label := ""
 			if component != "" {

--- a/providers/app-studio/api/assistant_turn_profile.go
+++ b/providers/app-studio/api/assistant_turn_profile.go
@@ -388,6 +388,35 @@ func (p projectAssistantTurnPolicy) AllowsTool(spec projectAssistantToolSpec) bo
 	}
 }
 
+// projectAssistantTurnProfileRank orders profiles by tool permissiveness so a
+// resumed run can escalate its policy but never silently downgrade mid-run.
+func projectAssistantTurnProfileRank(profile projectAssistantTurnProfile) int {
+	switch normalizeProjectAssistantTurnProfile(profile) {
+	case projectAssistantTurnProfileImplementation, projectAssistantTurnProfileDebugFix:
+		return 3
+	case projectAssistantTurnProfileDebugging:
+		return 2
+	case projectAssistantTurnProfileExploration:
+		return 1
+	default: // discussion, guidance, unknown
+		return 0
+	}
+}
+
+// escalateProjectAssistantTurnPolicy merges the run's saved policy with a
+// fresh routing decision, keeping the more permissive profile. A run that
+// began as a discussion question must gain tools when the user's follow-up is
+// an instruction ("go for it"); the reverse — losing tools because a
+// follow-up reads as chit-chat — would strand an in-flight fix.
+func escalateProjectAssistantTurnPolicy(current, next projectAssistantTurnPolicy) projectAssistantTurnPolicy {
+	merged := current
+	if projectAssistantTurnProfileRank(next.profile) > projectAssistantTurnProfileRank(current.profile) {
+		merged.profile = normalizeProjectAssistantTurnProfile(next.profile)
+	}
+	merged.requiresRuntimeState = current.requiresRuntimeState || next.requiresRuntimeState
+	return normalizeProjectAssistantTurnPolicy(merged, projectAssistantTurnProfileDiscussion)
+}
+
 func projectAssistantToolsForTurnProfile(tools []projectAssistantTool, profile projectAssistantTurnProfile) []projectAssistantTool {
 	return projectAssistantToolsForTurnPolicy(tools, projectAssistantTurnPolicyForProfile(profile))
 }

--- a/providers/app-studio/api/assistant_turn_profile.go
+++ b/providers/app-studio/api/assistant_turn_profile.go
@@ -125,16 +125,43 @@ func projectAssistantFallbackTurnRouter(_ context.Context, req projectAssistantT
 	return fallbackProjectAssistantTurnDecision(req.History), nil
 }
 
+// fallbackProjectAssistantTurnDecision classifies without a model. Terse
+// follow-ups ("do it", "just check the workspace") carry the conversation's
+// STANDING intent, not a fresh one — classifying the last message in
+// isolation strands an instructed task in a read-only profile. So the
+// fallback merges the keyword decisions of the recent user messages,
+// escalate-only: the most permissive recent profile wins. This widens which
+// tools the model may attempt, not what it may do — mutations stay behind
+// the plan-approval gate.
 func fallbackProjectAssistantTurnDecision(history []store.Message) projectAssistantTurnDecision {
-	for i := len(history) - 1; i >= 0; i-- {
+	const window = 5
+	merged := projectAssistantTurnDecision{}
+	seen := 0
+	for i := len(history) - 1; i >= 0 && seen < window; i-- {
 		if history[i].Role != aiv1alpha1.ProjectMessageRoleUser {
 			continue
 		}
-		if content := strings.TrimSpace(history[i].Content); content != "" {
-			return fallbackProjectAssistantTurnDecisionForMessage(content)
+		content := strings.TrimSpace(history[i].Content)
+		if content == "" {
+			continue
 		}
+		decision := fallbackProjectAssistantTurnDecisionForMessage(content)
+		if seen == 0 {
+			merged = decision
+		} else {
+			if projectAssistantTurnProfileRank(decision.Profile) > projectAssistantTurnProfileRank(merged.Profile) {
+				merged.Profile = decision.Profile
+			}
+			merged.RequiresCurrentState = merged.RequiresCurrentState || decision.RequiresCurrentState
+			merged.RequiresRuntimeState = merged.RequiresRuntimeState || decision.RequiresRuntimeState
+			merged.RequestsMutation = merged.RequestsMutation || decision.RequestsMutation
+		}
+		seen++
 	}
-	return fallbackProjectAssistantTurnDecisionWithProfile(projectAssistantTurnProfileDiscussion)
+	if seen == 0 {
+		return fallbackProjectAssistantTurnDecisionWithProfile(projectAssistantTurnProfileDiscussion)
+	}
+	return merged
 }
 
 func fallbackProjectAssistantTurnDecisionForMessage(content string) projectAssistantTurnDecision {
@@ -167,6 +194,14 @@ func fallbackProjectAssistantTurnDecisionForMessage(content string) projectAssis
 	if containsProjectAssistantTurnKeyword(normalized, []string{
 		"build", "add", "change", "update", "implement", "write", "make the app", "create", "remove", "delete", "ship", "commit", "deploy", "provision",
 		"git", "push", "pull request", "branch", "merge",
+		"wire", "hook up", "set up", "setup", "configure", "connect", "integrate", "install", "refactor", "rename", "migrate", "enable", "disable",
+		// Runtime actions are mutations too — "reload the backend container"
+		// must not land in a toolless profile.
+		"restart", "reload", "redeploy", "rebuild", "bounce",
+		// Continuation imperatives: the user is telling the assistant to
+		// execute what the conversation already established.
+		"do it", "do that", "do this", "go for it", "go ahead", "proceed", "do whats needed", "do what's needed",
+		"dont stop", "don't stop", "keep going", "continue", "finish it", "get it done", "just do",
 	}) {
 		return fallbackProjectAssistantTurnDecisionWithProfile(projectAssistantTurnProfileImplementation)
 	}

--- a/providers/app-studio/api/assistant_turn_profile_test.go
+++ b/providers/app-studio/api/assistant_turn_profile_test.go
@@ -325,6 +325,31 @@ func TestProjectAssistantModePromptsPutBuilderGuidanceOnlyOnWriteProfiles(t *tes
 	}
 }
 
+// The bound template is the app's environment contract — the prompt must
+// direct the model to describe THAT template (agent.usage) before reasoning
+// about what infrastructure the app has, and must forbid concluding a
+// declared backing service (e.g. the application template's Postgres +
+// injected DATABASE_URL) is missing just because the code doesn't use it.
+func TestProjectAssistantPromptTreatsBoundTemplateAsEnvironmentContract(t *testing.T) {
+	project := projectWithRepository("demo-repo", "demo", "github")
+	project.Name = "demo-project"
+	project.Spec.Template = &aiv1alpha1.ProjectTemplateSpec{Name: "application"}
+	repository := &ProjectRepositoryView{Ref: "demo-repo", Name: "demo", Status: projectRepositoryStatusReady, Ready: true}
+
+	prompt := projectSystemPrompt(project, repository, projectAssistantTurnProfileImplementation)
+	for _, want := range []string{
+		"Development template: application",
+		"ENVIRONMENT CONTRACT",
+		"infrastructure__describe_template on THIS template",
+		"DATABASE_URL",
+		"do not conclude a declared service is missing",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
 func TestProjectAssistantPromptRequiresEvidenceForProductCapabilities(t *testing.T) {
 	project := projectWithRepository("demo-repo", "demo", "github")
 	project.Name = "demo-project"

--- a/providers/app-studio/api/assistant_turn_profile_test.go
+++ b/providers/app-studio/api/assistant_turn_profile_test.go
@@ -483,4 +483,47 @@ func TestProjectAssistantTurnPolicyAllowsRuntimeReadsForRuntimeStateExploration(
 	}
 }
 
+// The regression this guards: a run that starts as a discussion question is
+// checkpointed with a toolless policy; when the user's follow-up answer is an
+// instruction ("go for it"), the resume must escalate to the re-routed
+// profile — and an in-flight implementation run must never downgrade because
+// a follow-up reads as chit-chat.
+func TestEscalateProjectAssistantTurnPolicy(t *testing.T) {
+	discussion := projectAssistantTurnPolicyForProfile(projectAssistantTurnProfileDiscussion)
+	implementation := projectAssistantTurnPolicyForProfile(projectAssistantTurnProfileImplementation)
+
+	if got := escalateProjectAssistantTurnPolicy(discussion, implementation); got.profile != projectAssistantTurnProfileImplementation {
+		t.Errorf("discussion + implementation = %q, want escalation to implementation", got.profile)
+	}
+	if got := escalateProjectAssistantTurnPolicy(implementation, discussion); got.profile != projectAssistantTurnProfileImplementation {
+		t.Errorf("implementation + discussion = %q, must not downgrade", got.profile)
+	}
+	// Empty next policy (resume without a re-routed decision, e.g. a plain
+	// approve/deny) keeps the checkpoint policy untouched.
+	if got := escalateProjectAssistantTurnPolicy(implementation, projectAssistantTurnPolicy{}); got.profile != projectAssistantTurnProfileImplementation {
+		t.Errorf("implementation + empty = %q, want implementation", got.profile)
+	}
+	// requiresRuntimeState is sticky in both directions (OR).
+	withRuntime := projectAssistantTurnPolicy{profile: projectAssistantTurnProfileExploration, requiresRuntimeState: true}
+	if got := escalateProjectAssistantTurnPolicy(withRuntime, discussion); !got.requiresRuntimeState {
+		t.Error("runtime-state requirement lost on merge with discussion")
+	}
+	if got := escalateProjectAssistantTurnPolicy(discussion, withRuntime); !got.requiresRuntimeState {
+		t.Error("runtime-state requirement not gained from next policy")
+	}
+	// The escalated policy actually grants tools a discussion policy denies.
+	escalated := escalateProjectAssistantTurnPolicy(discussion, implementation)
+	registry := projectAssistantLocalToolRegistry(nil)
+	spec, ok := registry.Spec(projectToolReadProjectFile)
+	if !ok {
+		t.Fatalf("tool %s missing from registry", projectToolReadProjectFile)
+	}
+	if discussion.AllowsTool(spec) {
+		t.Fatal("discussion policy unexpectedly allows workspace reads")
+	}
+	if !escalated.AllowsTool(spec) {
+		t.Fatal("escalated policy still denies workspace reads")
+	}
+}
+
 var _ einomodel.BaseChatModel = (*repositoryFlowEinoChatModel)(nil)

--- a/providers/app-studio/api/assistant_turn_profile_test.go
+++ b/providers/app-studio/api/assistant_turn_profile_test.go
@@ -209,14 +209,41 @@ func TestProjectAssistantSemanticTurnClassifierRejectsToolCalls(t *testing.T) {
 	}
 }
 
-func TestProjectAssistantTurnProfileClassifierUsesLatestUserMessage(t *testing.T) {
+// The fallback merges the recent user messages escalate-only: once the user
+// has instructed work ("Add a dashboard"), a follow-up that reads as guidance
+// or a terse continuation must not downgrade the turn to a toolless profile —
+// that stranded instructed tasks ("go for it" → "I need access to the
+// files"). Mutations stay behind plan approval regardless of profile.
+func TestProjectAssistantTurnProfileClassifierKeepsStandingIntent(t *testing.T) {
 	got := classifyProjectAssistantTurnProfile([]store.Message{
 		{Role: aiv1alpha1.ProjectMessageRoleUser, Content: "Add a dashboard"},
 		{Role: aiv1alpha1.ProjectMessageRoleAssistant, Content: "I can do that."},
 		{Role: aiv1alpha1.ProjectMessageRoleUser, Content: "Actually, how should I think about the design?"},
 	})
+	if got != projectAssistantTurnProfileImplementation {
+		t.Fatalf("profile = %q, want implementation kept from the standing instruction", got)
+	}
+
+	// Terse continuations inherit the instruction even when they carry no
+	// keyword of their own ("just check in your workspace" reads as
+	// exploration in isolation).
+	got = classifyProjectAssistantTurnProfile([]store.Message{
+		{Role: aiv1alpha1.ProjectMessageRoleUser, Content: "wire the /api proxy in the web component"},
+		{Role: aiv1alpha1.ProjectMessageRoleAssistant, Content: "I need to inspect the files first."},
+		{Role: aiv1alpha1.ProjectMessageRoleUser, Content: "just check in your workspace."},
+	})
+	if got != projectAssistantTurnProfileImplementation {
+		t.Fatalf("profile = %q, want implementation kept across terse continuation", got)
+	}
+
+	// A conversation with no instruction anywhere stays advisory/toolless.
+	got = classifyProjectAssistantTurnProfile([]store.Message{
+		{Role: aiv1alpha1.ProjectMessageRoleUser, Content: "How should I think about the architecture?"},
+		{Role: aiv1alpha1.ProjectMessageRoleAssistant, Content: "Here are the tradeoffs."},
+		{Role: aiv1alpha1.ProjectMessageRoleUser, Content: "What about the design approach?"},
+	})
 	if got != projectAssistantTurnProfileGuidance {
-		t.Fatalf("profile = %q, want latest user guidance", got)
+		t.Fatalf("profile = %q, want guidance for a purely advisory conversation", got)
 	}
 }
 

--- a/providers/app-studio/api/assistant_ui_events.go
+++ b/providers/app-studio/api/assistant_ui_events.go
@@ -303,12 +303,27 @@ func discloseProjectAssistantUIAction(action projectAssistantUIAction, name, arg
 // stream pipeline sends pre-summarized arguments (paths/counts, no file
 // contents), but if a raw JSON argument payload ever reaches an action, run
 // it through the per-tool summarizer instead of disclosing it verbatim.
+//
+// The summarizer's default case (unknown/MCP tools with no bespoke summary)
+// falls back to marshaling the full argument map, which can carry large or
+// sensitive fields (file contents, secrets). Drop any output that still looks
+// like a raw JSON object/array so the "never raw file contents or secrets"
+// boundary holds even for tools without a dedicated summary.
 func projectAssistantUIActionToolArguments(name, raw string) string {
 	raw = strings.TrimSpace(raw)
-	if strings.HasPrefix(raw, "{") || strings.HasPrefix(raw, "[") {
-		return summarizeProjectToolArguments(name, raw)
+	if !looksLikeRawJSON(raw) {
+		return raw
 	}
-	return raw
+	summarized := strings.TrimSpace(summarizeProjectToolArguments(name, raw))
+	if looksLikeRawJSON(summarized) {
+		return ""
+	}
+	return summarized
+}
+
+func looksLikeRawJSON(s string) bool {
+	s = strings.TrimSpace(s)
+	return strings.HasPrefix(s, "{") || strings.HasPrefix(s, "[")
 }
 
 func projectAssistantUIActionFromPermission(permission projectAssistantPermission) projectAssistantUIAction {

--- a/providers/app-studio/api/assistant_ui_events.go
+++ b/providers/app-studio/api/assistant_ui_events.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package api
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const projectAssistantUIRootComponentID = "root-col"
 const projectAssistantUIDevelopmentPreviewRefreshKey = "development.previewRefreshNeeded"
@@ -85,6 +88,13 @@ type projectAssistantUIAction struct {
 	Label   string `json:"label"`
 	Summary string `json:"summary,omitempty"`
 	Count   int    `json:"count,omitempty"`
+	// Tool-level transparency: the actual tool name, its (summarized)
+	// arguments, and the (summarized) result or error — so the portal can
+	// show WHAT ran and what came back, expandable on demand, instead of
+	// only a generic "Completed actions" label.
+	Tool      string `json:"tool,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	Detail    string `json:"detail,omitempty"`
 }
 
 type projectAssistantUIDataModelUpdate struct {
@@ -254,11 +264,37 @@ func projectAssistantUIFollowUpInterruptRequestEvent(surfaceID string, followUp 
 }
 
 func projectAssistantUIActionFromToolCall(toolCall projectToolCallStreamEvent) projectAssistantUIAction {
-	return projectAssistantUIActionFromFields(toolCall.ID, toolCall.Name, toolCall.Status)
+	action := projectAssistantUIActionFromFields(toolCall.ID, toolCall.Name, toolCall.Status)
+	action.Tool = strings.TrimSpace(toolCall.Name)
+	action.Arguments = projectAssistantUIActionToolArguments(toolCall.Name, toolCall.Arguments)
+	action.Detail = strings.TrimSpace(toolCall.Summary)
+	if action.Detail == "" {
+		action.Detail = strings.TrimSpace(toolCall.Error)
+	}
+	return action
 }
 
 func projectAssistantUIActionFromAssistantToolCall(toolCall projectAssistantToolCall) projectAssistantUIAction {
-	return projectAssistantUIActionFromFields(toolCall.ID, toolCall.Name, toolCall.Status)
+	action := projectAssistantUIActionFromFields(toolCall.ID, toolCall.Name, toolCall.Status)
+	action.Tool = strings.TrimSpace(toolCall.Name)
+	action.Arguments = projectAssistantUIActionToolArguments(toolCall.Name, toolCall.Arguments)
+	action.Detail = strings.TrimSpace(toolCall.Summary)
+	if action.Detail == "" {
+		action.Detail = strings.TrimSpace(toolCall.Error)
+	}
+	return action
+}
+
+// projectAssistantUIActionToolArguments guards the disclosure boundary: the
+// stream pipeline sends pre-summarized arguments (paths/counts, no file
+// contents), but if a raw JSON argument payload ever reaches an action, run
+// it through the per-tool summarizer instead of disclosing it verbatim.
+func projectAssistantUIActionToolArguments(name, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "{") || strings.HasPrefix(raw, "[") {
+		return summarizeProjectToolArguments(name, raw)
+	}
+	return raw
 }
 
 func projectAssistantUIActionFromPermission(permission projectAssistantPermission) projectAssistantUIAction {

--- a/providers/app-studio/api/assistant_ui_events.go
+++ b/providers/app-studio/api/assistant_ui_events.go
@@ -18,8 +18,18 @@ package api
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
+
+// projectAssistantToolDisclosureMinimal switches the chat back to the fully
+// opaque pre-disclosure behavior: generic action labels only, no tool names,
+// no summarized input/output. For deployments whose users should not see
+// implementation detail. Set APP_STUDIO_TOOL_DISCLOSURE=minimal; the default
+// ("summary") disclosure shows tool names plus the per-tool summarizer
+// output — paths, queries, counts — never raw file contents or secrets.
+var projectAssistantToolDisclosureMinimal = strings.EqualFold(
+	strings.TrimSpace(os.Getenv("APP_STUDIO_TOOL_DISCLOSURE")), "minimal")
 
 const projectAssistantUIRootComponentID = "root-col"
 const projectAssistantUIDevelopmentPreviewRefreshKey = "development.previewRefreshNeeded"
@@ -265,22 +275,26 @@ func projectAssistantUIFollowUpInterruptRequestEvent(surfaceID string, followUp 
 
 func projectAssistantUIActionFromToolCall(toolCall projectToolCallStreamEvent) projectAssistantUIAction {
 	action := projectAssistantUIActionFromFields(toolCall.ID, toolCall.Name, toolCall.Status)
-	action.Tool = strings.TrimSpace(toolCall.Name)
-	action.Arguments = projectAssistantUIActionToolArguments(toolCall.Name, toolCall.Arguments)
-	action.Detail = strings.TrimSpace(toolCall.Summary)
-	if action.Detail == "" {
-		action.Detail = strings.TrimSpace(toolCall.Error)
-	}
-	return action
+	return discloseProjectAssistantUIAction(action, toolCall.Name, toolCall.Arguments, toolCall.Summary, toolCall.Error)
 }
 
 func projectAssistantUIActionFromAssistantToolCall(toolCall projectAssistantToolCall) projectAssistantUIAction {
 	action := projectAssistantUIActionFromFields(toolCall.ID, toolCall.Name, toolCall.Status)
-	action.Tool = strings.TrimSpace(toolCall.Name)
-	action.Arguments = projectAssistantUIActionToolArguments(toolCall.Name, toolCall.Arguments)
-	action.Detail = strings.TrimSpace(toolCall.Summary)
+	return discloseProjectAssistantUIAction(action, toolCall.Name, toolCall.Arguments, toolCall.Summary, toolCall.Error)
+}
+
+// discloseProjectAssistantUIAction attaches tool-level transparency to an
+// action per the deployment's disclosure mode. Minimal mode keeps actions at
+// the generic label ("Edited files · 1 edit action") only.
+func discloseProjectAssistantUIAction(action projectAssistantUIAction, name, arguments, summary, errText string) projectAssistantUIAction {
+	if projectAssistantToolDisclosureMinimal {
+		return action
+	}
+	action.Tool = strings.TrimSpace(name)
+	action.Arguments = projectAssistantUIActionToolArguments(name, arguments)
+	action.Detail = strings.TrimSpace(summary)
 	if action.Detail == "" {
-		action.Detail = strings.TrimSpace(toolCall.Error)
+		action.Detail = strings.TrimSpace(errText)
 	}
 	return action
 }

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -1620,7 +1620,9 @@ func projectSystemPrompt(p *aiv1alpha1.Project, repository *ProjectRepositoryVie
 	b.WriteString("Project metadata:\n")
 	b.WriteString("- Name: " + p.Name + "\n")
 	if p.Spec.Template != nil && strings.TrimSpace(p.Spec.Template.Name) != "" {
-		b.WriteString("- Development template: " + strings.TrimSpace(p.Spec.Template.Name) + " (the development environment runs this infrastructure template in development mode; source directories map to its declared components, so keep new code under the component directories)\n")
+		b.WriteString("- Development template: " + strings.TrimSpace(p.Spec.Template.Name) + " (the development environment runs this infrastructure template in development mode; source directories map to its declared components, so keep new code under the component directories). " +
+			"This template is the app's ENVIRONMENT CONTRACT: before reasoning about what infrastructure, backing services, or environment variables the app has, call infrastructure__describe_template on THIS template and treat its agent.usage / agent.outputs as authoritative. " +
+			"Backing services the template declares (for example a managed database) exist for the development instance too, with the same injected environment (for example DATABASE_URL) — do not conclude a declared service is missing just because the app code does not use it yet, and do not provision a separate instance of a service the bound template already provides.\n")
 	} else {
 		b.WriteString("- Development template: NONE — the project has no development environment yet, so nothing runs and no preview exists until one is bound. Binding a template is your FIRST implementation step: translate the user's business intent into requirements yourself, pick the matching template via infrastructure__list_templates / infrastructure__describe_template, and bind it with select_project_template. Only templates that declare development components qualify. Template selection is INDEPENDENT of repository provisioning — never wait for the repository to bind a template; repository state only gates committing files, not template selection or workspace edits.\n")
 	}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"sort"
@@ -291,6 +292,11 @@ func (s *Server) generateProjectAssistantStream(
 		return "", err
 	}
 	turnPolicy := projectAssistantTurnPolicyForDecision(turnDecision)
+	// The router decides which tool bundles this turn gets; a silent
+	// misclassification reads exactly like a model refusing to work, so keep
+	// the decision observable.
+	log.Printf("assistant turn route: project=%s profile=%s confidence=%s mutation=%v runtime=%v",
+		p.Name, turnDecision.Profile, turnDecision.Confidence, turnDecision.RequestsMutation, turnDecision.RequiresRuntimeState)
 	req := projectAssistantRunRequest{
 		Identity:                 id,
 		HTTPRequest:              r,

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"sort"
@@ -38,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 	asclient "github.com/faroshq/provider-app-studio/client"
@@ -294,9 +294,10 @@ func (s *Server) generateProjectAssistantStream(
 	turnPolicy := projectAssistantTurnPolicyForDecision(turnDecision)
 	// The router decides which tool bundles this turn gets; a silent
 	// misclassification reads exactly like a model refusing to work, so keep
-	// the decision observable.
-	log.Printf("assistant turn route: project=%s profile=%s confidence=%s mutation=%v runtime=%v",
-		p.Name, turnDecision.Profile, turnDecision.Confidence, turnDecision.RequestsMutation, turnDecision.RequiresRuntimeState)
+	// the decision observable (V(2): per-turn, debugging signal).
+	klog.FromContext(ctx).V(2).Info("assistant turn route",
+		"project", p.Name, "profile", turnDecision.Profile, "confidence", turnDecision.Confidence,
+		"mutation", turnDecision.RequestsMutation, "runtime", turnDecision.RequiresRuntimeState)
 	req := projectAssistantRunRequest{
 		Identity:                 id,
 		HTTPRequest:              r,

--- a/providers/app-studio/api/projects.go
+++ b/providers/app-studio/api/projects.go
@@ -1263,6 +1263,17 @@ func mergeProjectAssistantUIAction(existing, next projectAssistantUIAction) proj
 	if next.Count == 0 {
 		next.Count = existing.Count
 	}
+	// A tool call streams as started (name+arguments) then finished
+	// (result/error) — keep whichever side each event carried.
+	if next.Tool == "" {
+		next.Tool = existing.Tool
+	}
+	if next.Arguments == "" {
+		next.Arguments = existing.Arguments
+	}
+	if next.Detail == "" {
+		next.Detail = existing.Detail
+	}
 	return next
 }
 

--- a/providers/app-studio/api/repository_flow_test.go
+++ b/providers/app-studio/api/repository_flow_test.go
@@ -1157,11 +1157,16 @@ func TestStreamProjectAssistantPersistsPermissionTimelineMessage(t *testing.T) {
 	if len(actions) != 1 || actions[0].Status != "awaiting_approval" || actions[0].Kind != projectAssistantUIActionEdit {
 		t.Fatalf("assistant actions = %#v, want pending edit disclosure", actions)
 	}
+	// Tool-level transparency: the action names the tool and its summarized
+	// arguments (path + byte count — never the file contents).
+	if actions[0].Tool != projectToolWriteFile || !strings.Contains(actions[0].Arguments, "src/App.tsx") {
+		t.Fatalf("assistant action disclosure = %#v, want tool name and summarized arguments", actions[0])
+	}
 	interrupt := projectAssistantUIInterruptFromMetadata(assistant.Metadata[projectMessageMetadataAssistantInterrupt])
 	if interrupt == nil || interrupt.Status != "pending" || interrupt.Action == nil || interrupt.Action.RunID == "" || interrupt.Action.RequestID == "" {
 		t.Fatalf("assistant interrupt = %#v, want pending resume handle", interrupt)
 	}
-	assertProjectAssistantMetadataDoesNotContain(t, assistant.Metadata, "src/App.tsx", "hello", "permission_required", "waiting_for_permission")
+	assertProjectAssistantMetadataDoesNotContain(t, assistant.Metadata, "hello", "permission_required", "waiting_for_permission")
 }
 
 func TestStreamProjectAssistantPersistsPermissionTimelineAfterStreamWriteFailure(t *testing.T) {
@@ -1225,7 +1230,7 @@ func TestStreamProjectAssistantPersistsPermissionTimelineAfterStreamWriteFailure
 	if assistant.Metadata[projectMessageMetadataStatus] != projectMessageStatusPendingPermission || len(actions) != 1 || actions[0].Status != "awaiting_approval" || interrupt == nil || interrupt.Action == nil {
 		t.Fatalf("assistant metadata = %#v, want pending permission with checkpoint after stream write failure", assistant.Metadata)
 	}
-	assertProjectAssistantMetadataDoesNotContain(t, assistant.Metadata, "src/App.tsx", "hello", "permission_required", "waiting_for_permission")
+	assertProjectAssistantMetadataDoesNotContain(t, assistant.Metadata, "hello", "permission_required", "waiting_for_permission")
 }
 
 type projectAssistantPermissionFixture struct {
@@ -2563,7 +2568,11 @@ func TestResumeProjectAssistantRunRejectsStaleRepositoryBinding(t *testing.T) {
 	if len(updatedActions) != 1 || updatedActions[0].Status != "failed" {
 		t.Fatalf("updated actions = %#v, want failed stale binding action", updatedActions)
 	}
-	assertProjectAssistantMetadataDoesNotContain(t, updatedMessage.Metadata, "repository binding changed")
+	// Failed tools disclose their reason: the user sees WHY the commit did
+	// not happen instead of an opaque "Commit failed".
+	if !strings.Contains(updatedActions[0].Detail, "repository binding changed") {
+		t.Fatalf("updated action detail = %q, want the stale-binding reason disclosed", updatedActions[0].Detail)
+	}
 }
 
 func TestResumeProjectAssistantRunPreemptsToolBatchAfterApprovedPermission(t *testing.T) {

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -100,6 +100,13 @@ spec:
             - name: APP_STUDIO_IN_MEMORY_MESSAGE_STORE
               value: "true"
             {{- end }}
+            {{- with .Values.assistant.toolDisclosure }}
+            # "minimal" hides tool names and summarized input/output from the
+            # chat (opaque business-user mode); default "summary" shows tool
+            # names + sanitized summaries (never raw file contents).
+            - name: APP_STUDIO_TOOL_DISCLOSURE
+              value: {{ . | quote }}
+            {{- end }}
             {{- if .Values.store.messageRetention }}
             - name: APP_STUDIO_MESSAGE_RETENTION
               value: {{ .Values.store.messageRetention | quote }}

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -34,6 +34,15 @@ catalogEntry:
 providerKubeconfig:
   secretName: kedge-provider-kubeconfig
 
+# Assistant chat behavior.
+assistant:
+  # How much tool-level detail the chat disclosures show.
+  #   "" / "summary" (default) — tool names + per-tool sanitized summaries
+  #     (paths, queries, counts — never raw file contents or secrets).
+  #   "minimal" — fully opaque generic labels only ("Edited files"), for
+  #     deployments whose users should not see implementation detail.
+  toolDisclosure: ""
+
 # App Studio no longer holds a kubeconfig to the runtime cluster. The sandbox
 # data plane (sync, logs, restart, preview readiness) is served by the
 # infrastructure provider as subresources on the SandboxRunner instance, reached

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -112,6 +112,8 @@ interface ProjectAssistantSurfaceCard {
   id: string
   role: string
   body: string
+  tool?: string
+  output?: string
 }
 type AssistantTraceItemStatus = 'running' | 'complete' | 'waiting' | 'error'
 interface AssistantTraceItem {
@@ -120,6 +122,8 @@ interface AssistantTraceItem {
   label: string
   detail: string
   status: AssistantTraceItemStatus
+  tool?: string
+  output?: string
 }
 type ProjectMessageView = ProjectMessage & {
   viewStatus?: ProjectMessageViewStatus
@@ -2694,7 +2698,18 @@ function assistantActionCards(actions?: ProjectAssistantActionView[]): ProjectAs
     id: action.id,
     role: assistantActionCardRole(action),
     body: action.summary ? `${action.label}\n${action.summary}` : action.label,
+    tool: action.tool,
+    output: assistantActionOutput(action),
   }))
+}
+
+// assistantActionOutput renders the expandable per-tool transcript: what the
+// tool was called with and what it returned (or the error).
+function assistantActionOutput(action: ProjectAssistantActionView): string {
+  const parts: string[] = []
+  if (action.arguments) parts.push(`args: ${action.arguments}`)
+  if (action.detail) parts.push(action.detail)
+  return parts.join('\n')
 }
 
 function assistantActionCardRole(action: ProjectAssistantActionView): string {
@@ -2717,8 +2732,11 @@ function assistantTraceItems(message: ProjectMessageView): AssistantTraceItem[] 
       id: card.id,
       role: card.role,
       label,
-      detail: lines.slice(1).join('\n') || lines[0] || card.role,
+      // Prefer the real tool output over the generic count text.
+      detail: card.output || lines.slice(1).join('\n') || lines[0] || card.role,
       status: assistantTraceStatus(card.role),
+      tool: card.tool,
+      output: card.output,
     }
   })
 }
@@ -2748,7 +2766,11 @@ function assistantTraceLabel(value: string): string {
 }
 
 function assistantTraceSummary(message: ProjectMessageView): string {
-  const labels = assistantTraceItems(message).map((item) => item.label).filter(Boolean)
+  // Prefer the concrete tool names over the generic kind labels so the
+  // collapsed row already says WHAT ran (read_project_file · write_file …).
+  const labels = assistantTraceItems(message)
+    .map((item) => item.tool || item.label)
+    .filter(Boolean)
   if (labels.length === 0) return ''
   const visible = labels.slice(0, 3).join(' · ')
   return labels.length > 3 ? `${visible} · ${labels.length - 3} more` : visible
@@ -3420,6 +3442,7 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
                           <Check v-else class="h-3.5 w-3.5" :stroke-width="2" />
                         </span>
                         <span class="min-w-0 truncate font-medium text-text-primary">{{ item.label }}</span>
+                        <span v-if="item.tool" class="shrink-0 rounded bg-surface-overlay px-1.5 py-0.5 font-mono text-[10px] text-text-muted">{{ item.tool }}</span>
                         <span class="ml-auto shrink-0 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">{{ item.role }}</span>
                       </div>
                       <div

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -33,6 +33,12 @@ export interface ProjectAssistantUIAction {
   label: string
   summary?: string
   count?: number
+  /** Actual tool name (e.g. read_project_file) — shown so users can see what ran. */
+  tool?: string
+  /** Summarized tool arguments. */
+  arguments?: string
+  /** Summarized tool result (or error) — the expandable output. */
+  detail?: string
 }
 
 export interface ProjectAssistantUIComponent {

--- a/providers/infrastructure/backend/kro/backend.go
+++ b/providers/infrastructure/backend/kro/backend.go
@@ -88,6 +88,10 @@ const (
 //   - KEDGE_GATEWAY_NAME / KEDGE_GATEWAY_NAMESPACE — the exposure-layer Gateway
 //     parent every template's HTTPRoutes (apps AND sandbox previews) attach to
 //     (defaults "cloudflare-tunnel" / "cfgate-system").
+//   - KEDGE_APP_PUBLIC_PORT — bare port number appended (as ":<port>") to
+//     synthesized exposure URLs via ${kedge.appPublicPort}. Unset in
+//     production (443 implied); local kind sets 10443 (the envoy
+//     port-forward).
 //
 // Per-instance inputs (container images, etc.) are NOT env tokens — templates
 // declare them as schema fields with sane defaults (e.g. simple-webapp's
@@ -102,9 +106,14 @@ func New(runtime dynamic.Interface) *Backend {
 	if gatewayNamespace == "" {
 		gatewayNamespace = DefaultGatewayNamespace
 	}
+	appPublicPort := ""
+	if port := strings.TrimSpace(os.Getenv("KEDGE_APP_PUBLIC_PORT")); port != "" {
+		appPublicPort = ":" + port
+	}
 	tokens := map[string]string{
 		gatewayNameToken:      gatewayName,
 		gatewayNamespaceToken: gatewayNamespace,
+		appPublicPortToken:    appPublicPort,
 	}
 	maps.Copy(tokens, devImageTokens())
 	return &Backend{runtime: runtime, tokens: tokens}

--- a/providers/infrastructure/backend/kro/backend.go
+++ b/providers/infrastructure/backend/kro/backend.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"strconv"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -106,17 +107,30 @@ func New(runtime dynamic.Interface) *Backend {
 	if gatewayNamespace == "" {
 		gatewayNamespace = DefaultGatewayNamespace
 	}
-	appPublicPort := ""
-	if port := strings.TrimSpace(os.Getenv("KEDGE_APP_PUBLIC_PORT")); port != "" {
-		appPublicPort = ":" + port
-	}
 	tokens := map[string]string{
 		gatewayNameToken:      gatewayName,
 		gatewayNamespaceToken: gatewayNamespace,
-		appPublicPortToken:    appPublicPort,
+		appPublicPortToken:    appPublicPortSuffix(os.Getenv("KEDGE_APP_PUBLIC_PORT")),
 	}
 	maps.Copy(tokens, devImageTokens())
 	return &Backend{runtime: runtime, tokens: tokens}
+}
+
+// appPublicPortSuffix turns KEDGE_APP_PUBLIC_PORT into the ":<port>" suffix
+// spliced into backendConfig JSON/CEL by plain byte substitution. The value is
+// operator-provided and substituted unescaped, so accept only a bare port in
+// the valid range (a stray quote, ":", or path would corrupt every synthesized
+// RGD / produce invalid URLs). Anything else is logged and treated as unset.
+func appPublicPortSuffix(raw string) string {
+	port := strings.TrimPrefix(strings.TrimSpace(raw), ":")
+	if port == "" {
+		return ""
+	}
+	if n, err := strconv.Atoi(port); err == nil && n >= 1 && n <= 65535 {
+		return ":" + strconv.Itoa(n)
+	}
+	klog.Background().Info("ignoring invalid KEDGE_APP_PUBLIC_PORT (want a bare port number 1-65535)", "value", raw)
+	return ""
 }
 
 // DefaultNodeDevImage / DefaultDevAgentImage back the dev-overlay images when

--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -203,3 +203,31 @@ func TestBuildRGDRequiresBackendConfig(t *testing.T) {
 		t.Fatal("expected error when backendConfig is missing")
 	}
 }
+
+func TestAppPublicPortSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"unset", "", ""},
+		{"bare port", "10443", ":10443"},
+		{"leading colon tolerated", ":10443", ":10443"},
+		{"whitespace trimmed", "  8080  ", ":8080"},
+		{"lower bound", "1", ":1"},
+		{"upper bound", "65535", ":65535"},
+		{"zero rejected", "0", ""},
+		{"out of range rejected", "70000", ""},
+		{"non-numeric rejected", "abc", ""},
+		{"double colon rejected", "::10443", ""},
+		{"path injection rejected", "10443/foo", ""},
+		{"quote injection rejected", `10443"`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appPublicPortSuffix(tt.raw); got != tt.want {
+				t.Errorf("appPublicPortSuffix(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -163,6 +163,25 @@ func TestSubstituteTokensLeavesKroRefs(t *testing.T) {
 	}
 }
 
+func TestSubstituteTokensAppPublicPort(t *testing.T) {
+	// The status.url CEL embeds the token inside a quoted CEL string; both
+	// values must yield a valid expression.
+	in := []byte(`{"url":"${\"https://\" + httpRoute.spec.hostnames[0] + \"${kedge.appPublicPort}\"}"}`)
+
+	// Local kind: KEDGE_APP_PUBLIC_PORT=10443 → ":10443" suffix.
+	out := string(substituteTokens(in, map[string]string{appPublicPortToken: ":10443"}))
+	if want := `{"url":"${\"https://\" + httpRoute.spec.hostnames[0] + \":10443\"}"}`; out != want {
+		t.Errorf("with port: substituteTokens = %s, want %s", out, want)
+	}
+
+	// Production (token unset in the caller's map): the placeholder must not
+	// leak — it resolves to the empty string.
+	out = string(substituteTokens(in, map[string]string{}))
+	if want := `{"url":"${\"https://\" + httpRoute.spec.hostnames[0] + \"\"}"}`; out != want {
+		t.Errorf("without port: substituteTokens = %s, want %s", out, want)
+	}
+}
+
 // testTokens is the platform-config token map the backend builds from env (the
 // exposure-layer Gateway parent + the dev-overlay images), for buildRGD tests.
 func testTokens() map[string]string {

--- a/providers/infrastructure/backend/kro/rgd.go
+++ b/providers/infrastructure/backend/kro/rgd.go
@@ -41,6 +41,13 @@ const (
 	// kedge-dev-agent binary every dev-mode component runs
 	// (KEDGE_DEV_AGENT_IMAGE).
 	devAgentImageToken = "${kedge.devAgentImage}"
+
+	// appPublicPortToken is the ":<port>" suffix templates append to
+	// synthesized exposure URLs (status.url). Empty in production — the
+	// Gateway serves on 443 and the URL implies it — and ":10443" style when
+	// the Gateway is only reachable on a forwarded port (local kind).
+	// Resolved from KEDGE_APP_PUBLIC_PORT (the bare port number).
+	appPublicPortToken = "${kedge.appPublicPort}"
 )
 
 const (
@@ -169,6 +176,12 @@ func substituteTokens(raw []byte, tokens map[string]string) []byte {
 	}
 	if resolved[gatewayNamespaceToken] == "" {
 		resolved[gatewayNamespaceToken] = DefaultGatewayNamespace
+	}
+	// Unlike the tokens above, empty is the CORRECT production value here
+	// (no port suffix). Force the key so the placeholder never leaks into
+	// the RGD when a caller's token map omits it.
+	if _, ok := resolved[appPublicPortToken]; !ok {
+		resolved[appPublicPortToken] = ""
 	}
 	for token, value := range resolved {
 		raw = bytes.ReplaceAll(raw, []byte(token), []byte(value))

--- a/providers/infrastructure/docs/template-conventions.md
+++ b/providers/infrastructure/docs/template-conventions.md
@@ -17,7 +17,7 @@ invalid field into a materialized resource.
 |---|---|---|
 | **Per-instance, configurable** (image, version, size, replicas) | `spec.schema` field **with a `default`**; the resource references `${schema.spec.<field>}` | `simple-webapp.spec.image` (`default: "nginx:latest"`); `postgres-database.spec.version` |
 | **Fixed sidecar / tooling image** (not user-facing) | **hardcoded literal** in the resource | the control-token `bitnami/kubectl` job (database, redis, application); `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` |
-| **Platform-global, no universal default** | a reserved `${kedge.*}` substitution token, resolved by the kro backend from env | the exposure Gateway parent: `${kedge.gatewayName}` / `${kedge.gatewayNamespace}` (the **only** tokens that exist) |
+| **Platform-global, no universal default** | a reserved `${kedge.*}` substitution token, resolved by the kro backend from env | the exposure Gateway parent `${kedge.gatewayName}` / `${kedge.gatewayNamespace}`; the dev-overlay images `${kedge.devImage.<toolchain>}` / `${kedge.devAgentImage}`; the exposure-URL port suffix `${kedge.appPublicPort}` (empty in prod, `:10443` on local kind) |
 
 ## Why not `${kedge.*}` env tokens for images?
 

--- a/providers/infrastructure/docs/template-conventions.md
+++ b/providers/infrastructure/docs/template-conventions.md
@@ -37,9 +37,15 @@ They were tried for the sandbox runner and removed. The failure modes:
   images; an env-token outlier is one more thing to wire (chart env, operator
   passthrough, dev Makefile) and one more thing to forget.
 
-`${kedge.*}` tokens remain only for the exposure Gateway, which is genuinely one
-platform-wide value with no sane universal default and is referenced identically
-by every app's `HTTPRoute`.
+`${kedge.*}` tokens are reserved for the handful of genuinely platform-wide
+values that have no sane universal default and are referenced identically across
+apps: the exposure Gateway (`${kedge.gatewayName}` / `${kedge.gatewayNamespace}`,
+every `HTTPRoute`), the dev-overlay images (`${kedge.devImage.<toolchain>}` /
+`${kedge.devAgentImage}`, injected only in development mode), and the exposure-URL
+port suffix (`${kedge.appPublicPort}`, empty in production). All of these are
+platform config, never per-tenant inputs — which is exactly why they are env
+tokens rather than schema fields. A per-instance value (an app's own image,
+version, size) is never a `${kedge.*}` token.
 
 ## Checklist for a new template
 

--- a/providers/infrastructure/install/templates/application.yaml
+++ b/providers/infrastructure/install/templates/application.yaml
@@ -849,10 +849,14 @@ spec:
     # The HTTPRoute is always created (only its backend changes by mode).
     # Per-tier readiness lets the portal show progress. No secret values are
     # surfaced.
+    # ${kedge.appPublicPort} is substituted by the kro backend BEFORE kro sees
+    # this CEL: "" in production (443 implied), ":<port>" when the Gateway is
+    # only reachable on a forwarded port (local kind). The empty case leaves a
+    # harmless `+ ""` in the expression.
     status:
-      url: ${"https://" + httpRoute.spec.hostnames[0]}
+      url: ${"https://" + httpRoute.spec.hostnames[0] + "${kedge.appPublicPort}"}
       host: ${httpRoute.spec.hostnames[0]}
-      redirectURL: ${"https://" + httpRoute.spec.hostnames[0] + "/oauth2/callback"}
+      redirectURL: ${"https://" + httpRoute.spec.hostnames[0] + "${kedge.appPublicPort}" + "/oauth2/callback"}
       frontendReady: ${frontendDeployment.status.readyReplicas}
       backendReady: ${backendDeployment.status.readyReplicas}
       databaseReady: ${dbStatefulSet.status.readyReplicas}


### PR DESCRIPTION
Follow-up to #410. Started as an infrastructure dev-preview reachability fix; while validating it against a live multi-tier app I hit a chain of App Studio assistant bugs and fixed them in the same branch. Both areas are called out below so reviewers can assess each independently.

## Infrastructure — dev preview reachability
Locally (Tiltfile.cluster) the App Studio preview iframe never loaded, for two independent reasons:
1. **Dead URL**: `status.url` was synthesized as `https://<host>` — correct in prod (cfgate serves 443), dead on local kind where the envoy apps listener is only reachable via the `localhost:10443` port-forward.
2. **CSP**: the hub still passed `--portal-frame-source=https://*.preview.localhost:10443` (the deleted preview-gateway origin), so the browser refused to frame the app's real URL.

Changes:
- New reserved token `${kedge.appPublicPort}` (from `KEDGE_APP_PUBLIC_PORT`, `:<port>` suffix, empty when unset), appended to the `application` template's `status.url` / `status.redirectURL`. Production unchanged. Value is validated as a bare port 1-65535 before it's spliced into the RGD.
- `Tiltfile.cluster`: hub `portalFrameSources` now allows the local apps domain; the infra provider gets `KEDGE_APP_PUBLIC_PORT=10443`.
- `template-conventions.md`: `${kedge.*}` narrative updated for the actual token set.

## App Studio — assistant fixes (found while testing the preview)
- **Resume policy trap**: a run that started as a discussion question was checkpointed with the toolless policy and never re-routed, so follow-up instructions ("go for it") could never regain tools. Resume now re-routes free-text answers and escalate-merges the policy.
- **Terse-message routing**: the keyword fallback classified each terse follow-up in isolation ("just reload the backend" → zero tools). It now merges the last 5 user messages escalate-only and recognizes continuation/runtime-action/instruction verbs.
- **Component-scoped restart**: `restart_runtime` gained an optional `component` argument for multi-component apps.
- **Environment-contract prompt**: the assistant denied the Postgres its own bound template provisions; the system prompt now treats the bound template's `agent.usage` as authoritative and forbids concluding a declared service is missing.
- **Tool-call transparency + security mode**: the chat now discloses tool names and sanitized argument/result summaries (expandable), with `APP_STUDIO_TOOL_DISCLOSURE=minimal` (chart `assistant.toolDisclosure`) restoring the fully opaque mode. Raw file contents/secrets are excluded in both modes.
- Assistant routing decisions are logged at `klog` V(2).

All builds/vets/tests green across the app-studio and infrastructure packages; portal typechecks and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
