### PR TITLE
ci: speed up provider image builds (native arm64 + build cache)

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -56,6 +56,8 @@ jobs:
           # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=hub
+          cache-to: type=gha,mode=max,scope=hub
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -129,6 +131,8 @@ jobs:
           # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=provider-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=provider-${{ matrix.name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -166,6 +170,8 @@ jobs:
           # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=agent
+          cache-to: type=gha,mode=max,scope=agent
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -14,6 +14,12 @@ name: Provider release (image + chart)
 # (images.yaml / helm-images.yaml) builds providers in build-only PR validation
 # mode and no longer publishes them, and the split-*.yaml mirrors publish source
 # only (no version tag → no mirror image build), so there is no double-build.
+#
+# Multi-arch strategy: each arch is built on its OWN native runner (amd64 on
+# ubuntu-latest, arm64 on ubuntu-24.04-arm) and pushed by digest, then the
+# `merge` job assembles the multi-arch manifest. This avoids QEMU emulation of
+# the arm64 build (the portal `npm ci` + `go build`), which is 5-10x slower than
+# native. A per-arch GHA layer cache skips unchanged steps across runs.
 
 on:
   push:
@@ -29,8 +35,16 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  release:
+  # Parse the provider + version out of the tag once, and expose them as job
+  # outputs the build/merge jobs consume. Kept separate so the matrix build
+  # doesn't re-parse per arch.
+  meta:
     runs-on: ubuntu-latest
+    outputs:
+      provider: ${{ steps.tag.outputs.provider }}
+      version: ${{ steps.tag.outputs.version }}
+      semver: ${{ steps.tag.outputs.semver }}
+      image: ${{ steps.tag.outputs.image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -57,6 +71,30 @@ jobs:
           echo "semver=${VERSION#v}"    >> "$GITHUB_OUTPUT"   # 0.0.9  (chart version, OCI convention)
           echo "image=${IMAGE}"         >> "$GITHUB_OUTPUT"
 
+  # One job per architecture, each on its native runner (no QEMU). Builds and
+  # pushes the image BY DIGEST only (no tag yet) and uploads the digest so the
+  # merge job can stitch the manifest list.
+  build:
+    needs: meta
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Arch label (for artifact/cache names)
+        id: prep
+        run: echo "arch=${PLATFORM##*/}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -67,16 +105,71 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
-          context: ./providers/${{ steps.tag.outputs.provider }}
-          file: ./providers/${{ steps.tag.outputs.provider }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.version }}
-            ${{ env.REGISTRY }}/${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.semver }}
+          context: ./providers/${{ needs.meta.outputs.provider }}
+          file: ./providers/${{ needs.meta.outputs.provider }}/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ needs.meta.outputs.provider }}-${{ steps.prep.outputs.arch }}
+          cache-to: type=gha,mode=max,scope=${{ needs.meta.outputs.provider }}-${{ steps.prep.outputs.arch }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ needs.meta.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ needs.meta.outputs.provider }}-${{ steps.prep.outputs.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the multi-arch manifest from the per-arch digests, tag it, and
+  # publish the companion dev-agent image + Helm chart.
+  merge:
+    needs: [meta, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ needs.meta.outputs.provider }}-*
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ needs.meta.outputs.image }}
+          VERSION: ${{ needs.meta.outputs.version }}
+          SEMVER: ${{ needs.meta.outputs.semver }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE}:${VERSION}" \
+            -t "${IMAGE}:${SEMVER}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
       # The infrastructure provider ships a companion image: the dev-agent its
       # kro backend injects into development-mode pods (providers/infrastructure/
@@ -84,17 +177,26 @@ jobs:
       # the provider — publish it on the same tag so deployments can pin
       # KEDGE_DEV_AGENT_IMAGE / development.agentImage to vX.Y.Z, and refresh
       # :latest, which backs the in-binary default for stock deployments.
+      #
+      # It's a tiny stdlib-only Go binary, so multi-arch via QEMU here is cheap
+      # (no npm, no dependency graph) — not worth a second native-split matrix.
+      - name: Set up QEMU
+        if: needs.meta.outputs.provider == 'infrastructure'
+        uses: docker/setup-qemu-action@v3
+
       - name: Build and push dev-agent image
-        if: steps.tag.outputs.provider == 'infrastructure'
+        if: needs.meta.outputs.provider == 'infrastructure'
         uses: docker/build-push-action@v6
         with:
           context: ./providers/infrastructure/dev-agent
           file: ./providers/infrastructure/dev-agent/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          cache-from: type=gha,scope=dev-agent
+          cache-to: type=gha,mode=max,scope=dev-agent
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:${{ steps.tag.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:${{ steps.tag.outputs.semver }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:${{ needs.meta.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:${{ needs.meta.outputs.semver }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/kedge-dev-agent:latest
 
       - name: Install Helm
@@ -105,18 +207,21 @@ jobs:
       - name: Package and push chart
         env:
           HELM_EXPERIMENTAL_OCI: 1
+          PROVIDER: ${{ needs.meta.outputs.provider }}
+          VERSION: ${{ needs.meta.outputs.version }}
+          SEMVER: ${{ needs.meta.outputs.semver }}
         run: |
           set -euo pipefail
           echo "${{ github.token }}" | helm registry login "${REGISTRY}" --username ${{ github.actor }} --password-stdin
 
-          chart_dir="providers/${{ steps.tag.outputs.provider }}/deploy/chart/"
+          chart_dir="providers/${PROVIDER}/deploy/chart/"
           chart_name=$(grep -E '^name:' "${chart_dir}Chart.yaml" | head -1 | awk '{print $2}')
 
           # Chart version follows OCI/semver convention (no 'v'); appVersion keeps
           # the 'v' so the chart's image.tag default (.Chart.AppVersion) matches
           # the 'vX.Y.Z' image tag pushed above.
-          CHART_VERSION="${{ steps.tag.outputs.semver }}"
-          APP_VERSION="${{ steps.tag.outputs.version }}"
+          CHART_VERSION="${SEMVER}"
+          APP_VERSION="${VERSION}"
 
           # lint renders templates against default values (package only tars), so
           # a broken template fails here rather than shipping.

--- a/deploy/Dockerfile.agent
+++ b/deploy/Dockerfile.agent
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 
 ARG TARGETARCH
@@ -9,7 +10,7 @@ COPY go.mod go.sum ./
 # `replace => ./provider-sdk`; go mod download reads its go.mod to resolve
 # the replacement, so it must be present before the download step.
 COPY provider-sdk/go.mod provider-sdk/go.sum provider-sdk/
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 COPY . .
 
@@ -17,7 +18,8 @@ ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w \
       -X github.com/faroshq/faros-kedge/pkg/version.Version=${VERSION} \
       -X github.com/faroshq/faros-kedge/pkg/version.GitCommit=${GIT_COMMIT} \

--- a/deploy/Dockerfile.hub
+++ b/deploy/Dockerfile.hub
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM node:22-alpine AS portal
 WORKDIR /src
 
@@ -5,7 +6,7 @@ WORKDIR /src
 # now live in their own out-of-process provider images, so the hub image
 # only builds the main SPA.
 COPY portal/package.json portal/package-lock.json portal/
-RUN cd portal && npm ci
+RUN --mount=type=cache,target=/root/.npm cd portal && npm ci
 
 # Sources for the main SPA. Done after `npm ci` so the install layer
 # caches across source-only edits.
@@ -25,7 +26,7 @@ COPY go.mod go.sum ./
 # `replace => ./provider-sdk`; go mod download reads its go.mod to resolve
 # the replacement, so it must be present before the download step.
 COPY provider-sdk/go.mod provider-sdk/go.sum provider-sdk/
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 COPY . .
 COPY --from=portal /src/portal/dist pkg/hub/portal/dist/
@@ -34,7 +35,8 @@ ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -tags portal_embed \
     -ldflags="-s -w \
       -X github.com/faroshq/faros-kedge/pkg/version.Version=${VERSION} \

--- a/providers/agents/Dockerfile
+++ b/providers/agents/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -12,7 +12,7 @@ RUN npm run build
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY main.go heartbeat.go assets.go init_cmd.go ./
 COPY apis ./apis
 COPY api ./api
@@ -25,7 +25,7 @@ COPY store ./store
 COPY tenant ./tenant
 COPY tools ./tools
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/agents-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/agents-provider .
 
 # 3. Minimal runtime image. APIResourceSchemas the `init` subcommand applies are
 #    baked at /etc/kedge/schemas (KEDGE_SCHEMAS_DIR).

--- a/providers/app-studio/Dockerfile
+++ b/providers/app-studio/Dockerfile
@@ -11,7 +11,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -22,10 +22,10 @@ RUN npm run build
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . ./
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/app-studio-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/app-studio-provider .
 
 # 3. Minimal runtime image. The portal bundle is baked into the binary; the
 #    APIResourceSchemas the `init` subcommand applies are baked at

--- a/providers/code/Dockerfile
+++ b/providers/code/Dockerfile
@@ -6,7 +6,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -22,10 +22,10 @@ RUN npm run build
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . ./
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/code-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/code-provider .
 
 # 3. Minimal runtime image. The portal assets are baked into the binary; the
 #    APIResourceSchemas the `init` subcommand applies are baked at

--- a/providers/databricks/Dockerfile
+++ b/providers/databricks/Dockerfile
@@ -3,17 +3,17 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . ./
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/databricks-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/databricks-provider .
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/databricks-provider /databricks-provider

--- a/providers/edges/Dockerfile
+++ b/providers/edges/Dockerfile
@@ -11,7 +11,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -20,10 +20,10 @@ RUN npm run build
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . ./
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 GOWORK=off go build -trimpath -ldflags="-s -w" -o /out/edges-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOWORK=off go build -trimpath -ldflags="-s -w" -o /out/edges-provider .
 
 # 3. Minimal runtime image. The KubernetesCluster + LinuxServer APIResourceSchemas
 #    the `init` subcommand applies are baked at /etc/kedge/schemas

--- a/providers/infrastructure/Dockerfile
+++ b/providers/infrastructure/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -14,10 +14,10 @@ RUN npm run build
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . ./
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infrastructure-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infrastructure-provider .
 
 # 2b. Fetch the helm CLI. The operator (`controller` subcommand) shells out to
 #     helm to install/upgrade the kro release, so the runtime image needs it.

--- a/providers/infrastructure/dev-agent/Dockerfile
+++ b/providers/infrastructure/dev-agent/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # kedge-dev-agent — the injected control process for development-mode
 # components of any infrastructure Template (docs/app-studio-template-sandboxes.md §2).
 # The image is scratch on purpose: it exists only to carry the static binary
@@ -7,7 +8,8 @@
 FROM golang:1.26 AS build
 WORKDIR /src
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/kedge-dev-agent .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/kedge-dev-agent .
 
 FROM scratch
 COPY --from=build /out/kedge-dev-agent /kedge-dev-agent

--- a/providers/kuery/Dockerfile
+++ b/providers/kuery/Dockerfile
@@ -6,7 +6,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -23,14 +23,14 @@ WORKDIR /src
 # `replace => ../../provider-sdk` that only resolves in the monorepo (go.work).
 # Standalone image builds need the SDK published (drop the replace) or vendored.
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY main.go assets.go init_cmd.go ./
 COPY core/ ./core/
 COPY engagement/ ./engagement/
 COPY mcpserver/ ./mcpserver/
 COPY queryapi/ ./queryapi/
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=1 go build -trimpath -ldflags="-s -w" -o /out/kuery-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=1 go build -trimpath -ldflags="-s -w" -o /out/kuery-provider .
 
 # 3. Runtime image: distroless/base (NOT static) for the glibc the CGO
 #    sqlite driver links against. /data is the conventional store mount. The

--- a/providers/quickstart/Dockerfile
+++ b/providers/quickstart/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22-alpine AS portal
 WORKDIR /portal
 COPY portal/package.json portal/package-lock.json* ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
 COPY portal/ ./
 RUN npm run build
 
@@ -13,10 +13,10 @@ RUN npm run build
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY main.go assets.go init_cmd.go ./
 COPY --from=portal /portal/dist ./portal/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/quickstart-provider .
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/quickstart-provider .
 
 # 3. Minimal runtime image. APIResourceSchemas the `init` subcommand applies are
 #    baked at /etc/kedge/schemas (KEDGE_SCHEMAS_DIR).


### PR DESCRIPTION
## Problem

Provider release builds are slow. The log that prompted this shows the arm64 half of a multi-arch build crawling through the portal `npm install` and `go build`:

```
#34 [linux/arm64 portal 4/6] RUN npm install --no-audit --no-fund
```

Root cause: `provider-release.yaml` built `linux/amd64,linux/arm64` in **one job on an amd64 runner**, so the `linux/arm64` layers ran under **QEMU emulation** (5–10× slower than native). On top of that, no build layer cache existed anywhere, so every run redid `npm install` / `go mod download` / `go build` cold.

## Changes

**Native arm64 (the big win)** — `provider-release.yaml` restructured into:
- `meta` — parse provider + version from the tag once, expose as job outputs.
- `build` (matrix) — amd64 on `ubuntu-latest`, arm64 on **`ubuntu-24.04-arm`** (free for public repos). Each arch builds natively and pushes **by digest**.
- `merge` — assembles the multi-arch manifest via `docker buildx imagetools create`, then publishes the dev-agent image + Helm chart as before.

The dev-agent stays a simple QEMU multi-arch build — it's a tiny stdlib-only binary, so emulation is cheap and not worth a second matrix.

**Layer caching** — `cache-from/cache-to: type=gha` (scoped per provider+arch) added to every `build-push-action` step in `provider-release.yaml` and `images.yaml` (hub, provider matrix, agent).

**Dockerfile cache mounts** — across all 8 provider Dockerfiles + hub/agent/dev-agent:
- `npm install` → `npm ci` (lockfiles confirmed present) with a `--mount=type=cache` npm cache.
- `--mount=type=cache` for the Go module cache (`/go/pkg/mod`) and build cache (`/root/.cache/go-build`).
- Added `# syntax=docker/dockerfile:1` to hub/agent/dev-agent so cache mounts work across BuildKit versions (providers already had it).

## Verification

GitHub Actions can't run locally, so the by-digest → merge flow is validated by inspection. Both workflow YAMLs parse; all 13 Dockerfiles carry the syntax directive. The single-arch amd64 PR-validation builds in `images.yaml` exercise the Dockerfile changes first (lower risk).

**On the first `providers/<name>/v*` tag after merge, confirm:**
1. Both arch jobs schedule (watch that `ubuntu-24.04-arm` is available to the org).
2. The merge job's `imagetools inspect` shows two platforms.
3. The pushed `:vX.Y.Z` tag is a proper manifest list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)