### PR TITLE
feat(infrastructure): development-capable simple-webapp template

### DIFF
--- a/providers/infrastructure/backend/kro/e2e_test.go
+++ b/providers/infrastructure/backend/kro/e2e_test.go
@@ -82,8 +82,7 @@ const (
 // e2eMinimalSpecs supplies a valid instance spec for templates that ship no
 // sampleValues (those that do — application, database — use them directly).
 var e2eMinimalSpecs = map[string]map[string]any{
-	"redis-cache":    {"name": "e2e-redis"},
-	"simple-webapp":  {"name": "e2e-web"},
+	"redis-cache": {"name": "e2e-redis"},
 }
 
 // e2ePlatformStamped are spec fields a platform component normally writes onto an
@@ -99,6 +98,10 @@ var e2ePlatformStamped = map[string]map[string]any{
 	"application": {
 		"expose":                map[string]any{"fqdn": "demo.e2e.test"},
 		"credentialsSecretName": "demo-oidc",
+	},
+	// simple-webapp is exposure-only: the controller stamps just expose.fqdn.
+	"simple-webapp": {
+		"expose": map[string]any{"fqdn": "web.e2e.test"},
 	},
 }
 

--- a/providers/infrastructure/backend/kro/seedtemplates_test.go
+++ b/providers/infrastructure/backend/kro/seedtemplates_test.go
@@ -115,6 +115,56 @@ func TestSeedTemplatesIncludeStandaloneDatabase(t *testing.T) {
 	}
 }
 
+// TestSeedTemplatesSimpleWebappIsDevelopmentCapable pins the simple-webapp
+// contract App Studio depends on: a single dev component ("app") claiming the
+// workspace root, the synthesized dev overlay in the RGD, public exposure via
+// HTTPRoute, and the status fields the preview (status.url) and data plane
+// (controlSecretRef, components) resolve through.
+func TestSeedTemplatesSimpleWebappIsDevelopmentCapable(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "install", "templates", "simple-webapp.yaml"))
+	if err != nil {
+		t.Fatalf("read simple-webapp seed template: %v", err)
+	}
+	tmpl := decodeTemplate(t, raw)
+	if got, want := tmpl.Spec.InstanceCRD.Kind, "SimpleWebApp"; got != want {
+		t.Fatalf("instance kind = %q, want %q", got, want)
+	}
+	if tmpl.Spec.Development == nil {
+		t.Fatal("simple-webapp declares no spec.development — it cannot back an App Studio project")
+	}
+	comp, ok := tmpl.Spec.Development.Components["app"]
+	if !ok {
+		t.Fatalf("development components = %v, want key %q", tmpl.Spec.Development.Components, "app")
+	}
+	if got, want := comp.WorkspacePath, "."; got != want {
+		t.Fatalf("app component workspacePath = %q, want %q (whole workspace)", got, want)
+	}
+	if tmpl.Spec.DataPlane == nil {
+		t.Fatal("simple-webapp declares no dataPlane — sync/log/restart verbs would 404")
+	}
+	if _, ok := tmpl.Spec.DataPlane.Components["app"]; !ok {
+		t.Fatal("simple-webapp declares no dataPlane component for app — sync/log/restart verbs would 404")
+	}
+
+	rgd, err := buildRGD(tmpl, testTokens())
+	if err != nil {
+		t.Fatalf("buildRGD(simple-webapp): %v", err)
+	}
+	for _, id := range []string{"appDeployment", "appService", "httpRoute", "appDevDeployment", "appDevWorkspace", "appDevControlService", "kedgeDevControlSecret"} {
+		if findResource(t, rgd, id) == nil {
+			t.Fatalf("simple-webapp RGD missing %s resource", id)
+		}
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(rgd.Object, "spec", "schema", "spec", "kedgeMode"); !found {
+		t.Fatal("simple-webapp RGD schema missing kedgeMode (dev overlay not applied)")
+	}
+	for _, field := range []string{"url", "host", "ready", "runtimeNamespace", "controlSecretRef", "components"} {
+		if _, found, _ := unstructured.NestedFieldNoCopy(rgd.Object, "spec", "schema", "status", field); !found {
+			t.Fatalf("simple-webapp status missing %s", field)
+		}
+	}
+}
+
 func TestSeedTemplatesDoNotExposeStandaloneSandboxPreviewHTTPRoute(t *testing.T) {
 	path := filepath.Join("..", "..", "install", "templates", "sandbox-preview-httproute.yaml")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/providers/infrastructure/controller/application/controller.go
+++ b/providers/infrastructure/controller/application/controller.go
@@ -237,7 +237,7 @@ func (r *instanceReconciler) Reconcile(ctx context.Context, req mcreconcile.Requ
 	// Exposure-only kinds: stamp the fqdn and stop — no cross-cluster state,
 	// no finalizer, nothing to clean up on deletion.
 	if !r.kind.oidc {
-		if app.GetDeletionTimestamp() != nil && !app.GetDeletionTimestamp().IsZero() {
+		if !app.GetDeletionTimestamp().IsZero() {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, c.stampSpec(ctx, tenantClient, tenant, app, false)

--- a/providers/infrastructure/controller/application/controller.go
+++ b/providers/infrastructure/controller/application/controller.go
@@ -6,26 +6,29 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Package application reconciles Application instances across every tenant
-// workspace that enabled the infrastructure provider, through the provider's
-// APIExport virtual workspace (the same cross-tenant rail the kuery provider's
-// engagement controller uses).
+// Package application reconciles exposed template instances across every
+// tenant workspace that enabled the infrastructure provider, through the
+// provider's APIExport virtual workspace (the same cross-tenant rail the
+// kuery provider's engagement controller uses).
 //
-// The kro fork materializes an Application's workloads on the runtime cluster
+// The kro fork materializes an instance's workloads on the runtime cluster
 // from the RGD, but two things the RGD can't produce itself need a controller:
 //
 //   - spec.expose.fqdn — the public hostname, <prefix|name>-<tenantHash>.<base>.
 //     kro can't derive a tenant hash in-graph, so the controller stamps it onto
 //     spec; the RGD then reads ${schema.spec.expose.fqdn} for the HTTPRoute
-//     hostname and the oauth2-proxy redirect URL.
-//   - the OIDC client secret — it must land as a Secret beside the oauth2-proxy
-//     pod on the runtime cluster WITHOUT sitting in the CR spec in clear text.
-//     The controller bridges it into cloud-credentials-<name> in the per-tenant
-//     runtime namespace (BYO: read from the tenant's cloud-credentials Secret;
-//     Platform SSO: minted via Dex — wired in a follow-up).
+//     hostname (and, on Application, the oauth2-proxy redirect URL). Every
+//     exposed instance kind (Application, SimpleWebApp) needs this.
+//   - the OIDC client secret (Application only) — it must land as a Secret
+//     beside the oauth2-proxy pod on the runtime cluster WITHOUT sitting in
+//     the CR spec in clear text. The controller bridges it into
+//     cloud-credentials-<name> in the per-tenant runtime namespace (BYO: read
+//     from the tenant's cloud-credentials Secret; Platform SSO: minted via
+//     Dex — wired in a follow-up).
 //
 // Cleanup is finalizer-driven: the bridged Secret lives on a different cluster
-// than the instance, so cross-cluster ownerRefs don't apply.
+// than the instance, so cross-cluster ownerRefs don't apply. Exposure-only
+// kinds create no cross-cluster state and carry no finalizer.
 package application
 
 import (
@@ -60,10 +63,31 @@ import (
 	"github.com/faroshq/provider-infrastructure/kro"
 )
 
-// appGVK is read with unstructured so the controller doesn't depend on a
-// generated client for the per-template CRD (its schema is authored at runtime
-// by the Template controller).
-var appGVK = schema.GroupVersionKind{Group: "infrastructure.kedge.faros.sh", Version: "v1alpha1", Kind: "Application"}
+// Instance kinds are read with unstructured so the controller doesn't depend
+// on generated clients for the per-template CRDs (their schemas are authored
+// at runtime by the Template controller).
+var (
+	appGVK    = schema.GroupVersionKind{Group: "infrastructure.kedge.faros.sh", Version: "v1alpha1", Kind: "Application"}
+	webappGVK = schema.GroupVersionKind{Group: "infrastructure.kedge.faros.sh", Version: "v1alpha1", Kind: "SimpleWebApp"}
+)
+
+// instanceKind pairs an exposed instance GVK with the treatment it needs.
+// oidc kinds get the credentialsSecretName stamp, the OIDC secret bridge, and
+// the finalizer guarding that cross-cluster Secret; exposure-only kinds get
+// just the fqdn stamp.
+type instanceKind struct {
+	name string // controller name, unique per kind
+	gvk  schema.GroupVersionKind
+	oidc bool
+}
+
+// instanceKinds is every template instance kind the controller reconciles.
+// A new exposed template (spec.expose + HTTPRoute in its graph) is one line
+// here — oidc only when its graph runs an oauth2-proxy gate.
+var instanceKinds = []instanceKind{
+	{name: "infra-application", gvk: appGVK, oidc: true},
+	{name: "infra-simplewebapp", gvk: webappGVK, oidc: false},
+}
 
 // secretGVK is used to Get/Create Secrets via the controller-runtime client
 // (tenant side) and shape the bridged Secret (runtime side).
@@ -162,27 +186,38 @@ func New(cfg Config) (*Controller, error) {
 		return nil, fmt.Errorf("creating multicluster manager: %w", err)
 	}
 
-	app := &unstructured.Unstructured{}
-	app.SetGroupVersionKind(appGVK)
-	if err := mcbuilder.ControllerManagedBy(mgr).
-		Named("infra-application").
-		For(app).
-		Complete(c); err != nil {
-		return nil, fmt.Errorf("registering application reconciler: %w", err)
+	for _, k := range instanceKinds {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(k.gvk)
+		if err := mcbuilder.ControllerManagedBy(mgr).
+			Named(k.name).
+			For(obj).
+			Complete(&instanceReconciler{c: c, kind: k}); err != nil {
+			return nil, fmt.Errorf("registering %s reconciler: %w", k.gvk.Kind, err)
+		}
 	}
 
 	c.mgr = mgr
 	return c, nil
 }
 
+// instanceReconciler reconciles one instance kind; the shared Controller
+// carries the config and cross-kind helpers.
+type instanceReconciler struct {
+	c    *Controller
+	kind instanceKind
+}
+
 // Start runs the multicluster manager (blocking).
 func (c *Controller) Start(ctx context.Context) error { return c.mgr.Start(ctx) }
 
-// Reconcile stamps the computed fqdn + credentialsSecretName onto the
-// instance and bridges the OIDC client secret onto the runtime cluster.
-func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
+// Reconcile stamps the computed fqdn (and, for oidc kinds,
+// credentialsSecretName) onto the instance and bridges the OIDC client secret
+// onto the runtime cluster.
+func (r *instanceReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
+	c := r.c
 	tenant := string(req.ClusterName)
-	log := klog.FromContext(ctx).WithValues("cluster", tenant, "application", req.Name)
+	log := klog.FromContext(ctx).WithValues("cluster", tenant, "kind", r.kind.gvk.Kind, "instance", req.Name)
 
 	cl, err := c.mgr.GetCluster(ctx, req.ClusterName)
 	if err != nil {
@@ -191,12 +226,21 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	tenantClient := cl.GetClient()
 
 	app := &unstructured.Unstructured{}
-	app.SetGroupVersionKind(appGVK)
+	app.SetGroupVersionKind(r.kind.gvk)
 	if err := tenantClient.Get(ctx, req.NamespacedName, app); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Exposure-only kinds: stamp the fqdn and stop — no cross-cluster state,
+	// no finalizer, nothing to clean up on deletion.
+	if !r.kind.oidc {
+		if app.GetDeletionTimestamp() != nil && !app.GetDeletionTimestamp().IsZero() {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, c.stampSpec(ctx, tenantClient, tenant, app, false)
 	}
 
 	// Deletion: clean up the cross-cluster bridged Secret, then drop the
@@ -224,7 +268,7 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	}
 
 	// 1. Stamp spec.expose.fqdn + spec.credentialsSecretName (idempotent).
-	if err := c.stampSpec(ctx, tenantClient, tenant, app); err != nil {
+	if err := c.stampSpec(ctx, tenantClient, tenant, app, true); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -268,27 +312,34 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-// stampSpec computes the fqdn + bridged-Secret name and writes them onto the
-// instance spec if not already set. Idempotent: a no-op once both are stamped.
-func (c *Controller) stampSpec(ctx context.Context, tenantClient client.Client, tenant string, app *unstructured.Unstructured) error {
+// stampSpec computes the fqdn (and, when withCredentials, the bridged-Secret
+// name) and writes them onto the instance spec if not already set. Idempotent:
+// a no-op once everything is stamped. Exposure-only kinds don't declare
+// credentialsSecretName in their schema, so stamping it would be pruned —
+// they stamp only the fqdn.
+func (c *Controller) stampSpec(ctx context.Context, tenantClient client.Client, tenant string, app *unstructured.Unstructured, withCredentials bool) error {
 	prefix := nestedString(app, "spec", "expose", "hostnamePrefix")
 	curFQDN := nestedString(app, "spec", "expose", "fqdn")
-	curSecret := nestedString(app, "spec", "credentialsSecretName")
 
 	fqdn, err := apps.Host(prefix, app.GetName(), tenant, c.cfg.BaseDomain)
 	if err != nil {
 		return fmt.Errorf("computing fqdn: %w", err)
 	}
-	wantSecret := kro.CredentialsSecretName(app.GetName())
 
-	if curFQDN == fqdn && curSecret == wantSecret {
+	current := curFQDN == fqdn
+	if withCredentials {
+		current = current && nestedString(app, "spec", "credentialsSecretName") == kro.CredentialsSecretName(app.GetName())
+	}
+	if current {
 		return nil
 	}
 	if err := unstructured.SetNestedField(app.Object, fqdn, "spec", "expose", "fqdn"); err != nil {
 		return fmt.Errorf("set spec.expose.fqdn: %w", err)
 	}
-	if err := unstructured.SetNestedField(app.Object, wantSecret, "spec", "credentialsSecretName"); err != nil {
-		return fmt.Errorf("set spec.credentialsSecretName: %w", err)
+	if withCredentials {
+		if err := unstructured.SetNestedField(app.Object, kro.CredentialsSecretName(app.GetName()), "spec", "credentialsSecretName"); err != nil {
+			return fmt.Errorf("set spec.credentialsSecretName: %w", err)
+		}
 	}
 	if err := tenantClient.Update(ctx, app); err != nil {
 		return fmt.Errorf("stamping spec: %w", err)

--- a/providers/infrastructure/docs/template-conventions.md
+++ b/providers/infrastructure/docs/template-conventions.md
@@ -15,7 +15,7 @@ invalid field into a materialized resource.
 
 | Kind | How to express it | Example |
 |---|---|---|
-| **Per-instance, configurable** (image, version, size, replicas) | `spec.schema` field **with a `default`**; the resource references `${schema.spec.<field>}` | `simple-webapp.spec.image` (`default: "nginx:latest"`); `postgres-database.spec.version` |
+| **Per-instance, configurable** (image, version, size, replicas) | `spec.schema` field **with a `default`**; the resource references `${schema.spec.<field>}` | `simple-webapp.spec.port` (`default: 8080`); `postgres-database.spec.version` |
 | **Fixed sidecar / tooling image** (not user-facing) | **hardcoded literal** in the resource | the control-token `bitnami/kubectl` job (database, redis, application); `quay.io/oauth2-proxy/oauth2-proxy:v7.6.0` |
 | **Platform-global, no universal default** | a reserved `${kedge.*}` substitution token, resolved by the kro backend from env | the exposure Gateway parent `${kedge.gatewayName}` / `${kedge.gatewayNamespace}`; the dev-overlay images `${kedge.devImage.<toolchain>}` / `${kedge.devAgentImage}`; the exposure-URL port suffix `${kedge.appPublicPort}` (empty in prod, `:10443` on local kind) |
 

--- a/providers/infrastructure/install/templates/application.yaml
+++ b/providers/infrastructure/install/templates/application.yaml
@@ -29,6 +29,9 @@ spec:
       Deploys a 3-tier web app on ONE public URL: UI at `/`, API at `/api/*`, and a
       managed PostgreSQL database. Choose this to ship a containerized web app with
       a relational DB behind a single endpoint when you can supply both images.
+      For a frontend-only or single-container app with no API tier and no database
+      (a static site, an SPA, a self-contained server), prefer the simple-webapp
+      template — it is also development-capable and carries none of this weight.
 
       YOU SUPPLY exactly two container images — frontendImage and backendImage —
       and nothing else app-side. The platform provisions Postgres, injects the DB

--- a/providers/infrastructure/install/templates/redis-cache.yaml
+++ b/providers/infrastructure/install/templates/redis-cache.yaml
@@ -8,6 +8,29 @@ spec:
   category: Databases
   version: 0.1.0
   backend: kro
+  sampleValues:
+    name: cache
+    size: small
+  # Operational guidance for AI agents discovering this template over MCP —
+  # same convention as the database template.
+  agent:
+    usage: |
+      Provisions only a Redis instance: a credentials Secret, password
+      generator Job, StatefulSet, and ClusterIP Service. Choose this when an
+      app already has a runtime or development environment and needs a
+      standalone cache or ephemeral key-value store, without deploying a new
+      web app stack.
+
+      Consumers read the full connection URI from Secret
+      `<name>-credentials`, key `uri`. The URI has the form
+      `redis://:<password>@<name>:6379`. Redis may not be ready the moment a
+      consuming app starts — retry the initial connection. This template does
+      not expose Redis publicly, and persistent=false (the default) means data
+      does not survive a restart.
+    outputs:
+      - "status.host / status.port — the in-cluster Service endpoint for Redis."
+      - "status.ready — ready replica count for the Redis StatefulSet."
+      - "status.connectionSecretRef — Secret '<name>-credentials' containing host, port, password, and uri keys. Secret values are not surfaced in status."
   instanceCRD:
     group: infrastructure.kedge.faros.sh
     version: v1alpha1

--- a/providers/infrastructure/install/templates/simple-webapp.yaml
+++ b/providers/infrastructure/install/templates/simple-webapp.yaml
@@ -3,51 +3,194 @@ kind: Template
 metadata:
   name: simple-webapp
 spec:
-  displayName: "Simple webapp"
-  description: "A web application — Deployment + Service, nginx by default. Scales via the replicas input."
+  displayName: "Simple web app"
+  description: "A single-container web app on a public URL — Deployment + Service + HTTPRoute. No backend tiers, no database. Development-capable: can back an App Studio project with a hot-reload dev server."
   category: Workloads
-  version: 0.1.0
+  version: 0.2.0
   backend: kro
+  # One-click provision defaults for the portal form. nginx serves its welcome
+  # page on port 80, so "Provision → see it working" needs zero external setup.
+  sampleValues:
+    name: demo-site
+    image: nginx:latest
+    port: 80
+  # Operational guidance for AI agents discovering this template over MCP. Not
+  # shown in the portal UI — it tells an LLM how to use the template and where
+  # its outputs land.
+  agent:
+    usage: |
+      Deploys ONE container serving HTTP on ONE public URL. Choose this for
+      frontend-only or single-process apps — static sites, single-page apps, a
+      self-contained server — when there is no separate backend tier and no
+      managed database. If the app needs an API tier + Postgres, use the
+      "application" template instead; if it only needs a standalone database or
+      cache next to an existing runtime, use "database" or "redis-cache".
+
+      PRODUCTION MODE — you supply exactly one container image (the image
+      input) and nothing else:
+        • Plain HTTP server, any language/base image. Bind to 0.0.0.0 on the
+          port input (default 8080), NOT 127.0.0.1, or the platform cannot
+          route to it.
+        • Stateless — no persistent disk. Pods may be restarted or scaled
+          (the replicas input).
+        • The platform provisions the Service, the public route, and the URL;
+          you do NOT create Services, Ingresses, or routes.
+
+      DEVELOPMENT MODE (the platform-injected kedgeMode field): the image input
+      is ignored (and may be omitted) — the platform runs a Node.js dev
+      container against the project workspace and serves it on the same public
+      URL a production instance would get. The whole project workspace is the
+      app (workspacePath "."); a package.json with a dev script (vite et al)
+      is auto-detected, otherwise vite is bootstrapped directly.
+
+      INPUTS you set when provisioning: name (required); image (required in
+      production, ignored in development), port, replicas, expose.hostnamePrefix.
+      The platform stamps spec.expose.fqdn — do not set it.
+    outputs:
+      - "status.url — the public HTTPS URL the app is served on (status.host = bare hostname)."
+      - "status.ready — ready replica count for the app Deployment."
+  # ── Portal presentation ───────────────────────────────────────────────
+  view:
+    columns:
+      - header: URL
+        value: "${status.url}"
+        type: link
+    detail:
+      - title: Access
+        fields:
+          - label: URL
+            value: "${status.url}"
+            type: link
+          - label: Hostname
+            path: status.host
+            type: code
+      - title: Readiness
+        fields:
+          - label: App
+            path: status.ready
   instanceCRD:
     group: infrastructure.kedge.faros.sh
     version: v1alpha1
     resource: simplewebapps
     kind: SimpleWebApp
+  # ── Tenant-facing inputs ──────────────────────────────────────────────
+  # spec.expose.fqdn is populated by the instance controller, NOT the tenant
+  # (same convention as the application template): the public hostname,
+  # computed as <prefix|name>-<tenantHash>.<appBaseDomain>. The RGD references
+  # it for the HTTPRoute hostname.
   schema:
     type: object
     properties:
       name:
         type: string
-        description: "Logical name; used as Deployment + Service name in the tenant namespace."
+        description: "Logical name; used as the resource-name prefix in the tenant namespace and the default hostname prefix."
+      image:
+        type: string
+        description: "Container image serving HTTP. Required in production mode; ignored (and may be omitted) when kedgeMode is development — dev mode runs the platform dev image against the project workspace."
+      port:
+        type: integer
+        default: 8080
+        description: "Port the container listens on (dev mode: the port the dev server must bind)."
       replicas:
         type: integer
         default: 1
         minimum: 1
         maximum: 10
-      image:
-        type: string
-        default: "nginx:latest"
-      port:
-        type: integer
-        default: 80
-      serviceType:
-        type: string
-        enum: ["ClusterIP", "NodePort", "LoadBalancer"]
-        default: "ClusterIP"
+      # default: {} so nested defaults apply and the controller can stamp fqdn
+      # onto an instance that omitted the expose object.
+      expose:
+        type: object
+        default: {}
+        properties:
+          hostnamePrefix:
+            type: string
+            pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            maxLength: 50
+            description: "Left-most DNS label. Defaults to .name. Final host = <prefix>-<tenantHash>.<appBaseDomain>."
+          fqdn:
+            type: string
+            description: "Computed by the platform — do NOT set. The public hostname the app is served on."
     required:
       - name
+    # The image is only required when the instance actually runs it: production
+    # mode. Development mode swaps the workload onto the platform dev image, so
+    # a dev-only project needs none. Enforced on the kcp-side CRD; kedgeMode
+    # defaults to "production".
+    x-kubernetes-validations:
+      - rule: "(has(self.kedgeMode) && self.kedgeMode == 'development') || has(self.image)"
+        message: "image is required in production mode"
+
+  # ── Development mode (docs/app-studio-template-sandboxes.md) ──────────
+  # Single component claiming the whole project workspace (workspacePath "."),
+  # so an App Studio project's files land at the dev container's /workspace
+  # root. The start command reuses the proven vite shim from the application
+  # template's frontend tier: it forces server.host + server.allowedHosts so
+  # the dev server accepts the proxied preview Host header.
+  development:
+    components:
+      app:
+        workspacePath: .
+        devImage: "${kedge.devImage.node}"
+        workingDir: /workspace
+        startCommand: "SHIM=.kedge-vite.config.mjs; printf '%s' 'ZXhwb3J0IGRlZmF1bHQgYXN5bmMgKGVudikgPT4gewogIGNvbnN0IGZvcmNlZCA9IHsgc2VydmVyOiB7IGhvc3Q6IHRydWUsIGFsbG93ZWRIb3N0czogdHJ1ZSB9IH0KICBsZXQgbG9hZENvbmZpZ0Zyb21GaWxlLCBtZXJnZUNvbmZpZwogIHRyeSB7CiAgICAoeyBsb2FkQ29uZmlnRnJvbUZpbGUsIG1lcmdlQ29uZmlnIH0gPSBhd2FpdCBpbXBvcnQoJ3ZpdGUnKSkKICB9IGNhdGNoIChlKSB7CiAgICByZXR1cm4gZm9yY2VkCiAgfQogIGxldCBiYXNlID0ge30KICB0cnkgewogICAgY29uc3QgbG9hZGVkID0gYXdhaXQgbG9hZENvbmZpZ0Zyb21GaWxlKGVudiwgdW5kZWZpbmVkLCBwcm9jZXNzLmN3ZCgpKQogICAgaWYgKGxvYWRlZCAmJiBsb2FkZWQuY29uZmlnKSBiYXNlID0gbG9hZGVkLmNvbmZpZwogIH0gY2F0Y2ggKGUpIHsKICAgIGNvbnNvbGUuZXJyb3IoJ1trZWRnZV0gY291bGQgbm90IGxvYWQgcHJvamVjdCB2aXRlIGNvbmZpZzonLCBlKQogIH0KICByZXR1cm4gbWVyZ2VDb25maWcoYmFzZSwgZm9yY2VkKQp9Cg==' | base64 -d > $SHIM; grep -qxF $SHIM .gitignore 2>/dev/null || echo $SHIM >> .gitignore; if [ -f package.json ]; then (npm run dev -- --host 0.0.0.0 --port $PORT --config $SHIM || npm run dev -- --host 0.0.0.0 --port $PORT || npm start); else npx --yes vite --host 0.0.0.0 --port $PORT --config $SHIM || npx --yes vite --host 0.0.0.0 --port $PORT; fi"
+        port: app
+        reload:
+          strategy: process
+          rules:
+            - paths: ["package.json", "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml"]
+              command: "npm install --no-audit --no-fund"
+
+  # ── Data plane (development mode) ─────────────────────────────────────
+  # Per-component control verbs, served as
+  # …/simplewebapps/<name>/components/app/{sync,restart,log,env}. The status
+  # paths they resolve through are published by the synthesized dev overlay,
+  # so in production mode these verbs answer 409 instance-not-ready.
+  dataPlane:
+    runtimeNamespacePath: status.runtimeNamespace
+    tokenSecretPath: status.controlSecretRef
+    endpoints:
+      status:
+        fromStatus: true
+    components:
+      app:
+        endpoints:
+          sync:
+            servicePath: status.components.app.controlServiceRef
+            port: control
+            upstreamPath: /sync
+            methods: ["POST"]
+          restart:
+            servicePath: status.components.app.controlServiceRef
+            port: control
+            upstreamPath: /restart
+            methods: ["POST"]
+          env:
+            servicePath: status.components.app.controlServiceRef
+            port: control
+            upstreamPath: /env
+            methods: ["POST"]
+          log:
+            servicePath: status.components.app.controlServiceRef
+            port: control
+            upstreamPath: /logs
+            methods: ["GET"]
+            stream: true
+
+  # ── backendConfig: the kro resource graph ─────────────────────────────
+  # Every resource sets namespace: default — the control-plane/data-plane split
+  # materializes these on the runtime cluster and remaps that to the per-tenant
+  # namespace. ${kedge.gatewayName} / ${kedge.gatewayNamespace} are substituted
+  # for the platform's configured Gateway API parent before the RGD is authored.
   backendConfig:
     resources:
-      - id: deployment
+      # The graph id follows the dev-overlay convention: component "app" →
+      # workload id "appDeployment".
+      - id: appDeployment
         template:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
             name: ${schema.spec.name}
-            # Required: the instance CRD is cluster-scoped, so kro demands an
-            # explicit namespace on every namespaced child (it has no instance
-            # namespace to inherit). "default" is remapped to the per-tenant
-            # namespace on the runtime cluster — same convention as redis-cache.
             namespace: default
           spec:
             replicas: ${schema.spec.replicas}
@@ -64,7 +207,7 @@ spec:
                     image: ${schema.spec.image}
                     ports:
                       - containerPort: ${schema.spec.port}
-      - id: service
+      - id: appService
         template:
           apiVersion: v1
           kind: Service
@@ -72,9 +215,43 @@ spec:
             name: ${schema.spec.name}
             namespace: default
           spec:
-            type: ${schema.spec.serviceType}
+            type: ClusterIP
             selector:
               app: ${schema.spec.name}
             ports:
               - port: ${schema.spec.port}
                 targetPort: ${schema.spec.port}
+
+      # ──────────────── HTTPRoute (Gateway API exposure layer) ────────────────
+      # Attaches to the platform Gateway; TLS terminates at the Gateway edge,
+      # which programs the DNS record + tunnel route from this hostname.
+      - id: httpRoute
+        template:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: ${schema.spec.name}
+            namespace: default
+          spec:
+            parentRefs:
+              - group: gateway.networking.k8s.io
+                kind: Gateway
+                name: ${kedge.gatewayName}
+                namespace: ${kedge.gatewayNamespace}
+            hostnames:
+              - ${schema.spec.expose.fqdn}
+            rules:
+              - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                backendRefs:
+                  - name: ${schema.spec.name}
+                    port: ${schema.spec.port}
+    # url/host are read from the HTTPRoute (this kro fork forbids ${schema.*}
+    # in status), same as the application template. ${kedge.appPublicPort} is
+    # substituted by the kro backend before kro sees this CEL.
+    status:
+      url: ${"https://" + httpRoute.spec.hostnames[0] + "${kedge.appPublicPort}"}
+      host: ${httpRoute.spec.hostnames[0]}
+      ready: ${appDeployment.status.readyReplicas}


### PR DESCRIPTION
## Why

The template catalog had exactly one development-capable template (`application`: frontend + backend + Postgres). An App Studio project that only needs a single-container web app — a static site, an SPA, a meme page — either got forced onto the full 3-tier stack or dead-ended in the assistant's template interview. `simple-webapp` itself was vestigial: no public URL, no development support, predating the Gateway API exposure work and the template-native sandbox design (docs/app-studio-template-sandboxes.md).

## What

**`simple-webapp` reworked (v0.2.0)** into the single-tier counterpart of `application`:
- Public exposure: HTTPRoute on the platform Gateway parent, controller-stamped `expose.fqdn`, `status.url`/`host` — the wiring App Studio's preview reads.
- `spec.development`: one component `app` claiming the workspace root (`workspacePath: "."`), node dev image, the proven vite shim start command carried verbatim from the application frontend tier.
- `spec.dataPlane`: sync/restart/env/log verbs for that component.
- `image` required in production only (same CEL pattern as `application`); a dev-only project provisions with just `{name, kedgeMode}`. `serviceType` dropped.
- `agent.usage` guidance, `sampleValues`, portal `view`.

**Instance controller generalized** into a table of exposed instance kinds: `Application` keeps the full treatment (fqdn + credentialsSecretName + OIDC bridge + finalizer); `SimpleWebApp` gets an exposure-only reconciler that stamps just `spec.expose.fqdn` — no cross-cluster state, no finalizer. A future exposed template is one line in `instanceKinds`.

**Catalog guidance**: `application`'s agent usage now cross-points at `simple-webapp` for frontend-only apps (so the assistant never again reasons "only development-capable option"); `redis-cache` gets the `agent:` block it was missing.

**Test**: `TestSeedTemplatesSimpleWebappIsDevelopmentCapable` pins the contract App Studio depends on — dev component, workspace-root claim, synthesized overlay resources in the RGD, and the status fields the preview (`status.url`) and data plane (`controlSecretRef`, `components`) resolve through.

No app-studio changes needed — it reads `development.components` live from the catalog, so simple-webapp appears in the portal picker and the assistant's selectable set automatically.

## Rollout note

Live environments need the provider re-seeded so the 0.2.0 Template (and its re-authored instance CRD) replaces 0.1.0 — worth confirming the seeding path updates existing Template CRs rather than create-if-absent.

## Verification

`go build ./...`, `go vet ./...`, and the full `go test ./...` of the infrastructure provider pass. The generic `TestSeedTemplatesBuildRGD` runs the new template through the real RGD build including dev-overlay synthesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)