### PR TITLE
fix(edges): build provider image from its own context (unblock release)

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -93,6 +93,8 @@ jobs:
             image: ${{ github.repository_owner }}/kedge-databricks-provider
           - name: agents
             image: ${{ github.repository_owner }}/kedge-agents-provider
+          - name: edges
+            image: ${{ github.repository_owner }}/kedge-edges-provider
           # Companion image of the infrastructure provider (the dev-agent its
           # kro backend injects into development-mode pods); published by
           # provider-release.yaml on the infrastructure provider's tag.

--- a/Makefile
+++ b/Makefile
@@ -169,10 +169,11 @@ uninstall-provider-edges: ## Delete edges CatalogEntry + Provider
 		--insecure-skip-tls-verify \
 		delete -f $(EDGES_MANIFEST) -f $(EDGES_PROVIDER_MANIFEST)
 
-docker-build-edges-provider: ## Build the edges provider image (context = repo root)
-	docker build -f providers/edges/Dockerfile \
+docker-build-edges-provider: ## Build the edges provider image (context = providers/edges)
+	docker build \
 		--platform $(DOCKER_PLATFORM) \
-		-t ghcr.io/faroshq/kedge-edges-provider:$(VERSION) .
+		-t ghcr.io/faroshq/kedge-edges-provider:$(VERSION) \
+		providers/edges
 
 build-app-studio-provider-portal: ## Build the App Studio provider's micro-frontend (Vite + TS → portal/dist)
 	cd providers/app-studio/portal && npm install --no-audit --no-fund && npm run build

--- a/providers/edges/Dockerfile
+++ b/providers/edges/Dockerfile
@@ -1,40 +1,36 @@
 # syntax=docker/dockerfile:1
 #
-# BUILD CONTEXT = REPO ROOT (not this dir), because go.mod has
-#   replace github.com/faroshq/provider-sdk => ../../provider-sdk
-# so the SDK source must be present as a sibling at build time. From the repo
-# root:
-#
-#   docker build -f providers/edges/Dockerfile -t IMAGE .
-#
-# (The Makefile `docker-build-edges-provider` target does this.)
+# BUILD CONTEXT = this dir (providers/edges), matching the other providers and
+# the provider-release workflow (`context: ./providers/<name>`). The provider
+# SDK is consumed as a PUBLISHED module (github.com/faroshq/provider-sdk), not a
+# `replace => ../../provider-sdk` sibling, so no repo-root context is needed.
+# Host/Tilt dev builds still resolve the local SDK via go.work.
 
 # 1. Build the portal micro-frontend (Vite → portal/dist), embedded by the Go
 #    binary via //go:embed in assets.go.
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY providers/edges/portal/package.json providers/edges/portal/package-lock.json* ./
+COPY portal/package.json portal/package-lock.json* ./
 RUN npm install --no-audit --no-fund
-COPY providers/edges/portal/ ./
+COPY portal/ ./
 RUN npm run build
 
-# 2. Build the Go binary standalone (no go.work — the workspace file is not
-#    copied, so each module resolves via its own go.mod + the local SDK replace).
+# 2. Build the Go binary standalone (no go.work — each module resolves via its
+#    own go.mod; the SDK is fetched from the module proxy).
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-# The SDK first so its layer caches independently of provider churn.
-COPY provider-sdk/ ./provider-sdk/
-COPY providers/edges/ ./providers/edges/
-COPY --from=portal /portal/dist ./providers/edges/portal/dist
-WORKDIR /src/providers/edges
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+COPY --from=portal /portal/dist ./portal/dist
 RUN CGO_ENABLED=0 GOWORK=off go build -trimpath -ldflags="-s -w" -o /out/edges-provider .
 
-# 2. Minimal runtime image. The KubernetesCluster + LinuxServer APIResourceSchemas
+# 3. Minimal runtime image. The KubernetesCluster + LinuxServer APIResourceSchemas
 #    the `init` subcommand applies are baked at /etc/kedge/schemas
 #    (KEDGE_SCHEMAS_DIR), synced there by `make codegen-edges-provider`.
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/edges-provider /edges-provider
-COPY providers/edges/deploy/chart/files/schemas /etc/kedge/schemas
+COPY deploy/chart/files/schemas /etc/kedge/schemas
 EXPOSE 8084
 ENV PORT=8084
 USER nonroot:nonroot

--- a/providers/edges/go.mod
+++ b/providers/edges/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/containers/kubernetes-mcp-server v0.0.58
-	github.com/faroshq/provider-sdk v0.0.1
+	github.com/faroshq/provider-sdk v0.0.13
 	github.com/function61/holepunch-server v0.0.0-20210312073819-8f5e8775e813
 	github.com/go-logr/logr v1.4.3
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -173,7 +173,6 @@ require (
 )
 
 // Pin k8s.io/* to the kcp staging forks the kedge providers + SDK use.
-replace github.com/faroshq/provider-sdk => ../../provider-sdk
 
 // The full kcp k8s.io/* staging fork replace set, mirrored from the root
 // module. The edges provider imports kubernetes-mcp-server's helm toolset,

--- a/providers/edges/go.sum
+++ b/providers/edges/go.sum
@@ -71,6 +71,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
+github.com/faroshq/provider-sdk v0.0.13 h1:EIN7tUtiInZBFcSimV00hGalY8WMsX4QA9X8X2HQRKk=
+github.com/faroshq/provider-sdk v0.0.13/go.mod h1:/STVscKK+rrvTuLTvN0ntWxFzMbt9dZ5BbCMxdfyNO8=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
The `providers/edges/v0.0.1` release failed to build the image:

```
failed to compute cache key: "/providers/edges/deploy/chart/files/schemas": not found
```

**Cause:** the provider-release workflow builds each provider with `context: ./providers/<name>`, but the edges provider was the lone exception — it carried a local `replace github.com/faroshq/provider-sdk => ../../provider-sdk` and a repo-root Dockerfile (`COPY provider-sdk/`, `COPY providers/edges/...`). Those paths don't exist under the `providers/edges` build context.

**Fix** — align edges with the convention every other provider already uses:
- `go.mod`: drop the local SDK replace; require the published `github.com/faroshq/provider-sdk v0.0.13` (the local tree is that same tag). `go.work` still resolves the local SDK for dev/e2e.
- `Dockerfile`: context-relative paths; SDK comes from the module proxy.
- `Makefile` `docker-build-edges-provider`: context = `providers/edges`.

**Verified:** standalone `GOWORK=off` build (readonly), go.work build, and a full `docker build providers/edges` all succeed and bake `/etc/kedge/schemas`.

After merge, re-cut the `providers/edges/v0.0.1` tag (or `v0.0.2`) to re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)