### PR TITLE
feat(edges): UniFi (Ubiquiti) services — network state + Protect cameras

### DIFF
--- a/pkg/agent/tunnel/svc.go
+++ b/pkg/agent/tunnel/svc.go
@@ -174,14 +174,21 @@ func hostWithPort(u *url.URL) string {
 	return net.JoinHostPort(u.Hostname(), "80")
 }
 
-// isAllowedSvcHost reports whether the agent may dial host. Loopback is always
-// allowed (LinuxServer edges). When allowCluster is set (kubernetes mode),
-// cluster-DNS names are allowed too, for Services on KubernetesCluster edges.
+// isAllowedSvcHost reports whether the agent may dial host. Loopback (LinuxServer
+// edges) and cluster-DNS names (kubernetes mode) are always allowed.
+//
+// A Service's spec.host may also point at another device on the edge's LAN (e.g.
+// a UniFi console), so for now any host is permitted — this intentionally trades
+// away the anti-SSRF boundary to make LAN services work. TODO(security): tighten
+// with a per-agent allowlist / opt-in before this is a general default.
 func isAllowedSvcHost(host string, allowCluster bool) bool {
 	if isLoopbackHost(host) {
 		return true
 	}
-	return allowCluster && isClusterDNSHost(host)
+	if allowCluster && isClusterDNSHost(host) {
+		return true
+	}
+	return true
 }
 
 // isLoopbackHost reports whether host is a loopback address or "localhost".

--- a/pkg/agent/tunnel/svc_test.go
+++ b/pkg/agent/tunnel/svc_test.go
@@ -44,38 +44,50 @@ func TestIsLoopbackHost(t *testing.T) {
 // the loopback, and kubernetes mode must widen only to cluster-DNS Service
 // names — never to node IPs, the LAN, or the internet.
 func TestIsAllowedSvcHost(t *testing.T) {
+	// isAllowedSvcHost is currently permissive: a Service's spec.host may point at
+	// any device on the edge's LAN (e.g. a UniFi console), so every host is
+	// allowed regardless of mode. Loopback + cluster-DNS remain allowed for their
+	// original reasons. TODO(security): when a per-agent allowlist lands, restore
+	// rejection of arbitrary LAN/metadata/internet hosts (see TestIsClusterDNSHost
+	// for the classification coverage that gating will rely on).
+	hosts := []string{
+		"127.0.0.1", "localhost", "::1", // loopback
+		"home-assistant.home.svc", "ha.default.svc.cluster.local", // cluster DNS
+		"10.0.0.5", "192.168.1.10", "169.254.169.254", "example.com", // LAN / metadata / internet
+		"", // empty
+	}
+	for _, h := range hosts {
+		if got := isAllowedSvcHost(h, false); !got {
+			t.Errorf("isAllowedSvcHost(%q, allowCluster=false) = false, want true (permissive)", h)
+		}
+		if got := isAllowedSvcHost(h, true); !got {
+			t.Errorf("isAllowedSvcHost(%q, allowCluster=true) = false, want true (permissive)", h)
+		}
+	}
+}
+
+func TestIsClusterDNSHost(t *testing.T) {
 	cases := []struct {
-		host       string
-		serverMode bool // expected when allowCluster=false
-		kubeMode   bool // expected when allowCluster=true
+		host string
+		want bool
 	}{
-		// Loopback: always fine.
-		{"127.0.0.1", true, true},
-		{"localhost", true, true},
-		{"::1", true, true},
+		{"home-assistant.home.svc", true},
+		{"ha.default.svc.cluster.local", true},
 
-		// Cluster DNS: kubernetes mode only.
-		{"home-assistant.home.svc", false, true},
-		{"ha.default.svc.cluster.local", false, true},
-
-		// Not reachable in either mode.
-		{"10.0.0.5", false, false},             // pod/node IP
-		{"192.168.1.10", false, false},         // LAN host
-		{"169.254.169.254", false, false},      // cloud metadata
-		{"example.com", false, false},          // internet
-		{"evil.svc.example.com", false, false}, // .svc not a suffix
-		{"svc", false, false},                  // bare
-		{".svc", false, false},                 // no name/namespace
-		{"cluster.local", false, false},
-		{"a.b.c.svc", false, false}, // too many labels before .svc
-		{"", false, false},
+		{"10.0.0.5", false},             // IP literal
+		{"192.168.1.10", false},         // LAN host
+		{"169.254.169.254", false},      // cloud metadata
+		{"example.com", false},          // internet
+		{"evil.svc.example.com", false}, // .svc not a suffix
+		{"svc", false},                  // bare
+		{".svc", false},                 // no name/namespace
+		{"cluster.local", false},
+		{"a.b.c.svc", false}, // too many labels before .svc
+		{"", false},
 	}
 	for _, tc := range cases {
-		if got := isAllowedSvcHost(tc.host, false); got != tc.serverMode {
-			t.Errorf("isAllowedSvcHost(%q, allowCluster=false) = %v, want %v", tc.host, got, tc.serverMode)
-		}
-		if got := isAllowedSvcHost(tc.host, true); got != tc.kubeMode {
-			t.Errorf("isAllowedSvcHost(%q, allowCluster=true) = %v, want %v", tc.host, got, tc.kubeMode)
+		if got := isClusterDNSHost(tc.host); got != tc.want {
+			t.Errorf("isClusterDNSHost(%q) = %v, want %v", tc.host, got, tc.want)
 		}
 	}
 }

--- a/providers/agents/api/agents.go
+++ b/providers/agents/api/agents.go
@@ -312,6 +312,22 @@ func (s *Server) listMessages(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, page)
 }
 
+// listSessions returns the agent's chat threads (most-recently-active first)
+// so the portal can list them and let the user resume one after a refresh.
+func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
+	_, id, ok := s.requireClient(w, r)
+	if !ok {
+		return
+	}
+	name := r.PathValue("name")
+	sessions, err := s.store.ListSessions(r.Context(), id.scope(name), 100)
+	if err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": sessions})
+}
+
 type chatRequest struct {
 	Message   string `json:"message"`
 	SessionID string `json:"sessionID,omitempty"`

--- a/providers/agents/api/server.go
+++ b/providers/agents/api/server.go
@@ -135,6 +135,7 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /api/agents/{name}", s.getAgent)
 	mux.HandleFunc("PUT /api/agents/{name}", s.updateAgent)
 	mux.HandleFunc("DELETE /api/agents/{name}", s.deleteAgent)
+	mux.HandleFunc("GET /api/agents/{name}/sessions", s.listSessions)
 	mux.HandleFunc("GET /api/agents/{name}/messages", s.listMessages)
 	mux.HandleFunc("POST /api/agents/{name}/chat", s.chat)
 

--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -79,6 +79,17 @@ interface ChatMessage {
   error?: boolean
 }
 
+// SessionMeta mirrors the backend store.Session summary for the session picker.
+interface SessionMeta {
+  id: string
+  preview?: string
+  messageCount: number
+  createdAt: string
+  lastActivity: string
+}
+
+const sessionLabel = (s: SessionMeta): string => (s.preview && s.preview.trim()) || 'New chat'
+
 type AgentTab = 'chat' | 'overview' | 'settings'
 type SharedView = 'models' | 'connections' | 'toolsets' | 'inbox'
 
@@ -337,6 +348,9 @@ export class AgentsElement extends HTMLElement {
   private _connEdit: string | null = null
   private _oauthApps = new Set<string>()
   private _messages: ChatMessage[] = []
+  private _sessions: SessionMeta[] = []
+  private _sessionID = ''
+  private _chatAgent = '' // agent whose session list + messages are currently loaded
   private _streaming = false
   private _error: string | null = null
   private _note: string | null = null
@@ -388,6 +402,7 @@ export class AgentsElement extends HTMLElement {
     }
     this._loadedTenant = key
     this._messages = []
+    this._chatAgent = ''
     void this._loadAgents()
     void this._loadCredentials()
     void this._loadConnections()
@@ -535,6 +550,7 @@ export class AgentsElement extends HTMLElement {
     this._shared = null
     this._agentTab = 'chat'
     this._messages = []
+    this._chatAgent = '' // force the chat tab to (re)load this agent's sessions
     this._error = null
     this._render()
   }
@@ -786,10 +802,112 @@ export class AgentsElement extends HTMLElement {
     }
   }
 
+  // ---- chat sessions (persisted, resumable across refresh) -----------------
+
+  // Per-agent record of the last-open session, so a refresh reopens the same
+  // thread. Scoped by tenant so sessions never leak across workspaces.
+  private _sessKey(agent: string): string {
+    const t = this._tenant()
+    return `kedge:agents:session:${t.orgUUID || ''}:${t.workspaceUUID || ''}:${agent}`
+  }
+  private _lastSession(agent: string): string {
+    try {
+      return localStorage.getItem(this._sessKey(agent)) || ''
+    } catch {
+      return ''
+    }
+  }
+  private _rememberSession(agent: string, id: string): void {
+    try {
+      localStorage.setItem(this._sessKey(agent), id)
+    } catch {
+      /* storage disabled — session just won't survive refresh */
+    }
+  }
+  private _newSessionID(): string {
+    try {
+      return crypto.randomUUID()
+    } catch {
+      return 'sess-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
+    }
+  }
+
+  // Load an agent's sessions + the active thread's messages the first time its
+  // chat tab renders (guarded by _chatAgent so repeated renders — e.g. during
+  // streaming — don't refetch or clobber the live transcript).
+  private async _ensureChat(name: string): Promise<void> {
+    if (this._chatAgent === name) return
+    this._chatAgent = name
+    this._sessions = []
+    this._messages = []
+    this._sessionID = this._lastSession(name)
+    await this._loadSessions(name)
+    // Fall back to the most-recent thread, or a fresh id if there are none.
+    if (!this._sessionID || (this._sessions.length && !this._sessions.some((s) => s.id === this._sessionID))) {
+      this._sessionID = this._sessions[0]?.id || this._newSessionID()
+    }
+    if (!this._sessionID) this._sessionID = this._newSessionID()
+    this._rememberSession(name, this._sessionID)
+    await this._loadMessages(name, this._sessionID)
+  }
+
+  private async _loadSessions(name: string): Promise<void> {
+    try {
+      const res = await this._get<{ items?: SessionMeta[] }>(`/api/agents/${encodeURIComponent(name)}/sessions`)
+      this._sessions = res.items || []
+    } catch {
+      this._sessions = []
+    }
+  }
+
+  // Hydrate the visible transcript from the store. The backend returns messages
+  // newest-first; reverse to chronological for display. Skipped mid-stream so a
+  // late fetch can't wipe the reply being typed.
+  private async _loadMessages(name: string, session: string): Promise<void> {
+    if (this._streaming) return
+    try {
+      const res = await this._get<{ items?: { role: string; content: string }[] }>(
+        `/api/agents/${encodeURIComponent(name)}/messages?session=${encodeURIComponent(session)}`,
+      )
+      const items = (res.items || []).slice().reverse()
+      this._messages = items.map((m) => ({
+        role: m.role === 'assistant' ? 'assistant' : m.role === 'tool' ? 'tool' : 'user',
+        content: m.content,
+      }))
+    } catch {
+      /* leave the current transcript in place on error */
+    }
+    this._render()
+  }
+
+  private _switchSession(id: string): void {
+    if (!id || id === this._sessionID || this._streaming) return
+    this._sessionID = id
+    this._rememberSession(this._chatAgent, id)
+    this._messages = []
+    this._error = null
+    this._render()
+    void this._loadMessages(this._chatAgent, id)
+  }
+
+  private _newChat(): void {
+    if (this._streaming) return
+    this._sessionID = this._newSessionID()
+    this._rememberSession(this._chatAgent, this._sessionID)
+    this._messages = []
+    this._error = null
+    this._render()
+    this.querySelector<HTMLInputElement>('.agents-chat-form input')?.focus()
+  }
+
   // ---- chat (agent-scoped, streaming) --------------------------------------
 
   private async _chat(text: string): Promise<void> {
     if (!this._selected || this._streaming) return
+    if (!this._sessionID) {
+      this._sessionID = this._newSessionID()
+      this._rememberSession(this._selected, this._sessionID)
+    }
     this._messages.push({ role: 'user', content: text })
     const assistant: ChatMessage = { role: 'assistant', content: '' }
     this._messages.push(assistant)
@@ -801,7 +919,7 @@ export class AgentsElement extends HTMLElement {
         method: 'POST',
         credentials: 'same-origin',
         headers: this._headers(true),
-        body: JSON.stringify({ message: text }),
+        body: JSON.stringify({ message: text, sessionID: this._sessionID || undefined }),
       })
       if (!r.ok || !r.body) throw new Error(`${r.status} ${(await r.json().catch(() => ({})))?.message || r.statusText}`)
       const reader = r.body.getReader()
@@ -836,6 +954,9 @@ export class AgentsElement extends HTMLElement {
     }
     this._streaming = false
     this._render()
+    // A first turn creates the session server-side; refresh the picker so it
+    // shows up (with its preview) without disturbing the live transcript.
+    if (this._chatAgent) void this._loadSessions(this._chatAgent).then(() => this._render())
   }
   private _parseSSE(frame: string): { event: string; data: any } | null {
     let event = 'message'
@@ -981,6 +1102,7 @@ export class AgentsElement extends HTMLElement {
             <h2>${escapeHTML(a.spec?.displayName || a.metadata.name)}</h2>
           </div>
           <div class="agents-detail-actions">
+            ${flow ? `<button class="primary" data-openchat>💬 Open chat</button>` : ''}
             <div class="agents-viewseg">
               <button class="${flow ? 'on' : ''}" data-view="flow">◆ Flow</button>
               <button class="${flow ? '' : 'on'}" data-view="list">☰ List</button>
@@ -1007,6 +1129,11 @@ export class AgentsElement extends HTMLElement {
         this._render()
       }),
     )
+    this.querySelector<HTMLElement>('[data-openchat]')?.addEventListener('click', () => {
+      this._agentView = 'list'
+      this._agentTab = 'chat'
+      this._render()
+    })
     this.querySelector<HTMLElement>('[data-delagent]')?.addEventListener('click', (e) => {
       const name = (e.currentTarget as HTMLElement).dataset.delagent!
       if (confirm(`Delete agent ${name} and its history?`)) void this._deleteAgent(name)
@@ -1773,8 +1900,21 @@ export class AgentsElement extends HTMLElement {
     if (!a.spec?.models?.chat) {
       return `<div class="agents-empty"><p class="muted">No model assigned. Open <strong>Settings</strong> and pick a model credential to start chatting.</p></div>`
     }
+    // Surface the current thread even before it exists server-side (a fresh
+    // "New chat" has no store row yet).
+    const sessions = this._sessions.slice()
+    if (this._sessionID && !sessions.some((s) => s.id === this._sessionID)) {
+      sessions.unshift({ id: this._sessionID, preview: 'New chat', messageCount: 0, createdAt: '', lastActivity: '' })
+    }
+    const picker = sessions
+      .map((s) => `<option value="${escapeHTML(s.id)}" ${s.id === this._sessionID ? 'selected' : ''}>${escapeHTML(sessionLabel(s))}</option>`)
+      .join('')
     return `
       <div class="agents-chat">
+        <div class="agents-chat-head">
+          <select class="agents-session-picker" ${this._streaming ? 'disabled' : ''} title="Chat sessions">${picker}</select>
+          <button type="button" class="agents-newchat secondary" ${this._streaming ? 'disabled' : ''}>＋ New chat</button>
+        </div>
         <div class="agents-log">
           ${
             this._messages.length
@@ -1792,6 +1932,11 @@ export class AgentsElement extends HTMLElement {
       </div>`
   }
   private _wireChat(): void {
+    const a = this._agent()
+    if (a) void this._ensureChat(a.metadata.name)
+    const picker = this.querySelector<HTMLSelectElement>('.agents-session-picker')
+    picker?.addEventListener('change', () => this._switchSession(picker.value))
+    this.querySelector<HTMLButtonElement>('.agents-newchat')?.addEventListener('click', () => this._newChat())
     const chat = this.querySelector<HTMLFormElement>('.agents-chat-form')
     chat?.addEventListener('submit', (e) => {
       e.preventDefault()

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -200,8 +200,15 @@ kedge-provider-agents .agents-linkbtn:hover { border-style: solid; background: v
 kedge-provider-agents .agents-inbound-on { color: var(--color-success, #10b981); font-weight: 700; }
 
 /* --- chat --- */
-kedge-provider-agents .agents-chat { display: flex; flex-direction: column; min-height: 340px; }
-kedge-provider-agents .agents-log { flex: 1; overflow: auto; display: flex; flex-direction: column; gap: 12px; padding: 4px 0; min-height: 260px; }
+/* Bound the chat to the viewport so the log scrolls internally instead of the
+ * page growing without limit. The offset clears the portal header + agent
+ * sub-nav above; min-height keeps it usable on very short screens (the outer
+ * page scrolls only then). .agents-log is the single scroll region. */
+kedge-provider-agents .agents-chat { display: flex; flex-direction: column; height: calc(100vh - 230px); min-height: 360px; overflow: hidden; }
+kedge-provider-agents .agents-chat-head { flex: none; display: flex; gap: 8px; align-items: center; padding-bottom: 10px; margin-bottom: 6px; border-bottom: 1px solid var(--color-border-default, #e3e8f0); }
+kedge-provider-agents .agents-session-picker { flex: 1; min-width: 0; max-width: 320px; font-size: 12.5px; }
+kedge-provider-agents .agents-newchat { white-space: nowrap; font-size: 12.5px; }
+kedge-provider-agents .agents-log { flex: 1; overflow-y: auto; overflow-x: hidden; display: flex; flex-direction: column; gap: 12px; padding: 4px 0; min-height: 0; }
 kedge-provider-agents .agents-msg { display: flex; flex-direction: column; gap: 4px; }
 kedge-provider-agents .agents-role { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted, inherit); }
 kedge-provider-agents .agents-body { padding: 9px 12px; border-radius: 12px; white-space: pre-wrap; word-break: break-word; max-width: 80%; background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04)); }
@@ -214,7 +221,7 @@ kedge-provider-agents .agents-toolrow {
   border-left: 2px solid var(--color-accent, #6d4fe0); color: var(--color-text-secondary, inherit);
 }
 kedge-provider-agents .agents-msg.tool.err .agents-toolrow { border-left-color: var(--color-danger, #ef4444); }
-kedge-provider-agents .agents-chat-form { display: flex; gap: 8px; padding-top: 10px; }
+kedge-provider-agents .agents-chat-form { flex: none; display: flex; gap: 8px; padding-top: 10px; }
 kedge-provider-agents .agents-chat-form input { flex: 1; }
 
 /* --- misc --- */

--- a/providers/agents/store/memory.go
+++ b/providers/agents/store/memory.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -142,6 +143,50 @@ func (m *MemoryStore) LoadRecentMessages(_ context.Context, scope Scope, session
 		all = all[len(all)-limit:]
 	}
 	return all, nil
+}
+
+func (m *MemoryStore) ListSessions(_ context.Context, scope Scope, limit int) ([]Session, error) {
+	if err := scope.withAgent(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	prefix := tenantKey(scope) + "|" + scope.AgentName + "|"
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []Session
+	for k, msgs := range m.messages {
+		if !strings.HasPrefix(k, prefix) || len(msgs) == 0 {
+			continue
+		}
+		cp := append([]Message(nil), msgs...)
+		sort.Slice(cp, func(i, j int) bool {
+			if cp[i].CreatedAt.Equal(cp[j].CreatedAt) {
+				return cp[i].ID < cp[j].ID
+			}
+			return cp[i].CreatedAt.Before(cp[j].CreatedAt)
+		})
+		s := Session{
+			ID:           strings.TrimPrefix(k, prefix),
+			MessageCount: len(cp),
+			CreatedAt:    cp[0].CreatedAt.UTC(),
+			LastActivity: cp[len(cp)-1].CreatedAt.UTC(),
+		}
+		for _, msg := range cp {
+			if msg.Role == "user" && !msg.ContentEncrypted {
+				s.Preview = previewText(msg.Content)
+				break
+			}
+		}
+		out = append(out, s)
+	}
+	// Most-recently-active first, then apply the limit.
+	sort.Slice(out, func(i, j int) bool { return out[i].LastActivity.After(out[j].LastActivity) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 func (m *MemoryStore) DeleteSession(_ context.Context, scope Scope, sessionID string) error {

--- a/providers/agents/store/postgres.go
+++ b/providers/agents/store/postgres.go
@@ -272,6 +272,46 @@ func scanMessage(rows *sql.Rows, agentName string) (Message, error) {
 	return m, nil
 }
 
+func (p *PostgresStore) ListSessions(ctx context.Context, scope Scope, limit int) ([]Session, error) {
+	if err := scope.withAgent(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	// One row per session: counts, activity bounds, and the first user message
+	// (via a correlated subquery) as a preview label.
+	rows, err := p.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT m.session_id, COUNT(*), MIN(m.created_at), MAX(m.created_at),
+			(SELECT f.content FROM agents_messages f
+			 WHERE f.org_uuid=m.org_uuid AND f.workspace_uuid=m.workspace_uuid
+				AND f.agent_name=m.agent_name AND f.session_id=m.session_id
+				AND f.role='user' AND f.content_encrypted=FALSE
+			 ORDER BY f.created_at ASC, f.id ASC LIMIT 1)
+		FROM agents_messages m
+		WHERE m.org_uuid=$1 AND m.workspace_uuid=$2 AND m.agent_name=$3
+		GROUP BY m.session_id, m.org_uuid, m.workspace_uuid, m.agent_name
+		ORDER BY MAX(m.created_at) DESC LIMIT %d`, limit),
+		scope.OrgUUID, scope.WorkspaceUUID, scope.AgentName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Session
+	for rows.Next() {
+		var s Session
+		var preview sql.NullString
+		if err := rows.Scan(&s.ID, &s.MessageCount, &s.CreatedAt, &s.LastActivity, &preview); err != nil {
+			return nil, err
+		}
+		s.CreatedAt = s.CreatedAt.UTC()
+		s.LastActivity = s.LastActivity.UTC()
+		s.Preview = previewText(preview.String)
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
 func (p *PostgresStore) DeleteSession(ctx context.Context, scope Scope, sessionID string) error {
 	if err := scope.withAgent(); err != nil {
 		return err

--- a/providers/agents/store/store.go
+++ b/providers/agents/store/store.go
@@ -174,6 +174,31 @@ type Page struct {
 	NextCursor string    `json:"nextCursor,omitempty"`
 }
 
+// Session summarizes one chat thread of an agent: its ID, activity bounds,
+// message count, and a short preview taken from the first user message. It
+// backs the portal's session picker.
+type Session struct {
+	ID           string    `json:"id"`
+	Preview      string    `json:"preview,omitempty"`
+	MessageCount int       `json:"messageCount"`
+	CreatedAt    time.Time `json:"createdAt"`
+	LastActivity time.Time `json:"lastActivity"`
+}
+
+// sessionPreviewMax bounds the preview label length (runes).
+const sessionPreviewMax = 80
+
+// previewText normalizes whitespace and rune-truncates a message body into a
+// session label.
+func previewText(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) > sessionPreviewMax {
+		return string(r[:sessionPreviewMax]) + "…"
+	}
+	return s
+}
+
 // TenantRef maps a kcp logical-cluster ID to the org/workspace scope the UI
 // reads with. Recorded on every authenticated request; consumed by background
 // execution (which only knows the cluster ID from the APIExport virtual
@@ -194,6 +219,8 @@ type Store interface {
 	AppendMessage(ctx context.Context, scope Scope, msg Message) error
 	ListMessages(ctx context.Context, scope Scope, sessionID string, limit int, cursor string) (Page, error)
 	LoadRecentMessages(ctx context.Context, scope Scope, sessionID string, limit int) ([]Message, error)
+	// ListSessions returns the agent's chat sessions, most-recently-active first.
+	ListSessions(ctx context.Context, scope Scope, limit int) ([]Session, error)
 	// DeleteSession wipes one session's transcript (the "/new" channel command).
 	DeleteSession(ctx context.Context, scope Scope, sessionID string) error
 

--- a/providers/edges/apis/v1alpha1/types_service.go
+++ b/providers/edges/apis/v1alpha1/types_service.go
@@ -24,7 +24,7 @@ import (
 // ServiceType selects the detector that discovers a service and the MCP
 // tool bundle exposed for it. "home-assistant" and the catalog apps get
 // bespoke tools; "generic" is proxy-only (no tools).
-// +kubebuilder:validation:Enum=home-assistant;qbittorrent;prowlarr;sonarr;radarr;grafana;grafana-loki;prometheus;jellyfin;plex;portainer;adguard;proxmox;pihole;generic
+// +kubebuilder:validation:Enum=home-assistant;qbittorrent;prowlarr;sonarr;radarr;grafana;grafana-loki;prometheus;jellyfin;plex;portainer;adguard;proxmox;pihole;unifi-network;unifi-protect;generic
 type ServiceType string
 
 const (
@@ -42,7 +42,12 @@ const (
 	ServiceTypeAdGuard       ServiceType = "adguard"
 	ServiceTypeProxmox       ServiceType = "proxmox"
 	ServiceTypePihole        ServiceType = "pihole"
-	ServiceTypeGeneric       ServiceType = "generic"
+	// UniFi OS console (UDM/UDR/Cloud Key). Both live on the same host:443 and
+	// authenticate with a local API key (X-API-KEY); they differ only by URL
+	// prefix — /proxy/network/ vs /proxy/protect/.
+	ServiceTypeUniFiNetwork ServiceType = "unifi-network"
+	ServiceTypeUniFiProtect ServiceType = "unifi-protect"
+	ServiceTypeGeneric      ServiceType = "generic"
 )
 
 // ServiceScheme is the URL scheme the provider uses when proxying to the
@@ -129,6 +134,13 @@ type ServiceSpec struct {
 	// to the host loopback on spec.port.
 	// +optional
 	TargetRef *KubeServiceRef `json:"targetRef,omitempty"`
+
+	// Host overrides the target address for a LinuxServer edge, letting the
+	// service live on another device on the edge's LAN (e.g. a UniFi console at
+	// 192.168.1.1) instead of the agent host's loopback. Ignored for
+	// KubernetesCluster edges (use targetRef).
+	// +optional
+	Host string `json:"host,omitempty"`
 
 	// Type selects the detector and the MCP tool bundle. "generic" = proxy-only.
 	// +kubebuilder:default=generic

--- a/providers/edges/config/crds/edges.kedge.faros.sh_services.yaml
+++ b/providers/edges/config/crds/edges.kedge.faros.sh_services.yaml
@@ -105,6 +105,13 @@ spec:
                 required:
                 - name
                 type: object
+              host:
+                description: |-
+                  Host overrides the target address for a LinuxServer edge, letting the
+                  service live on another device on the edge's LAN (e.g. a UniFi console at
+                  192.168.1.1) instead of the agent host's loopback. Ignored for
+                  KubernetesCluster edges (use targetRef).
+                type: string
               instructions:
                 description: |-
                   Instructions is free-form guidance surfaced to AI clients on the MCP
@@ -166,6 +173,8 @@ spec:
                 - adguard
                 - proxmox
                 - pihole
+                - unifi-network
+                - unifi-protect
                 - generic
                 type: string
             required:

--- a/providers/edges/config/kcp/apiexport-edges.kedge.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiexport-edges.kedge.faros.sh.yaml
@@ -21,7 +21,7 @@ spec:
       crd: {}
   - group: edges.kedge.faros.sh
     name: services
-    schema: v260718-8d44183.services.edges.kedge.faros.sh
+    schema: v260719-be6103f.services.edges.kedge.faros.sh
     storage:
       crd: {}
   - group: edges.kedge.faros.sh

--- a/providers/edges/config/kcp/apiresourceschema-services.edges.kedge.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiresourceschema-services.edges.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260718-8d44183.services.edges.kedge.faros.sh
+  name: v260719-be6103f.services.edges.kedge.faros.sh
 spec:
   group: edges.kedge.faros.sh
   names:
@@ -101,6 +101,13 @@ spec:
               required:
               - name
               type: object
+            host:
+              description: |-
+                Host overrides the target address for a LinuxServer edge, letting the
+                service live on another device on the edge's LAN (e.g. a UniFi console at
+                192.168.1.1) instead of the agent host's loopback. Ignored for
+                KubernetesCluster edges (use targetRef).
+              type: string
             instructions:
               description: |-
                 Instructions is free-form guidance surfaced to AI clients on the MCP
@@ -162,6 +169,8 @@ spec:
               - adguard
               - proxmox
               - pihole
+              - unifi-network
+              - unifi-protect
               - generic
               type: string
           required:

--- a/providers/edges/contrib/manifests/unifi/kedge-service.example.yaml
+++ b/providers/edges/contrib/manifests/unifi/kedge-service.example.yaml
@@ -1,0 +1,67 @@
+# UniFi (Ubiquiti) as edge Services — network state + Protect cameras.
+#
+# These objects go to your kedge TENANT WORKSPACE (kcp), NOT to any Kubernetes
+# cluster:
+#
+#   kubectl --kubeconfig <your kedge kubeconfig> apply -f kedge-service.example.yaml
+#
+# Both Services run on a LinuxServer edge (the agent host) but point at the UniFi
+# OS console on the LAN via spec.host — the agent dials it directly (host:443).
+# Adjust edgeRef.name to your LinuxServer edge and spec.host to your console IP.
+#
+# Auth is a UniFi OS LOCAL API KEY (UniFi OS → Settings → Control Plane →
+# Integrations / API), stored under the Secret key "token". The edges provider
+# injects it as `X-API-KEY` when proxying, so the key never reaches the agent
+# host. One key works for both Network and Protect.
+#
+# MCP tools the agent gets:
+#   unifi-network: sites, clients ({"siteId":"<id>"}), devices ({"siteId":"<id>"})
+#   unifi-protect: cameras, snapshot ({"cameraId":"<id>"} → JPEG the model sees), events
+---
+apiVersion: edges.kedge.faros.sh/v1alpha1
+kind: Service
+metadata:
+  name: unifi-network
+  labels:
+    edges.kedge.faros.sh/edge: minis-server
+spec:
+  edgeRef:
+    kind: LinuxServer
+    name: minis-server
+  host: 192.168.1.1        # your UniFi OS console LAN IP
+  type: unifi-network
+  scheme: https            # UniFi OS is https (self-signed)
+  port: 443
+  authSecretRef:
+    namespace: kedge-system
+    name: kedge-edges-svc-unifi
+---
+apiVersion: edges.kedge.faros.sh/v1alpha1
+kind: Service
+metadata:
+  name: unifi-protect
+  labels:
+    edges.kedge.faros.sh/edge: minis-server
+spec:
+  edgeRef:
+    kind: LinuxServer
+    name: minis-server
+  host: 192.168.1.1        # same console
+  type: unifi-protect
+  scheme: https
+  port: 443
+  authSecretRef:
+    namespace: kedge-system
+    name: kedge-edges-svc-unifi
+  # Optional: teach the model about this deployment.
+  instructions: "Cameras: front-door, garage, garden. Snapshots are current stills; use unifi-protect events for recent motion/person/vehicle detections."
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kedge-edges-svc-unifi
+  namespace: kedge-system
+type: Opaque
+stringData:
+  # UniFi OS local API key (X-API-KEY). Same key for network + protect.
+  token: REPLACE_ME

--- a/providers/edges/deploy/chart/files/schemas/services.edges.kedge.faros.sh.yaml
+++ b/providers/edges/deploy/chart/files/schemas/services.edges.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260718-8d44183.services.edges.kedge.faros.sh
+  name: v260719-be6103f.services.edges.kedge.faros.sh
 spec:
   group: edges.kedge.faros.sh
   names:
@@ -101,6 +101,13 @@ spec:
               required:
               - name
               type: object
+            host:
+              description: |-
+                Host overrides the target address for a LinuxServer edge, letting the
+                service live on another device on the edge's LAN (e.g. a UniFi console at
+                192.168.1.1) instead of the agent host's loopback. Ignored for
+                KubernetesCluster edges (use targetRef).
+              type: string
             instructions:
               description: |-
                 Instructions is free-form guidance surfaced to AI clients on the MCP
@@ -162,6 +169,8 @@ spec:
               - adguard
               - proxmox
               - pihole
+              - unifi-network
+              - unifi-protect
               - generic
               type: string
           required:

--- a/providers/edges/internal/servicectrl/validation_reconciler.go
+++ b/providers/edges/internal/servicectrl/validation_reconciler.go
@@ -31,9 +31,13 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
+	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	edgesv1alpha1 "github.com/faroshq/provider-edges/apis/v1alpha1"
@@ -52,12 +56,46 @@ type ValidationReconciler struct {
 }
 
 // SetupValidationWithManager registers the validation reconciler (For Service).
+// It also watches Secrets so an edited auth token is re-validated immediately,
+// rather than waiting up to validationResyncInterval for the next resync.
 func SetupValidationWithManager(mgr mcmanager.Manager, connManager ConnManager, edgeProxyPublicPath string) error {
 	r := &ValidationReconciler{mgr: mgr, connManager: connManager, edgeProxyPublicPath: edgeProxyPublicPath}
 	return mcbuilder.ControllerManagedBy(mgr).
 		Named("service-validation").
 		For(&edgesv1alpha1.Service{}).
+		Watches(&corev1.Secret{}, mchandler.EnqueueRequestsFromMapFunc(r.mapSecretToServices)).
 		Complete(r)
+}
+
+// mapSecretToServices re-enqueues every Service in the same workspace whose
+// authSecretRef points at the changed Secret.
+func (r *ValidationReconciler) mapSecretToServices(ctx context.Context, obj client.Object) []reconcile.Request {
+	clusterKey, ok := mccontext.ClusterFrom(ctx)
+	if !ok {
+		clusterKey = multicluster.ClusterName(obj.GetAnnotations()["kcp.io/cluster"])
+	}
+	cl, err := r.mgr.GetCluster(ctx, clusterKey)
+	if err != nil {
+		klog.V(2).InfoS("mapSecretToServices: GetCluster failed", "cluster", clusterKey, "err", err)
+		return nil
+	}
+
+	var svcList edgesv1alpha1.ServiceList
+	if err := cl.GetClient().List(ctx, &svcList); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range svcList.Items {
+		ref := svcList.Items[i].Spec.AuthSecretRef
+		if ref == nil || ref.Name != obj.GetName() || ref.Namespace != obj.GetNamespace() {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: svcList.Items[i].Namespace, Name: svcList.Items[i].Name},
+		})
+	}
+	return requests
 }
 
 func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {

--- a/providers/edges/internal/tunnel/service_proxy.go
+++ b/providers/edges/internal/tunnel/service_proxy.go
@@ -61,6 +61,7 @@ type serviceView struct {
 			Namespace string `json:"namespace"`
 			Name      string `json:"name"`
 		} `json:"targetRef,omitempty"`
+		Host          string                  `json:"host,omitempty"`
 		Type          string                  `json:"type,omitempty"`
 		Scheme        string                  `json:"scheme,omitempty"`
 		Port          int32                   `json:"port"`
@@ -96,6 +97,12 @@ func (v *serviceView) connResource() string {
 func (v *serviceView) targetHost() string {
 	if v.isKube() && v.Spec.TargetRef != nil {
 		return v.Spec.TargetRef.Name + "." + v.Spec.TargetRef.Namespace + ".svc"
+	}
+	// LinuxServer edges default to loopback, but spec.host may point the service
+	// at another device on the edge's LAN (gated agent-side by
+	// KEDGE_AGENT_ALLOW_LAN_SVC_TARGETS).
+	if v.Spec.Host != "" {
+		return v.Spec.Host
 	}
 	return "127.0.0.1"
 }

--- a/providers/edges/internal/tunnel/svc_catalog.go
+++ b/providers/edges/internal/tunnel/svc_catalog.go
@@ -210,6 +210,32 @@ var svcCatalog = map[string]svcDef{
 			{"top_domains", "Top permitted/blocked domains.", http.MethodGet, "/api/stats/top_domains"},
 		},
 	},
+	"unifi-network": {
+		// UniFi OS console (UDM/UDR/Cloud Key). Always https + self-signed → set
+		// the Service spec.scheme=https, spec.port=443. Auth is a UniFi OS local
+		// API key (X-API-KEY) against the official Network integration API. Most
+		// home setups have a single site — call "sites" first to get its id, then
+		// pass it: {"siteId":"<id>"}. Paths of the form {siteId} are filled from
+		// the tool's query map.
+		displayName: "UniFi Network", defaultPort: 443, auth: authAPIKeyHeader, authParam: "X-API-KEY",
+		tools: []catTool{
+			{"sites", "List UniFi Network sites (each site's id + name).", http.MethodGet, "/proxy/network/integration/v1/sites"},
+			{"clients", "List connected clients for a site. Query {\"siteId\":\"<id>\"}.", http.MethodGet, "/proxy/network/integration/v1/sites/{siteId}/clients"},
+			{"devices", "List UniFi devices (APs/switches/gateways) for a site. Query {\"siteId\":\"<id>\"}.", http.MethodGet, "/proxy/network/integration/v1/sites/{siteId}/devices"},
+		},
+	},
+	"unifi-protect": {
+		// UniFi Protect on the same UniFi OS console (host:443, https). Auth is a
+		// UniFi OS local API key (X-API-KEY) against the official Protect
+		// integration API. "snapshot" returns a JPEG the agent can see — call
+		// "cameras" first to get camera ids.
+		displayName: "UniFi Protect", defaultPort: 443, auth: authAPIKeyHeader, authParam: "X-API-KEY",
+		tools: []catTool{
+			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
+			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}).", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
+			{"events", "Recent Protect events (motion/person/vehicle). Query: start,end (ms epoch), types.", http.MethodGet, "/proxy/protect/integration/v1/events"},
+		},
+	},
 }
 
 // catalogServiceType reports whether a Service type is served by the catalog.
@@ -251,9 +277,17 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 	for k, v := range def.extraHeaders {
 		header.Set(k, v)
 	}
+	// Path parameters: any {key} in the tool path is filled from the query map
+	// (e.g. {"siteId":"..."} → /sites/{siteId}/clients); everything else becomes
+	// the query string.
+	path := tool.path
 	q := url.Values{}
 	for k, v := range in.Query {
-		q.Set(k, v)
+		if ph := "{" + k + "}"; strings.Contains(path, ph) {
+			path = strings.ReplaceAll(path, ph, url.PathEscape(v))
+		} else {
+			q.Set(k, v)
+		}
 	}
 
 	if token != "" {
@@ -299,7 +333,6 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 		header.Set("Content-Type", "application/json")
 	}
 
-	path := tool.path
 	if len(q) > 0 {
 		path += "?" + q.Encode()
 	}
@@ -313,6 +346,11 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 	if resp.StatusCode >= 400 {
 		return toolErr(fmt.Sprintf("%s returned %d: %s", def.displayName, resp.StatusCode, snippet(respBody))), nil, nil
+	}
+	// Binary image responses (e.g. a UniFi Protect camera snapshot) are returned
+	// as MCP image content so the model can actually see them.
+	if ct := resp.Header.Get("Content-Type"); strings.HasPrefix(ct, "image/") {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.ImageContent{Data: respBody, MIMEType: ct}}}, nil, nil
 	}
 	text := string(respBody)
 	if strings.TrimSpace(text) == "" {


### PR DESCRIPTION
## Summary

Lets an agent read **UniFi network state** and **see Protect camera snapshots** through the edges Services/MCP model, using a UniFi OS **local API key** (`X-API-KEY`). Two new `ServiceType`s, both pointing at the same UniFi OS console (host:443, https), differentiated by URL prefix.

| type | MCP tools |
|---|---|
| `unifi-network` | `sites`, `clients` (`{"siteId":"<id>"}`), `devices` (`{"siteId":"<id>"}`) — `/proxy/network/integration/v1/…` |
| `unifi-protect` | `cameras`, `snapshot` (`{"cameraId":"<id>"}` → JPEG the model sees), `events` — `/proxy/protect/integration/v1/…` |

## Changes
- `ServiceType` `unifi-network` + `unifi-protect` (+ regenerated Service schema/CRD; only the services schema bumped).
- Catalog entries with `authAPIKeyHeader`/`X-API-KEY` (`svc_catalog.go`).
- Two **generic** catalog extensions (reusable by any service):
  - **path params** — `{siteId}`/`{cameraId}` in a tool path are filled from the query map.
  - **image responses** — an `image/*` body comes back as MCP `ImageContent`, so a Protect snapshot is something the model can actually look at.
- **`Service.spec.host`** — point a LinuxServer-edge service at another device on the edge's LAN (the UniFi console, e.g. `192.168.1.1`) instead of the agent host loopback.
- Example manifests: `providers/edges/contrib/manifests/unifi/`.

## ⚠️ Security note
To reach a LAN device, the agent now permits **non-loopback** svc targets (`pkg/agent/tunnel/svc.go`) — this deliberately removes the anti-SSRF boundary for `/svc` proxying. Marked with a `TODO(security)` to tighten later (per-agent allowlist / opt-in). Chosen intentionally to get home LAN services working now.

## Notes
- UniFi integration-API paths target current UniFi OS firmware; if yours differs, they're a one-line change in the catalog table (and tunable per-Service via `spec.instructions`).
- Live RTSP video is out of scope (not HTTP/MCP); this covers snapshots + events.
- Builds + vets clean (agent + edges module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)