### PR TITLE
fix(edges): add review claims to chart CatalogEntry + document claim sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,29 @@ permission claims, and inline `APIResourceSchema` bodies. The hub's catalog
 controller reads it and provisions the kcp side (sub-workspace, ServiceAccount,
 APIExport, schemas) and registers routing/heartbeat state.
 
+> **⚠️ Permission claims live in THREE places that MUST stay in sync.** Changing
+> a provider's claim contract (adding/removing a `permissionClaim`) means editing
+> all of:
+> 1. `providers/<name>/manifest.yaml` — the CatalogEntry source of truth.
+> 2. `providers/<name>/init_cmd.go` — the `sdkinstall.PermissionClaim` list that
+>    `init` stamps onto the **APIExport** (`spec.permissionClaims`).
+> 3. `providers/<name>/deploy/chart/templates/catalogentry.yaml` — the CatalogEntry
+>    the Helm chart actually applies in prod. **This is the easy one to forget**;
+>    if it drifts, `init` updates the APIExport but the deployed CatalogEntry (and
+>    thus what the hub Enable flow offers tenants) still advertises the old set.
+>
+> **Existing tenants do NOT auto-migrate.** `init` only touches the provider-side
+> APIExport, never per-tenant `APIBinding`s (they live in tenant workspaces, written
+> by the hub Enable flow). A tenant's binding keeps its old accepted claims until it
+> re-Enables or a migration re-accepts them — and a provider that starts *requiring*
+> a newly-added claim (e.g. delegated `tokenreviews`/`subjectaccessreviews` for
+> data-plane auth) will break every already-enabled tenant on rollout. Ship a
+> migration (re-accept claims on all existing bindings) or a compatibility fallback
+> BEFORE deploying code that depends on the new claim. Symptom of the gap: provider
+> logs `User "system:serviceaccount:default:provider" cannot create <resource>` and
+> the binding's `status.exportPermissionClaims` lists the claim but `spec` /
+> `status.appliedPermissionClaims` do not.
+
 ### 5.2 Hub-side provider integration (`pkg/hub/providers/`)
 
 | File | Role |

--- a/providers/edges/deploy/chart/templates/catalogentry.yaml
+++ b/providers/edges/deploy/chart/templates/catalogentry.yaml
@@ -62,4 +62,15 @@ data:
             resource: clusterrolebindings
             verbs: [get, list, watch, create, update, patch, delete]
             tenantScoped: true
+          # Delegated authn/authz for the data plane (kcp#4279 / kcp#4280): the
+          # provider validates presented tokens and authorizes the resolved
+          # identity against the consumer workspace via the APIExport VW. Must
+          # match manifest.yaml + init_cmd.go. Built-in review APIs: verb create
+          # only, not tenantScoped (nothing to list/watch).
+          - group: authentication.k8s.io
+            resource: tokenreviews
+            verbs: [create]
+          - group: authorization.k8s.io
+            resource: subjectaccessreviews
+            verbs: [create]
 {{- end }}


### PR DESCRIPTION
## Summary

Follow-up to #441. That PR added the delegated-auth permission claims (`tokenreviews`, `subjectaccessreviews`) to `manifest.yaml` and `init_cmd.go` (the APIExport) but **missed the Helm chart's `catalogentry.yaml`** — the CatalogEntry actually applied in prod.

Result observed in prod: `init` stamped the APIExport with 7 claims, but the deployed CatalogEntry still advertised 5, so the hub Enable flow never offered tenants the review claims. Existing edges' agents then failed delegated auth on reconnect:

```
Rejected edge agent tunnel: SA token failed delegated authorization
err="token review: tokenreviews.authentication.k8s.io is forbidden:
User \"system:serviceaccount:default:provider\" cannot create tokenreviews ... access denied"
```

## Changes
- `deploy/chart/templates/catalogentry.yaml`: add `tokenreviews` + `subjectaccessreviews` (now consistent with `manifest.yaml` + `init_cmd.go`).
- `AGENTS.md §5.1`: document that permission claims live in **three** synced places, and that existing tenant `APIBinding`s do **not** auto-migrate — a provider that starts requiring a new claim breaks already-enabled tenants without a migration.

## ⚠️ Migration still required (not in this PR)
This makes **new** enables correct. **Already-enabled tenants** keep their old accepted claims — their edges APIBindings need the two review claims added (`state: Accepted`) before/with the new provider rollout, or their agents break. Options: a reconciler that re-accepts claims on existing edges bindings, or a one-off. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)