### PR TITLE
feat(agents): model fallback chain (spec.modelFallbacks)

### DIFF
--- a/providers/agents/api/agents.go
+++ b/providers/agents/api/agents.go
@@ -74,6 +74,9 @@ type createAgentRequest struct {
 	SystemPrompt    string `json:"systemPrompt,omitempty"`
 	Autonomy        string `json:"autonomy,omitempty"`
 	ModelCredential string `json:"modelCredential,omitempty"`
+	// ModelFallbacks are additional credential names tried, in order, when the
+	// primary model fails.
+	ModelFallbacks []string `json:"modelFallbacks,omitempty"`
 	// BudgetTokens caps tokens per month (0 = unlimited).
 	BudgetTokens int64 `json:"budgetTokens,omitempty"`
 	// BudgetUSD caps spend per month as a decimal string (empty = unlimited).
@@ -113,6 +116,9 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	if cred := strings.TrimSpace(req.ModelCredential); cred != "" {
 		a.Spec.Models = map[string]string{"chat": cred}
 	}
+	if fb := trimmedList(req.ModelFallbacks); len(fb) > 0 {
+		a.Spec.ModelFallbacks = fb
+	}
 	if req.BudgetTokens > 0 || strings.TrimSpace(req.BudgetUSD) != "" {
 		a.Spec.Budget = &agentsv1alpha1.AgentBudget{Window: "month", TokenLimit: req.BudgetTokens, USDLimit: strings.TrimSpace(req.BudgetUSD)}
 	}
@@ -130,6 +136,22 @@ var knownToolFamilies = map[string]bool{"core": true, "web": true, "github": tru
 
 // normalizeFamilies keeps only recognized families, always includes core, and
 // de-duplicates â€” so the stored grant is clean regardless of UI input.
+// trimmedList trims each entry and drops blanks and duplicates, preserving
+// order. Used for ordered name lists like model fallbacks.
+func trimmedList(in []string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
 func normalizeFamilies(in []string) []string {
 	seen := map[string]bool{"core": true}
 	out := []string{"core"}
@@ -145,6 +167,7 @@ func normalizeFamilies(in []string) []string {
 
 type updateAgentRequest struct {
 	ModelCredential  *string   `json:"modelCredential,omitempty"`
+	ModelFallbacks   *[]string `json:"modelFallbacks,omitempty"`
 	SystemPrompt     *string   `json:"systemPrompt,omitempty"`
 	Autonomy         *string   `json:"autonomy,omitempty"`
 	BudgetTokens     *int64    `json:"budgetTokens,omitempty"`
@@ -193,6 +216,9 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request) {
 		} else {
 			agent.Spec.Models["chat"] = cred
 		}
+	}
+	if req.ModelFallbacks != nil {
+		agent.Spec.ModelFallbacks = trimmedList(*req.ModelFallbacks)
 	}
 	if req.SystemPrompt != nil {
 		agent.Spec.SystemPrompt = *req.SystemPrompt
@@ -383,15 +409,46 @@ var errNoCredential = errors.New("this agent has no model credential assigned â€
 // builds the Eino model from it. Agents reference a credential by name in
 // spec.models["chat"]; the credential is its own Secret (kedge-agents-model-<name>).
 func (s *Server) buildChatModelCtx(ctx context.Context, creds llm.SecretGetter, agent *agentsv1alpha1.Agent) (einomodel.BaseChatModel, error) {
-	cred := strings.TrimSpace(agent.Spec.Models["chat"])
-	if cred == "" {
+	primary := strings.TrimSpace(agent.Spec.Models["chat"])
+	if primary == "" {
 		return nil, errNoCredential
 	}
-	profile, err := llm.LoadCredential(ctx, creds, cred)
-	if err != nil {
-		return nil, err
+	// Primary first, then the ordered fallbacks. Skip blanks and duplicates.
+	names := []string{primary}
+	seen := map[string]bool{primary: true}
+	for _, f := range agent.Spec.ModelFallbacks {
+		f = strings.TrimSpace(f)
+		if f == "" || seen[f] {
+			continue
+		}
+		seen[f] = true
+		names = append(names, f)
 	}
-	return llm.BuildModel(ctx, profile)
+
+	var members []einomodel.BaseChatModel
+	var built []string
+	var lastErr error
+	for _, name := range names {
+		profile, err := llm.LoadCredential(ctx, creds, name)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		m, err := llm.BuildModel(ctx, profile)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		members = append(members, m)
+		built = append(built, name)
+	}
+	if len(members) == 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, errNoCredential
+	}
+	return llm.NewFallbackModel(members, built), nil
 }
 
 // credentialsError reports whether err is a missing/invalid model-credentials

--- a/providers/agents/apis/v1alpha1/types_agent.go
+++ b/providers/agents/apis/v1alpha1/types_agent.go
@@ -77,6 +77,14 @@ type AgentSpec struct {
 	// +optional
 	Models map[string]string `json:"models,omitempty"`
 
+	// ModelFallbacks is an ordered list of additional model-credential names
+	// tried, in order, when the primary chat model (models["chat"]) fails to
+	// respond — a provider outage, rate limit, timeout, or connection error.
+	// The first credential that responds is used. Streaming only falls back
+	// before the first token is emitted. Empty means no fallback.
+	// +optional
+	ModelFallbacks []string `json:"modelFallbacks,omitempty"`
+
 	// Runner selects the execution backend: "auto" (default) runs in-process
 	// on Eino unless the task is long-running and the claude-code runner is
 	// available; "eino" pins the in-process loop; "claude-code" pins the

--- a/providers/agents/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/providers/agents/apis/v1alpha1/zz_generated.deepcopy.go
@@ -127,6 +127,11 @@ func (in *AgentSpec) DeepCopyInto(out *AgentSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ModelFallbacks != nil {
+		in, out := &in.ModelFallbacks, &out.ModelFallbacks
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Delegates != nil {
 		in, out := &in.Delegates, &out.Delegates
 		*out = make([]string, len(*in))

--- a/providers/agents/config/crds/agents.kedge.faros.sh_agents.yaml
+++ b/providers/agents/config/crds/agents.kedge.faros.sh_agents.yaml
@@ -150,6 +150,16 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+              modelFallbacks:
+                description: |-
+                  ModelFallbacks is an ordered list of additional model-credential names
+                  tried, in order, when the primary chat model (models["chat"]) fails to
+                  respond — a provider outage, rate limit, timeout, or connection error.
+                  The first credential that responds is used. Streaming only falls back
+                  before the first token is emitted. Empty means no fallback.
+                items:
+                  type: string
+                type: array
               models:
                 additionalProperties:
                   type: string

--- a/providers/agents/config/kcp/apiexport-agents.kedge.faros.sh.yaml
+++ b/providers/agents/config/kcp/apiexport-agents.kedge.faros.sh.yaml
@@ -6,7 +6,7 @@ spec:
   resources:
   - group: agents.kedge.faros.sh
     name: agents
-    schema: v260714-8e565fc.agents.agents.kedge.faros.sh
+    schema: v260714-c1f41b8.agents.agents.kedge.faros.sh
     storage:
       crd: {}
   - group: agents.kedge.faros.sh

--- a/providers/agents/config/kcp/apiresourceschema-agents.agents.kedge.faros.sh.yaml
+++ b/providers/agents/config/kcp/apiresourceschema-agents.agents.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260714-8e565fc.agents.agents.kedge.faros.sh
+  name: v260714-c1f41b8.agents.agents.kedge.faros.sh
 spec:
   group: agents.kedge.faros.sh
   names:
@@ -145,6 +145,16 @@ spec:
                   minimum: 0
                   type: integer
               type: object
+            modelFallbacks:
+              description: |-
+                ModelFallbacks is an ordered list of additional model-credential names
+                tried, in order, when the primary chat model (models["chat"]) fails to
+                respond — a provider outage, rate limit, timeout, or connection error.
+                The first credential that responds is used. Streaming only falls back
+                before the first token is emitted. Empty means no fallback.
+              items:
+                type: string
+              type: array
             models:
               additionalProperties:
                 type: string

--- a/providers/agents/deploy/chart/files/schemas/agents.agents.kedge.faros.sh.yaml
+++ b/providers/agents/deploy/chart/files/schemas/agents.agents.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260714-8e565fc.agents.agents.kedge.faros.sh
+  name: v260714-c1f41b8.agents.agents.kedge.faros.sh
 spec:
   group: agents.kedge.faros.sh
   names:
@@ -145,6 +145,16 @@ spec:
                   minimum: 0
                   type: integer
               type: object
+            modelFallbacks:
+              description: |-
+                ModelFallbacks is an ordered list of additional model-credential names
+                tried, in order, when the primary chat model (models["chat"]) fails to
+                respond — a provider outage, rate limit, timeout, or connection error.
+                The first credential that responds is used. Streaming only falls back
+                before the first token is emitted. Empty means no fallback.
+              items:
+                type: string
+              type: array
             models:
               additionalProperties:
                 type: string

--- a/providers/agents/llm/fallback.go
+++ b/providers/agents/llm/fallback.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	einomodel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// FallbackModel wraps an ordered chain of chat models and tries them in turn:
+// the first model that responds wins, and a model that fails (provider outage,
+// rate limit, timeout, connection error) is skipped so the next one is tried.
+//
+// Streaming falls back only up to the first token. If a model errors before it
+// emits any content — including an HTTP error that a provider surfaces on the
+// first Recv rather than from Stream itself — the chain moves on. Once a model
+// has streamed content and then fails mid-response, the error is surfaced to
+// the caller: we cannot replay a half-finished answer through a different model.
+//
+// The only error that is never retried is caller cancellation (ctx.Err): if the
+// caller went away, trying another provider is pointless.
+type FallbackModel struct {
+	members []einomodel.BaseChatModel
+	// names is parallel to members and only used to make errors legible.
+	names []string
+}
+
+// NewFallbackModel builds a chain from the given members. A single member is
+// returned unwrapped so the common (no-fallback) case carries no overhead and
+// preserves the member's own capabilities (e.g. tool binding).
+func NewFallbackModel(members []einomodel.BaseChatModel, names []string) einomodel.BaseChatModel {
+	if len(members) == 1 {
+		return members[0]
+	}
+	return &FallbackModel{members: members, names: names}
+}
+
+var _ einomodel.ToolCallingChatModel = (*FallbackModel)(nil)
+
+// Generate tries each member in order and returns the first success.
+func (f *FallbackModel) Generate(ctx context.Context, in []*schema.Message, opts ...einomodel.Option) (*schema.Message, error) {
+	var errs []error
+	for i, m := range f.members {
+		msg, err := m.Generate(ctx, in, opts...)
+		if err == nil {
+			return msg, nil
+		}
+		if ctx.Err() != nil {
+			return nil, err
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", f.names[i], err))
+	}
+	return nil, fmt.Errorf("all %d models failed: %w", len(f.members), errors.Join(errs...))
+}
+
+// Stream tries each member in order, peeking the first chunk so an error that
+// surfaces on the first Recv still falls back. On success it returns a reader
+// that re-emits the peeked chunk ahead of the rest of the stream.
+func (f *FallbackModel) Stream(ctx context.Context, in []*schema.Message, opts ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	var errs []error
+	for i, m := range f.members {
+		sr, err := m.Stream(ctx, in, opts...)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, err
+			}
+			errs = append(errs, fmt.Errorf("%s: %w", f.names[i], err))
+			continue
+		}
+		first, ferr := sr.Recv()
+		if ferr != nil && !errors.Is(ferr, io.EOF) {
+			sr.Close()
+			if ctx.Err() != nil {
+				return nil, ferr
+			}
+			errs = append(errs, fmt.Errorf("%s: %w", f.names[i], ferr))
+			continue
+		}
+		// This member produced a first chunk (or a clean, empty EOF). Commit to
+		// it and hand back a reader that replays the peeked chunk first.
+		return prependChunk(first, ferr, sr), nil
+	}
+	return nil, fmt.Errorf("all %d models failed to start streaming: %w", len(f.members), errors.Join(errs...))
+}
+
+// WithTools binds tools to every member and returns a new chain. A member that
+// does not support tool binding is kept as-is (tools are a no-op for it).
+func (f *FallbackModel) WithTools(tools []*schema.ToolInfo) (einomodel.ToolCallingChatModel, error) {
+	bound := make([]einomodel.BaseChatModel, len(f.members))
+	for i, m := range f.members {
+		tcm, ok := m.(einomodel.ToolCallingChatModel)
+		if !ok {
+			bound[i] = m
+			continue
+		}
+		b, err := tcm.WithTools(tools)
+		if err != nil {
+			return nil, fmt.Errorf("bind tools to %s: %w", f.names[i], err)
+		}
+		bound[i] = b
+	}
+	return &FallbackModel{members: bound, names: f.names}, nil
+}
+
+// prependChunk returns a stream that yields the already-received first chunk and
+// then the remainder of rest. firstErr is the error Recv returned alongside
+// first (io.EOF for an empty stream, nil otherwise).
+func prependChunk(first *schema.Message, firstErr error, rest *schema.StreamReader[*schema.Message]) *schema.StreamReader[*schema.Message] {
+	sr, sw := schema.Pipe[*schema.Message](2)
+	go func() {
+		defer rest.Close()
+		defer sw.Close()
+		if firstErr == nil {
+			if sw.Send(first, nil) {
+				return
+			}
+		}
+		for {
+			chunk, err := rest.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				sw.Send(nil, err)
+				return
+			}
+			if sw.Send(chunk, nil) {
+				return
+			}
+		}
+	}()
+	return sr
+}

--- a/providers/agents/llm/fallback_test.go
+++ b/providers/agents/llm/fallback_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	einomodel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// fakeModel is a scriptable ToolCallingChatModel for exercising FallbackModel.
+type fakeModel struct {
+	genErr       error
+	genContent   string
+	streamErr    error    // error returned by Stream() itself
+	firstRecvErr error    // error surfaced on the first Recv (post-Stream)
+	chunks       []string // content chunks emitted by Stream
+}
+
+func (f *fakeModel) Generate(_ context.Context, _ []*schema.Message, _ ...einomodel.Option) (*schema.Message, error) {
+	if f.genErr != nil {
+		return nil, f.genErr
+	}
+	return &schema.Message{Role: schema.Assistant, Content: f.genContent}, nil
+}
+
+func (f *fakeModel) Stream(_ context.Context, _ []*schema.Message, _ ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
+	if f.streamErr != nil {
+		return nil, f.streamErr
+	}
+	sr, sw := schema.Pipe[*schema.Message](8)
+	go func() {
+		defer sw.Close()
+		if f.firstRecvErr != nil {
+			sw.Send(nil, f.firstRecvErr)
+			return
+		}
+		for _, c := range f.chunks {
+			if sw.Send(&schema.Message{Role: schema.Assistant, Content: c}, nil) {
+				return
+			}
+		}
+	}()
+	return sr, nil
+}
+
+func (f *fakeModel) WithTools(_ []*schema.ToolInfo) (einomodel.ToolCallingChatModel, error) {
+	return f, nil
+}
+
+func drain(t *testing.T, sr *schema.StreamReader[*schema.Message]) string {
+	t.Helper()
+	defer sr.Close()
+	var b strings.Builder
+	for {
+		m, err := sr.Recv()
+		if errors.Is(err, io.EOF) {
+			return b.String()
+		}
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		b.WriteString(m.Content)
+	}
+}
+
+func TestFallbackGenerateSkipsFailures(t *testing.T) {
+	m := NewFallbackModel(
+		[]einomodel.BaseChatModel{
+			&fakeModel{genErr: errors.New("rate limited")},
+			&fakeModel{genContent: "second wins"},
+		},
+		[]string{"primary", "backup"},
+	)
+	msg, err := m.Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content != "second wins" {
+		t.Fatalf("got %q, want the backup's response", msg.Content)
+	}
+}
+
+func TestFallbackGenerateAllFail(t *testing.T) {
+	m := NewFallbackModel(
+		[]einomodel.BaseChatModel{
+			&fakeModel{genErr: errors.New("boom-1")},
+			&fakeModel{genErr: errors.New("boom-2")},
+		},
+		[]string{"a", "b"},
+	)
+	if _, err := m.Generate(context.Background(), nil); err == nil {
+		t.Fatal("expected an error when every model fails")
+	}
+}
+
+// A provider that errors on the first Recv (not from Stream itself) must still
+// fall back — this is the common HTTP-error-on-first-chunk case.
+func TestFallbackStreamFallsBackOnFirstRecvError(t *testing.T) {
+	m := NewFallbackModel(
+		[]einomodel.BaseChatModel{
+			&fakeModel{firstRecvErr: errors.New("429 after stream opened")},
+			&fakeModel{chunks: []string{"hel", "lo"}},
+		},
+		[]string{"primary", "backup"},
+	)
+	sr, err := m.Stream(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := drain(t, sr); got != "hello" {
+		t.Fatalf("got %q, want %q from the backup", got, "hello")
+	}
+}
+
+// When the first model streams content, the reassembled reader must replay the
+// peeked first chunk plus the remainder — no dropped or duplicated tokens.
+func TestFallbackStreamUsesFirstAndReplaysPeek(t *testing.T) {
+	m := NewFallbackModel(
+		[]einomodel.BaseChatModel{
+			&fakeModel{chunks: []string{"a", "b", "c"}},
+			&fakeModel{chunks: []string{"should", "not", "run"}},
+		},
+		[]string{"primary", "backup"},
+	)
+	sr, err := m.Stream(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := drain(t, sr); got != "abc" {
+		t.Fatalf("got %q, want %q", got, "abc")
+	}
+}
+
+func TestFallbackStreamAllFail(t *testing.T) {
+	m := NewFallbackModel(
+		[]einomodel.BaseChatModel{
+			&fakeModel{streamErr: errors.New("dial tcp: refused")},
+			&fakeModel{firstRecvErr: errors.New("500")},
+		},
+		[]string{"a", "b"},
+	)
+	if _, err := m.Stream(context.Background(), nil); err == nil {
+		t.Fatal("expected an error when every model fails to stream")
+	}
+}
+
+func TestFallbackWithToolsBindsAllMembers(t *testing.T) {
+	m := NewFallbackModel(
+		[]einomodel.BaseChatModel{
+			&fakeModel{genErr: errors.New("down")},
+			&fakeModel{genContent: "ok"},
+		},
+		[]string{"a", "b"},
+	)
+	tcm, ok := m.(einomodel.ToolCallingChatModel)
+	if !ok {
+		t.Fatal("FallbackModel must implement ToolCallingChatModel")
+	}
+	bound, err := tcm.WithTools([]*schema.ToolInfo{{Name: "search"}})
+	if err != nil {
+		t.Fatalf("WithTools: %v", err)
+	}
+	msg, err := bound.Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Generate after WithTools: %v", err)
+	}
+	if msg.Content != "ok" {
+		t.Fatalf("got %q, want the backup's response through the bound chain", msg.Content)
+	}
+}
+
+func TestNewFallbackModelSingleMemberUnwrapped(t *testing.T) {
+	only := &fakeModel{genContent: "solo"}
+	m := NewFallbackModel([]einomodel.BaseChatModel{only}, []string{"solo"})
+	if _, isFallback := m.(*FallbackModel); isFallback {
+		t.Fatal("a single member should be returned unwrapped, not decorated")
+	}
+}

--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -28,6 +28,7 @@ interface Agent {
     systemPrompt?: string
     autonomy?: string
     models?: Record<string, string>
+    modelFallbacks?: string[]
     defaultNotifyConnection?: string
     delegates?: string[]
     budget?: { window?: string; usdLimit?: string; tokenLimit?: number }
@@ -1032,6 +1033,7 @@ export class AgentsElement extends HTMLElement {
     const scheds = this._schedules.filter((s) => s.spec.agentRef === name)
     const trigs = this._triggers.filter((t) => t.spec.agentRef === name)
     const model = a.spec?.models?.chat
+    const fallbacks = a.spec?.modelFallbacks || []
     const notify = a.spec?.defaultNotifyConnection
     const directTools = Array.from(new Set([...(a.spec?.tools?.interactive?.connections || []), ...(a.spec?.tools?.background?.connections || [])]))
     const toolsets = Array.from(new Set([...(a.spec?.tools?.interactive?.toolsets || []), ...(a.spec?.tools?.background?.toolsets || [])]))
@@ -1062,6 +1064,7 @@ export class AgentsElement extends HTMLElement {
           <div class="agents-ov-card">
             <div class="agents-ov-k">Model</div>
             <div class="agents-ov-v ${model ? '' : 'warn'}">${model ? escapeHTML(model) : 'none set'}</div>
+            ${fallbacks.length ? `<div class="agents-ov-sub">↳ fallback: ${fallbacks.map((f) => escapeHTML(f)).join(' → ')}</div>` : ''}
           </div>
           <div class="agents-ov-card">
             <div class="agents-ov-k">Notify channel</div>
@@ -1383,6 +1386,7 @@ export class AgentsElement extends HTMLElement {
     const scheds = this._schedules.filter((s) => s.spec.agentRef === name)
     const trigs = this._triggers.filter((t) => t.spec.agentRef === name)
     const model = a.spec?.models?.chat
+    const fallbacks = a.spec?.modelFallbacks || []
     const notify = a.spec?.defaultNotifyConnection
     const agentTools = new Set([...(a.spec?.tools?.interactive?.connections || []), ...(a.spec?.tools?.background?.connections || [])])
     const usedConns = new Set<string>()
@@ -1482,6 +1486,18 @@ export class AgentsElement extends HTMLElement {
             value: model,
             options: [{ value: '', label: '— no model —' }, ...this._credentials.map((x) => ({ value: x.name, label: x.name + (x.model ? ` (${x.model})` : '') }))],
             hint: 'Switch which credential this agent reasons with.',
+          },
+          {
+            key: 'modelFallbacks',
+            label: 'Fallbacks',
+            kind: 'chips',
+            // Saved fallbacks first (preserves their order), then the rest.
+            chips: [...fallbacks.filter((n2) => n2 !== model), ...this._credentials.map((x) => x.name).filter((n2) => n2 !== model && !fallbacks.includes(n2))].map((n2) => ({
+              value: n2,
+              label: n2,
+              on: fallbacks.includes(n2),
+            })),
+            hint: 'If this model fails (outage, rate limit, timeout), try these in order.',
           },
         ],
       })
@@ -1610,7 +1626,10 @@ export class AgentsElement extends HTMLElement {
       take('task')
       if (Object.keys(patch).length) await this._updateTrigger(id.slice(5), patch)
     } else if (id.startsWith('model:')) {
-      if ('modelCredential' in values) await this._updateAgent({ modelCredential: str(values.modelCredential) }, 'Model reassigned.')
+      const p: Record<string, unknown> = {}
+      if ('modelCredential' in values) p.modelCredential = str(values.modelCredential)
+      if ('modelFallbacks' in values) p.modelFallbacks = Array.isArray(values.modelFallbacks) ? values.modelFallbacks : []
+      if (Object.keys(p).length) await this._updateAgent(p, 'Model updated.')
     } else if (id.startsWith('conn:')) {
       take('displayName')
       take('baseURL')

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -472,6 +472,7 @@ kedge-provider-agents .agents-ov-k { font-size: 11px; letter-spacing: .06em; tex
 kedge-provider-agents .agents-ov-v { font-size: 14px; font-weight: 600; color: var(--color-text-primary, #123); display: flex; flex-wrap: wrap; gap: 4px; }
 kedge-provider-agents .agents-ov-v.warn { color: var(--color-warning, #d97706); }
 kedge-provider-agents .agents-ov-v.muted { color: var(--color-text-muted, #889); font-weight: 400; }
+kedge-provider-agents .agents-ov-sub { margin-top: 5px; font-size: 12px; font-weight: 400; color: var(--color-text-muted, #889); }
 kedge-provider-agents .agents-checkrow { display: flex; flex-wrap: wrap; gap: 8px 16px; }
 kedge-provider-agents .agents-toolset-form { display: flex; flex-direction: column; gap: 12px; }
 kedge-provider-agents .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; }


### PR DESCRIPTION
An agent can now list **ordered fallback model credentials**, tried in order when the primary chat model fails — a provider outage, rate limit, timeout, or connection refusal. The first credential that responds is used.

## Backend
- **`llm.FallbackModel`** — a decorator implementing `einomodel.ToolCallingChatModel` (`Generate`, `Stream`, `WithTools`) that wraps an ordered chain:
  - `Generate` tries each member in order, returns the first success.
  - `Stream` **peeks the first chunk**, so an HTTP error a provider surfaces on the first `Recv` (not from `Stream()` itself — the common 429/5xx case) still falls back; it then replays the peeked chunk ahead of the rest of the stream.
  - **Streaming only falls back before the first token.** Once content has streamed, a mid-response failure surfaces to the caller — we can't replay a half-finished answer through a different provider.
  - Caller cancellation (`ctx.Err`) is never retried.
- `buildChatModelCtx` builds the chain from `models["chat"]` + `spec.modelFallbacks`, skipping duplicates and any credential that fails to load — a misconfigured fallback never breaks a run.
- `AgentSpec.ModelFallbacks []string` + create/update API wiring; regenerated CRD, APIResourceSchema, and chart schema.

## Portal
- The Flow **model node** gains a **Fallbacks** chips field (all other credentials, saved ones first to preserve order); toggling auto-saves `modelFallbacks`.
- The overview **Model** card shows the chain (`a → b → c`).

## Tests
`llm/fallback_test.go` — Generate fallback, first-`Recv` stream fallback, peek-replay (no dropped/dup tokens), all-fail, `WithTools` chaining, single-member unwrap. All pass.

Verified end to end: Go unit tests pass; Playwright confirms the Fallbacks chips render and toggling fires `PUT {modelFallbacks:[...]}` with zero console errors.

**Follow-up:** fallbacks are an unordered chip set today (order follows the saved list); drag-to-reorder is a later nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)