### PR TITLE
feat(agents): Flow tools composition + collapse Tools/Toolset naming

### DIFF
--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -10,7 +10,7 @@
 // sidebar footer — they live outside any single agent.
 
 import { FlowCanvas } from './flow'
-import type { FlowModel, FNode, FNodeType, FWire, FlowCallbacks, DraftSpec } from './flow'
+import type { FlowModel, FNode, FWire, FlowCallbacks, DraftSpec } from './flow'
 
 export interface KedgeContext {
   token?: string | null
@@ -1096,11 +1096,12 @@ export class AgentsElement extends HTMLElement {
   // The create-form spec for a draggable node type (null = not a standalone
   // object). Schedule/trigger/model wire straight into the agent; a connection
   // stands alone until you wire it.
-  private _flowDraftFor(t: FNodeType): DraftSpec | null {
+  private _flowDraftFor(key: string): DraftSpec | null {
     const nameField = { key: 'name', label: 'Name', kind: 'text' as const, placeholder: 'lowercase-with-dashes', hint: 'a-z, 0-9 and dashes' }
-    if (t === 'schedule')
+    if (key === 'schedule')
       return {
         title: 'new schedule',
+        nodeType: 'schedule',
         ins: [],
         outs: ['fire'],
         outPort: 'fire',
@@ -1112,9 +1113,10 @@ export class AgentsElement extends HTMLElement {
           { key: 'task', label: 'Task', kind: 'textarea', placeholder: 'Summarise today’s open PRs and post to my channel.' },
         ],
       }
-    if (t === 'trigger')
+    if (key === 'trigger')
       return {
         title: 'new trigger',
+        nodeType: 'trigger',
         ins: ['src'],
         outs: ['fire'],
         outPort: 'fire',
@@ -1126,9 +1128,10 @@ export class AgentsElement extends HTMLElement {
           { key: 'task', label: 'Task on fire', kind: 'textarea', placeholder: 'Triage the incoming event.' },
         ],
       }
-    if (t === 'model')
+    if (key === 'model')
       return {
         title: 'new model',
+        nodeType: 'model',
         ins: [],
         outs: ['infer'],
         outPort: 'infer',
@@ -1141,21 +1144,52 @@ export class AgentsElement extends HTMLElement {
           { key: 'apiKey', label: 'API key', kind: 'text', mono: true, placeholder: 'sk-…', hint: 'stored as a Secret' },
         ],
       }
-    if (t === 'connection')
+    if (key === 'connection')
       return {
         title: 'new connection',
+        nodeType: 'connection',
         ins: ['notify'],
         outs: ['events'],
         fields: [
           nameField,
-          { key: 'type', label: 'Type', kind: 'select', value: 'github', options: Object.keys(CONN_CATEGORY).map((v) => ({ value: v, label: v })) },
+          { key: 'type', label: 'Type', kind: 'select', value: 'discord', options: Object.keys(CONN_CATEGORY).map((v) => ({ value: v, label: v })) },
           { key: 'displayName', label: 'Display name', kind: 'text', placeholder: 'optional' },
         ],
       }
-    if (t === 'toolset')
+    // Tool nodes: tool-type Connections. Wire one into a Toolset to enable it.
+    if (key === 'tool-mcp')
+      return {
+        title: 'new mcp tool',
+        nodeType: 'tool',
+        ins: [],
+        outs: ['events'],
+        fields: [
+          nameField,
+          { key: 'baseURL', label: 'MCP server URL', kind: 'text', mono: true, placeholder: 'https://host/mcp', hint: 'the remote MCP endpoint' },
+          { key: 'displayName', label: 'Display name', kind: 'text', placeholder: 'optional' },
+        ],
+      }
+    if (key === 'tool-github')
+      return {
+        title: 'new github tool',
+        nodeType: 'tool',
+        ins: [],
+        outs: ['events'],
+        fields: [nameField, { key: 'displayName', label: 'Display name', kind: 'text', placeholder: 'optional' }],
+      }
+    if (key === 'tool-web')
+      return {
+        title: 'web search',
+        nodeType: 'tool',
+        ins: [],
+        outs: ['events'],
+        fields: [nameField, { key: 'displayName', label: 'Display name', kind: 'text', placeholder: 'optional' }],
+      }
+    if (key === 'toolset')
       return {
         title: 'new toolset',
-        ins: ['conn'],
+        nodeType: 'toolset',
+        ins: ['tool'],
         outs: ['use'],
         outPort: 'use',
         agentPort: 'tools',
@@ -1164,10 +1198,10 @@ export class AgentsElement extends HTMLElement {
           { key: 'displayName', label: 'Display name', kind: 'text', placeholder: 'e.g. dev-tools' },
           {
             key: 'families',
-            label: 'Families',
+            label: 'Built-in families',
             kind: 'chips',
             chips: ['web', 'github', 'mcp', 'edges'].map((f) => ({ value: f, label: f, on: false })),
-            hint: 'A shared bundle. Wire connections into it after creating.',
+            hint: 'A shared bundle. Wire tools into it after creating.',
           },
         ],
       }
@@ -1175,7 +1209,7 @@ export class AgentsElement extends HTMLElement {
   }
 
   // Write the object a draft describes; return its real flow-node id on success.
-  private async _flowCreate(t: FNodeType, values: Record<string, string | string[]>): Promise<string | null> {
+  private async _flowCreate(key: string, values: Record<string, string | string[]>): Promise<string | null> {
     const s = (k: string): string => String(values[k] ?? '').trim()
     const name = s('name')
     if (!/^[a-z0-9-]+$/.test(name)) {
@@ -1184,29 +1218,36 @@ export class AgentsElement extends HTMLElement {
     }
     const agent = this._selected as string
     try {
-      if (t === 'schedule') {
+      if (key === 'schedule') {
         await this._send('POST', '/api/schedules', { name, agentRef: agent, type: 'cron', schedule: s('schedule'), timeZone: s('timeZone'), task: s('task') })
         await this._loadSchedules()
         return 'sched:' + name
       }
-      if (t === 'trigger') {
+      if (key === 'trigger') {
         await this._send('POST', '/api/triggers', { name, agentRef: agent, source: s('source') || 'webhook', connectionRef: s('connectionRef'), task: s('task') })
         await this._loadTriggers()
         return 'trig:' + name
       }
-      if (t === 'model') {
+      if (key === 'model') {
         await this._send('POST', '/api/credentials', { name, provider: s('provider'), baseURL: s('baseURL'), model: s('model'), apiKey: s('apiKey') })
         await this._send('PUT', `/api/agents/${encodeURIComponent(agent)}`, { modelCredential: name })
         await this._loadCredentials()
         await this._loadAgents()
         return 'model:' + name
       }
-      if (t === 'connection') {
+      if (key === 'connection') {
         await this._send('POST', '/api/connections', { name, type: s('type'), displayName: s('displayName') })
         await this._loadConnections()
         return 'conn:' + name
       }
-      if (t === 'toolset') {
+      // Tools are tool-type Connections.
+      const toolType: Record<string, string> = { 'tool-mcp': 'mcp', 'tool-github': 'github', 'tool-web': 'websearch' }
+      if (key in toolType) {
+        await this._send('POST', '/api/connections', { name, type: toolType[key], baseURL: s('baseURL'), displayName: s('displayName') })
+        await this._loadConnections()
+        return 'conn:' + name
+      }
+      if (key === 'toolset') {
         const families = ['core', ...((values.families as string[]) || [])]
         await this._send('POST', '/api/toolsets', { name, displayName: s('displayName'), families })
         // link the new toolset to this agent's interactive tools
@@ -1258,6 +1299,13 @@ export class AgentsElement extends HTMLElement {
         { key: 'displayName', label: 'Display name', kind: 'text', value: a.spec?.displayName || name },
         { key: 'systemPrompt', label: 'System prompt', kind: 'textarea', value: a.spec?.systemPrompt || '', placeholder: 'You are a concise assistant that…' },
         { key: 'autonomy', label: 'Autonomy', kind: 'select', value: a.spec?.autonomy || 'ask', options: ['suggest', 'ask', 'auto'].map((v) => ({ value: v, label: v })) },
+        {
+          key: 'families',
+          label: 'Built-in tools',
+          kind: 'chips',
+          chips: ['web', 'github', 'mcp', 'edges'].map((f) => ({ value: f, label: f, on: new Set(a.spec?.tools?.interactive?.families || ['core', 'web', 'github', 'mcp', 'edges']).has(f) })),
+          hint: 'Capabilities this agent has directly. Link a Toolset for shared bundles.',
+        },
       ],
     })
 
@@ -1343,30 +1391,10 @@ export class AgentsElement extends HTMLElement {
       wires.push({ from: [id, 'infer'], to: ['agent', 'model'] })
     }
 
-    // built-in tools (the agent's own inline families — always present)
+    // The agent's own built-in families live on the Agent node's settings
+    // (see fields above) — not a separate bundle node — so "Tool" and "Toolset"
+    // stay the only two tool concepts on the canvas.
     const known = ['core', 'web', 'github', 'mcp', 'edges']
-    const inter = new Set(a.spec?.tools?.interactive?.families || ['core', 'web', 'github', 'mcp', 'edges'])
-    const fams = known.filter((f) => f !== 'core' && inter.has(f))
-    nodes.push({
-      id: 'tools',
-      type: 'tools',
-      title: 'built-in tools',
-      ins: [],
-      outs: ['use'],
-      tags: fams.length ? fams : undefined,
-      sub: fams.length ? undefined : 'no extra tools granted',
-      status: fams.length ? ['ok', fams.length + ' families'] : ['off', 'core only'],
-      fields: [
-        {
-          key: 'families',
-          label: 'Capability families',
-          kind: 'chips',
-          chips: known.filter((f) => f !== 'core').map((f) => ({ value: f, label: f, on: inter.has(f) })),
-          hint: 'This agent’s own families. Core memory/notify is always on.',
-        },
-      ],
-    })
-    wires.push({ from: ['tools', 'use'], to: ['agent', 'tools'] })
 
     // toolsets (shared bundles; all render, linked ones wire into agent.tools)
     const linked = new Set([...(a.spec?.tools?.interactive?.toolsets || []), ...(a.spec?.tools?.background?.toolsets || [])])
@@ -1379,39 +1407,45 @@ export class AgentsElement extends HTMLElement {
         id,
         type: 'toolset',
         title: ts.spec.displayName || tn,
-        ins: ['conn'],
+        ins: ['tool'],
         outs: ['use'],
         tags: tfams.length ? tfams.filter((f) => f !== 'core') : undefined,
-        sub: ts.spec.description ? escapeHTML(ts.spec.description) : `<span class="mono">shared</span>${tconns.length ? ` · ${tconns.length} connection${tconns.length === 1 ? '' : 's'}` : ''}`,
+        sub: ts.spec.description ? escapeHTML(ts.spec.description) : `<span class="mono">shared</span>${tconns.length ? ` · ${tconns.length} tool${tconns.length === 1 ? '' : 's'}` : ''}`,
         status: linked.has(tn) ? ['ok', 'linked'] : ['off', 'available'],
         canDelete: true,
         fields: [
           { key: 'displayName', label: 'Display name', kind: 'text', value: ts.spec.displayName || tn },
-          { key: 'families', label: 'Families', kind: 'chips', chips: known.filter((f) => f !== 'core').map((f) => ({ value: f, label: f, on: tfams.includes(f) })) },
-          { key: 'connections', label: 'Connections', kind: 'static', value: tconns.join(', ') || '— drag a connection’s events port here —' },
+          { key: 'families', label: 'Built-in families', kind: 'chips', chips: known.filter((f) => f !== 'core').map((f) => ({ value: f, label: f, on: tfams.includes(f) })) },
+          { key: 'connections', label: 'Tools', kind: 'static', value: tconns.join(', ') || '— drag a tool here —' },
         ],
       })
       if (linked.has(tn)) wires.push({ from: [id, 'use'], to: ['agent', 'tools'] })
-      for (const cn of tconns) if (this._connections.some((c) => c.metadata.name === cn)) wires.push({ from: ['conn:' + cn, 'events'], to: [id, 'conn'] })
+      for (const cn of tconns) if (this._connections.some((c) => c.metadata.name === cn)) wires.push({ from: ['conn:' + cn, 'events'], to: [id, 'tool'] })
     }
 
-    // connections (real wiring hubs: events → triggers, notify ← agent)
+    // connections: tool-category ones (mcp/github/websearch) render as Tool
+    // nodes; channel ones as Connection nodes (notify sink + event source).
     for (const c of this._connections) {
       const cn = c.metadata.name
-      const isChannel = CONN_CATEGORY[c.spec.type] === 'channel'
+      const cat = CONN_CATEGORY[c.spec.type]
+      const isChannel = cat === 'channel'
+      const isTool = cat === 'tool'
       const id = 'conn:' + cn
       const used = usedConns.has(cn)
+      const webish = c.spec.type === 'websearch'
       nodes.push({
         id,
-        type: 'connection',
-        title: cn,
+        type: isTool ? 'tool' : 'connection',
+        title: c.spec.displayName || cn,
         ins: isChannel ? ['notify'] : [],
         outs: ['events'],
-        sub: `<span class="mono">${escapeHTML(c.spec.type)}</span>${c.status?.oauthConnected ? ' · connected' : used ? '' : ' · unwired'}`,
-        status: c.status?.oauthConnected || c.status?.phase === 'Ready' ? ['ok', 'connected'] : ['warn', c.status?.phase || 'setup'],
+        sub: `<span class="mono">${escapeHTML(c.spec.type)}</span>${c.status?.oauthConnected ? ' · connected' : webish ? '' : used ? '' : ' · unwired'}`,
+        status: c.status?.oauthConnected || c.status?.phase === 'Ready' || webish ? ['ok', webish ? 'ready' : 'connected'] : ['warn', c.status?.phase || 'setup'],
+        canDelete: isTool,
         fields: [
           { key: 'type', label: 'Type', kind: 'static', value: c.spec.type },
-          { key: 'phase', label: 'Status', kind: 'static', value: c.status?.phase || (c.status?.oauthConnected ? 'connected' : 'setup') },
+          ...(c.spec.baseURL ? [{ key: 'baseURL', label: 'Endpoint', kind: 'static' as const, mono: true, value: c.spec.baseURL }] : []),
+          { key: 'phase', label: 'Status', kind: 'static', value: c.status?.phase || (webish ? 'ready' : c.status?.oauthConnected ? 'connected' : 'setup') },
         ],
       })
       trigs.forEach((t) => {
@@ -1454,6 +1488,11 @@ export class AgentsElement extends HTMLElement {
       take('displayName')
       take('systemPrompt')
       take('autonomy')
+      if ('families' in values) {
+        const fams = ['core', ...((values.families as string[]) || [])]
+        patch.interactiveFamilies = fams
+        patch.backgroundFamilies = fams.filter((f) => f === 'core' || f === 'web')
+      }
       if (Object.keys(patch).length) await this._updateAgent(patch)
     } else if (id.startsWith('sched:')) {
       take('schedule')
@@ -1467,11 +1506,6 @@ export class AgentsElement extends HTMLElement {
       if (Object.keys(patch).length) await this._updateTrigger(id.slice(5), patch)
     } else if (id.startsWith('model:')) {
       if ('modelCredential' in values) await this._updateAgent({ modelCredential: str(values.modelCredential) }, 'Model reassigned.')
-    } else if (id === 'tools') {
-      if ('families' in values) {
-        const fams = ['core', ...((values.families as string[]) || [])]
-        await this._updateAgent({ interactiveFamilies: fams, backgroundFamilies: fams.filter((f) => f === 'core' || f === 'web') })
-      }
     } else if (id.startsWith('toolset:')) {
       const tp: Record<string, unknown> = {}
       if ('displayName' in values) tp.displayName = str(values.displayName)
@@ -1514,29 +1548,36 @@ export class AgentsElement extends HTMLElement {
       await this._loadAgents()
       return
     }
-    // connection.events → toolset.conn : add this connection to the toolset
-    if (fromNode.startsWith('conn:') && toNode.startsWith('toolset:') && toPort === 'conn') {
-      const ts = this._toolsets.find((x) => x.metadata.name === toNode.slice(8))
-      const cur = ts?.spec.connections || []
+    // tool.provide → toolset.tool : add the tool (a tool-type connection) to the
+    // bundle, and enable the matching built-in family so it actually resolves.
+    if (fromNode.startsWith('conn:') && toNode.startsWith('toolset:') && toPort === 'tool') {
+      const tsName = toNode.slice(8)
       const cn = fromNode.slice(5)
-      if (!cur.includes(cn)) return void this._updateToolset(toNode.slice(8), { connections: [...cur, cn] })
+      const conn = this._connections.find((c) => c.metadata.name === cn)
+      const ts = this._toolsets.find((x) => x.metadata.name === tsName)
+      const famFor: Record<string, string> = { mcp: 'mcp', github: 'github', websearch: 'web' }
+      const fam = conn ? famFor[conn.spec.type] : undefined
+      const conns = ts?.spec.connections || []
+      const fams = ts?.spec.families || []
+      const patch: Record<string, unknown> = {}
+      // websearch has no server to dial → enable the 'web' family only.
+      if (conn?.spec.type !== 'websearch' && !conns.includes(cn)) patch.connections = [...conns, cn]
+      if (fam && !fams.includes(fam)) patch.families = [...fams, fam]
+      if (Object.keys(patch).length) return void this._updateToolset(tsName, patch)
       return
     }
-    this._flow?.toast('These ports don’t connect — try schedule/trigger → agent, model → agent, or toolset → agent.')
+    this._flow?.toast('These ports don’t connect — try tool → toolset, toolset → agent, or schedule/trigger → agent.')
   }
 
-  private _flowAdd(type: FNodeType): void {
-    // Creating a resource needs details (name, cron, credentials) — route to the
-    // matching form rather than dropping an incomplete node on the canvas.
-    if (type === 'schedule' || type === 'trigger' || type === 'chat') {
+  private _flowAdd(key: string): void {
+    // Non-creatable palette items route to the matching form.
+    if (key === 'chat') {
       this._agentView = 'list'
-      this._agentTab = type === 'chat' ? 'chat' : (type as AgentTab)
+      this._agentTab = 'chat'
       this._render()
-    } else if (type === 'model') {
-      this._openShared('models')
-    } else if (type === 'connection' || type === 'output') {
+    } else if (key === 'output') {
       this._openShared('connections')
-    } else if (type === 'tools' || type === 'delegate') {
+    } else if (key === 'delegate') {
       this._agentView = 'list'
       this._agentTab = 'settings'
       this._render()

--- a/providers/agents/portal/src/flow.ts
+++ b/providers/agents/portal/src/flow.ts
@@ -14,6 +14,7 @@ export type FNodeType =
   | 'connection'
   | 'model'
   | 'tools'
+  | 'tool'
   | 'toolset'
   | 'output'
   | 'delegate'
@@ -46,12 +47,14 @@ export interface FNode {
   canRun?: boolean
   canDelete?: boolean
   draft?: boolean // unsaved: shows a Create button instead of auto-save
+  createKey?: string // palette key used to create this draft
 }
 
 // DraftSpec describes a new, unsaved node dropped from the palette: the fields
 // to collect before it can be written, and how it wires to the agent.
 export interface DraftSpec {
   title: string
+  nodeType: FNodeType // how the draft node renders (icon/color)
   ins: string[]
   outs: string[]
   fields: FieldSpec[]
@@ -73,17 +76,25 @@ export interface FlowModel {
 export interface FlowCallbacks {
   onEdit(nodeId: string, values: Record<string, string | string[]>): void
   onLink(from: [string, string], to: [string, string]): void
-  onAdd(type: FNodeType): void
+  onAdd(key: string): void
   onRun(nodeId: string): void
   onDelete(nodeId: string): void
   onOpenChat(): void
   onToast(msg: string): void
-  // draftFor returns the create-form spec for a draggable/creatable type, or
-  // null for types that aren't standalone objects (chat/tools/notify/delegate).
-  draftFor(type: FNodeType): DraftSpec | null
+  // draftFor returns the create-form spec for a draggable/creatable palette key,
+  // or null for keys that aren't standalone objects (chat/tools/notify/delegate).
+  draftFor(key: string): DraftSpec | null
   // create writes the object from the draft's values; returns the real node id
   // (e.g. "sched:daily") on success so the canvas can place it, or null on fail.
-  create(type: FNodeType, values: Record<string, string | string[]>): Promise<string | null>
+  create(key: string, values: Record<string, string | string[]>): Promise<string | null>
+}
+
+// PaletteItem is one entry in the left rail: a create-key, its label, and the
+// node type used for its icon/color.
+interface PaletteItem {
+  key: string
+  label: string
+  icon: FNodeType
 }
 
 interface TypeDef {
@@ -100,16 +111,30 @@ const TYPES: Record<FNodeType, TypeDef> = {
   agent: { label: 'Agent', color: '--flow-agent', icon: '<path d="M12 2.5 3.5 7v10L12 21.5 20.5 17V7z"/><circle cx="12" cy="12" r="3.2"/>' },
   model: { label: 'Model', color: '--flow-model', icon: '<rect x="5.5" y="5.5" width="13" height="13" rx="2.5"/><path d="M9 2.5v3M15 2.5v3M9 18.5v3M15 18.5v3M2.5 9h3M2.5 15h3M18.5 9h3M18.5 15h3"/>' },
   tools: { label: 'Tools', color: '--flow-tools', icon: '<path d="M14.5 6.5a3.8 3.8 0 0 1-5 5l-5.5 5.5 2.5 2.5 5.5-5.5a3.8 3.8 0 0 0 5-5l-2.3 2.3-2.2-.5-.5-2.2z"/>' },
+  tool: { label: 'Tool', color: '--flow-tool', icon: '<path d="M14.5 6.5a3.8 3.8 0 0 1-5 5l-5.5 5.5 2.5 2.5 5.5-5.5a3.8 3.8 0 0 0 5-5l-2.3 2.3-2.2-.5-.5-2.2z"/>' },
   toolset: { label: 'Toolset', color: '--flow-toolset', icon: '<path d="M12 2.5 3 7l9 4.5L21 7z"/><path d="M3 12l9 4.5L21 12M3 16.5 12 21l9-4.5"/>' },
   output: { label: 'Notify', color: '--flow-output', icon: '<path d="M6 16.5V11a6 6 0 1 1 12 0v5.5l1.8 1.8H4.2z"/><path d="M10 20.3a2 2 0 0 0 4 0"/>' },
   delegate: { label: 'Delegate', color: '--flow-delegate', icon: '<circle cx="6" cy="6" r="2.2"/><circle cx="6" cy="18" r="2.2"/><circle cx="17.5" cy="9" r="2.2"/><path d="M6 8.2v7.6M6 12h5.5a4 4 0 0 0 4-4"/>' },
 }
 
-const RAIL: [string, FNodeType[]][] = [
-  ['In', ['schedule', 'trigger', 'chat']],
-  ['Brain', ['model', 'tools', 'toolset']],
-  ['Out', ['output', 'delegate']],
-  ['IO', ['connection']],
+const RAIL: [string, PaletteItem[]][] = [
+  ['In', [
+    { key: 'schedule', label: 'Schedule', icon: 'schedule' },
+    { key: 'trigger', label: 'Trigger', icon: 'trigger' },
+    { key: 'chat', label: 'Chat', icon: 'chat' },
+  ]],
+  ['Tools', [
+    { key: 'tool-mcp', label: 'MCP', icon: 'tool' },
+    { key: 'tool-github', label: 'GitHub', icon: 'tool' },
+    { key: 'tool-web', label: 'Web search', icon: 'tool' },
+    { key: 'toolset', label: 'Toolset', icon: 'toolset' },
+  ]],
+  ['Brain', [{ key: 'model', label: 'Model', icon: 'model' }]],
+  ['Out', [
+    { key: 'output', label: 'Notify', icon: 'output' },
+    { key: 'delegate', label: 'Delegate', icon: 'delegate' },
+  ]],
+  ['IO', [{ key: 'connection', label: 'Connection', icon: 'connection' }]],
 ]
 
 const NS = 'http://www.w3.org/2000/svg'
@@ -232,7 +257,7 @@ export class FlowCanvas {
     const colOf = (t: FNodeType): keyof typeof colX =>
       t === 'agent'
         ? 'agent'
-        : t === 'connection'
+        : t === 'connection' || t === 'tool'
           ? 'connection'
           : t === 'output' || t === 'delegate'
             ? 'out'
@@ -524,7 +549,7 @@ export class FlowCanvas {
     }
     const draftId = n.id
     const p = this.pos.get(draftId)
-    const realId = await this.cb.create(n.type, values)
+    const realId = await this.cb.create(n.createKey || n.type, values)
     if (!realId) {
       if (btn) {
         btn.disabled = false
@@ -773,25 +798,25 @@ export class FlowCanvas {
       l.className = 'flow-rlab'
       l.textContent = label
       rail.appendChild(l)
-      for (const type of list) {
+      for (const item of list) {
         const b = document.createElement('button')
         b.className = 'flow-palnode'
-        b.style.setProperty('--nc', cvar(type))
-        b.style.setProperty('--nc-soft', `color-mix(in srgb, ${cvar(type)} 15%, var(--color-surface-raised, #fff))`)
-        b.style.setProperty('--nc-line', `color-mix(in srgb, ${cvar(type)} 40%, var(--color-border-default, #ccc))`)
-        const creatable = !!this.cb.draftFor(type)
+        b.style.setProperty('--nc', cvar(item.icon))
+        b.style.setProperty('--nc-soft', `color-mix(in srgb, ${cvar(item.icon)} 15%, var(--color-surface-raised, #fff))`)
+        b.style.setProperty('--nc-line', `color-mix(in srgb, ${cvar(item.icon)} 40%, var(--color-border-default, #ccc))`)
+        const creatable = !!this.cb.draftFor(item.key)
         b.classList.toggle('draggable', creatable)
-        b.innerHTML = `<span class="chip">${svgIcon(type)}</span><span>${TYPES[type].label}</span>`
-        if (creatable) this.wirePaletteDrag(b, type)
-        else b.onclick = () => this.cb.onAdd(type)
+        b.innerHTML = `<span class="chip">${svgIcon(item.icon)}</span><span>${item.label}</span>`
+        if (creatable) this.wirePaletteDrag(b, item.key, item.icon)
+        else b.onclick = () => this.cb.onAdd(item.key)
         rail.appendChild(b)
       }
     }
   }
 
-  // A palette item for a creatable type: click drops a draft at canvas centre;
+  // A palette item for a creatable key: click drops a draft at canvas centre;
   // drag drops it where released. Either way the draft opens for editing.
-  private wirePaletteDrag(b: HTMLElement, type: FNodeType): void {
+  private wirePaletteDrag(b: HTMLElement, key: string, icon: FNodeType): void {
     b.onpointerdown = (e) => {
       e.preventDefault()
       const sx = e.clientX
@@ -801,8 +826,8 @@ export class FlowCanvas {
         if (!ghost && Math.hypot(ev.clientX - sx, ev.clientY - sy) > 6) {
           ghost = document.createElement('div')
           ghost.className = 'flow-ghost'
-          ghost.style.setProperty('--nc', cvar(type))
-          ghost.innerHTML = `<span class="flow-nic">${svgIcon(type)}</span>${TYPES[type].label}`
+          ghost.style.setProperty('--nc', cvar(icon))
+          ghost.innerHTML = `<span class="flow-nic">${svgIcon(icon)}</span>${TYPES[icon].label}`
           document.body.appendChild(ghost)
         }
         if (ghost) {
@@ -822,7 +847,7 @@ export class FlowCanvas {
           dropped && over
             ? { x: (ev.clientX - r.left - this.view.x) / this.view.k - NW / 2, y: (ev.clientY - r.top - this.view.y) / this.view.k - 40 }
             : { x: (r.width / 2 - this.view.x) / this.view.k - NW / 2, y: (r.height / 2 - this.view.y) / this.view.k - 40 }
-        if (!dropped || over) this.createDraft(type, world)
+        if (!dropped || over) this.createDraft(key, world)
       }
       window.addEventListener('pointermove', move)
       window.addEventListener('pointerup', up)
@@ -831,11 +856,11 @@ export class FlowCanvas {
 
   // Drop an unsaved draft node, wire it to the agent where applicable, and open
   // its create dialog.
-  private createDraft(type: FNodeType, pos: Pos): void {
-    const spec = this.cb.draftFor(type)
+  private createDraft(key: string, pos: Pos): void {
+    const spec = this.cb.draftFor(key)
     if (!spec) return
-    const id = 'draft:' + type + ':' + ++this.draftSeq
-    const n: FNode = { id, type, title: spec.title, ins: spec.ins, outs: spec.outs, fields: spec.fields, draft: true, canDelete: true }
+    const id = 'draft:' + key + ':' + ++this.draftSeq
+    const n: FNode = { id, type: spec.nodeType, title: spec.title, ins: spec.ins, outs: spec.outs, fields: spec.fields, draft: true, canDelete: true, createKey: key }
     this.pos.set(id, pos)
     this.drafts.push(n)
     if (spec.outPort && spec.agentPort && this.node('agent')) this.draftWires.push({ from: [id, spec.outPort], to: ['agent', spec.agentPort] })

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -179,10 +179,6 @@ kedge-provider-agents .agents-badge:first-child { margin-left: 0; }
 kedge-provider-agents .agents-badge-muted { opacity: 0.75; font-style: italic; }
 kedge-provider-agents .agents-empty-row td { text-align: center; padding: 22px 10px; }
 kedge-provider-agents .agents-empty { color: var(--color-text-muted, inherit); font-size: 13px; }
-/* The inline empty-row span reuses .agents-empty for muted text but must not
-   pick up the full-panel empty-state layout (flex + min-height:340px), which
-   would blow the empty table up to ~half the screen. */
-kedge-provider-agents .agents-empty-row .agents-empty { display: inline; flex: none; min-height: 0; }
 kedge-provider-agents .agents-check { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 kedge-provider-agents .agents-check input { width: auto; }
 kedge-provider-agents .agents-form-actions { display: flex; gap: 8px; }
@@ -314,7 +310,7 @@ kedge-provider-agents .agents-adv[open] { display: flex; flex-direction: column;
 kedge-provider-agents {
   --flow-schedule: #e08a12; --flow-trigger: #7c5cff; --flow-chat: #1a9fe0;
   --flow-agent: #0fb9a3; --flow-model: #5b6bf0; --flow-tools: #16a86b;
-  --flow-toolset: #6f8c1a;
+  --flow-tool: #0891b2; --flow-toolset: #6f8c1a;
   --flow-output: #e5476b; --flow-delegate: #c150dd; --flow-connection: #7a8698;
   --flow-grid: color-mix(in srgb, var(--color-text-muted, #889) 16%, transparent);
 }


### PR DESCRIPTION
Follow-up to #427. Its squash-merge captured the Flow view up to the "Toolset nodes" commit but predated these two portal commits, so `main` is missing them:

1. **Tools composition** — the palette gains a **Tools** group (MCP · GitHub · Web search): each drag-creates a tool-type `Connection`; tool-category connections render as **Tool** nodes; wiring a Tool into a Toolset adds it **and enables the matching built-in family** (mcp→mcp, github→github, websearch→web) so it resolves at run time.
2. **De-confuse Tools/Tool/Toolset** — the old "built-in tools" bundle node read as a duplicate of Toolset. Dropped it; the agent's own families (web/github/mcp/edges) move onto the **Agent node's settings**. The canvas now has exactly two tool concepts: **Tool** (one capability) and **Toolset** (shareable bundle).

Portal only — talks to `/api/toolsets` + `/api/connections`, both already on `main` (from #428/#427). Builds clean (`tsc` + `vite`); verified end-to-end earlier with Playwright against the built bundle (create MCP tool → wire into toolset → link toolset to agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)