### PR TITLE
feat(app-studio): project lifecycle checkpoints — header chips + assistant tool

### DIFF
--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -333,6 +333,28 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 		},
 		projectAssistantToolFunc{
 			spec: projectAssistantToolSpec{
+				Name:        projectToolGetCheckpoints,
+				Description: "Report the project's four lifecycle checkpoints — Template bound, Git established, CI committed, Production running — each with a state (done/pending/blocked/error), a human-readable reason, and remediation. Use this at the start of a session, or whenever the user asks \"where is this project\"/\"what's left\", to decide what to do next: for a pending checkpoint whose remediation.kind is \"auto\", call the named remediation.tool to advance it; for \"manual\", tell the user the exact action to take (e.g. promotion is a button the user clicks). Prefer advancing checkpoints in order (template → git → ci → production).",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+				Risk:        projectAssistantToolRiskRead,
+			},
+			call: func(ctx context.Context, req projectAssistantToolCallRequest) (string, error) {
+				s, err := projectAssistantToolServer(server)
+				if err != nil {
+					return "", err
+				}
+				if req.Project == nil {
+					return "", errors.New("no project on this run")
+				}
+				c, err := server.clientFor(req.Identity)
+				if err != nil {
+					return "", err
+				}
+				return projectAssistantToolJSONResult(s.projectCheckpoints(ctx, c, req.Identity, req.Project), nil)
+			},
+		},
+		projectAssistantToolFunc{
+			spec: projectAssistantToolSpec{
 				Name:        projectToolCheckProjectBuild,
 				Description: "Check whether the project's launchable components have a built container image recorded in git. The per-component build runs in CI after commit_files and, on success, commits per-component image digests back to the repository; this tool reads them. Use it after committing to confirm the build succeeded before launching, and to drive the build-fix loop: status \"built\" means every component has an image (ready to launch); \"incomplete\"/\"none\" means some or all builds are still running or have failed — re-check shortly, and if they stay unbuilt inspect the failing component's build inputs and commit a fix.",
 				Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),

--- a/providers/app-studio/api/project_checkpoints.go
+++ b/providers/app-studio/api/project_checkpoints.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+	asclient "github.com/faroshq/provider-app-studio/client"
+)
+
+// Project lifecycle checkpoints — the four gates a project passes through on
+// its way to a running production deployment. They are computed on demand from
+// the backing Code- and Infrastructure-provider resources (there is no
+// persisted status); the portal renders them as header chips and the assistant
+// reads them (get_project_checkpoints) to know what to do next.
+const (
+	projectCheckpointTemplate   = "template"
+	projectCheckpointGit        = "git"
+	projectCheckpointCI         = "ci"
+	projectCheckpointProduction = "production"
+
+	// checkpoint states.
+	projectCheckpointStateDone    = "done"    // satisfied
+	projectCheckpointStatePending = "pending" // not yet satisfied; in progress or awaiting an action
+	projectCheckpointStateBlocked = "blocked" // cannot progress until an earlier checkpoint or an external prerequisite is met
+	projectCheckpointStateError   = "error"   // failed and needs attention
+
+	// remediation kinds — how the checkpoint is advanced.
+	projectCheckpointFixAuto   = "auto"   // the assistant can advance it by calling Tool
+	projectCheckpointFixManual = "manual" // a human must act (click a button, grant an OAuth scope)
+
+	projectToolGetCheckpoints = "get_project_checkpoints"
+)
+
+// projectCheckpointRemediation tells a consumer how to advance a checkpoint:
+// whether the assistant can do it (Tool names the assistant tool to call) or a
+// human must (ActionURL / Message describe the manual step).
+type projectCheckpointRemediation struct {
+	Kind      string `json:"kind"`
+	Tool      string `json:"tool,omitempty"`
+	ActionURL string `json:"actionUrl,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+type projectCheckpoint struct {
+	Key         string                        `json:"key"`
+	Label       string                        `json:"label"`
+	State       string                        `json:"state"`
+	Reason      string                        `json:"reason,omitempty"`
+	Remediation *projectCheckpointRemediation `json:"remediation,omitempty"`
+}
+
+type projectCheckpointsResponse struct {
+	Items []projectCheckpoint `json:"items"`
+}
+
+// projectCheckpoints assembles the four lifecycle checkpoints from the
+// project's current backing resources. It reuses the same primitives the
+// portal already reads (repository view, build check, production binding) so
+// the chips, the promotion form, and the assistant never disagree.
+func (s *Server) projectCheckpoints(ctx context.Context, c *asclient.Client, id identity, p *aiv1alpha1.Project) projectCheckpointsResponse {
+	templateName := ""
+	if p.Spec.Template != nil {
+		templateName = strings.TrimSpace(p.Spec.Template.Name)
+	}
+	repo := projectRepositoryView(ctx, c, p)
+
+	template := s.checkpointTemplate(templateName)
+	git := s.checkpointGit(repo)
+	ci := s.checkpointCI(repo, git.State)
+
+	// The build check is the promotion gate; compute it once and share it
+	// between the CI-context reason and the production checkpoint. It is a
+	// no-op ("unsupported") for template-less projects.
+	build, err := s.checkProjectBuild(ctx, c, id, p)
+	if err != nil {
+		build = projectBuildCheckResult{Status: "unavailable", Note: err.Error()}
+	}
+	production := s.checkpointProduction(ctx, c, id, p, templateName, build)
+
+	return projectCheckpointsResponse{Items: []projectCheckpoint{template, git, ci, production}}
+}
+
+func (s *Server) checkpointTemplate(templateName string) projectCheckpoint {
+	cp := projectCheckpoint{Key: projectCheckpointTemplate, Label: "Template"}
+	if templateName != "" {
+		cp.State = projectCheckpointStateDone
+		cp.Reason = "Bound to template " + templateName + "."
+		return cp
+	}
+	cp.State = projectCheckpointStatePending
+	cp.Reason = "No template selected yet."
+	cp.Remediation = &projectCheckpointRemediation{
+		Kind:    projectCheckpointFixAuto,
+		Tool:    projectToolSelectTemplate,
+		Message: "Select a development template for this project.",
+	}
+	return cp
+}
+
+func (s *Server) checkpointGit(repo *ProjectRepositoryView) projectCheckpoint {
+	cp := projectCheckpoint{Key: projectCheckpointGit, Label: "Git"}
+	if repo == nil || strings.TrimSpace(repo.Ref) == "" {
+		cp.State = projectCheckpointStatePending
+		cp.Reason = "No repository connected."
+		cp.Remediation = &projectCheckpointRemediation{
+			Kind:    projectCheckpointFixAuto,
+			Tool:    projectToolHydrateWorkspace,
+			Message: "Connect a Git repository to hold the project's source.",
+		}
+		return cp
+	}
+	switch repo.Status {
+	case projectRepositoryStatusReady:
+		cp.State = projectCheckpointStateDone
+		cp.Reason = "Repository " + repoDisplayName(repo) + " is connected."
+	case projectRepositoryStatusConnectionMissing:
+		cp.State = projectCheckpointStateBlocked
+		cp.Reason = firstNonEmpty(repo.Message, "The repository has no Code connection.")
+		cp.Remediation = &projectCheckpointRemediation{
+			Kind:    projectCheckpointFixManual,
+			Message: "Connect a Git provider (grant access) to establish the repository.",
+		}
+	case projectRepositoryStatusFailed:
+		cp.State = projectCheckpointStateError
+		cp.Reason = firstNonEmpty(repo.Message, "The repository failed to reconcile.")
+		cp.Remediation = &projectCheckpointRemediation{
+			Kind:    projectCheckpointFixManual,
+			Message: "Resolve the repository error, then retry.",
+		}
+	default: // Provisioning / Unavailable / RepositoryMissing / empty
+		cp.State = projectCheckpointStatePending
+		cp.Reason = firstNonEmpty(repo.Message, "Repository is provisioning.")
+	}
+	return cp
+}
+
+// checkpointCI reports whether CI is established in the repository. App Studio
+// commits generated GitHub Actions workflow(s) alongside the source, so a
+// successful RepositoryCommit is the "CI committed in git" signal.
+func (s *Server) checkpointCI(repo *ProjectRepositoryView, gitState string) projectCheckpoint {
+	cp := projectCheckpoint{Key: projectCheckpointCI, Label: "CI"}
+	if gitState != projectCheckpointStateDone {
+		cp.State = projectCheckpointStateBlocked
+		cp.Reason = "Connect a repository before committing CI."
+		return cp
+	}
+	if repo != nil {
+		for _, commit := range repo.Commits {
+			if commit.Phase == "Succeeded" {
+				cp.State = projectCheckpointStateDone
+				cp.Reason = "CI workflow committed to the repository."
+				return cp
+			}
+		}
+	}
+	cp.State = projectCheckpointStatePending
+	cp.Reason = "No commit has landed yet; committing the project adds the CI workflow."
+	cp.Remediation = &projectCheckpointRemediation{
+		Kind:    projectCheckpointFixAuto,
+		Tool:    projectToolCommitProjectFiles,
+		Message: "Commit the project to establish CI (grant the connection 'workflow' scope if the commit is rejected).",
+	}
+	return cp
+}
+
+func (s *Server) checkpointProduction(ctx context.Context, c *asclient.Client, id identity, p *aiv1alpha1.Project, templateName string, build projectBuildCheckResult) projectCheckpoint {
+	cp := projectCheckpoint{Key: projectCheckpointProduction, Label: "Production"}
+	if templateName == "" {
+		cp.State = projectCheckpointStateBlocked
+		cp.Reason = "Select a template before promoting to production."
+		return cp
+	}
+
+	if prod := findProjectProductionBinding(p); prod != nil {
+		st := projectProviderBindingStatus(ctx, c, p, *prod, id)
+		if strings.EqualFold(st.Phase, "Ready") {
+			cp.State = projectCheckpointStateDone
+			cp.Reason = firstNonEmpty(prodRunningReason(st), "Production is running.")
+			return cp
+		}
+		cp.State = projectCheckpointStatePending
+		cp.Reason = firstNonEmpty(st.Phase, "Production is deploying.")
+		return cp
+	}
+
+	// Never promoted. Promotion is a manual, user-initiated action, but it is
+	// only offered once the build is green.
+	if build.Status == "built" {
+		cp.State = projectCheckpointStatePending
+		cp.Reason = "Build is green; ready to promote to production."
+		cp.Remediation = &projectCheckpointRemediation{
+			Kind:    projectCheckpointFixManual,
+			Message: "Click \"Promote to production\" to launch the production instance.",
+		}
+		return cp
+	}
+	cp.State = projectCheckpointStateBlocked
+	cp.Reason = firstNonEmpty(build.Note, "The build must be green before promoting.")
+	cp.Remediation = &projectCheckpointRemediation{
+		Kind:    projectCheckpointFixAuto,
+		Tool:    projectToolCheckProjectBuild,
+		Message: "Get the build green (commit/rebuild), then promote.",
+	}
+	return cp
+}
+
+func prodRunningReason(st aiv1alpha1.ProjectProviderBindingStatus) string {
+	if url := strings.TrimSpace(st.URL); url != "" {
+		return "Production is running at " + url + "."
+	}
+	return ""
+}
+
+func repoDisplayName(repo *ProjectRepositoryView) string {
+	if repo == nil {
+		return ""
+	}
+	return firstNonEmpty(strings.TrimSpace(repo.Name), strings.TrimSpace(repo.Ref))
+}
+
+// getProjectCheckpoints is GET /api/projects/{project}/checkpoints — the portal
+// polls it to render the lifecycle chips in the project header.
+func (s *Server) getProjectCheckpoints(w http.ResponseWriter, r *http.Request) {
+	c, id, p, ok := s.requireProjectWithClient(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, s.projectCheckpoints(r.Context(), c, id, p))
+}

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -152,6 +152,7 @@ func (s *Server) Register(r *mux.Router) {
 	r.HandleFunc("/api/projects/{project}/messages/stream", s.createProjectMessageStream).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/{project}/template", s.putProjectTemplate).Methods(http.MethodPut)
 	r.HandleFunc("/api/projects/{project}/promotion", s.getProjectPromotion).Methods(http.MethodGet)
+	r.HandleFunc("/api/projects/{project}/checkpoints", s.getProjectCheckpoints).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/{project}/promote", s.promoteProjectHandler).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/{project}/hydrate-workspace", s.hydrateProjectWorkspace).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/{project}/sync-development", s.syncProjectDevelopment).Methods(http.MethodPost)

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -37,6 +37,7 @@ import {
 } from './createReadiness'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import StatusBadge from '@/components/StatusBadge.vue'
+import CheckpointChip from '@/components/CheckpointChip.vue'
 import { useEscapeKey } from '@/composables/useEscapeKey'
 import {
   activateWorkbenchTab,
@@ -68,6 +69,7 @@ import type {
   ProjectRepositoryCommit,
   ProjectMessageStreamEvent,
   ProjectPromotionReadiness,
+  ProjectCheckpoint,
   ProviderItem,
 } from './types'
 
@@ -321,6 +323,7 @@ const publishingAccess = ref<'public' | 'members' | 'private'>('members')
 
 // Promote to Prod (the publishing tab's real action): read build readiness +
 // the live production environment, and stand up / redeploy production.
+const checkpoints = ref<ProjectCheckpoint[]>([])
 const promotion = ref<ProjectPromotionReadiness | null>(null)
 const promotionBusy = ref(false)
 const promotionError = ref<string | null>(null)
@@ -1158,6 +1161,43 @@ async function loadPromotion() {
   schedulePromotionPoll()
 }
 
+// Lifecycle checkpoints (Template / Git / CI / Production) shown as header chips.
+async function loadCheckpoints() {
+  const name = selected.value?.name
+  if (!name) {
+    checkpoints.value = []
+    return
+  }
+  try {
+    const resp = await api.getCheckpoints(props.ctx, name)
+    checkpoints.value = resp.items ?? []
+  } catch (err) {
+    if (!isProjectAPIInitializingError(err)) {
+      checkpoints.value = []
+    }
+  }
+}
+
+// Clicking a not-yet-done checkpoint chip advances it: "auto" remediation seeds
+// the assistant with a request to fix it; "manual" routes the user to the
+// action they must take themselves (connect Git, click Promote).
+function actOnCheckpoint(cp: ProjectCheckpoint) {
+  const rem = cp.remediation
+  if (!rem) return
+  if (rem.kind === 'manual') {
+    if (cp.key === 'production') {
+      openBuiltInWorkbenchTab('publishing')
+      return
+    }
+    const url = rem.actionUrl || (cp.key === 'git' ? CODE_CONNECTIONS_URL : '')
+    if (url) window.location.assign(url)
+    return
+  }
+  // auto: seed the chat composer so the user can review and send.
+  const detail = cp.remediation?.message || cp.reason || ''
+  prompt.value = `Advance the "${cp.label}" checkpoint${detail ? `: ${detail}` : '.'}`
+}
+
 async function promoteToProd() {
   const name = selected.value?.name
   if (!name || !canPromote.value) return
@@ -1176,6 +1216,7 @@ async function promoteToProd() {
   try {
     await api.promoteProject(props.ctx, name, values)
     await loadPromotion()
+    void loadCheckpoints()
   } catch (err) {
     promotionError.value = err instanceof Error ? err.message : String(err)
   } finally {
@@ -1193,6 +1234,16 @@ watch(
       clearPromotionPoll()
     }
   },
+)
+
+// Refresh lifecycle checkpoints whenever the open project changes.
+watch(
+  () => selected.value?.name,
+  (name) => {
+    if (name) void loadCheckpoints()
+    else checkpoints.value = []
+  },
+  { immediate: true },
 )
 
 onBeforeUnmount(clearPromotionPoll)
@@ -2107,6 +2158,9 @@ async function sendMessage() {
     conversationStatus.value = ''
     messageStreaming.value = false
     busy.value = false
+    // The assistant may have advanced a checkpoint (selected a template,
+    // committed CI, …); refresh the header chips to reflect it.
+    void loadCheckpoints()
   }
 }
 
@@ -3385,6 +3439,14 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
               <span class="truncate">{{ selected?.description || selected?.name || 'App Studio project' }}</span>
             </template>
           </div>
+        </div>
+        <div v-if="checkpoints.length" class="hidden shrink-0 items-center gap-1.5 sm:flex">
+          <CheckpointChip
+            v-for="cp in checkpoints"
+            :key="cp.key"
+            :checkpoint="cp"
+            @act="actOnCheckpoint"
+          />
         </div>
         <button
           type="button"

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -14,6 +14,7 @@ import type {
   ProjectMessageStreamControlEvent,
   ProjectMessageStreamEvent,
   ProjectMessagesPage,
+  ProjectCheckpoints,
   ProjectPromotionReadiness,
   ProjectPromoteResult,
   ProviderItem,
@@ -641,6 +642,14 @@ export const api = {
       ctx,
       'GET',
       `${baseURL(ctx)}/${encodeURIComponent(name)}/promotion`,
+    )
+  },
+
+  async getCheckpoints(ctx: KedgeContext | null, name: string): Promise<ProjectCheckpoints> {
+    return request<ProjectCheckpoints>(
+      ctx,
+      'GET',
+      `${baseURL(ctx)}/${encodeURIComponent(name)}/checkpoints`,
     )
   },
 

--- a/providers/app-studio/portal/src/components/CheckpointChip.vue
+++ b/providers/app-studio/portal/src/components/CheckpointChip.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { CheckCircle, Clock, AlertTriangle, Lock } from 'lucide-vue-next'
+import type { ProjectCheckpoint } from '../types'
+
+const props = defineProps<{ checkpoint: ProjectCheckpoint }>()
+const emit = defineEmits<{ (e: 'act', checkpoint: ProjectCheckpoint): void }>()
+
+const config = computed(() => {
+  switch (props.checkpoint.state) {
+    case 'done':
+      return { bg: 'bg-success-subtle', text: 'text-success', icon: CheckCircle, dot: 'bg-success' }
+    case 'error':
+      return { bg: 'bg-danger-subtle', text: 'text-danger', icon: AlertTriangle, dot: 'bg-danger' }
+    case 'blocked':
+      return { bg: 'bg-surface-overlay', text: 'text-text-muted', icon: Lock, dot: 'bg-text-muted' }
+    default: // pending
+      return { bg: 'bg-warning-subtle', text: 'text-warning', icon: Clock, dot: 'bg-warning' }
+  }
+})
+
+// A checkpoint is actionable when it is not yet done and has a remediation.
+const actionable = computed(
+  () => props.checkpoint.state !== 'done' && !!props.checkpoint.remediation,
+)
+
+const title = computed(() => {
+  const parts = [props.checkpoint.reason]
+  const message = props.checkpoint.remediation?.message
+  if (message && message !== props.checkpoint.reason) parts.push(message)
+  return parts.filter(Boolean).join(' — ')
+})
+</script>
+
+<template>
+  <button
+    type="button"
+    :disabled="!actionable"
+    :title="title"
+    class="inline-flex items-center gap-1.5 rounded-full border border-current/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide transition-colors duration-150"
+    :class="[config.bg, config.text, actionable ? 'cursor-pointer hover:brightness-110' : 'cursor-default']"
+    @click="actionable && emit('act', checkpoint)"
+  >
+    <component :is="config.icon" class="h-3 w-3" :stroke-width="2" />
+    {{ checkpoint.label }}
+  </button>
+</template>

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -264,6 +264,26 @@ export interface ProjectPromotionReadiness {
   production?: ProjectProviderBinding
 }
 
+// One of the four project lifecycle checkpoints (template, git, ci, production).
+// state: done | pending | blocked | error.
+export interface ProjectCheckpoint {
+  key: string
+  label: string
+  state: string
+  reason?: string
+  remediation?: {
+    kind: string // auto | manual
+    tool?: string
+    actionUrl?: string
+    message?: string
+  }
+}
+
+// Result of GET /api/projects/{name}/checkpoints.
+export interface ProjectCheckpoints {
+  items: ProjectCheckpoint[]
+}
+
 // Result of POST /api/projects/{name}/promote.
 export interface ProjectPromoteResult {
   environment: string


### PR DESCRIPTION
## What

Surfaces the four gates a project passes through — **Template bound → Git established → CI committed → Production running** — as a single computed aggregation that three consumers share: header chips, the assistant, and a REST endpoint.

Compute-only: no CRD schema change, no new write paths. State is derived on demand from the same primitives the portal already reads (repository view, build check, production binding), so the chips, the promotion form, and the assistant can't disagree.

## Checkpoints

| Checkpoint | `done` when | remediation |
|---|---|---|
| Template | `Spec.Template` set | **auto** → `select_project_template` |
| Git | repository status `Ready` | **auto** → `hydrate_workspace`; **manual** (connect Git) when the connection is missing |
| CI | a `Succeeded` RepositoryCommit exists | **auto** → `commit_project_files` (message flags the `workflow`-scope trap) |
| Production | prod binding phase `Ready` | **manual** → click Promote; **blocked** (auto build-fix) until the build is green |

Each checkpoint returns `{ key, label, state, reason, remediation }` where `state ∈ done|pending|blocked|error` and `remediation.kind ∈ auto|manual`.

## Backend

- `providers/app-studio/api/project_checkpoints.go` (new) — `GET /api/projects/{project}/checkpoints`.
- `get_project_checkpoints` assistant tool: the agent reads where a project stands and advances `auto` checkpoints via the named tool, or tells the user the exact manual action (promotion is a button the user clicks).

## Frontend

- `CheckpointChip.vue` (new) — state-colored pill (done/pending/blocked/error) with a reason tooltip; clickable only when actionable.
- Four chips in the project detail header. Clicking an `auto` checkpoint seeds the chat composer with an advance-this-checkpoint prompt (user reviews, then sends); `manual` routes to the Git connections page or the Publishing tab.
- Chips refresh on project switch, after an assistant run, and after promote.

## Notes / for review

- **CI-committed signal** is defined as "a `Succeeded` commit exists" (App Studio commits the generated workflow with the source). If we'd rather it strictly mean "`.github/workflows` present," that's a small change to the check.
- Chip row is hidden below the `sm` breakpoint to avoid crowding the header on narrow panes.

## Test

`go build ./...` and `vue-tsc --noEmit` + `vite build` all pass. Exercise locally: open a project and watch the header — fresh project shows Template/Git pending; committing flips CI green; a green build turns Production amber ("ready to promote").

🤖 Generated with [Claude Code](https://claude.com/claude-code)