### PR TITLE
feat(infrastructure): template catalog hardening — worker + cron-job, honest redis knobs, tenant LimitRange

### DIFF
--- a/providers/infrastructure/backend/kro/e2e_devmode_test.go
+++ b/providers/infrastructure/backend/kro/e2e_devmode_test.go
@@ -63,7 +63,9 @@ import (
 // NOT need — dev mode swaps the tier images for platform dev images, so the
 // instance is created without them to prove the graph renders regardless.
 var e2eDevImageStripped = map[string][]string{
-	"application": {"frontendImage", "backendImage"},
+	"application":   {"frontendImage", "backendImage"},
+	"simple-webapp": {"image"},
+	"worker":        {"image"},
 }
 
 func TestE2EDevelopmentMode(t *testing.T) {

--- a/providers/infrastructure/backend/kro/e2e_test.go
+++ b/providers/infrastructure/backend/kro/e2e_test.go
@@ -81,9 +81,7 @@ const (
 
 // e2eMinimalSpecs supplies a valid instance spec for templates that ship no
 // sampleValues (those that do — application, database — use them directly).
-var e2eMinimalSpecs = map[string]map[string]any{
-	"redis-cache": {"name": "e2e-redis"},
-}
+var e2eMinimalSpecs = map[string]map[string]any{}
 
 // e2ePlatformStamped are spec fields a platform component normally writes onto an
 // instance before kro reconciles it — values the user does NOT supply (the

--- a/providers/infrastructure/deploy/chart/templates/deployment.yaml
+++ b/providers/infrastructure/deploy/chart/templates/deployment.yaml
@@ -141,6 +141,12 @@ spec:
             - name: KEDGE_GATEWAY_NAMESPACE
               value: {{ . | quote }}
             {{- end }}
+            {{- if not .Values.tenantLimitRange.enabled }}
+            # Opt out of stamping the kedge-defaults LimitRange into tenant
+            # namespaces (for clusters that manage resource policy themselves).
+            - name: KEDGE_TENANT_LIMITRANGE
+              value: "disabled"
+            {{- end }}
             {{- with .Values.development.agentImage }}
             # Dev-mode agent injector image (${kedge.devAgentImage}).
             - name: KEDGE_DEV_AGENT_IMAGE

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -58,6 +58,14 @@ application:
     name: "cloudflare-tunnel"
     namespace: "cfgate-system"
 
+# Default container resource policy stamped into every tenant namespace as a
+# LimitRange named "kedge-defaults" (defaultRequest 50m/128Mi, default limit
+# 500m/512Mi, max 2cpu/2Gi per container). Create-only — operators may
+# hand-tune a tenant's copy without it being overwritten. Disable when the
+# runtime cluster manages its own resource policy.
+tenantLimitRange:
+  enabled: true
+
 # Development-mode images (docs/app-studio-template-sandboxes.md). These run
 # TENANT code, so production deployments should pin them by digest. Empty
 # values fall back to the in-binary defaults (node → the kedge sandbox-runner

--- a/providers/infrastructure/install/templates/cron-job.yaml
+++ b/providers/infrastructure/install/templates/cron-job.yaml
@@ -1,0 +1,116 @@
+apiVersion: infrastructure.kedge.faros.sh/v1alpha1
+kind: Template
+metadata:
+  name: cron-job
+spec:
+  displayName: "Scheduled job"
+  description: "A container that runs on a cron schedule and exits — CronJob only, no Service, no URL. Reports, cleanups, periodic syncs."
+  category: Workloads
+  version: 0.1.0
+  backend: kro
+  # One-click provision defaults for the portal form. busybox's default
+  # entrypoint exits 0 immediately, so the sample schedule visibly produces
+  # completed Jobs with zero external setup.
+  sampleValues:
+    name: demo-job
+    image: busybox:stable
+    schedule: "*/30 * * * *"
+  # Operational guidance for AI agents discovering this template over MCP.
+  agent:
+    usage: |
+      Runs ONE container on a cron schedule; each run must do its work and
+      EXIT 0. Choose this for periodic work — reports, cleanups, backups,
+      syncs. It is the opposite lifecycle of the worker template (a process
+      that runs forever): a cron-job container that never exits will pile up
+      overlapping-forbidden runs, not "keep running".
+
+      YOU SUPPLY exactly one container image whose ENTRYPOINT performs the
+      task and exits: 0 on success, non-zero on failure (failed runs are
+      retried up to 3 times, then recorded as a failed Job). There is no
+      command/args input — bake the task into the image entrypoint.
+
+      SCHEDULE: standard 5-field cron (schedule input, default "0 * * * *" =
+      hourly, evaluated in UTC). Concurrent runs are forbidden — if a run is
+      still going when the next tick fires, the new run is skipped. Runs may
+      occasionally fire late or be skipped; the task must be idempotent and
+      tolerate that.
+
+      This template has NO development mode — develop and test the image
+      elsewhere, then provision it here. No network exposure; durable state
+      belongs in a database template instance.
+
+      INPUTS you set when provisioning: name, image (both required); schedule.
+    outputs:
+      - "status.schedule — the active cron schedule."
+  # ── Portal presentation ───────────────────────────────────────────────
+  view:
+    columns:
+      - header: Schedule
+        path: spec.schedule
+        type: code
+    detail:
+      - title: Configuration
+        fields:
+          - label: Schedule
+            path: status.schedule
+            type: code
+          - label: Image
+            path: spec.image
+            type: code
+  instanceCRD:
+    group: infrastructure.kedge.faros.sh
+    version: v1alpha1
+    resource: scheduledjobs
+    kind: ScheduledJob
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: "Logical name; used as the CronJob name in the tenant namespace."
+      image:
+        type: string
+        description: "Container image whose entrypoint performs the task and exits (0 = success)."
+      schedule:
+        type: string
+        default: "0 * * * *"
+        description: "Standard 5-field cron expression, evaluated in UTC. Default: hourly."
+    required:
+      - name
+      - image
+
+  # ── backendConfig: the kro resource graph ─────────────────────────────
+  # namespace: default is remapped to the per-tenant namespace on the runtime
+  # cluster — same convention as every seed template.
+  backendConfig:
+    resources:
+      - id: cronJob
+        template:
+          apiVersion: batch/v1
+          kind: CronJob
+          metadata:
+            name: ${schema.spec.name}
+            namespace: default
+          spec:
+            schedule: ${schema.spec.schedule}
+            # A run still going when the next tick fires wins; the new run is
+            # skipped. Matches the agent contract above.
+            concurrencyPolicy: Forbid
+            successfulJobsHistoryLimit: 3
+            failedJobsHistoryLimit: 1
+            jobTemplate:
+              spec:
+                backoffLimit: 3
+                template:
+                  metadata:
+                    labels:
+                      app: ${schema.spec.name}
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: job
+                        image: ${schema.spec.image}
+    # Echoed from the materialized CronJob (this kro fork forbids ${schema.*}
+    # in status — status may reference resources only).
+    status:
+      schedule: ${cronJob.spec.schedule}

--- a/providers/infrastructure/install/templates/database.yaml
+++ b/providers/infrastructure/install/templates/database.yaml
@@ -33,6 +33,33 @@ spec:
       - "status.host / status.port - the in-cluster Service endpoint for PostgreSQL."
       - "status.ready - ready replica count for the Postgres StatefulSet."
       - "status.connectionSecretRef - Secret '<name>-db-credentials' containing host, port, user, dbname, password, and uri keys. Secret values are not surfaced in status."
+  # ── Portal presentation ───────────────────────────────────────────────
+  view:
+    columns:
+      - header: Version
+        path: spec.version
+        type: badge
+    detail:
+      - title: Connection
+        fields:
+          - label: Host
+            path: status.host
+            type: code
+          - label: Port
+            path: status.port
+            type: code
+          - label: Credentials secret
+            path: status.connectionSecretRef.name
+            type: code
+      - title: Configuration
+        fields:
+          - label: Postgres version
+            path: spec.version
+            type: badge
+      - title: Readiness
+        fields:
+          - label: Database
+            path: status.ready
   instanceCRD:
     group: infrastructure.kedge.faros.sh
     version: v1alpha1

--- a/providers/infrastructure/install/templates/redis-cache.yaml
+++ b/providers/infrastructure/install/templates/redis-cache.yaml
@@ -4,9 +4,9 @@ metadata:
   name: redis-cache
 spec:
   displayName: "Redis cache"
-  description: "A Redis instance for caching workloads. StatefulSet + Service; size knob picks the memory limit."
+  description: "A Redis instance for caching workloads — StatefulSet + Service; the size knob picks the memory bucket. Ephemeral: data does not survive a restart."
   category: Databases
-  version: 0.1.0
+  version: 0.2.0
   backend: kro
   sampleValues:
     name: cache
@@ -25,12 +25,46 @@ spec:
       `<name>-credentials`, key `uri`. The URI has the form
       `redis://:<password>@<name>:6379`. Redis may not be ready the moment a
       consuming app starts — retry the initial connection. This template does
-      not expose Redis publicly, and persistent=false (the default) means data
-      does not survive a restart.
+      not expose Redis publicly.
+
+      Redis is EPHEMERAL here: no persistence is configured, so a pod restart
+      loses all data. Treat it strictly as a cache — never as a system of
+      record; durable state belongs in the database template. The size input
+      picks the container memory bucket: small=64Mi, medium=256Mi, large=1Gi.
     outputs:
       - "status.host / status.port — the in-cluster Service endpoint for Redis."
       - "status.ready — ready replica count for the Redis StatefulSet."
       - "status.connectionSecretRef — Secret '<name>-credentials' containing host, port, password, and uri keys. Secret values are not surfaced in status."
+  # ── Portal presentation ───────────────────────────────────────────────
+  view:
+    columns:
+      - header: Size
+        path: spec.size
+        type: badge
+    detail:
+      - title: Connection
+        fields:
+          - label: Host
+            path: status.host
+            type: code
+          - label: Port
+            path: status.port
+            type: code
+          - label: Credentials secret
+            path: status.connectionSecretRef.name
+            type: code
+      - title: Configuration
+        fields:
+          - label: Size
+            path: spec.size
+            type: badge
+          - label: Redis version
+            path: spec.version
+            type: badge
+      - title: Readiness
+        fields:
+          - label: Redis
+            path: status.ready
   instanceCRD:
     group: infrastructure.kedge.faros.sh
     version: v1alpha1
@@ -46,14 +80,11 @@ spec:
         type: string
         enum: ["small", "medium", "large"]
         default: "small"
-        description: "Memory bucket (64Mi / 256Mi / 1Gi)."
+        description: "Memory bucket, wired to the container's memory request+limit (small=64Mi, medium=256Mi, large=1Gi)."
       version:
         type: string
         enum: ["6", "7"]
         default: "7"
-      persistent:
-        type: boolean
-        default: false
     required:
       - name
   # backendConfig is interpreted by the kro backend. Every resource sets
@@ -168,7 +199,17 @@ spec:
                 containers:
                   - name: redis
                     image: redis:${schema.spec.version}
-                    command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
+                    # maxmemory sits ~25% under the container limit (working
+                    # memory + fragmentation headroom) with LRU eviction, so
+                    # a full cache evicts instead of OOM-killing the pod.
+                    command:
+                      - redis-server
+                      - --requirepass
+                      - $(REDIS_PASSWORD)
+                      - --maxmemory
+                      - '${schema.spec.size == "small" ? "48mb" : (schema.spec.size == "medium" ? "192mb" : "768mb")}'
+                      - --maxmemory-policy
+                      - allkeys-lru
                     env:
                       - name: REDIS_PASSWORD
                         valueFrom:
@@ -177,6 +218,16 @@ spec:
                             key: password
                     ports:
                       - containerPort: 6379
+                    # The size bucket bounds the container: memory request ==
+                    # limit (Redis is memory, an OOM-kill under the limit is
+                    # the contract working). Single-quoted: the CEL ternaries
+                    # contain ": " which YAML would otherwise read as mappings.
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: '${schema.spec.size == "small" ? "64Mi" : (schema.spec.size == "medium" ? "256Mi" : "1Gi")}'
+                      limits:
+                        memory: '${schema.spec.size == "small" ? "64Mi" : (schema.spec.size == "medium" ? "256Mi" : "1Gi")}'
       - id: service
         template:
           apiVersion: v1

--- a/providers/infrastructure/install/templates/worker.yaml
+++ b/providers/infrastructure/install/templates/worker.yaml
@@ -1,0 +1,161 @@
+apiVersion: infrastructure.kedge.faros.sh/v1alpha1
+kind: Template
+metadata:
+  name: worker
+spec:
+  displayName: "Background worker"
+  description: "A long-running background process — Deployment only, no Service, no URL. Queue consumers, bots, pollers. Development-capable: can back an App Studio project with a hot-reload dev process."
+  category: Workloads
+  version: 0.1.0
+  backend: kro
+  # One-click provision defaults for the portal form. nginx is a stand-in
+  # long-running process that always starts; a real worker replaces it.
+  sampleValues:
+    name: demo-worker
+    image: nginx:latest
+  # Operational guidance for AI agents discovering this template over MCP.
+  agent:
+    usage: |
+      Runs ONE container as a long-running background process with NO network
+      exposure: no Service, no route, no URL. Choose this for queue consumers,
+      chat/Discord/Telegram bots, pollers, and schedulers that run
+      continuously. It is NOT reachable over HTTP — if the app must serve
+      requests, use simple-webapp (one container + URL) or application
+      (frontend + API + database). For work that runs on a schedule and exits,
+      use the cron-job template instead.
+
+      PRODUCTION MODE — you supply exactly one container image (the image
+      input) and nothing else:
+        • The entrypoint must run FOREVER; a process that exits is restarted
+          (crash-looping is treated as failure, not completion).
+        • Stateless — no persistent disk. Pods may be restarted or scaled
+          (the replicas input). Durable state belongs in a database template
+          instance; read its connection URI from the Secret it publishes.
+        • Configuration comes from your image; there is no platform-injected
+          env.
+
+      DEVELOPMENT MODE (the platform-injected kedgeMode field): the image
+      input is ignored (and may be omitted) — the platform runs a Node.js dev
+      container against the project workspace (workspacePath "."). The dev
+      process is `npm run dev` (falling back to `npm start`); logs and
+      restarts are available through the project's development runtime verbs.
+
+      INPUTS you set when provisioning: name (required); image (required in
+      production, ignored in development), replicas.
+    outputs:
+      - "status.ready — ready replica count for the worker Deployment."
+  # ── Portal presentation ───────────────────────────────────────────────
+  view:
+    detail:
+      - title: Readiness
+        fields:
+          - label: Worker
+            path: status.ready
+  instanceCRD:
+    group: infrastructure.kedge.faros.sh
+    version: v1alpha1
+    resource: workers
+    kind: Worker
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        description: "Logical name; used as the Deployment name in the tenant namespace."
+      image:
+        type: string
+        description: "Container image running the background process. Required in production mode; ignored (and may be omitted) when kedgeMode is development — dev mode runs the platform dev image against the project workspace."
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 5
+    required:
+      - name
+    # The image is only required when the instance actually runs it: production
+    # mode. Enforced on the kcp-side CRD; kedgeMode defaults to "production".
+    x-kubernetes-validations:
+      - rule: "(has(self.kedgeMode) && self.kedgeMode == 'development') || has(self.image)"
+        message: "image is required in production mode"
+
+  # ── Development mode (docs/app-studio-template-sandboxes.md) ──────────
+  # Single component claiming the whole project workspace. The component
+  # declares no port — a worker serves no traffic; the dev overlay still
+  # injects the control port for sync/logs/restart.
+  development:
+    components:
+      worker:
+        workspacePath: .
+        devImage: "${kedge.devImage.node}"
+        workingDir: /workspace
+        startCommand: "npm run dev || npm start"
+        reload:
+          strategy: process
+          rules:
+            - paths: ["package.json", "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml"]
+              command: "npm install --no-audit --no-fund"
+
+  # ── Data plane (development mode) ─────────────────────────────────────
+  # Per-component control verbs, served as
+  # …/workers/<name>/components/worker/{sync,restart,log,env}. Production
+  # mode answers 409 instance-not-ready — the data plane is a
+  # development-mode surface.
+  dataPlane:
+    runtimeNamespacePath: status.runtimeNamespace
+    tokenSecretPath: status.controlSecretRef
+    endpoints:
+      status:
+        fromStatus: true
+    components:
+      worker:
+        endpoints:
+          sync:
+            servicePath: status.components.worker.controlServiceRef
+            port: control
+            upstreamPath: /sync
+            methods: ["POST"]
+          restart:
+            servicePath: status.components.worker.controlServiceRef
+            port: control
+            upstreamPath: /restart
+            methods: ["POST"]
+          env:
+            servicePath: status.components.worker.controlServiceRef
+            port: control
+            upstreamPath: /env
+            methods: ["POST"]
+          log:
+            servicePath: status.components.worker.controlServiceRef
+            port: control
+            upstreamPath: /logs
+            methods: ["GET"]
+            stream: true
+
+  # ── backendConfig: the kro resource graph ─────────────────────────────
+  # namespace: default is remapped to the per-tenant namespace on the runtime
+  # cluster — same convention as every seed template. The graph id follows
+  # the dev-overlay convention: component "worker" → id "workerDeployment".
+  backendConfig:
+    resources:
+      - id: workerDeployment
+        template:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: ${schema.spec.name}
+            namespace: default
+          spec:
+            replicas: ${schema.spec.replicas}
+            selector:
+              matchLabels:
+                app: ${schema.spec.name}
+            template:
+              metadata:
+                labels:
+                  app: ${schema.spec.name}
+              spec:
+                containers:
+                  - name: worker
+                    image: ${schema.spec.image}
+    status:
+      ready: ${workerDeployment.status.readyReplicas}

--- a/providers/infrastructure/kro/namespace.go
+++ b/providers/infrastructure/kro/namespace.go
@@ -22,7 +22,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var namespaceGVR = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+var (
+	namespaceGVR  = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
+	limitRangeGVR = schema.GroupVersionResource{Version: "v1", Resource: "limitranges"}
+)
+
+const (
+	// tenantLimitRangeName is the LimitRange every tenant namespace gets on
+	// creation. Create-only: an operator may hand-tune a tenant's copy and we
+	// never fight them over it.
+	tenantLimitRangeName = "kedge-defaults"
+
+	// tenantLimitRangeDisableEnv opts the platform out of stamping the
+	// LimitRange (KEDGE_TENANT_LIMITRANGE=disabled) — for runtime clusters
+	// that manage resource policy themselves (their own LimitRange/Kyverno/
+	// quota tooling).
+	tenantLimitRangeDisableEnv = "KEDGE_TENANT_LIMITRANGE"
+)
 
 // tenantNamespaceName derives a deterministic namespace name from a
 // kcp workspace path. SHA256-truncated to 12 hex chars so it's
@@ -96,8 +112,68 @@ func (c *realClient) EnsureTenantNamespace(ctx context.Context, tenantPath strin
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return "", fmt.Errorf("create namespace %s: %w", name, err)
 	}
+	if err := c.ensureTenantLimitRange(ctx, tenantPath, name); err != nil {
+		return "", err
+	}
 	c.nsCache.Store(tenantPath, name)
 	return name, nil
+}
+
+// ensureTenantLimitRange stamps the default container resource policy into a
+// tenant namespace. No seed template pins its own CPU/memory (except where a
+// knob is explicitly wired, e.g. redis-cache's size), so without this a
+// tenant workload on the shared runtime cluster is unbounded — the
+// noisy-neighbor hole. The LimitRange closes it at admission time:
+//
+//   - containers with no resources get defaultRequest 50m/128Mi and a
+//     default limit of 500m/512Mi;
+//   - a container may still ask for more explicitly, but never past max
+//     (2 CPU / 2Gi) — the per-container ceiling of the platform's dev-grade
+//     tier.
+//
+// Create-only and sitting BEFORE the nsCache store, so a provider restart
+// retrofits namespaces created before this policy existed, while an
+// operator's hand-tuned copy is never overwritten. Disable with
+// KEDGE_TENANT_LIMITRANGE=disabled when the runtime cluster manages its own
+// resource policy.
+func (c *realClient) ensureTenantLimitRange(ctx context.Context, tenantPath, namespace string) error {
+	if os.Getenv(tenantLimitRangeDisableEnv) == "disabled" {
+		return nil
+	}
+	lr := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "LimitRange",
+		"metadata": map[string]any{
+			"name":      tenantLimitRangeName,
+			"namespace": namespace,
+			"labels": map[string]any{
+				LabelTenant:    tenantHash(tenantPath),
+				LabelManagedBy: ManagedByValue,
+			},
+		},
+		"spec": map[string]any{
+			"limits": []any{map[string]any{
+				"type": "Container",
+				"defaultRequest": map[string]any{
+					"cpu":    "50m",
+					"memory": "128Mi",
+				},
+				"default": map[string]any{
+					"cpu":    "500m",
+					"memory": "512Mi",
+				},
+				"max": map[string]any{
+					"cpu":    "2",
+					"memory": "2Gi",
+				},
+			}},
+		},
+	}}
+	_, err := c.dyn.Resource(limitRangeGVR).Namespace(namespace).Create(ctx, lr, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create limitrange %s/%s: %w", namespace, tenantLimitRangeName, err)
+	}
+	return nil
 }
 
 // toUnstructured marshals a typed object into the unstructured shape

--- a/providers/infrastructure/kro/namespace_test.go
+++ b/providers/infrastructure/kro/namespace_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kro
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// TestEnsureTenantNamespaceStampsLimitRange pins the tenant resource policy:
+// creating a tenant namespace also creates the kedge-defaults LimitRange
+// (the noisy-neighbor bound), idempotently, and an existing — possibly
+// operator-tuned — LimitRange is never overwritten.
+func TestEnsureTenantNamespaceStampsLimitRange(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := &realClient{dyn: dyn}
+
+	const tenant = "root:kedge:orgs:test"
+	ns, err := c.EnsureTenantNamespace(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("EnsureTenantNamespace: %v", err)
+	}
+
+	lr, err := dyn.Resource(limitRangeGVR).Namespace(ns).Get(context.Background(), tenantLimitRangeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get LimitRange %s/%s: %v", ns, tenantLimitRangeName, err)
+	}
+	limits, found, _ := unstructured.NestedSlice(lr.Object, "spec", "limits")
+	if !found || len(limits) != 1 {
+		t.Fatalf("LimitRange spec.limits = %v, want exactly one Container entry", limits)
+	}
+	entry, _ := limits[0].(map[string]any)
+	if got, _, _ := unstructured.NestedString(entry, "type"); got != "Container" {
+		t.Fatalf("limit type = %q, want Container", got)
+	}
+	for _, field := range []string{"defaultRequest", "default", "max"} {
+		if _, found, _ := unstructured.NestedMap(entry, field); !found {
+			t.Fatalf("LimitRange entry missing %s", field)
+		}
+	}
+	if got, _, _ := unstructured.NestedString(lr.Object, "metadata", "labels", LabelManagedBy); got != ManagedByValue {
+		t.Fatalf("managed-by label = %q, want %q", got, ManagedByValue)
+	}
+
+	// An operator hand-tunes the LimitRange; a cold-cache re-ensure (fresh
+	// client, same cluster) must not put ours back.
+	tuned := lr.DeepCopy()
+	limits[0].(map[string]any)["max"] = map[string]any{"cpu": "8", "memory": "16Gi"}
+	if err := unstructured.SetNestedSlice(tuned.Object, limits, "spec", "limits"); err != nil {
+		t.Fatalf("set tuned limits: %v", err)
+	}
+	if _, err := dyn.Resource(limitRangeGVR).Namespace(ns).Update(context.Background(), tuned, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update LimitRange: %v", err)
+	}
+
+	c2 := &realClient{dyn: dyn}
+	if _, err := c2.EnsureTenantNamespace(context.Background(), tenant); err != nil {
+		t.Fatalf("re-ensure: %v", err)
+	}
+	after, err := dyn.Resource(limitRangeGVR).Namespace(ns).Get(context.Background(), tenantLimitRangeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-get LimitRange: %v", err)
+	}
+	afterLimits, _, _ := unstructured.NestedSlice(after.Object, "spec", "limits")
+	gotMax, _, _ := unstructured.NestedString(afterLimits[0].(map[string]any), "max", "cpu")
+	if gotMax != "8" {
+		t.Fatalf("re-ensure overwrote the operator-tuned LimitRange: max.cpu = %q, want 8", gotMax)
+	}
+}
+
+// TestEnsureTenantNamespaceLimitRangeDisabled pins the opt-out: with
+// KEDGE_TENANT_LIMITRANGE=disabled no LimitRange is stamped.
+func TestEnsureTenantNamespaceLimitRangeDisabled(t *testing.T) {
+	t.Setenv(tenantLimitRangeDisableEnv, "disabled")
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	c := &realClient{dyn: dyn}
+
+	ns, err := c.EnsureTenantNamespace(context.Background(), "root:kedge:orgs:optout")
+	if err != nil {
+		t.Fatalf("EnsureTenantNamespace: %v", err)
+	}
+	if _, err := dyn.Resource(limitRangeGVR).Namespace(ns).Get(context.Background(), tenantLimitRangeName, metav1.GetOptions{}); err == nil {
+		t.Fatal("LimitRange was created despite KEDGE_TENANT_LIMITRANGE=disabled")
+	}
+}


### PR DESCRIPTION
Batch one of the template-catalog review (follow-up to #414), aimed at two personas: simple developers (coverage gaps) and enterprise actors (resource honesty + bounds).

## redis-cache v0.2.0 — make the knobs honest
The `size` input claimed to "pick the memory limit" but the StatefulSet set **no resources at all**, and `persistent` was accepted while **no PVC existed** — two silent no-ops. Now:
- `size` wires the container memory request+limit (64Mi/256Mi/1Gi) **and** redis `--maxmemory` (~25% under the limit, `allkeys-lru`) so a full cache evicts instead of OOM-killing.
- `persistent` is removed; the template is explicitly an ephemeral cache ("never a system of record" in the agent guidance).
- Portal `view` block added.

## New: `worker` template
One container running forever — no Service, no route, no URL. Queue consumers, bots, pollers. Development-capable (single component claiming the workspace root, node toolchain, full sync/restart/log/env data plane); `image` required in production only, same CEL pattern as simple-webapp. Fills the "my app doesn't serve HTTP" gap that previously forced everything onto a web template.

## New: `cron-job` template
A container on a 5-field cron schedule (instance kind `ScheduledJob`): `concurrencyPolicy: Forbid`, 3 retries, history limits. Deliberately no dev mode (the dev overlay supports Deployments only) — the agent contract says bake the task into the image entrypoint and exit 0.

## Tenant LimitRange (noisy-neighbor bound)
No seed template pins its own CPU/memory, so tenant workloads on the shared runtime cluster were unbounded. `EnsureTenantNamespace` now stamps a create-only `kedge-defaults` LimitRange into every tenant namespace: defaultRequest 50m/128Mi, default limit 500m/512Mi, max 2cpu/2Gi per container.
- Create-only: an operator-tuned copy is never overwritten.
- Sits before the namespace cache store, so a provider restart retrofits pre-existing namespaces.
- Opt out with `KEDGE_TENANT_LIMITRANGE=disabled` / chart `tenantLimitRange.enabled: false` for clusters that manage their own resource policy.

## Smaller
- `database`: portal `view` block (connection, version, readiness) instead of the raw values dump.
- e2e: worker/simple-webapp dev instances are created **without** their image inputs to prove development mode needs none; dead `e2eMinimalSpecs` entries dropped (every seed template now ships `sampleValues`).

## Verification
- Unit: new `kro` package tests pin the LimitRange stamp, the never-overwrite rule, and the opt-out; full `go test ./...`, `go vet`, and `helm lint`/`helm template` pass.
- Full local kind e2e (`make e2e-infrastructure`): all six seed templates apply; worker passes both production and development sweeps.

Follow-ups from the review, not in this PR: external/BYO database mode on `application`, python dev toolchain, `api-service` template, internal-only exposure, object storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)