### PR TITLE
fix(agents): re-arm schedule nextRun when the spec is edited

### DIFF
--- a/providers/agents/api/background.go
+++ b/providers/agents/api/background.go
@@ -256,14 +256,35 @@ func (b *background) process(ctx context.Context, u *unstructured.Unstructured, 
 		return nil
 	}
 
+	// A spec edit bumps metadata.generation. The stored nextRun was computed
+	// from the previous cron/timezone/runAt, so it is stale — drop it and let
+	// scheduleDue re-derive the next fire time from the new spec. Without this
+	// an edited schedule keeps firing (or waiting) on its old clock until it
+	// happens to fire once and recomputes.
+	genChanged := u.GetGeneration() != sched.Status.ObservedGeneration
+	if genChanged {
+		sched.Status.NextRun = nil
+	}
+
 	fire, next, permErr := scheduleDue(sched, now)
 	if permErr != nil {
-		return b.updateStatus(ctx, clusterID, u, map[string]any{"disabledReason": permErr.Error()})
+		return b.updateStatus(ctx, clusterID, u, map[string]any{
+			"disabledReason":     permErr.Error(),
+			"observedGeneration": u.GetGeneration(),
+		})
 	}
 	if !fire {
-		// Initialize nextRun on first sight so the UI shows it.
+		// Persist a freshly-armed nextRun on first sight or after a spec edit,
+		// and record the observed generation so the re-arm happens exactly once.
+		fields := map[string]any{}
+		if genChanged {
+			fields["observedGeneration"] = u.GetGeneration()
+		}
 		if sched.Status.NextRun == nil && !next.IsZero() {
-			return b.updateStatus(ctx, clusterID, u, map[string]any{"nextRun": next.Format(time.RFC3339)})
+			fields["nextRun"] = next.Format(time.RFC3339)
+		}
+		if len(fields) > 0 {
+			return b.updateStatus(ctx, clusterID, u, fields)
 		}
 		return nil
 	}
@@ -271,6 +292,9 @@ func (b *background) process(ctx context.Context, u *unstructured.Unstructured, 
 	// Claim: advance lastRun/nextRun with the listed resourceVersion. A
 	// conflict means another replica claimed this fire — skip silently.
 	claim := map[string]any{"lastRun": now.Format(time.RFC3339)}
+	if genChanged {
+		claim["observedGeneration"] = u.GetGeneration()
+	}
 	if !next.IsZero() {
 		claim["nextRun"] = next.Format(time.RFC3339)
 	}

--- a/providers/agents/api/background_test.go
+++ b/providers/agents/api/background_test.go
@@ -75,6 +75,31 @@ func TestScheduleDue(t *testing.T) {
 		}
 	})
 
+	t.Run("edited cron re-arms from new spec once stale nextRun is dropped", func(t *testing.T) {
+		// Regression: a schedule first created with a "soon" test cron fires and
+		// stores nextRun at that old cadence. The user then retimes it to
+		// "0 9 * * *" Europe/Vilnius. process() detects the generation bump and
+		// drops the stale nextRun; scheduleDue must then re-derive the next fire
+		// from the NEW spec (09:00 Vilnius = 06:00 UTC) rather than honoring the
+		// old value or firing immediately.
+		s := mkSched("cron", "0 9 * * *", "Europe/Vilnius")
+		stale := metav1.NewTime(now.Add(-2 * time.Hour)) // old cadence, in the past
+		s.Status.NextRun = &stale
+
+		// process() nils NextRun when generation != observedGeneration.
+		s.Status.NextRun = nil
+
+		fire, next, err := scheduleDue(s, now)
+		if err != nil || fire {
+			t.Fatalf("fire=%v err=%v, want re-arm without firing", fire, err)
+		}
+		// now is 09:00 UTC = 12:00 Vilnius, so 09:00 Vilnius already passed today;
+		// the next fire is tomorrow 09:00 Vilnius = 06:00 UTC on the 14th.
+		if !next.Equal(time.Date(2026, 7, 14, 6, 0, 0, 0, time.UTC)) {
+			t.Fatalf("next=%v, want 06:00 UTC on the 14th (09:00 Vilnius)", next)
+		}
+	})
+
 	t.Run("bad cron is a permanent error", func(t *testing.T) {
 		s := mkSched("cron", "not-a-cron", "")
 		if _, _, err := scheduleDue(s, now); err == nil {

--- a/providers/agents/apis/v1alpha1/types_schedule.go
+++ b/providers/agents/apis/v1alpha1/types_schedule.go
@@ -115,6 +115,13 @@ type ScheduleRetryPolicy struct {
 
 // AgentScheduleStatus is the observed schedule state.
 type AgentScheduleStatus struct {
+	// ObservedGeneration is the spec generation the scheduler last reconciled.
+	// When it lags metadata.generation the schedule was edited, and the
+	// scheduler re-derives NextRun from the new spec instead of honoring the
+	// stale value computed from the previous cron/timezone/runAt.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// NextRun is the next planned fire time.
 	// +optional
 	NextRun *metav1.Time `json:"nextRun,omitempty"`

--- a/providers/agents/config/crds/agents.kedge.faros.sh_agentschedules.yaml
+++ b/providers/agents/config/crds/agents.kedge.faros.sh_agentschedules.yaml
@@ -146,6 +146,14 @@ spec:
                 description: NextRun is the next planned fire time.
                 format: date-time
                 type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the spec generation the scheduler last reconciled.
+                  When it lags metadata.generation the schedule was edited, and the
+                  scheduler re-derives NextRun from the new spec instead of honoring the
+                  stale value computed from the previous cron/timezone/runAt.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/providers/agents/config/kcp/apiexport-agents.kedge.faros.sh.yaml
+++ b/providers/agents/config/kcp/apiexport-agents.kedge.faros.sh.yaml
@@ -16,7 +16,7 @@ spec:
       crd: {}
   - group: agents.kedge.faros.sh
     name: agentschedules
-    schema: v260712-dabfd8e.agentschedules.agents.kedge.faros.sh
+    schema: v260714-2b7a0f5.agentschedules.agents.kedge.faros.sh
     storage:
       crd: {}
   - group: agents.kedge.faros.sh

--- a/providers/agents/config/kcp/apiresourceschema-agentschedules.agents.kedge.faros.sh.yaml
+++ b/providers/agents/config/kcp/apiresourceschema-agentschedules.agents.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260712-dabfd8e.agentschedules.agents.kedge.faros.sh
+  name: v260714-2b7a0f5.agentschedules.agents.kedge.faros.sh
 spec:
   group: agents.kedge.faros.sh
   names:
@@ -141,6 +141,14 @@ spec:
               description: NextRun is the next planned fire time.
               format: date-time
               type: string
+            observedGeneration:
+              description: |-
+                ObservedGeneration is the spec generation the scheduler last reconciled.
+                When it lags metadata.generation the schedule was edited, and the
+                scheduler re-derives NextRun from the new spec instead of honoring the
+                stale value computed from the previous cron/timezone/runAt.
+              format: int64
+              type: integer
           type: object
       type: object
     served: true

--- a/providers/agents/deploy/chart/files/schemas/agentschedules.agents.kedge.faros.sh.yaml
+++ b/providers/agents/deploy/chart/files/schemas/agentschedules.agents.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260712-dabfd8e.agentschedules.agents.kedge.faros.sh
+  name: v260714-2b7a0f5.agentschedules.agents.kedge.faros.sh
 spec:
   group: agents.kedge.faros.sh
   names:
@@ -141,6 +141,14 @@ spec:
               description: NextRun is the next planned fire time.
               format: date-time
               type: string
+            observedGeneration:
+              description: |-
+                ObservedGeneration is the spec generation the scheduler last reconciled.
+                When it lags metadata.generation the schedule was edited, and the
+                scheduler re-derives NextRun from the new spec instead of honoring the
+                stale value computed from the previous cron/timezone/runAt.
+              format: int64
+              type: integer
           type: object
       type: object
     served: true

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -179,6 +179,10 @@ kedge-provider-agents .agents-badge:first-child { margin-left: 0; }
 kedge-provider-agents .agents-badge-muted { opacity: 0.75; font-style: italic; }
 kedge-provider-agents .agents-empty-row td { text-align: center; padding: 22px 10px; }
 kedge-provider-agents .agents-empty { color: var(--color-text-muted, inherit); font-size: 13px; }
+/* The inline empty-row span reuses .agents-empty for muted text but must not
+   pick up the full-panel empty-state layout (flex + min-height:340px), which
+   would blow the empty table up to ~half the screen. */
+kedge-provider-agents .agents-empty-row .agents-empty { display: inline; flex: none; min-height: 0; }
 kedge-provider-agents .agents-check { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 kedge-provider-agents .agents-check input { width: auto; }
 kedge-provider-agents .agents-form-actions { display: flex; gap: 8px; }


### PR DESCRIPTION
## Problem

An `AgentSchedule` retimed via the portal keeps firing on its **old** clock. A user set `news` to `0 9 * * *` **Europe/Vilnius** (09:00 → 06:00 UTC), but 09:00 came and went with no run.

Root cause: the background scheduler only (re)computes `status.nextRun` when a schedule **fires** or when `nextRun` is **unset**. It never revisits `nextRun` on a spec change. So a schedule first created with a "soon" test cron fires once, stores `nextRun` at that cadence, and — after the user edits the cron/timezone — keeps waiting on that stale value.

Live evidence from the affected schedule:

```
spec:   schedule: "0 9 * * *"   timeZone: Europe/Vilnius
status: lastRun:  2026-07-13T18:05:18Z
        nextRun:  2026-07-14T18:05:00Z   # = lastRun + 24h, NOT derivable from "0 9"
```

A `0 9 * * *` cron (minute `0`) can never produce a `nextRun` ending in `:05:00` — it's a leftover from the schedule's original test spec.

## Fix

Track `status.observedGeneration`. When it lags `metadata.generation` the spec was edited, so:
- drop the stale `nextRun` and let `scheduleDue` re-derive the next fire from the new cron/timezone/runAt,
- never fire on the edit tick (re-arm only),
- stamp `observedGeneration` so the re-arm happens exactly once (covered on the fire, permanent-error, and not-due paths).

Existing schedules (unset `observedGeneration`) **self-heal** on the first reconcile after rollout.

## Changes
- `apis/v1alpha1/types_schedule.go` — add `AgentScheduleStatus.ObservedGeneration`
- `api/background.go` — re-arm gate in `process()`
- regenerated CRD / kcp APIResourceSchema / chart schema (`make codegen-agents-provider`)
- `api/background_test.go` — regression test for the edit-then-re-arm path

## Testing
- `go build ./...`, `go vet`, `go test ./api/... ./apis/...` pass
- Verified live: clearing the stale `nextRun` on the affected schedule made the scheduler recompute it to `2026-07-15T06:00:00Z` (09:00 Vilnius) as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)