### PR TITLE
feat(edges): decouple service targeting from edge kind (Host vs K8s Service)

### DIFF
--- a/providers/edges/apis/v1alpha1/types_service.go
+++ b/providers/edges/apis/v1alpha1/types_service.go
@@ -124,21 +124,27 @@ type ServiceList struct {
 }
 
 // ServiceSpec defines the desired state of a Service.
-// +kubebuilder:validation:XValidation:rule="self.edgeRef.kind != 'KubernetesCluster' || has(self.targetRef)",message="spec.targetRef is required when spec.edgeRef.kind is KubernetesCluster"
+// +kubebuilder:validation:XValidation:rule="self.edgeRef.kind != 'KubernetesCluster' || has(self.targetRef) || has(self.host)",message="a KubernetesCluster service needs spec.targetRef (a cluster Service) or spec.host (a reachable address)"
 type ServiceSpec struct {
 	// EdgeRef points at the connectable this service runs on.
 	EdgeRef ServiceEdgeRef `json:"edgeRef"`
 
-	// TargetRef names the Kubernetes Service to proxy to. Required when
-	// edgeRef.kind is KubernetesCluster; ignored for LinuxServer, which proxies
-	// to the host loopback on spec.port.
+	// How the service is reached is chosen by spec.host / spec.targetRef, NOT by
+	// the edge kind: set spec.host to dial an address directly (loopback on the
+	// agent, or a device on the edge's LAN like a UniFi console), or spec.targetRef
+	// to reach a Kubernetes Service by cluster DNS. host takes precedence.
+	// A KubernetesCluster edge needs one of the two; a LinuxServer edge defaults
+	// to host loopback when neither is set.
+
+	// TargetRef names a Kubernetes Service (cluster DNS) to proxy to. Mutually
+	// exclusive with spec.host (host wins). Only meaningful on a KubernetesCluster
+	// edge.
 	// +optional
 	TargetRef *KubeServiceRef `json:"targetRef,omitempty"`
 
-	// Host overrides the target address for a LinuxServer edge, letting the
-	// service live on another device on the edge's LAN (e.g. a UniFi console at
-	// 192.168.1.1) instead of the agent host's loopback. Ignored for
-	// KubernetesCluster edges (use targetRef).
+	// Host is the address the agent dials directly: the agent-host loopback, or
+	// another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
+	// Takes precedence over targetRef and works on either edge kind.
 	// +optional
 	Host string `json:"host,omitempty"`
 

--- a/providers/edges/config/crds/edges.kedge.faros.sh_services.yaml
+++ b/providers/edges/config/crds/edges.kedge.faros.sh_services.yaml
@@ -107,10 +107,9 @@ spec:
                 type: object
               host:
                 description: |-
-                  Host overrides the target address for a LinuxServer edge, letting the
-                  service live on another device on the edge's LAN (e.g. a UniFi console at
-                  192.168.1.1) instead of the agent host's loopback. Ignored for
-                  KubernetesCluster edges (use targetRef).
+                  Host is the address the agent dials directly: the agent-host loopback, or
+                  another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
+                  Takes precedence over targetRef and works on either edge kind.
                 type: string
               instructions:
                 description: |-
@@ -138,9 +137,9 @@ spec:
                 type: string
               targetRef:
                 description: |-
-                  TargetRef names the Kubernetes Service to proxy to. Required when
-                  edgeRef.kind is KubernetesCluster; ignored for LinuxServer, which proxies
-                  to the host loopback on spec.port.
+                  TargetRef names a Kubernetes Service (cluster DNS) to proxy to. Mutually
+                  exclusive with spec.host (host wins). Only meaningful on a KubernetesCluster
+                  edge.
                 properties:
                   name:
                     description: Name of the Kubernetes Service.
@@ -182,8 +181,10 @@ spec:
             - port
             type: object
             x-kubernetes-validations:
-            - message: spec.targetRef is required when spec.edgeRef.kind is KubernetesCluster
+            - message: a KubernetesCluster service needs spec.targetRef (a cluster
+                Service) or spec.host (a reachable address)
               rule: self.edgeRef.kind != 'KubernetesCluster' || has(self.targetRef)
+                || has(self.host)
           status:
             description: ServiceStatus defines the observed state of a Service.
             properties:

--- a/providers/edges/config/kcp/apiexport-edges.kedge.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiexport-edges.kedge.faros.sh.yaml
@@ -21,7 +21,7 @@ spec:
       crd: {}
   - group: edges.kedge.faros.sh
     name: services
-    schema: v260719-be6103f.services.edges.kedge.faros.sh
+    schema: v260719-c339afb.services.edges.kedge.faros.sh
     storage:
       crd: {}
   - group: edges.kedge.faros.sh

--- a/providers/edges/config/kcp/apiresourceschema-services.edges.kedge.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiresourceschema-services.edges.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260719-be6103f.services.edges.kedge.faros.sh
+  name: v260719-c339afb.services.edges.kedge.faros.sh
 spec:
   group: edges.kedge.faros.sh
   names:
@@ -103,10 +103,9 @@ spec:
               type: object
             host:
               description: |-
-                Host overrides the target address for a LinuxServer edge, letting the
-                service live on another device on the edge's LAN (e.g. a UniFi console at
-                192.168.1.1) instead of the agent host's loopback. Ignored for
-                KubernetesCluster edges (use targetRef).
+                Host is the address the agent dials directly: the agent-host loopback, or
+                another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
+                Takes precedence over targetRef and works on either edge kind.
               type: string
             instructions:
               description: |-
@@ -134,9 +133,9 @@ spec:
               type: string
             targetRef:
               description: |-
-                TargetRef names the Kubernetes Service to proxy to. Required when
-                edgeRef.kind is KubernetesCluster; ignored for LinuxServer, which proxies
-                to the host loopback on spec.port.
+                TargetRef names a Kubernetes Service (cluster DNS) to proxy to. Mutually
+                exclusive with spec.host (host wins). Only meaningful on a KubernetesCluster
+                edge.
               properties:
                 name:
                   description: Name of the Kubernetes Service.
@@ -178,8 +177,10 @@ spec:
           - port
           type: object
           x-kubernetes-validations:
-          - message: spec.targetRef is required when spec.edgeRef.kind is KubernetesCluster
+          - message: a KubernetesCluster service needs spec.targetRef (a cluster Service)
+              or spec.host (a reachable address)
             rule: self.edgeRef.kind != 'KubernetesCluster' || has(self.targetRef)
+              || has(self.host)
         status:
           description: ServiceStatus defines the observed state of a Service.
           properties:

--- a/providers/edges/deploy/chart/files/schemas/services.edges.kedge.faros.sh.yaml
+++ b/providers/edges/deploy/chart/files/schemas/services.edges.kedge.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260719-be6103f.services.edges.kedge.faros.sh
+  name: v260719-c339afb.services.edges.kedge.faros.sh
 spec:
   group: edges.kedge.faros.sh
   names:
@@ -103,10 +103,9 @@ spec:
               type: object
             host:
               description: |-
-                Host overrides the target address for a LinuxServer edge, letting the
-                service live on another device on the edge's LAN (e.g. a UniFi console at
-                192.168.1.1) instead of the agent host's loopback. Ignored for
-                KubernetesCluster edges (use targetRef).
+                Host is the address the agent dials directly: the agent-host loopback, or
+                another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
+                Takes precedence over targetRef and works on either edge kind.
               type: string
             instructions:
               description: |-
@@ -134,9 +133,9 @@ spec:
               type: string
             targetRef:
               description: |-
-                TargetRef names the Kubernetes Service to proxy to. Required when
-                edgeRef.kind is KubernetesCluster; ignored for LinuxServer, which proxies
-                to the host loopback on spec.port.
+                TargetRef names a Kubernetes Service (cluster DNS) to proxy to. Mutually
+                exclusive with spec.host (host wins). Only meaningful on a KubernetesCluster
+                edge.
               properties:
                 name:
                   description: Name of the Kubernetes Service.
@@ -178,8 +177,10 @@ spec:
           - port
           type: object
           x-kubernetes-validations:
-          - message: spec.targetRef is required when spec.edgeRef.kind is KubernetesCluster
+          - message: a KubernetesCluster service needs spec.targetRef (a cluster Service)
+              or spec.host (a reachable address)
             rule: self.edgeRef.kind != 'KubernetesCluster' || has(self.targetRef)
+              || has(self.host)
         status:
           description: ServiceStatus defines the observed state of a Service.
           properties:

--- a/providers/edges/internal/tunnel/service_proxy.go
+++ b/providers/edges/internal/tunnel/service_proxy.go
@@ -95,14 +95,13 @@ func (v *serviceView) connResource() string {
 // targetHost is the agent-side address of the service: cluster DNS for a
 // KubernetesCluster edge, the host loopback for a LinuxServer edge.
 func (v *serviceView) targetHost() string {
-	if v.isKube() && v.Spec.TargetRef != nil {
-		return v.Spec.TargetRef.Name + "." + v.Spec.TargetRef.Namespace + ".svc"
-	}
-	// LinuxServer edges default to loopback, but spec.host may point the service
-	// at another device on the edge's LAN (gated agent-side by
-	// KEDGE_AGENT_ALLOW_LAN_SVC_TARGETS).
+	// spec.host wins on either edge kind: dial the address directly (loopback, or
+	// a device on the edge's LAN like a UniFi console).
 	if v.Spec.Host != "" {
 		return v.Spec.Host
+	}
+	if v.isKube() && v.Spec.TargetRef != nil {
+		return v.Spec.TargetRef.Name + "." + v.Spec.TargetRef.Namespace + ".svc"
 	}
 	return "127.0.0.1"
 }

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -46,6 +46,7 @@ function onTypeChange() {
   if (p) draft.value.port = p.port
   // UniFi OS speaks https (self-signed); default the scheme so it just works.
   if (draft.value.serviceType.startsWith('unifi-')) draft.value.scheme = 'https'
+  resetTargetMode()
 }
 
 const services = ref<EdgeService[]>([])
@@ -67,12 +68,28 @@ const draft = ref<EdgeServiceDraft>({
   instructions: '',
 })
 
-// The selected edge's kind decides the form shape: LinuxServer services target
-// the host (loopback, or spec.host for a LAN device like a UniFi console);
-// KubernetesCluster services target a named Kubernetes Service (targetRef).
+// How the service is reached is an explicit choice, independent of the edge kind:
+//   host — dial an address directly (agent loopback, or a LAN device like a UniFi
+//          console). Works on either edge kind.
+//   kube — reach a named Kubernetes Service by cluster DNS (KubernetesCluster only).
+const targetMode = ref<'host' | 'kube'>('host')
+
 const selectedEdgeIsServer = computed(
   () => edges.value.find((e) => e.name === draft.value.edgeName)?.type === 'server',
 )
+
+// Sensible default target mode when the edge or type changes: LAN-style services
+// (UniFi) and LinuxServer edges default to host; KubernetesCluster edges default
+// to a cluster Service. The user can override with the toggle.
+function resetTargetMode() {
+  const isLAN = draft.value.serviceType.startsWith('unifi-')
+  targetMode.value = selectedEdgeIsServer.value || isLAN ? 'host' : 'kube'
+}
+
+function toggleCreate() {
+  showCreate.value = !showCreate.value
+  if (showCreate.value) resetTargetMode()
+}
 
 // Per-row expand for edit (instructions) + connect (token).
 const expanded = ref<string | null>(null)
@@ -105,7 +122,8 @@ const canCreate = computed(
   () =>
     !!draft.value.name.trim() &&
     !!draft.value.edgeName &&
-    (selectedEdgeIsServer.value || !!draft.value.targetName.trim()),
+    // host mode: host optional (empty = agent loopback). kube mode: need a target.
+    (targetMode.value === 'host' || !!draft.value.targetName.trim()),
 )
 
 async function onCreate() {
@@ -113,16 +131,16 @@ async function onCreate() {
   busy.value = true
   error.value = null
   try {
-    const isServer = selectedEdgeIsServer.value
+    const byHost = targetMode.value === 'host'
     await createKubeEdgeService({
       name: draft.value.name.trim(),
       edgeName: draft.value.edgeName,
-      edgeKind: isServer ? 'LinuxServer' : 'KubernetesCluster',
+      edgeKind: selectedEdgeIsServer.value ? 'LinuxServer' : 'KubernetesCluster',
       serviceType: draft.value.serviceType,
       targetNamespace: draft.value.targetNamespace.trim() || 'default',
-      targetName: draft.value.targetName.trim(),
+      targetName: byHost ? '' : draft.value.targetName.trim(),
       scheme: draft.value.scheme || 'http',
-      host: isServer ? draft.value.host?.trim() || undefined : undefined,
+      host: byHost ? draft.value.host?.trim() || undefined : undefined,
       port: Number(draft.value.port) || 8123,
       instructions: draft.value.instructions?.trim() || undefined,
     })
@@ -194,7 +212,7 @@ function phaseClass(p?: string): string {
         <button class="btn" :disabled="loading" @click="refresh">
           <RefreshCw :size="14" :class="{ spin: loading }" /> Refresh
         </button>
-        <button class="btn primary" @click="showCreate = !showCreate">
+        <button class="btn primary" @click="toggleCreate">
           <Plus :size="14" /> New service
         </button>
       </div>
@@ -212,7 +230,7 @@ function phaseClass(p?: string): string {
         </label>
         <label class="fld" style="flex: 1;">
           <span class="lbl">Edge</span>
-          <select v-model="draft.edgeName" class="input">
+          <select v-model="draft.edgeName" class="input" @change="resetTargetMode">
             <option v-for="e in edges" :key="e.name" :value="e.name">{{ e.name }} ({{ e.type === 'server' ? 'LinuxServer' : 'KubernetesCluster' }})</option>
           </select>
         </label>
@@ -238,14 +256,26 @@ function phaseClass(p?: string): string {
           <input v-model="draft.port" type="number" min="1" max="65535" class="input" />
         </label>
       </div>
-      <!-- LinuxServer: reach the host loopback, or a device on the edge's LAN. -->
-      <div v-if="selectedEdgeIsServer" class="row" style="gap: 12px; align-items: flex-start;">
+      <!-- Target: an explicit choice, independent of the edge kind. -->
+      <label class="fld">
+        <span class="lbl">Target</span>
+        <div class="row" style="gap: 16px;">
+          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+            <input type="radio" value="host" v-model="targetMode" /> Host / IP
+          </label>
+          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;" :style="{ opacity: selectedEdgeIsServer ? 0.5 : 1 }">
+            <input type="radio" value="kube" v-model="targetMode" :disabled="selectedEdgeIsServer" /> Kubernetes Service
+          </label>
+        </div>
+      </label>
+      <!-- Host: dial an address directly (loopback, or a LAN device like UniFi). -->
+      <div v-if="targetMode === 'host'" class="row" style="gap: 12px; align-items: flex-start;">
         <label class="fld" style="flex: 1;">
-          <span class="lbl">Host (optional — device on the edge's LAN)</span>
-          <input v-model="draft.host" class="input" placeholder="127.0.0.1 (loopback) or e.g. 192.168.1.1 for a UniFi console" />
+          <span class="lbl">Host (blank = agent loopback)</span>
+          <input v-model="draft.host" class="input" placeholder="e.g. 192.168.1.1 (UniFi console) — leave blank for 127.0.0.1 on the agent host" />
         </label>
       </div>
-      <!-- KubernetesCluster: reach a named Kubernetes Service. -->
+      <!-- Kubernetes Service: reach it by cluster DNS. -->
       <div v-else class="row" style="gap: 12px; align-items: flex-start;">
         <label class="fld" style="flex: 1;">
           <span class="lbl">Target namespace</span>

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -91,6 +91,22 @@ function toggleCreate() {
   if (showCreate.value) resetTargetMode()
 }
 
+// spec.host is a bare hostname/IP (scheme + port are separate fields). If the
+// user pastes a full URL, split it into host + scheme + port for convenience.
+// Any path is dropped — services proxy at the root.
+function applyHostUrl() {
+  const raw = draft.value.host?.trim()
+  if (!raw || !/^https?:\/\//i.test(raw)) return
+  try {
+    const u = new URL(raw)
+    draft.value.scheme = u.protocol.replace(':', '')
+    draft.value.host = u.hostname
+    draft.value.port = Number(u.port) || (u.protocol === 'https:' ? 443 : 80)
+  } catch {
+    /* not a valid URL — leave the field as typed */
+  }
+}
+
 // Per-row expand for edit (instructions) + connect (token).
 const expanded = ref<string | null>(null)
 const editInstructions = ref('')
@@ -128,6 +144,7 @@ const canCreate = computed(
 
 async function onCreate() {
   if (!canCreate.value) return
+  if (targetMode.value === 'host') applyHostUrl() // normalize a pasted URL
   busy.value = true
   error.value = null
   try {
@@ -272,7 +289,7 @@ function phaseClass(p?: string): string {
       <div v-if="targetMode === 'host'" class="row" style="gap: 12px; align-items: flex-start;">
         <label class="fld" style="flex: 1;">
           <span class="lbl">Host (blank = agent loopback)</span>
-          <input v-model="draft.host" class="input" placeholder="e.g. 192.168.1.1 (UniFi console) — leave blank for 127.0.0.1 on the agent host" />
+          <input v-model="draft.host" class="input" @blur="applyHostUrl" placeholder="192.168.1.1, myui.example.com, or paste https://myui.example.com — blank = 127.0.0.1" />
         </label>
       </div>
       <!-- Kubernetes Service: reach it by cluster DNS. -->

--- a/providers/edges/portal/src/api.ts
+++ b/providers/edges/portal/src/api.ts
@@ -301,21 +301,20 @@ export async function updateEdgeServiceInstructions(name: string, instructions: 
 // object carries the edge label so it lists alongside discovered ones, but NOT
 // the discovered label — the discovery reconciler must never prune it.
 export async function createKubeEdgeService(d: EdgeServiceDraft): Promise<void> {
-  // LinuxServer edges reach the service on the host loopback, or — via spec.host —
-  // another device on the edge's LAN (e.g. a UniFi console). KubernetesCluster
-  // edges reach it behind a named Kubernetes Service (targetRef).
-  const isServer = d.edgeKind === 'LinuxServer'
+  // Targeting is independent of edge kind: spec.host dials an address directly
+  // (agent loopback, or a LAN device like a UniFi console); spec.targetRef reaches
+  // a named Kubernetes Service by cluster DNS. host wins if both are set.
   const spec: Record<string, unknown> = {
-    edgeRef: { kind: isServer ? 'LinuxServer' : 'KubernetesCluster', name: d.edgeName },
+    edgeRef: { kind: d.edgeKind || 'KubernetesCluster', name: d.edgeName },
     type: d.serviceType,
     port: d.port,
     ...(d.scheme ? { scheme: d.scheme } : {}),
     ...(d.instructions ? { instructions: d.instructions } : {}),
   }
-  if (isServer) {
-    if (d.host?.trim()) spec.host = d.host.trim()
-  } else {
-    spec.targetRef = { namespace: d.targetNamespace, name: d.targetName }
+  if (d.host?.trim()) {
+    spec.host = d.host.trim()
+  } else if (d.targetName?.trim()) {
+    spec.targetRef = { namespace: d.targetNamespace?.trim() || 'default', name: d.targetName.trim() }
   }
   const object: Record<string, unknown> = {
     metadata: {


### PR DESCRIPTION
## Summary

Fixes the Services form UX you flagged: `minis` is a **KubernetesCluster** edge, so the form only offered *Target namespace / service name* — you couldn't point a service at a **host** (a UniFi console on the LAN). The CRD enforced the same (`targetRef` required for kube edges). But *how* a service is reached shouldn't be tied to the edge kind.

## Changes
- **API** (`types_service.go`): `spec.host` now works on **either** edge kind and **takes precedence** over `targetRef`. `XValidation` relaxed — a KubernetesCluster service needs `targetRef` **or** `host`. `targetHost()` prefers `host`. Regenerated schema (only the services schema bumps).
- **UI** (`Services.vue`): a **Target** toggle — **Host / IP** vs **Kubernetes Service** — replaces the edge-kind branching. Host works everywhere (blank = agent loopback; or a LAN IP like a UniFi console). *Kubernetes Service* is offered only for KubernetesCluster edges. UniFi defaults to Host + `https`. `targetName` no longer required in host mode.
- **api.ts**: emits `spec.host` or `spec.targetRef` based on the chosen target, with the real edge kind in `edgeRef`.

Now for your case (`minis` kube edge + UniFi Protect): pick **Host**, enter the console IP — done.

Builds clean (edges module + portal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)