### PR TITLE
test(e2e): modernize the quickstart suite onto the current bootstrap

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,16 +13,13 @@ permissions:
 jobs:
   # Subprocess provider suites: hub with embedded kcp + provider binaries as
   # host processes, driven over HTTP + kcp dynamic clients. No kind, no Helm,
-  # no Docker — the cheapest full-kcp coverage we have.
-  #
-  # NOTE: the older quickstart suite (make e2e-provider) predates the
-  # provider bootstrap refactor (Provider CR + provider-run init) and fails
-  # against the current hub — it is deliberately NOT wired here until it is
-  # modernized onto the same bootstrap the infraprovider suite uses.
+  # no Docker — the cheapest full-kcp coverage we have. The suites share the
+  # embedded kcp's fixed etcd port (2380), so they run sequentially in one
+  # job rather than as a matrix.
   e2e-providers:
     name: Provider suites (embedded kcp subprocesses)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +29,9 @@ jobs:
 
       - name: Run infrastructure provider e2e
         run: make e2e-infra-provider
+
+      - name: Run quickstart provider e2e
+        run: make e2e-provider
 
   e2e-standalone:
     name: Standalone (embedded kcp + static token)

--- a/test/e2e/suites/provider/main_test.go
+++ b/test/e2e/suites/provider/main_test.go
@@ -169,8 +169,9 @@ func TestMain(m *testing.M) {
 	initCmd.Env = append(os.Environ(),
 		"KEDGE_PROVIDER_KUBECONFIG="+runtimeKubeconfig,
 		"QUICKSTART_WORKSPACE_PATH="+workspacePath,
-		// Same as the Makefile dev flow: no chart schemas dir on a host run.
-		"KEDGE_SCHEMAS_DIR=/nonexistent",
+		// The greetings APIResourceSchema the chart ships — init reads the
+		// schemas dir to author the APIExport's resources.
+		"KEDGE_SCHEMAS_DIR="+filepath.Join(repoRoot, "providers", "quickstart", "deploy", "chart", "files", "schemas"),
 	)
 	initCmd.Stdout = initLog
 	initCmd.Stderr = initLog

--- a/test/e2e/suites/provider/main_test.go
+++ b/test/e2e/suites/provider/main_test.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 // Package provider implements an end-to-end suite for the kedge provider
 // extension surface. It starts the kedge-hub with embedded kcp and the
-// reference quickstart provider as host subprocesses, then exercises the
-// full lifecycle: catalog provisioning (sub-workspace + APIResourceSchema
-// + APIExport + RBAC), the /api/providers and /ui|services/providers
-// proxies, tenant Enable via direct APIBinding, and heartbeat freshness.
+// reference quickstart provider as host subprocesses, following the current
+// bootstrap flow: Provider + CatalogEntry applied into
+// root:kedge:system:providers (the hub's Provider controller materializes
+// the sub-workspace + SA + provider-token), then `quickstart-provider init`
+// with the minted SA kubeconfig (APIExport + schemas + bind grant), then
+// serve. The tests exercise the full lifecycle: catalog provisioning, the
+// /api/providers and /ui|services/providers proxies, tenant Enable via
+// direct APIBinding, and heartbeat freshness.
 //
 // Runs without kind/Helm/Dex. Intentionally lighter-weight than the
 // standalone suite so iteration on the provider plumbing is fast.
@@ -27,6 +31,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -39,6 +44,9 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Suite-shared state populated by TestMain.
@@ -105,25 +113,7 @@ func TestMain(m *testing.M) {
 	}
 	fmt.Fprintf(os.Stderr, "hub started (pid=%d, log=%s)\n", hubCmd.Process.Pid, hubLog.Name())
 
-	provLog, _ := os.Create(filepath.Join(dataDir, "provider.log"))
-	provCmd := exec.Command(filepath.Join(repoRoot, "bin", "quickstart-provider"))
-	provCmd.Env = append(os.Environ(),
-		"PORT="+providerPort,
-		"KEDGE_HUB_URL="+hubURL,
-		"KEDGE_HUB_TOKEN="+staticToken,
-		"KEDGE_PROVIDER_NAME=quickstart",
-	)
-	provCmd.Stdout = provLog
-	provCmd.Stderr = provLog
-	provCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := provCmd.Start(); err != nil {
-		killGroup(hubCmd)
-		fmt.Fprintln(os.Stderr, "start provider:", err)
-		os.Exit(1)
-	}
-	fmt.Fprintf(os.Stderr, "quickstart-provider started (pid=%d, port=:%s)\n", provCmd.Process.Pid, providerPort)
-
-	// Cleanup on any exit path.
+	var provCmd *exec.Cmd
 	cleanup := func() {
 		killGroup(hubCmd)
 		killGroup(provCmd)
@@ -140,11 +130,6 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, "hub never ready:", err)
 		os.Exit(1)
 	}
-	if err := waitReady("http://127.0.0.1:"+providerPort+"/healthz", 10*time.Second); err != nil {
-		cleanup()
-		fmt.Fprintln(os.Stderr, "quickstart never ready:", err)
-		os.Exit(1)
-	}
 
 	// Snapshot the admin token from the kubeconfig the hub just wrote.
 	tok, err := extractToken(filepath.Join(dataDir, "kcp", "admin.kubeconfig"))
@@ -155,9 +140,133 @@ func TestMain(m *testing.M) {
 	}
 	adminToken = tok
 
+	// Provisioning: Provider + CatalogEntry into root:kedge:system:providers
+	// (mirrors `make install-provider-quickstart`); the hub's Provider
+	// controller materializes root:kedge:providers:quickstart, the provider
+	// SA, and the provider-token Secret.
+	if err := applyQuickstartManifests(); err != nil {
+		cleanup()
+		fmt.Fprintln(os.Stderr, "apply quickstart manifests:", err)
+		os.Exit(1)
+	}
+
+	// Mint the SA runtime kubeconfig from the provider-token Secret (mirrors
+	// `make init-provider-quickstart`) and run `quickstart-provider init` —
+	// the APIExport/schemas/bind-grant come from init, not the hub.
+	runtimeKubeconfig := filepath.Join(dataDir, "quickstart-runtime.kubeconfig")
+	if err := mintRuntimeKubeconfig(runtimeKubeconfig, 2*time.Minute); err != nil {
+		cleanup()
+		fmt.Fprintln(os.Stderr, "mint runtime kubeconfig:", err)
+		os.Exit(1)
+	}
+	initLog, err := os.Create(filepath.Join(dataDir, "init.log"))
+	if err != nil {
+		cleanup()
+		fmt.Fprintln(os.Stderr, "create init.log:", err)
+		os.Exit(1)
+	}
+	initCmd := exec.Command(filepath.Join(repoRoot, "bin", "quickstart-provider"), "init")
+	initCmd.Env = append(os.Environ(),
+		"KEDGE_PROVIDER_KUBECONFIG="+runtimeKubeconfig,
+		"QUICKSTART_WORKSPACE_PATH="+workspacePath,
+		// Same as the Makefile dev flow: no chart schemas dir on a host run.
+		"KEDGE_SCHEMAS_DIR=/nonexistent",
+	)
+	initCmd.Stdout = initLog
+	initCmd.Stderr = initLog
+	if err := initCmd.Run(); err != nil {
+		cleanup()
+		fmt.Fprintf(os.Stderr, "quickstart init failed: %v (log: %s)\n", err, initLog.Name())
+		os.Exit(1)
+	}
+
+	provLog, err := os.Create(filepath.Join(dataDir, "provider.log"))
+	if err != nil {
+		cleanup()
+		fmt.Fprintln(os.Stderr, "create provider.log:", err)
+		os.Exit(1)
+	}
+	provCmd = exec.Command(filepath.Join(repoRoot, "bin", "quickstart-provider"))
+	provCmd.Env = append(os.Environ(),
+		"PORT="+providerPort,
+		"KEDGE_HUB_URL="+hubURL,
+		"KEDGE_HUB_TOKEN="+staticToken,
+		"KEDGE_PROVIDER_NAME=quickstart",
+	)
+	provCmd.Stdout = provLog
+	provCmd.Stderr = provLog
+	provCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := provCmd.Start(); err != nil {
+		cleanup()
+		fmt.Fprintln(os.Stderr, "start provider:", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "quickstart-provider started (pid=%d, port=:%s)\n", provCmd.Process.Pid, providerPort)
+
+	if err := waitReady("http://127.0.0.1:"+providerPort+"/healthz", 30*time.Second); err != nil {
+		cleanup()
+		fmt.Fprintln(os.Stderr, "quickstart never ready:", err)
+		os.Exit(1)
+	}
+
 	code := m.Run()
 	cleanup()
 	os.Exit(code)
+}
+
+// mintRuntimeKubeconfig waits for the Provider controller to populate the
+// provider-token Secret in the sub-workspace and writes a workspace-scoped
+// kubeconfig around it — the same credential the provider pod mounts.
+func mintRuntimeKubeconfig(path string, timeout time.Duration) error {
+	cl, err := kcpDynamicRaw(workspacePath, adminToken)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(timeout)
+	var token string
+	var lastErr string
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		sec, err := cl.Resource(secretGVR).Namespace("default").Get(ctx, "provider-token", metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			lastErr = err.Error()
+		} else {
+			enc, _, _ := unstructured.NestedString(sec.Object, "data", "token")
+			if enc != "" {
+				raw, err := base64.StdEncoding.DecodeString(enc)
+				if err != nil {
+					return fmt.Errorf("decode provider-token: %w", err)
+				}
+				token = string(raw)
+				break
+			}
+			lastErr = "provider-token Secret exists but token not yet populated"
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if token == "" {
+		return fmt.Errorf("provider-token never populated: %s", lastErr)
+	}
+	kc := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: kedge
+  cluster:
+    server: %s/clusters/%s
+    insecure-skip-tls-verify: true
+contexts:
+- name: kedge
+  context:
+    cluster: kedge
+    user: kedge
+current-context: kedge
+users:
+- name: kedge
+  user:
+    token: %s
+`, kcpServer, workspacePath, token)
+	return os.WriteFile(path, []byte(kc), 0o600)
 }
 
 // build runs `make build-hub build-quickstart-provider` so the test runs

--- a/test/e2e/suites/provider/provider_test.go
+++ b/test/e2e/suites/provider/provider_test.go
@@ -42,10 +42,36 @@ import (
 	"github.com/faroshq/faros-kedge/pkg/util/identity"
 )
 
+// workspacePath is the provider sub-workspace the hub's Provider controller
+// materializes from provider.yaml.
+const workspacePath = "root:kedge:providers:quickstart"
+
+var secretGVR = schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
+
 // providersWorkspaceClient returns a dynamic client targeting
-// root:kedge:providers (where CatalogEntry resources live).
+// root:kedge:providers (the parent workspace holding the provider
+// sub-workspace objects).
 func providersWorkspaceClient(t *testing.T) dynamic.Interface {
 	return kcpDynamic(t, "root:kedge:providers", adminToken)
+}
+
+// systemProvidersClient returns a dynamic client targeting
+// root:kedge:system:providers — where Provider + CatalogEntry live since the
+// provider bootstrap refactor.
+func systemProvidersClient(t *testing.T) dynamic.Interface {
+	return kcpDynamic(t, "root:kedge:system:providers", adminToken)
+}
+
+// kcpDynamicRaw is kcpDynamic for non-test callers (TestMain bootstrap).
+func kcpDynamicRaw(clusterPath, token string) (dynamic.Interface, error) {
+	cfg := &rest.Config{
+		Host:        kcpServer + "/clusters/" + clusterPath,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true, // dev cert is self-signed
+		},
+	}
+	return dynamic.NewForConfig(cfg)
 }
 
 // providerSubClient returns a dynamic client targeting
@@ -71,71 +97,77 @@ func kcpDynamic(t *testing.T, clusterPath, token string) dynamic.Interface {
 	return c
 }
 
-// applyManifest applies providers/quickstart/manifest.yaml into the
-// providers workspace as admin. Idempotent: handles AlreadyExists.
-func applyQuickstartManifest(t *testing.T) *unstructured.Unstructured {
-	t.Helper()
-	cl := providersWorkspaceClient(t)
-	manifest, err := os.ReadFile(filepath.Join(repoRoot, "providers", "quickstart", "manifest.yaml"))
+// applyQuickstartManifests applies provider.yaml (kind Provider) +
+// manifest.yaml (kind CatalogEntry) into root:kedge:system:providers,
+// mirroring `make install-provider-quickstart`. Called from TestMain. The
+// hub reports /readyz before those APIs are fully servable, so creates are
+// retried until the API answers.
+func applyQuickstartManifests() error {
+	cl, err := kcpDynamicRaw("root:kedge:system:providers", adminToken)
 	if err != nil {
-		t.Fatalf("read manifest: %v", err)
+		return fmt.Errorf("dynamic client: %w", err)
 	}
-	// The manifest is a single YAML document but has leading comments and
-	// a `---` document separator. Walk line-by-line and start at the first
-	// `apiVersion:` line — sigs.k8s.io/yaml then parses cleanly.
-	idx := bytes.Index(manifest, []byte("\napiVersion:"))
-	if idx < 0 {
-		t.Fatal("manifest has no apiVersion line")
+	gvrByKind := map[string]schema.GroupVersionResource{
+		"Provider":     {Group: "admin.kedge.faros.sh", Version: "v1alpha1", Resource: "providers"},
+		"CatalogEntry": {Group: "providers.kedge.faros.sh", Version: "v1alpha1", Resource: "catalogentries"},
 	}
-	doc := manifest[idx+1:]
-	obj := &unstructured.Unstructured{}
-	if err := yaml.Unmarshal(doc, &obj.Object); err != nil {
-		t.Fatalf("parse manifest: %v", err)
-	}
-	// Override ui.url and backend.url to the test's provider port. The
-	// committed manifest targets :8081 (matching `make run-provider-
-	// quickstart`), but the suite intentionally runs the binary on :18081
-	// to keep test ports separate from dev-loop ports.
-	overrideURL := "http://localhost:" + providerPort
-	_ = unstructured.SetNestedField(obj.Object, overrideURL, "spec", "ui", "url")
-	_ = unstructured.SetNestedField(obj.Object, overrideURL, "spec", "backend", "url")
-	gvr := schema.GroupVersionResource{
-		Group: "providers.kedge.faros.sh", Version: "v1alpha1", Resource: "catalogentries",
-	}
-	// The hub reports /readyz before the catalog APIs in
-	// root:kedge:providers are fully servable (same startup race
-	// loginStaticTokenAndGetCluster documents), so on a slow runner the
-	// first Create can fail with "the server could not find the requested
-	// resource". Retry until the API is up rather than failing the suite.
-	var created *unstructured.Unstructured
-	if !waitForCondition(t, 90*time.Second, func() (bool, string) {
-		var err error
-		created, err = cl.Resource(gvr).Create(ctxWithTimeout(t, 10*time.Second), obj, metav1.CreateOptions{})
-		if err == nil {
-			return true, ""
+	for _, file := range []string{"provider.yaml", "manifest.yaml"} {
+		raw, err := os.ReadFile(filepath.Join(repoRoot, "providers", "quickstart", file))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", file, err)
 		}
-		if apierrors.IsAlreadyExists(err) {
-			created, err = cl.Resource(gvr).Get(ctxWithTimeout(t, 5*time.Second), obj.GetName(), metav1.GetOptions{})
-			if err == nil {
-				return true, ""
+		for _, doc := range bytes.Split(raw, []byte("\n---")) {
+			if !bytes.Contains(doc, []byte("apiVersion:")) {
+				continue
 			}
-			return false, "get existing CatalogEntry: " + err.Error()
+			obj := &unstructured.Unstructured{}
+			if err := yaml.Unmarshal(doc, &obj.Object); err != nil {
+				return fmt.Errorf("parse %s: %w", file, err)
+			}
+			if obj.GetKind() == "" {
+				continue
+			}
+			gvr, ok := gvrByKind[obj.GetKind()]
+			if !ok {
+				return fmt.Errorf("%s: unexpected kind %q", file, obj.GetKind())
+			}
+			if obj.GetKind() == "CatalogEntry" {
+				// The committed manifest targets :8081 (`make
+				// run-provider-quickstart`); the suite runs on :18081 to
+				// keep test ports separate from dev-loop ports.
+				overrideURL := "http://localhost:" + providerPort
+				if err := unstructured.SetNestedField(obj.Object, overrideURL, "spec", "ui", "url"); err != nil {
+					return fmt.Errorf("%s: override spec.ui.url: %w", file, err)
+				}
+				if err := unstructured.SetNestedField(obj.Object, overrideURL, "spec", "backend", "url"); err != nil {
+					return fmt.Errorf("%s: override spec.backend.url: %w", file, err)
+				}
+			}
+			deadline := time.Now().Add(90 * time.Second)
+			for {
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				_, err = cl.Resource(gvr).Create(ctx, obj, metav1.CreateOptions{})
+				cancel()
+				if err == nil || apierrors.IsAlreadyExists(err) {
+					break
+				}
+				if time.Now().After(deadline) {
+					return fmt.Errorf("create %s %s: %w", obj.GetKind(), obj.GetName(), err)
+				}
+				time.Sleep(2 * time.Second)
+			}
 		}
-		return false, "create CatalogEntry: " + err.Error()
-	}) {
-		t.Fatal("CatalogEntry never became creatable (catalog API not servable?)")
 	}
-	return created
+	return nil
 }
 
-// TestACatalogProvisioning is the first test (name-sorted) so the rest can
-// assume the catalog entry exists. Asserts every kcp-side artefact the
-// catalog controller is supposed to materialize.
+// TestACatalogProvisioning asserts every kcp-side artefact provisioning is
+// supposed to leave behind. TestMain already applied Provider + CatalogEntry
+// (into root:kedge:system:providers) and ran `quickstart-provider init`, so
+// the sub-workspace artifacts here come from the Provider controller + init.
 func TestACatalogProvisioning(t *testing.T) {
-	applyQuickstartManifest(t)
-
-	// Wait for status.conditions[Ready] == True.
-	cl := providersWorkspaceClient(t)
+	// Wait for status.conditions[Ready] == True on the CatalogEntry.
+	cl := systemProvidersClient(t)
 	gvr := schema.GroupVersionResource{
 		Group: "providers.kedge.faros.sh", Version: "v1alpha1", Resource: "catalogentries",
 	}


### PR DESCRIPTION
Follow-up to #417, which descoped the quickstart suite from CI when its first-ever run exposed that it predates the provider bootstrap refactor.

## What changed

The suite's bootstrap moves into TestMain, mirroring the (CI-validated) infraprovider suite:

1. Apply `provider.yaml` (kind Provider) + `manifest.yaml` (kind CatalogEntry, backend/UI URLs overridden to the suite port) into **`root:kedge:system:providers`** — with the API-servable retry, since the hub reports `/readyz` before those APIs answer.
2. Wait for the hub's Provider controller to materialize the sub-workspace and populate the `provider-token` Secret; mint the workspace-scoped runtime kubeconfig around that token (exactly what `make init-provider-quickstart` scripts).
3. Run **`quickstart-provider init`** with the minted SA kubeconfig — the APIExport, schemas, and bind grant come from init now, not the hub.
4. Start serve and run the tests.

`TestACatalogProvisioning` stops applying manifests itself and reads the CatalogEntry from `root:kedge:system:providers`; the sub-workspace artifact assertions (APIResourceSchema, APIExport shape, bind grant, provider SA) are unchanged — the artifacts just have a different author now. All other tests (DTO, proxies, tenant enable/disable, heartbeat, edge-proxy grant) are untouched.

The suite is re-enabled in the `e2e-providers` CI job, sequential after the infraprovider suite (shared embedded-kcp etcd port).

## Verification

`go vet` passes; the CI job on this PR is the validating run (local execution is blocked by any running dev kcp on port 2380, by design).

Next in the series: app-studio and code provider subprocess suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)