### PR TITLE
feat(edges+agents): service instructions reach the model end-to-end (+ svccatalog refactor, Services UX)

### DIFF
--- a/providers/agents/api/run.go
+++ b/providers/agents/api/run.go
@@ -128,7 +128,7 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 
 	// Assemble the agent's tools for this trigger class (policy + approvals +
 	// audit + delegation); MCP sessions are released when the run ends.
-	toolset, closeTools := s.buildToolset(ctx, tools.Deps{
+	toolset, mcpInstructions, closeTools := s.buildToolset(ctx, tools.Deps{
 		Store: s.store, Scope: scope, Agent: agent, CR: run.CR,
 		Secrets: run.Creds, ConnSecretName: connectionSecretName,
 		RunID: runID,
@@ -150,7 +150,7 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 		Phase:       store.RunPhaseRunning, Input: run.Task, CreatedAt: now, UpdatedAt: now, StartedAt: &now,
 	})
 
-	msgs := s.assembleTurnCtx(ctx, scope, agent, sessionID, run.Task)
+	msgs := s.assembleTurnCtx(ctx, scope, agent, sessionID, run.Task, mcpInstructions)
 	res, err := s.engine.StreamTurnWithTools(ctx, model, msgs, toolset, maxIters, run.OnDelta, run.OnTool)
 	end := time.Now().UTC()
 	if err != nil {
@@ -187,10 +187,17 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 // assembleTurnCtx builds the message list (system prompt + recent history +
 // task) using a context rather than an *http.Request, so background callers
 // (scheduler) can reuse it.
-func (s *Server) assembleTurnCtx(ctx context.Context, scope store.Scope, agent *agentsv1alpha1.Agent, sessionID, task string) []engine.Message {
+func (s *Server) assembleTurnCtx(ctx context.Context, scope store.Scope, agent *agentsv1alpha1.Agent, sessionID, task, mcpInstructions string) []engine.Message {
 	var msgs []engine.Message
 	if sp := agent.Spec.SystemPrompt; sp != "" {
 		msgs = append(msgs, engine.Message{Role: engine.RoleSystem, Content: sp})
+	}
+	// Ambient guidance from connected MCP servers (e.g. an edges Service's
+	// spec.instructions describing its entity layout / quirks). Injected as a
+	// system message so it reaches the model even though MCP clients don't
+	// surface server `initialize` instructions on their own.
+	if mi := strings.TrimSpace(mcpInstructions); mi != "" {
+		msgs = append(msgs, engine.Message{Role: engine.RoleSystem, Content: "Guidance from connected tools/services:\n\n" + mi})
 	}
 	history, _ := s.store.LoadRecentMessages(ctx, scope, sessionID, chatHistoryLimit)
 	for _, m := range history {

--- a/providers/agents/api/toolset.go
+++ b/providers/agents/api/toolset.go
@@ -51,7 +51,10 @@ func defaultFamilies(_ bool) []string {
 // trigger class, MCP/GitHub connection sessions, the edges family, sub-agent
 // delegation, approval gating, and audit logging. The returned closer
 // releases MCP sessions after the run.
-func (s *Server) buildToolset(ctx context.Context, deps tools.Deps, run taskRun) ([]engine.Tool, func()) {
+// buildToolset returns the granted tools, the aggregated MCP server instructions
+// (each connected server's `initialize` guidance, e.g. an edges Service's
+// spec.instructions) for folding into the system context, and a closer.
+func (s *Server) buildToolset(ctx context.Context, deps tools.Deps, run taskRun) ([]engine.Tool, string, func()) {
 	trigger := run.Trigger
 	interactive := isInteractive(trigger)
 
@@ -163,12 +166,19 @@ func (s *Server) buildToolset(ctx context.Context, deps tools.Deps, run taskRun)
 		out[i] = s.wrapTool(out[i], deps, trigger, grant.RequireApproval)
 	}
 
+	var mcpInstr []string
+	for _, sess := range sessions {
+		if instr := strings.TrimSpace(sess.Instructions); instr != "" {
+			mcpInstr = append(mcpInstr, instr)
+		}
+	}
+
 	closer := func() {
 		for _, sess := range sessions {
 			sess.Close()
 		}
 	}
-	return out, closer
+	return out, strings.Join(mcpInstr, "\n\n"), closer
 }
 
 // expandToolsets merges every Toolset referenced by a grant into a copy of that

--- a/providers/agents/tools/mcp.go
+++ b/providers/agents/tools/mcp.go
@@ -30,8 +30,12 @@ const githubMCPEndpoint = "https://api.githubcopilot.com/mcp"
 // MCPSession wraps one live MCP connection's discovered tools. Close after
 // the run completes.
 type MCPSession struct {
-	Tools   []engine.Tool
-	session *mcp.ClientSession
+	Tools []engine.Tool
+	// Instructions is the server's ambient guidance from the MCP `initialize`
+	// response (e.g. an edges Service's spec.instructions describing its entity
+	// layout). The caller folds it into the agent's system context.
+	Instructions string
+	session      *mcp.ClientSession
 }
 
 func (s *MCPSession) Close() {
@@ -88,6 +92,9 @@ func ConnectMCPEndpoint(ctx context.Context, endpoint, bearer, prefix string, in
 	}
 
 	out := &MCPSession{session: session}
+	if ir := session.InitializeResult(); ir != nil {
+		out.Instructions = strings.TrimSpace(ir.Instructions)
+	}
 	conn := struct{ Name string }{Name: prefix}
 	for _, t := range listed.Tools {
 		toolName := t.Name

--- a/providers/edges/internal/servicectrl/target.go
+++ b/providers/edges/internal/servicectrl/target.go
@@ -37,12 +37,18 @@ func connResource(es *edgesv1alpha1.Service) string {
 	return edgesv1alpha1.LinuxServerResource
 }
 
-// targetHost is the agent-side address of the service: cluster DNS
-// ({name}.{namespace}.svc) for a KubernetesCluster edge, the host loopback for
-// a LinuxServer edge. Callers must have validated that a kube Service has a
-// targetRef; without one this falls back to loopback, which would resolve to
-// the agent pod itself.
+// targetHost is the agent-side address of the service. It must stay in lockstep
+// with the tunnel's serviceView.targetHost (service_proxy.go) so the validation
+// probe reaches the same host the proxy does:
+//   - spec.host wins on either edge kind — dial the address directly (loopback,
+//     or a device on the edge's LAN like a UniFi console at 192.168.1.1);
+//   - otherwise cluster DNS ({name}.{namespace}.svc) for a KubernetesCluster
+//     edge with a targetRef;
+//   - otherwise the host loopback (a LinuxServer edge's own agent host).
 func targetHost(es *edgesv1alpha1.Service) string {
+	if es.Spec.Host != "" {
+		return es.Spec.Host
+	}
 	if isKube(es) && es.Spec.TargetRef != nil {
 		return es.Spec.TargetRef.Name + "." + es.Spec.TargetRef.Namespace + ".svc"
 	}

--- a/providers/edges/internal/servicectrl/validation_reconciler.go
+++ b/providers/edges/internal/servicectrl/validation_reconciler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,6 +43,7 @@ import (
 
 	edgesv1alpha1 "github.com/faroshq/provider-edges/apis/v1alpha1"
 	"github.com/faroshq/provider-edges/internal/haclient"
+	"github.com/faroshq/provider-edges/internal/svccatalog"
 )
 
 // validationResyncInterval bounds how often a Ready Service is re-validated.
@@ -120,8 +122,16 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 	// Always keep status.URL current.
 	es.Status.URL = r.statusURL(string(req.ClusterName), es.Name)
 
-	// No credentials → nothing to validate.
-	if es.Spec.AuthSecretRef == nil {
+	// The catalog tells us how to probe this type: the health path, the auth
+	// style, and whether a 2xx proves the credential (ProbeValidate) or merely
+	// that the service is up (ProbeReachable). An unknown type falls back to a
+	// bare reachability probe on "/".
+	def, _ := svccatalog.Get(string(es.Spec.Type))
+
+	// No credentials → nothing to validate, unless the type is usable
+	// unauthenticated (e.g. Prometheus), in which case we still probe for
+	// reachability below with an empty token.
+	if es.Spec.AuthSecretRef == nil && !def.Credential.Optional {
 		setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionUnknown, "NoCredentials", "no authSecretRef configured")
 		if es.Status.Phase == "" {
 			es.Status.Phase = "Detected"
@@ -149,21 +159,42 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 		return r.commit(ctx, c, orig, es, 30*time.Second)
 	}
 
-	token, err := r.readToken(ctx, c, es)
-	if err != nil {
-		setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "SecretError", err.Error())
-		es.Status.Phase = "Unreachable"
-		return r.commit(ctx, c, orig, es, validationResyncInterval)
+	var token string
+	if es.Spec.AuthSecretRef != nil {
+		token, err = r.readToken(ctx, c, es)
+		if err != nil {
+			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "SecretError", err.Error())
+			es.Status.Phase = "Unreachable"
+			return r.commit(ctx, c, orig, es, validationResyncInterval)
+		}
 	}
 
-	// Validate. Home Assistant: GET /api/config returns { version, ... }.
+	// Build the probe request and apply the type's auth. For the session-login
+	// kinds (qBittorrent/Pi-hole) Apply performs the login, so a failure here is
+	// the credential being rejected rather than a transport error.
 	target := haclient.Target{
 		Scheme: schemeString(es.Spec.Scheme),
 		Host:   targetHost(es),
 		Port:   es.Spec.Port,
-		Token:  token,
 	}
-	resp, err := haclient.Do(ctx, dialer, target, http.MethodGet, "/api/config", nil)
+	header := http.Header{}
+	query := url.Values{}
+	if err := svccatalog.Apply(ctx, dialer, target, def, token, header, query); err != nil {
+		es.Status.Phase = "Unreachable"
+		setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "Unauthorized", err.Error())
+		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "Unauthorized", err.Error())
+		return r.commit(ctx, c, orig, es, validationResyncInterval)
+	}
+
+	probePath := def.ProbePath
+	if probePath == "" {
+		probePath = "/"
+	}
+	if q := query.Encode(); q != "" {
+		probePath += "?" + q
+	}
+
+	resp, err := haclient.DoWith(ctx, dialer, target, http.MethodGet, probePath, header, nil)
 	if err != nil {
 		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "ProbeFailed", err.Error())
 		setNotProbed(es, "the service could not be reached, so the token was never checked")
@@ -172,30 +203,65 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	switch {
-	case resp.StatusCode == http.StatusOK:
-		var cfg struct {
-			Version string `json:"version"`
+	mode := def.ProbeMode
+	if mode == "" {
+		if def.ProbePath != "" {
+			mode = svccatalog.ProbeValidate
+		} else {
+			mode = svccatalog.ProbeReachable
 		}
-		_ = json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&cfg)
-		if cfg.Version != "" {
-			es.Status.Version = cfg.Version
-		}
-		es.Status.Phase = "Ready"
-		setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionTrue, "Validated", "credentials accepted by the service")
-		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionTrue, "Ready", "service reachable and authenticated")
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		es.Status.Phase = "Unreachable"
-		setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "Unauthorized",
-			fmt.Sprintf("service rejected the token (%d)", resp.StatusCode))
-	default:
-		es.Status.Phase = "Unreachable"
-		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "ProbeFailed",
-			fmt.Sprintf("service returned %d", resp.StatusCode))
-		setNotProbed(es, fmt.Sprintf("service returned %d, so the token was never checked", resp.StatusCode))
 	}
 
-	logger.V(4).Info("validated service", "phase", es.Status.Phase)
+	switch mode {
+	case svccatalog.ProbeReachable:
+		// Any answer below 500 means the service is up. We can only claim the
+		// credential is valid if we actually sent one and it wasn't rejected.
+		if resp.StatusCode >= http.StatusInternalServerError {
+			es.Status.Phase = "Unreachable"
+			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "ProbeFailed",
+				fmt.Sprintf("service returned %d", resp.StatusCode))
+			setNotProbed(es, fmt.Sprintf("service returned %d, so the token was never checked", resp.StatusCode))
+			break
+		}
+		es.Status.Phase = "Ready"
+		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionTrue, "Ready", "service reachable")
+		if token != "" && resp.StatusCode < http.StatusMultipleChoices {
+			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionTrue, "Validated", "credentials accepted by the service")
+		} else {
+			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionUnknown, "NotVerified",
+				"service reachable; credentials are not verified for this service type")
+		}
+	default: // ProbeValidate — the probe path requires auth, so status is decisive.
+		switch {
+		case resp.StatusCode < http.StatusMultipleChoices:
+			// Home Assistant's /api/config returns { version, ... }.
+			if es.Spec.Type == edgesv1alpha1.ServiceTypeHomeAssistant {
+				var cfg struct {
+					Version string `json:"version"`
+				}
+				_ = json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&cfg)
+				if cfg.Version != "" {
+					es.Status.Version = cfg.Version
+				}
+			}
+			es.Status.Phase = "Ready"
+			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionTrue, "Validated", "credentials accepted by the service")
+			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionTrue, "Ready", "service reachable and authenticated")
+		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+			es.Status.Phase = "Unreachable"
+			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "Unauthorized",
+				fmt.Sprintf("service rejected the credentials (%d)", resp.StatusCode))
+			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "Unauthorized",
+				"service reachable but rejected the credentials")
+		default:
+			es.Status.Phase = "Unreachable"
+			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "ProbeFailed",
+				fmt.Sprintf("service returned %d", resp.StatusCode))
+			setNotProbed(es, fmt.Sprintf("service returned %d, so the credentials were never checked", resp.StatusCode))
+		}
+	}
+
+	logger.V(4).Info("validated service", "phase", es.Status.Phase, "type", es.Spec.Type)
 	return r.commit(ctx, c, orig, es, validationResyncInterval)
 }
 

--- a/providers/edges/internal/svccatalog/auth.go
+++ b/providers/edges/internal/svccatalog/auth.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package svccatalog
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/faroshq/provider-edges/internal/haclient"
+)
+
+// Apply configures authentication for one outgoing request to a service of the
+// given definition, mutating header and query in place. It first sets the
+// definition's always-sent ExtraHeaders, then applies the credential per
+// def.Auth. token is the raw Secret "token" value (a single string; multi-field
+// credentials such as qBittorrent's are packed as "username:password" — see
+// CredentialModel.Packing). An empty token is a no-op for optional/none auth.
+//
+// For the session-login kinds (qBittorrent, Pi-hole) Apply performs the login
+// round-trip through the dialer, so a returned error for those kinds usually
+// means the credential was rejected rather than a transport failure.
+func Apply(ctx context.Context, dialer haclient.Dialer, target haclient.Target, def Definition, token string, header http.Header, query url.Values) error {
+	for k, v := range def.ExtraHeaders {
+		header.Set(k, v)
+	}
+	if token == "" {
+		return nil
+	}
+	switch def.Auth {
+	case AuthBearer:
+		header.Set("Authorization", "Bearer "+token)
+	case AuthAPIKeyHeader:
+		header.Set(def.AuthParam, token)
+	case AuthAPIKeyQuery:
+		query.Set(def.AuthParam, token)
+	case AuthBasic:
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(token)))
+	case AuthProxmox:
+		header.Set("Authorization", "PVEAPIToken="+token)
+	case AuthQBittorrent:
+		sid, err := qbitLogin(ctx, dialer, target, token)
+		if err != nil {
+			return fmt.Errorf("qBittorrent login failed: %w", err)
+		}
+		header.Set("Cookie", "SID="+sid)
+		header.Set("Referer", target.SvcTarget())
+	case AuthPihole:
+		sid, err := piholeLogin(ctx, dialer, target, token)
+		if err != nil {
+			return fmt.Errorf("Pi-hole login failed: %w", err)
+		}
+		header.Set("X-FTL-SID", sid)
+	case AuthNone:
+		// no credential is applied
+	}
+	return nil
+}
+
+// qbitLogin performs qBittorrent's cookie login and returns the SID. cred is
+// "username:password" (the WebUI credentials). Returns an error if the app
+// rejects the login (wrong creds, or CSRF/host-header protection — whitelist the
+// edge or disable those checks in qBittorrent).
+func qbitLogin(ctx context.Context, dialer haclient.Dialer, target haclient.Target, cred string) (string, error) {
+	user, pass, ok := strings.Cut(cred, ":")
+	if !ok {
+		return "", fmt.Errorf("qBittorrent credential must be \"username:password\"")
+	}
+	form := url.Values{"username": {user}, "password": {pass}}
+	header := http.Header{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+		"Referer":      {target.SvcTarget()},
+	}
+	resp, err := haclient.DoWith(ctx, dialer, target, http.MethodPost, "/api/v2/auth/login", header, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode != http.StatusOK || strings.Contains(string(body), "Fails") {
+		return "", fmt.Errorf("login rejected (%d): %s", resp.StatusCode, snippet(body))
+	}
+	for _, c := range resp.Cookies() {
+		if c.Name == "SID" {
+			return c.Value, nil
+		}
+	}
+	return "", fmt.Errorf("no SID cookie in login response")
+}
+
+// piholeLogin performs Pi-hole v6's session login and returns the SID. cred is
+// the web-interface password. Returns an error if the app rejects it (wrong
+// password, or the API session limit is hit).
+func piholeLogin(ctx context.Context, dialer haclient.Dialer, target haclient.Target, password string) (string, error) {
+	header := http.Header{"Content-Type": {"application/json"}}
+	reqBody, err := json.Marshal(map[string]string{"password": password})
+	if err != nil {
+		return "", err
+	}
+	resp, err := haclient.DoWith(ctx, dialer, target, http.MethodPost, "/api/auth", header, strings.NewReader(string(reqBody)))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("login rejected (%d): %s", resp.StatusCode, snippet(body))
+	}
+	var out struct {
+		Session struct {
+			Valid bool   `json:"valid"`
+			SID   string `json:"sid"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("decode login response: %w", err)
+	}
+	if !out.Session.Valid || out.Session.SID == "" {
+		return "", fmt.Errorf("login not valid: %s", snippet(body))
+	}
+	return out.Session.SID, nil
+}
+
+// snippet trims a byte slice for inclusion in an error message.
+func snippet(b []byte) string {
+	const max = 240
+	s := strings.TrimSpace(string(b))
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}

--- a/providers/edges/internal/svccatalog/catalog.go
+++ b/providers/edges/internal/svccatalog/catalog.go
@@ -1,0 +1,455 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package svccatalog is the single source of truth for edge Service types. Each
+// entry declares how to reach the service (port/scheme/host defaults), how it
+// authenticates (auth kind + the credential fields the UI collects), how to
+// health-check it (probe path + mode, used by the validation reconciler), and —
+// for the popular self-hosted apps — the MCP tool bundle exposed for it.
+//
+// Three consumers share this table so it never drifts:
+//   - internal/tunnel builds MCP tools from Definition.Tools and authenticates
+//     proxied requests via Apply (auth.go).
+//   - internal/servicectrl probes ProbePath with Apply to stamp the Service's
+//     Ready / CredentialsValid conditions.
+//   - the provider's /catalog HTTP endpoint serves the UI-facing subset (the
+//     json-tagged fields) so the portal renders the "add/configure service"
+//     form from data instead of a hand-maintained mirror.
+package svccatalog
+
+import (
+	"net/http"
+	"sort"
+)
+
+// AuthKind selects how the service's credential authenticates a request. The
+// string values are stable (serialized to the UI and, implicitly, matched by
+// Apply) — do not rename without updating both.
+type AuthKind string
+
+const (
+	AuthNone         AuthKind = "none"         // no credential
+	AuthBearer       AuthKind = "bearer"       // Authorization: Bearer <token>   (Home Assistant, Grafana)
+	AuthAPIKeyHeader AuthKind = "apiKeyHeader" // <AuthParam>: <token>            (*arr X-Api-Key, Plex, UniFi)
+	AuthAPIKeyQuery  AuthKind = "apiKeyQuery"  // ?<AuthParam>=<token>
+	AuthBasic        AuthKind = "basic"        // Authorization: Basic base64(user:pass)   (AdGuard Home)
+	AuthProxmox      AuthKind = "proxmox"      // Authorization: PVEAPIToken=<token>        (Proxmox VE)
+	AuthPihole       AuthKind = "pihole"       // POST /api/auth {password} -> X-FTL-SID     (Pi-hole v6)
+	AuthQBittorrent  AuthKind = "qbittorrent"  // POST /api/v2/auth/login -> SID cookie
+)
+
+// Packing tells the UI (and Apply) how the credential fields combine into the
+// single Secret "token" value the provider reads.
+type Packing string
+
+const (
+	// PackSingle: a single field is stored verbatim as the token.
+	PackSingle Packing = "single"
+	// PackUserPass: username + password are stored as "username:password".
+	PackUserPass Packing = "userpass"
+)
+
+// CredentialField is one input the UI collects for a service's credential.
+type CredentialField struct {
+	// Key is the logical field id ("token", "username", "password", "apiKey").
+	Key string `json:"key"`
+	// Label is the form label.
+	Label string `json:"label"`
+	// Help is optional helper text under the field.
+	Help string `json:"help,omitempty"`
+	// Secret renders the input as a password field.
+	Secret bool `json:"secret,omitempty"`
+}
+
+// CredentialModel describes what the UI collects and how it packs into the
+// Secret "token" key the provider reads (see servicectrl.readToken /
+// tunnel.readServiceToken).
+type CredentialModel struct {
+	// Optional means the service may be used unauthenticated (e.g. Prometheus),
+	// so the form must not require a credential.
+	Optional bool `json:"optional,omitempty"`
+	// Packing is how Fields combine into the token value.
+	Packing Packing `json:"packing,omitempty"`
+	// Fields are the inputs to render, in order.
+	Fields []CredentialField `json:"fields,omitempty"`
+	// Hint is a short human explanation of what to paste (replaces the portal's
+	// old per-type tokenHint strings).
+	Hint string `json:"hint,omitempty"`
+}
+
+// Tool is one HTTP operation exposed as an MCP tool. Not serialized to the UI.
+type Tool struct {
+	Name   string
+	Desc   string
+	Method string
+	Path   string
+}
+
+// ProbeMode selects how the validation reconciler interprets the probe result.
+type ProbeMode string
+
+const (
+	// ProbeValidate: the probe path requires auth, so a 2xx proves the
+	// credential is valid and 401/403 proves it is not.
+	ProbeValidate ProbeMode = "validate"
+	// ProbeReachable: any HTTP answer (even 401/404) proves the service is up;
+	// the credential is not verified (marked Unknown unless the probe returned
+	// 2xx with a token set).
+	ProbeReachable ProbeMode = "reachable"
+)
+
+// Definition is one catalog entry. Fields with a json tag form the UI form
+// schema served at /catalog; json:"-" fields are backend-only (tools, probe,
+// always-sent headers).
+type Definition struct {
+	// Type is the Service.spec.type value (the map key).
+	Type string `json:"type"`
+	// DisplayName is the human name shown in the UI.
+	DisplayName string `json:"displayName"`
+	// Description is a one-line explanation for the UI.
+	Description string `json:"description,omitempty"`
+	// Category groups types in the UI picker ("Home", "Media", "Monitoring",
+	// "Network", "Infrastructure", "Other").
+	Category string `json:"category,omitempty"`
+
+	// DefaultPort seeds the port field.
+	DefaultPort int32 `json:"defaultPort,omitempty"`
+	// DefaultScheme seeds the scheme field ("http" | "https").
+	DefaultScheme string `json:"defaultScheme,omitempty"`
+	// SchemeLocked forces DefaultScheme (e.g. UniFi is always https).
+	SchemeLocked bool `json:"schemeLocked,omitempty"`
+	// HostRequired means the service is not on the agent loopback and the user
+	// must supply spec.host (e.g. a UniFi console at 192.168.1.1).
+	HostRequired bool `json:"hostRequired,omitempty"`
+	// HostHelp is helper text for the host field when HostRequired.
+	HostHelp string `json:"hostHelp,omitempty"`
+
+	// Auth is how the credential authenticates a request.
+	Auth AuthKind `json:"auth"`
+	// AuthParam is the header name (AuthAPIKeyHeader) or query key
+	// (AuthAPIKeyQuery). Empty for the other kinds.
+	AuthParam string `json:"authParam,omitempty"`
+	// Credential is the UI form model for the credential.
+	Credential CredentialModel `json:"credential"`
+
+	// ExtraHeaders are always sent (e.g. Accept: application/json for Plex).
+	ExtraHeaders map[string]string `json:"-"`
+	// ProbePath is the health endpoint the validation reconciler hits. Empty =>
+	// reachability probe on "/".
+	ProbePath string `json:"-"`
+	// ProbeMode selects how the probe status is interpreted (default validate
+	// when a ProbePath is set, reachable otherwise).
+	ProbeMode ProbeMode `json:"-"`
+	// Handcoded marks types whose MCP tools live in Go rather than in Tools
+	// (Home Assistant). Such a type still "has tools" for discovery purposes.
+	Handcoded bool `json:"-"`
+	// Tools are the data-driven MCP operations exposed for this type.
+	Tools []Tool `json:"-"`
+}
+
+// singleField is a helper for the common "one opaque token" credential.
+func singleField(key, label, help string) []CredentialField {
+	return []CredentialField{{Key: key, Label: label, Help: help, Secret: true}}
+}
+
+// userPassFields is the username + password pair.
+func userPassFields() []CredentialField {
+	return []CredentialField{
+		{Key: "username", Label: "Username"},
+		{Key: "password", Label: "Password", Secret: true},
+	}
+}
+
+// catalog is the registry. Keys are Service.spec.type values. Home Assistant is
+// included (Handcoded) so it participates in the UI form + probe even though its
+// MCP tools are hand-written in internal/tunnel/mcp_service.go.
+var catalog = map[string]Definition{
+	"home-assistant": {
+		Type: "home-assistant", DisplayName: "Home Assistant", Category: "Home",
+		Description: "Home automation hub — lights, sensors, scenes, and services.",
+		DefaultPort: 8123, DefaultScheme: "http",
+		Auth: AuthBearer,
+		Credential: CredentialModel{
+			Packing: PackSingle,
+			Fields:  singleField("token", "Long-lived access token", "Profile → Security → Long-lived access tokens → Create."),
+			Hint:    "A Home Assistant long-lived access token.",
+		},
+		ProbePath: "/api/config", ProbeMode: ProbeValidate,
+		Handcoded: true,
+	},
+	"qbittorrent": {
+		Type: "qbittorrent", DisplayName: "qBittorrent", Category: "Media",
+		Description: "BitTorrent client WebUI.",
+		DefaultPort: 8080, DefaultScheme: "http",
+		Auth: AuthQBittorrent,
+		Credential: CredentialModel{
+			Packing: PackUserPass,
+			Fields:  userPassFields(),
+			Hint:    "The qBittorrent WebUI username and password.",
+		},
+		ProbePath: "/api/v2/app/version", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"torrents", "List torrents (filter/category via query, e.g. {\"filter\":\"downloading\"}).", http.MethodGet, "/api/v2/torrents/info"},
+			{"transfer", "Global transfer stats (speeds, totals).", http.MethodGet, "/api/v2/transfer/info"},
+			{"add", "Add a torrent. Pass form {\"urls\":\"magnet:?...\"}.", http.MethodPost, "/api/v2/torrents/add"},
+			{"pause", "Pause torrents. Pass form {\"hashes\":\"<hash>|all\"}.", http.MethodPost, "/api/v2/torrents/pause"},
+			{"resume", "Resume torrents. Pass form {\"hashes\":\"<hash>|all\"}.", http.MethodPost, "/api/v2/torrents/resume"},
+			{"delete", "Delete torrents. Form {\"hashes\":\"<hash>\",\"deleteFiles\":\"false\"}.", http.MethodPost, "/api/v2/torrents/delete"},
+		},
+	},
+	"prowlarr": {
+		Type: "prowlarr", DisplayName: "Prowlarr", Category: "Media",
+		Description: "Indexer manager for the *arr apps.",
+		DefaultPort: 9696, DefaultScheme: "http",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-Api-Key",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "Settings → General → API Key."), Hint: "The Prowlarr API key."},
+		ProbePath: "/api/v1/system/status", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"indexers", "List configured Prowlarr indexers.", http.MethodGet, "/api/v1/indexer"},
+			{"search", "Search across indexers. Pass query params, e.g. {\"query\":\"ubuntu\",\"type\":\"search\"}.", http.MethodGet, "/api/v1/search"},
+			{"status", "Prowlarr system status/version.", http.MethodGet, "/api/v1/system/status"},
+		},
+	},
+	"sonarr": {
+		Type: "sonarr", DisplayName: "Sonarr", Category: "Media",
+		Description: "TV series library and download manager.",
+		DefaultPort: 8989, DefaultScheme: "http",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-Api-Key",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "Settings → General → API Key."), Hint: "The Sonarr API key."},
+		ProbePath: "/api/v3/system/status", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"series", "List all TV series in Sonarr.", http.MethodGet, "/api/v3/series"},
+			{"queue", "List the download queue.", http.MethodGet, "/api/v3/queue"},
+			{"calendar", "Upcoming/recent episodes (query: start, end as ISO dates).", http.MethodGet, "/api/v3/calendar"},
+			{"lookup", "Search for a series to add. Pass query {\"term\":\"the wire\"}.", http.MethodGet, "/api/v3/series/lookup"},
+		},
+	},
+	"radarr": {
+		Type: "radarr", DisplayName: "Radarr", Category: "Media",
+		Description: "Movie library and download manager.",
+		DefaultPort: 7878, DefaultScheme: "http",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-Api-Key",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "Settings → General → API Key."), Hint: "The Radarr API key."},
+		ProbePath: "/api/v3/system/status", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"movies", "List all movies in Radarr.", http.MethodGet, "/api/v3/movie"},
+			{"queue", "List the download queue.", http.MethodGet, "/api/v3/queue"},
+			{"lookup", "Search for a movie to add. Pass query {\"term\":\"dune 2021\"}.", http.MethodGet, "/api/v3/movie/lookup"},
+		},
+	},
+	"grafana": {
+		Type: "grafana", DisplayName: "Grafana", Category: "Monitoring",
+		Description: "Dashboards and data-source explorer.",
+		DefaultPort: 3000, DefaultScheme: "http",
+		Auth: AuthBearer,
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("token", "Service account token", "Administration → Service accounts → Add token."), Hint: "A Grafana service-account (or API) token."},
+		ProbePath: "/api/org", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"search", "Search dashboards/folders. Query: {\"query\":\"cpu\",\"type\":\"dash-db\"}.", http.MethodGet, "/api/search"},
+			{"datasources", "List configured data sources.", http.MethodGet, "/api/datasources"},
+			{"health", "Grafana health/version.", http.MethodGet, "/api/health"},
+			{"query", "Run a data-source query. Pass a JSON body per the Grafana /api/ds/query schema.", http.MethodPost, "/api/ds/query"},
+		},
+	},
+	"grafana-loki": {
+		Type: "grafana-loki", DisplayName: "Grafana Loki", Category: "Monitoring",
+		Description: "Log aggregation (LogQL).",
+		DefaultPort: 3100, DefaultScheme: "http",
+		Auth: AuthBearer,
+		Credential: CredentialModel{Optional: true, Packing: PackSingle, Fields: singleField("token", "Bearer token (optional)", "Leave empty if Loki is unauthenticated behind the tunnel."), Hint: "Optional bearer token; often unauthenticated behind the tunnel."},
+		ProbePath: "/ready", ProbeMode: ProbeReachable,
+		Tools: []Tool{
+			{"query", "LogQL instant query. Query {\"query\":\"{app=\\\"x\\\"}\"}.", http.MethodGet, "/loki/api/v1/query"},
+			{"query_range", "LogQL range query. Query {\"query\":\"...\",\"start\":\"...\",\"end\":\"...\"}.", http.MethodGet, "/loki/api/v1/query_range"},
+			{"labels", "List log stream labels.", http.MethodGet, "/loki/api/v1/labels"},
+		},
+	},
+	"prometheus": {
+		Type: "prometheus", DisplayName: "Prometheus", Category: "Monitoring",
+		Description: "Metrics and alerting (PromQL).",
+		DefaultPort: 9090, DefaultScheme: "http",
+		Auth: AuthBearer,
+		Credential: CredentialModel{Optional: true, Packing: PackSingle, Fields: singleField("token", "Bearer token (optional)", "Leave empty if Prometheus is unauthenticated behind the tunnel."), Hint: "Optional bearer token; often unauthenticated behind the tunnel."},
+		ProbePath: "/-/healthy", ProbeMode: ProbeReachable,
+		Tools: []Tool{
+			{"query", "Instant query. Pass query {\"query\":\"up\"}.", http.MethodGet, "/api/v1/query"},
+			{"query_range", "Range query. Query: {\"query\":\"rate(...)\",\"start\":\"...\",\"end\":\"...\",\"step\":\"60\"}.", http.MethodGet, "/api/v1/query_range"},
+			{"targets", "List scrape targets and their health.", http.MethodGet, "/api/v1/targets"},
+			{"alerts", "List active alerts.", http.MethodGet, "/api/v1/alerts"},
+		},
+	},
+	"jellyfin": {
+		Type: "jellyfin", DisplayName: "Jellyfin", Category: "Media",
+		Description: "Media server.",
+		DefaultPort: 8096, DefaultScheme: "http",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-Emby-Token",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "Dashboard → API Keys."), Hint: "A Jellyfin API key."},
+		ProbePath: "/System/Info", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"sessions", "List active playback sessions.", http.MethodGet, "/Sessions"},
+			{"system", "Server system info/version.", http.MethodGet, "/System/Info"},
+			{"search", "Search the library. Pass query {\"searchTerm\":\"dune\"}.", http.MethodGet, "/Search/Hints"},
+		},
+	},
+	"plex": {
+		Type: "plex", DisplayName: "Plex", Category: "Media",
+		Description: "Media server.",
+		DefaultPort: 32400, DefaultScheme: "http",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-Plex-Token",
+		ExtraHeaders: map[string]string{"Accept": "application/json"},
+		Credential:   CredentialModel{Packing: PackSingle, Fields: singleField("token", "X-Plex-Token", "See Plex support: 'Finding an authentication token'."), Hint: "A Plex authentication token (X-Plex-Token)."},
+		ProbePath:    "/identity", ProbeMode: ProbeReachable,
+		Tools: []Tool{
+			{"sessions", "List what's currently playing.", http.MethodGet, "/status/sessions"},
+			{"libraries", "List library sections.", http.MethodGet, "/library/sections"},
+			{"identity", "Server identity/version.", http.MethodGet, "/identity"},
+		},
+	},
+	"portainer": {
+		Type: "portainer", DisplayName: "Portainer", Category: "Infrastructure",
+		Description: "Container management UI.",
+		DefaultPort: 9000, DefaultScheme: "http",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-API-Key",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "My account → Access tokens → Add access token."), Hint: "A Portainer API access token."},
+		ProbePath: "/api/endpoints", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"endpoints", "List environments (endpoints).", http.MethodGet, "/api/endpoints"},
+			{"stacks", "List deployed stacks.", http.MethodGet, "/api/stacks"},
+			{"status", "Portainer status/version.", http.MethodGet, "/api/status"},
+		},
+	},
+	"adguard": {
+		Type: "adguard", DisplayName: "AdGuard Home", Category: "Network",
+		Description: "Network-wide DNS ad/tracker blocking.",
+		DefaultPort: 80, DefaultScheme: "http",
+		Auth: AuthBasic,
+		Credential: CredentialModel{Packing: PackUserPass, Fields: userPassFields(), Hint: "The AdGuard Home web interface username and password."},
+		ProbePath: "/control/status", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"status", "Protection status + version.", http.MethodGet, "/control/status"},
+			{"stats", "DNS query stats (top clients/domains, counts).", http.MethodGet, "/control/stats"},
+			{"filtering", "Filtering (blocklists) status.", http.MethodGet, "/control/filtering/status"},
+			{"protection", "Toggle protection. Body {\"enabled\":false,\"duration\":0}.", http.MethodPost, "/control/protection"},
+		},
+	},
+	"proxmox": {
+		Type: "proxmox", DisplayName: "Proxmox VE", Category: "Infrastructure",
+		Description: "Virtualization management (VMs, containers, storage).",
+		DefaultPort: 8006, DefaultScheme: "https",
+		Auth: AuthProxmox,
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("token", "API token", "Datacenter → Permissions → API Tokens. Format USER@REALM!TOKENID=UUID."), Hint: "A Proxmox API token: USER@REALM!TOKENID=UUID."},
+		ProbePath: "/api2/json/version", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"nodes", "List cluster nodes.", http.MethodGet, "/api2/json/nodes"},
+			{"resources", "List cluster resources (VMs, storage, nodes).", http.MethodGet, "/api2/json/cluster/resources"},
+			{"cluster_status", "Cluster/quorum status.", http.MethodGet, "/api2/json/cluster/status"},
+		},
+	},
+	"pihole": {
+		Type: "pihole", DisplayName: "Pi-hole", Category: "Network",
+		Description: "Network-wide DNS ad blocking (v6).",
+		DefaultPort: 80, DefaultScheme: "http",
+		Auth: AuthPihole,
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("password", "Web password", "The Pi-hole admin web interface password."), Hint: "The Pi-hole v6 web interface password."},
+		ProbePath: "/api/dns/blocking", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"summary", "Query/blocking summary stats.", http.MethodGet, "/api/stats/summary"},
+			{"blocking", "Blocking enabled/disabled status.", http.MethodGet, "/api/dns/blocking"},
+			{"disable", "Pause blocking. Body {\"blocking\":false,\"timer\":300}.", http.MethodPost, "/api/dns/blocking"},
+			{"top_domains", "Top permitted/blocked domains.", http.MethodGet, "/api/stats/top_domains"},
+		},
+	},
+	"unifi-network": {
+		Type: "unifi-network", DisplayName: "UniFi Network", Category: "Network",
+		Description: "UniFi OS console — clients, devices, sites.",
+		DefaultPort: 443, DefaultScheme: "https", SchemeLocked: true,
+		HostRequired: true, HostHelp: "The UniFi console address, e.g. 192.168.1.1.",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-API-KEY",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "UniFi OS → Control Plane → Integrations → create a local API key."), Hint: "A UniFi OS local API key."},
+		ProbePath: "/proxy/network/integration/v1/sites", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"sites", "List UniFi Network sites (each site's id + name).", http.MethodGet, "/proxy/network/integration/v1/sites"},
+			{"clients", "List connected clients for a site. Query {\"siteId\":\"<id>\"}.", http.MethodGet, "/proxy/network/integration/v1/sites/{siteId}/clients"},
+			{"devices", "List UniFi devices (APs/switches/gateways) for a site. Query {\"siteId\":\"<id>\"}.", http.MethodGet, "/proxy/network/integration/v1/sites/{siteId}/devices"},
+		},
+	},
+	"unifi-protect": {
+		Type: "unifi-protect", DisplayName: "UniFi Protect", Category: "Network",
+		Description: "UniFi OS console — cameras, snapshots, events.",
+		DefaultPort: 443, DefaultScheme: "https", SchemeLocked: true,
+		HostRequired: true, HostHelp: "The UniFi console address, e.g. 192.168.1.1.",
+		Auth: AuthAPIKeyHeader, AuthParam: "X-API-KEY",
+		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "UniFi OS → Control Plane → Integrations → create a local API key."), Hint: "A UniFi OS local API key (same key works for Network + Protect)."},
+		ProbePath: "/proxy/protect/integration/v1/cameras", ProbeMode: ProbeValidate,
+		Tools: []Tool{
+			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
+			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}).", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
+			{"events", "Recent Protect events (motion/person/vehicle). Query: start,end (ms epoch), types.", http.MethodGet, "/proxy/protect/integration/v1/events"},
+		},
+	},
+	"generic": {
+		Type: "generic", DisplayName: "Generic HTTP service", Category: "Other",
+		Description: "Any HTTP service — proxied through the tunnel, no MCP tools.",
+		DefaultPort: 80, DefaultScheme: "http",
+		Auth: AuthBearer,
+		Credential: CredentialModel{Optional: true, Packing: PackSingle, Fields: singleField("token", "Bearer token (optional)", "Injected as Authorization: Bearer when set."), Hint: "Optional bearer token injected on proxied requests."},
+		ProbeMode: ProbeReachable,
+	},
+}
+
+// Get returns the definition for a service type, if known.
+func Get(t string) (Definition, bool) {
+	d, ok := catalog[t]
+	return d, ok
+}
+
+// IsKnown reports whether t is a catalog type.
+func IsKnown(t string) bool {
+	_, ok := catalog[t]
+	return ok
+}
+
+// HasTools reports whether a type exposes any MCP tools (data-driven or the
+// hand-coded Home Assistant bundle). Replaces the old mcpServiceType.
+func HasTools(t string) bool {
+	d, ok := catalog[t]
+	return ok && (d.Handcoded || len(d.Tools) > 0)
+}
+
+// IsDataDriven reports whether a type's MCP tools come from Definition.Tools
+// (i.e. driven by the catalog registrar, not hand-coded). Replaces the old
+// catalogServiceType.
+func IsDataDriven(t string) bool {
+	d, ok := catalog[t]
+	return ok && len(d.Tools) > 0
+}
+
+// All returns every definition, sorted by category then display name — the
+// order the UI renders. Definitions are copied so callers cannot mutate the
+// registry.
+func All() []Definition {
+	out := make([]Definition, 0, len(catalog))
+	for _, d := range catalog {
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].DisplayName < out[j].DisplayName
+	})
+	return out
+}

--- a/providers/edges/internal/tunnel/mcp_root.go
+++ b/providers/edges/internal/tunnel/mcp_root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/faroshq/provider-edges/internal/haclient"
+	"github.com/faroshq/provider-edges/internal/svccatalog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -127,7 +128,7 @@ func (p *Server) buildRootMCPServer(ctx context.Context, cluster, token string, 
 		switch {
 		case h.reg.view.Spec.Type == "home-assistant":
 			p.registerHomeAssistantTools(srv, h.prefix, cluster, token, h.reg.view, h.dialer)
-		case catalogServiceType(h.reg.view.Spec.Type):
+		case svccatalog.IsDataDriven(h.reg.view.Spec.Type):
 			p.registerCatalogTools(srv, h.prefix, cluster, token, h.reg.view, h.dialer)
 		}
 		logger.Info("service tools registered", "service", h.reg.name, "type", h.reg.view.Spec.Type, "prefix", h.prefix)
@@ -144,13 +145,6 @@ func (p *Server) buildRootMCPServer(ctx context.Context, cluster, token string, 
 type readyHAService struct {
 	name string
 	view *serviceView
-}
-
-// mcpServiceType reports whether a Service type has an MCP tool bundle (Home
-// Assistant or any catalog app). Types without one are proxy-only and don't
-// contribute tools to the endpoint.
-func mcpServiceType(t string) bool {
-	return t == "home-assistant" || catalogServiceType(t)
 }
 
 // listReadyServices lists Ready Services in the tenant that expose MCP tools
@@ -186,7 +180,7 @@ func (p *Server) listReadyServices(ctx context.Context, cluster, token string) [
 			logger.Info("service discovery: skip (decode failed)", "service", name, "err", err.Error())
 			continue
 		}
-		if !mcpServiceType(view.Spec.Type) {
+		if !svccatalog.HasTools(view.Spec.Type) {
 			continue // proxy-only type — contributes no tools, not noteworthy
 		}
 		if view.Spec.EdgeRef.Name == "" || view.Spec.Port == 0 {

--- a/providers/edges/internal/tunnel/mcp_service.go
+++ b/providers/edges/internal/tunnel/mcp_service.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/faroshq/provider-edges/internal/haclient"
+	"github.com/faroshq/provider-edges/internal/svccatalog"
 )
 
 // serviceMCPImpl is advertised on `initialize` for a per-Service MCP
@@ -79,7 +80,7 @@ func (p *Server) buildServiceMCPServer(cluster, name, kcpToken string, svc *serv
 	switch {
 	case svc.Spec.Type == "home-assistant":
 		p.registerHomeAssistantTools(srv, "", cluster, kcpToken, svc, dialer)
-	case catalogServiceType(svc.Spec.Type):
+	case svccatalog.IsDataDriven(svc.Spec.Type):
 		p.registerCatalogTools(srv, "", cluster, kcpToken, svc, dialer)
 	}
 	return srv
@@ -213,7 +214,7 @@ func (p *Server) haPassthrough(ctx context.Context, cluster, kcpToken string, sv
 	if text == "" {
 		text = fmt.Sprintf("OK (%d)", resp.StatusCode)
 	}
-	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, nil, nil
+	return &mcp.CallToolResult{Content: withServiceNote(svc, &mcp.TextContent{Text: text})}, nil, nil
 }
 
 // haDo resolves the service token (from the Service's Secret, read as the
@@ -242,6 +243,18 @@ func toolErr(msg string) *mcp.CallToolResult {
 		IsError: true,
 		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
 	}
+}
+
+// withServiceNote prepends the Service's operator note (spec.instructions) to a
+// tool result's content. Server-level MCP `initialize` instructions are surfaced
+// inconsistently by clients (and only read once at connect); echoing the note in
+// the result delivers it to ANY MCP client — internal or external — at the exact
+// moment the service is used.
+func withServiceNote(svc *serviceView, content ...mcp.Content) []mcp.Content {
+	if note := strings.TrimSpace(svc.Spec.Instructions); note != "" {
+		return append([]mcp.Content{&mcp.TextContent{Text: "Operator note for service " + svc.Name + ":\n" + note + "\n---"}}, content...)
+	}
+	return content
 }
 
 // toolJSON marshals v into a JSON text content result.

--- a/providers/edges/internal/tunnel/svc_catalog.go
+++ b/providers/edges/internal/tunnel/svc_catalog.go
@@ -16,16 +16,16 @@ limitations under the License.
 
 package tunnel
 
-// The service catalog turns a handful of popular self-hosted apps into MCP
-// tools without bespoke Go per app: each is a data table (auth style + a list
-// of HTTP operations), and one generic registrar/executor drives them all.
-// Home Assistant stays hand-written (mcp_service.go) because its tools are
-// trimmed/reshaped; everything here is a thin, faithful proxy of the app's API.
+// This file adapts the shared service catalog (internal/svccatalog) to MCP: it
+// registers each catalog type's tools and executes them through the edge
+// tunnel. The catalog data (auth styles, ports, tool tables) and the auth
+// application (including the qBittorrent/Pi-hole session logins) live in
+// svccatalog so the validation reconciler and the /catalog UI endpoint share
+// one source of truth. Home Assistant's richer, reshaped tools stay hand-written
+// in mcp_service.go.
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,6 +35,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/faroshq/provider-edges/internal/haclient"
+	"github.com/faroshq/provider-edges/internal/svccatalog"
 )
 
 // snippet trims a byte slice for inclusion in an error message.
@@ -47,19 +48,6 @@ func snippet(b []byte) string {
 	return s
 }
 
-// authKind selects how the service's token authenticates a request.
-type authKind int
-
-const (
-	authBearer       authKind = iota // Authorization: Bearer <token>   (Grafana, Prometheus)
-	authAPIKeyHeader                 // <headerName>: <token>            (*arr apps: X-Api-Key; Jellyfin, Plex, Portainer)
-	authAPIKeyQuery                  // ?<param>=<token>
-	authQBittorrent                  // POST /api/v2/auth/login -> SID cookie
-	authBasic                        // Authorization: Basic base64("user:pass")   (AdGuard Home)
-	authProxmox                      // Authorization: PVEAPIToken=<token>          (Proxmox VE API token)
-	authPihole                       // POST /api/auth {password} -> SID; sent as X-FTL-SID (Pi-hole v6)
-)
-
 // catToolInput is the single, generic tool input. A tool's description tells the
 // model which of these to fill; reads typically need none.
 type catToolInput struct {
@@ -68,193 +56,17 @@ type catToolInput struct {
 	Body  string            `json:"body,omitempty" jsonschema:"description=Optional raw JSON request body for JSON POST/PUT actions."`
 }
 
-// catTool is one HTTP operation exposed as an MCP tool.
-type catTool struct {
-	name   string // suffix appended after the service prefix
-	desc   string
-	method string
-	path   string
-}
-
-// svcDef is a catalog entry: how to auth + which operations to expose.
-type svcDef struct {
-	displayName   string
-	defaultPort   int32
-	auth          authKind
-	authParam     string            // header name (authAPIKeyHeader) or query key (authAPIKeyQuery)
-	tokenOptional bool              // service may be unauthenticated (e.g. Prometheus) — don't require a token
-	extraHeaders  map[string]string // always-sent headers, e.g. Accept: application/json for Plex
-	tools         []catTool
-}
-
-// svcCatalog is the registry of data-driven service types. Keys are the
-// Service.spec.type values. Home Assistant is intentionally absent (hand-coded).
-var svcCatalog = map[string]svcDef{
-	"prowlarr": {
-		displayName: "Prowlarr", defaultPort: 9696, auth: authAPIKeyHeader, authParam: "X-Api-Key",
-		tools: []catTool{
-			{"indexers", "List configured Prowlarr indexers.", http.MethodGet, "/api/v1/indexer"},
-			{"search", "Search across indexers. Pass query params, e.g. {\"query\":\"ubuntu\",\"type\":\"search\"}.", http.MethodGet, "/api/v1/search"},
-			{"status", "Prowlarr system status/version.", http.MethodGet, "/api/v1/system/status"},
-		},
-	},
-	"sonarr": {
-		displayName: "Sonarr", defaultPort: 8989, auth: authAPIKeyHeader, authParam: "X-Api-Key",
-		tools: []catTool{
-			{"series", "List all TV series in Sonarr.", http.MethodGet, "/api/v3/series"},
-			{"queue", "List the download queue.", http.MethodGet, "/api/v3/queue"},
-			{"calendar", "Upcoming/recent episodes (query: start, end as ISO dates).", http.MethodGet, "/api/v3/calendar"},
-			{"lookup", "Search for a series to add. Pass query {\"term\":\"the wire\"}.", http.MethodGet, "/api/v3/series/lookup"},
-		},
-	},
-	"radarr": {
-		displayName: "Radarr", defaultPort: 7878, auth: authAPIKeyHeader, authParam: "X-Api-Key",
-		tools: []catTool{
-			{"movies", "List all movies in Radarr.", http.MethodGet, "/api/v3/movie"},
-			{"queue", "List the download queue.", http.MethodGet, "/api/v3/queue"},
-			{"lookup", "Search for a movie to add. Pass query {\"term\":\"dune 2021\"}.", http.MethodGet, "/api/v3/movie/lookup"},
-		},
-	},
-	"grafana": {
-		displayName: "Grafana", defaultPort: 3000, auth: authBearer,
-		tools: []catTool{
-			{"search", "Search dashboards/folders. Query: {\"query\":\"cpu\",\"type\":\"dash-db\"}.", http.MethodGet, "/api/search"},
-			{"datasources", "List configured data sources.", http.MethodGet, "/api/datasources"},
-			{"health", "Grafana health/version.", http.MethodGet, "/api/health"},
-			{"query", "Run a data-source query. Pass a JSON body per the Grafana /api/ds/query schema.", http.MethodPost, "/api/ds/query"},
-		},
-	},
-	"qbittorrent": {
-		displayName: "qBittorrent", defaultPort: 8080, auth: authQBittorrent,
-		tools: []catTool{
-			{"torrents", "List torrents (filter/category via query, e.g. {\"filter\":\"downloading\"}).", http.MethodGet, "/api/v2/torrents/info"},
-			{"transfer", "Global transfer stats (speeds, totals).", http.MethodGet, "/api/v2/transfer/info"},
-			{"add", "Add a torrent. Pass form {\"urls\":\"magnet:?...\"}.", http.MethodPost, "/api/v2/torrents/add"},
-			{"pause", "Pause torrents. Pass form {\"hashes\":\"<hash>|all\"}.", http.MethodPost, "/api/v2/torrents/pause"},
-			{"resume", "Resume torrents. Pass form {\"hashes\":\"<hash>|all\"}.", http.MethodPost, "/api/v2/torrents/resume"},
-			{"delete", "Delete torrents. Form {\"hashes\":\"<hash>\",\"deleteFiles\":\"false\"}.", http.MethodPost, "/api/v2/torrents/delete"},
-		},
-	},
-	"jellyfin": {
-		displayName: "Jellyfin", defaultPort: 8096, auth: authAPIKeyHeader, authParam: "X-Emby-Token",
-		tools: []catTool{
-			{"sessions", "List active playback sessions.", http.MethodGet, "/Sessions"},
-			{"system", "Server system info/version.", http.MethodGet, "/System/Info"},
-			{"search", "Search the library. Pass query {\"searchTerm\":\"dune\"}.", http.MethodGet, "/Search/Hints"},
-		},
-	},
-	"plex": {
-		// Plex speaks XML by default; ask for JSON. Token is the X-Plex-Token.
-		displayName: "Plex", defaultPort: 32400, auth: authAPIKeyHeader, authParam: "X-Plex-Token",
-		extraHeaders: map[string]string{"Accept": "application/json"},
-		tools: []catTool{
-			{"sessions", "List what's currently playing.", http.MethodGet, "/status/sessions"},
-			{"libraries", "List library sections.", http.MethodGet, "/library/sections"},
-			{"identity", "Server identity/version.", http.MethodGet, "/identity"},
-		},
-	},
-	"portainer": {
-		displayName: "Portainer", defaultPort: 9000, auth: authAPIKeyHeader, authParam: "X-API-Key",
-		tools: []catTool{
-			{"endpoints", "List environments (endpoints).", http.MethodGet, "/api/endpoints"},
-			{"stacks", "List deployed stacks.", http.MethodGet, "/api/stacks"},
-			{"status", "Portainer status/version.", http.MethodGet, "/api/status"},
-		},
-	},
-	"prometheus": {
-		// Often unauthenticated behind the tunnel; token (Bearer) is optional.
-		displayName: "Prometheus", defaultPort: 9090, auth: authBearer, tokenOptional: true,
-		tools: []catTool{
-			{"query", "Instant query. Pass query {\"query\":\"up\"}.", http.MethodGet, "/api/v1/query"},
-			{"query_range", "Range query. Query: {\"query\":\"rate(...)\",\"start\":\"...\",\"end\":\"...\",\"step\":\"60\"}.", http.MethodGet, "/api/v1/query_range"},
-			{"targets", "List scrape targets and their health.", http.MethodGet, "/api/v1/targets"},
-			{"alerts", "List active alerts.", http.MethodGet, "/api/v1/alerts"},
-		},
-	},
-	"grafana-loki": {
-		displayName: "Grafana Loki", defaultPort: 3100, auth: authBearer, tokenOptional: true,
-		tools: []catTool{
-			{"query", "LogQL instant query. Query {\"query\":\"{app=\\\"x\\\"}\"}.", http.MethodGet, "/loki/api/v1/query"},
-			{"query_range", "LogQL range query. Query {\"query\":\"...\",\"start\":\"...\",\"end\":\"...\"}.", http.MethodGet, "/loki/api/v1/query_range"},
-			{"labels", "List log stream labels.", http.MethodGet, "/loki/api/v1/labels"},
-		},
-	},
-	"adguard": {
-		// AdGuard Home uses HTTP Basic auth; token Secret holds "user:password".
-		displayName: "AdGuard Home", defaultPort: 80, auth: authBasic,
-		tools: []catTool{
-			{"status", "Protection status + version.", http.MethodGet, "/control/status"},
-			{"stats", "DNS query stats (top clients/domains, counts).", http.MethodGet, "/control/stats"},
-			{"filtering", "Filtering (blocklists) status.", http.MethodGet, "/control/filtering/status"},
-			{"protection", "Toggle protection. Body {\"enabled\":false,\"duration\":0}.", http.MethodPost, "/control/protection"},
-		},
-	},
-	"proxmox": {
-		// Proxmox VE: token Secret holds an API token "USER@REALM!TOKENID=UUID".
-		// Almost always https + self-signed — set the Service spec.scheme=https.
-		displayName: "Proxmox VE", defaultPort: 8006, auth: authProxmox,
-		tools: []catTool{
-			{"nodes", "List cluster nodes.", http.MethodGet, "/api2/json/nodes"},
-			{"resources", "List cluster resources (VMs, storage, nodes).", http.MethodGet, "/api2/json/cluster/resources"},
-			{"cluster_status", "Cluster/quorum status.", http.MethodGet, "/api2/json/cluster/status"},
-		},
-	},
-	"pihole": {
-		// Pi-hole v6 REST API: token Secret holds the web-password; we exchange it
-		// for a session SID (see piholeLogin) sent as X-FTL-SID.
-		displayName: "Pi-hole", defaultPort: 80, auth: authPihole,
-		tools: []catTool{
-			{"summary", "Query/blocking summary stats.", http.MethodGet, "/api/stats/summary"},
-			{"blocking", "Blocking enabled/disabled status.", http.MethodGet, "/api/dns/blocking"},
-			{"disable", "Pause blocking. Body {\"blocking\":false,\"timer\":300}.", http.MethodPost, "/api/dns/blocking"},
-			{"top_domains", "Top permitted/blocked domains.", http.MethodGet, "/api/stats/top_domains"},
-		},
-	},
-	"unifi-network": {
-		// UniFi OS console (UDM/UDR/Cloud Key). Always https + self-signed → set
-		// the Service spec.scheme=https, spec.port=443. Auth is a UniFi OS local
-		// API key (X-API-KEY) against the official Network integration API. Most
-		// home setups have a single site — call "sites" first to get its id, then
-		// pass it: {"siteId":"<id>"}. Paths of the form {siteId} are filled from
-		// the tool's query map.
-		displayName: "UniFi Network", defaultPort: 443, auth: authAPIKeyHeader, authParam: "X-API-KEY",
-		tools: []catTool{
-			{"sites", "List UniFi Network sites (each site's id + name).", http.MethodGet, "/proxy/network/integration/v1/sites"},
-			{"clients", "List connected clients for a site. Query {\"siteId\":\"<id>\"}.", http.MethodGet, "/proxy/network/integration/v1/sites/{siteId}/clients"},
-			{"devices", "List UniFi devices (APs/switches/gateways) for a site. Query {\"siteId\":\"<id>\"}.", http.MethodGet, "/proxy/network/integration/v1/sites/{siteId}/devices"},
-		},
-	},
-	"unifi-protect": {
-		// UniFi Protect on the same UniFi OS console (host:443, https). Auth is a
-		// UniFi OS local API key (X-API-KEY) against the official Protect
-		// integration API. "snapshot" returns a JPEG the agent can see — call
-		// "cameras" first to get camera ids.
-		displayName: "UniFi Protect", defaultPort: 443, auth: authAPIKeyHeader, authParam: "X-API-KEY",
-		tools: []catTool{
-			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
-			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}).", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
-			{"events", "Recent Protect events (motion/person/vehicle). Query: start,end (ms epoch), types.", http.MethodGet, "/proxy/protect/integration/v1/events"},
-		},
-	},
-}
-
-// catalogServiceType reports whether a Service type is served by the catalog.
-func catalogServiceType(t string) bool {
-	_, ok := svcCatalog[t]
-	return ok
-}
-
 // registerCatalogTools installs the MCP tools for a catalog service type.
 func (p *Server) registerCatalogTools(srv *mcp.Server, prefix, cluster, kcpToken string, svc *serviceView, dialer haclient.Dialer) {
-	def, ok := svcCatalog[svc.Spec.Type]
+	def, ok := svccatalog.Get(svc.Spec.Type)
 	if !ok {
 		return
 	}
-	for _, t := range def.tools {
+	for _, t := range def.Tools {
 		tool := t // capture
 		mcp.AddTool(srv, &mcp.Tool{
-			Name:        prefix + tool.name,
-			Description: def.displayName + " — " + tool.desc,
+			Name:        prefix + tool.Name,
+			Description: def.DisplayName + " — " + tool.Desc,
 		}, func(ctx context.Context, _ *mcp.CallToolRequest, in catToolInput) (*mcp.CallToolResult, any, error) {
 			return p.callCatalogTool(ctx, cluster, kcpToken, svc, dialer, def, tool, in)
 		})
@@ -262,25 +74,21 @@ func (p *Server) registerCatalogTools(srv *mcp.Server, prefix, cluster, kcpToken
 }
 
 // callCatalogTool executes one catalog tool: resolve the token, apply the auth
-// style, build the request (query/form/body), proxy it through the edge, and
-// return the response body verbatim.
-func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, svc *serviceView, dialer haclient.Dialer, def svcDef, tool catTool, in catToolInput) (*mcp.CallToolResult, any, error) {
+// (svccatalog.Apply), build the request (query/form/body), proxy it through the
+// edge, and return the response body verbatim.
+func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, svc *serviceView, dialer haclient.Dialer, def svccatalog.Definition, tool svccatalog.Tool, in catToolInput) (*mcp.CallToolResult, any, error) {
 	token, err := p.readServiceToken(ctx, cluster, svc, kcpToken)
 	if err != nil {
 		return toolErr("service credentials: " + err.Error()), nil, nil
 	}
-	if token == "" && !def.tokenOptional {
+	if token == "" && !def.Credential.Optional {
 		return toolErr("no auth token configured for this service (set spec.authSecretRef)"), nil, nil
 	}
 
-	header := http.Header{}
-	for k, v := range def.extraHeaders {
-		header.Set(k, v)
-	}
 	// Path parameters: any {key} in the tool path is filled from the query map
 	// (e.g. {"siteId":"..."} → /sites/{siteId}/clients); everything else becomes
 	// the query string.
-	path := tool.path
+	path := tool.Path
 	q := url.Values{}
 	for k, v := range in.Query {
 		if ph := "{" + k + "}"; strings.Contains(path, ph) {
@@ -290,32 +98,12 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 		}
 	}
 
-	if token != "" {
-		switch def.auth {
-		case authBearer:
-			header.Set("Authorization", "Bearer "+token)
-		case authAPIKeyHeader:
-			header.Set(def.authParam, token)
-		case authAPIKeyQuery:
-			q.Set(def.authParam, token)
-		case authBasic:
-			header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(token)))
-		case authProxmox:
-			header.Set("Authorization", "PVEAPIToken="+token)
-		case authQBittorrent:
-			sid, err := p.qbitLogin(ctx, cluster, svc, dialer, token)
-			if err != nil {
-				return toolErr("qBittorrent login failed: " + err.Error()), nil, nil
-			}
-			header.Set("Cookie", "SID="+sid)
-			header.Set("Referer", (haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port}).SvcTarget())
-		case authPihole:
-			sid, err := p.piholeLogin(ctx, cluster, svc, dialer, token)
-			if err != nil {
-				return toolErr("Pi-hole login failed: " + err.Error()), nil, nil
-			}
-			header.Set("X-FTL-SID", sid)
-		}
+	// Auth (headers + query) is applied by the shared catalog, which also runs
+	// the session-login round-trips for qBittorrent/Pi-hole.
+	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port}
+	header := http.Header{}
+	if err := svccatalog.Apply(ctx, dialer, target, def, token, header, q); err != nil {
+		return toolErr(err.Error()), nil, nil
 	}
 
 	// Request body: form-encoded (qBittorrent actions) or raw JSON.
@@ -337,90 +125,23 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 		path += "?" + q.Encode()
 	}
 
-	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port}
-	resp, err := haclient.DoWith(ctx, dialer, target, tool.method, path, header, bodyReader)
+	resp, err := haclient.DoWith(ctx, dialer, target, tool.Method, path, header, bodyReader)
 	if err != nil {
 		return toolErr(err.Error()), nil, nil
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 	if resp.StatusCode >= 400 {
-		return toolErr(fmt.Sprintf("%s returned %d: %s", def.displayName, resp.StatusCode, snippet(respBody))), nil, nil
+		return toolErr(fmt.Sprintf("%s returned %d: %s", def.DisplayName, resp.StatusCode, snippet(respBody))), nil, nil
 	}
 	// Binary image responses (e.g. a UniFi Protect camera snapshot) are returned
 	// as MCP image content so the model can actually see them.
 	if ct := resp.Header.Get("Content-Type"); strings.HasPrefix(ct, "image/") {
-		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.ImageContent{Data: respBody, MIMEType: ct}}}, nil, nil
+		return &mcp.CallToolResult{Content: withServiceNote(svc, &mcp.ImageContent{Data: respBody, MIMEType: ct})}, nil, nil
 	}
 	text := string(respBody)
 	if strings.TrimSpace(text) == "" {
 		text = fmt.Sprintf("OK (%d)", resp.StatusCode)
 	}
-	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, nil, nil
-}
-
-// qbitLogin performs qBittorrent's cookie login and returns the SID. The token
-// Secret holds "username:password" (the WebUI credentials). Returns an error if
-// the app rejects the login (wrong creds, or CSRF/host-header protection — in
-// which case whitelist the edge or disable those checks in qBittorrent).
-func (p *Server) qbitLogin(ctx context.Context, cluster string, svc *serviceView, dialer haclient.Dialer, cred string) (string, error) {
-	user, pass, ok := strings.Cut(cred, ":")
-	if !ok {
-		return "", fmt.Errorf("qBittorrent credential must be \"username:password\"")
-	}
-	form := url.Values{"username": {user}, "password": {pass}}
-	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port}
-	header := http.Header{
-		"Content-Type": {"application/x-www-form-urlencoded"},
-		"Referer":      {target.SvcTarget()},
-	}
-	resp, err := haclient.DoWith(ctx, dialer, target, http.MethodPost, "/api/v2/auth/login", header, strings.NewReader(form.Encode()))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
-	if resp.StatusCode != http.StatusOK || strings.Contains(string(body), "Fails") {
-		return "", fmt.Errorf("login rejected (%d): %s", resp.StatusCode, snippet(body))
-	}
-	for _, c := range resp.Cookies() {
-		if c.Name == "SID" {
-			return c.Value, nil
-		}
-	}
-	return "", fmt.Errorf("no SID cookie in login response")
-}
-
-// piholeLogin performs Pi-hole v6's session login and returns the SID. The token
-// Secret holds the web-interface password. Returns an error if the app rejects
-// it (wrong password, or the API session limit is hit).
-func (p *Server) piholeLogin(ctx context.Context, cluster string, svc *serviceView, dialer haclient.Dialer, password string) (string, error) {
-	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port}
-	header := http.Header{"Content-Type": {"application/json"}}
-	reqBody, err := json.Marshal(map[string]string{"password": password})
-	if err != nil {
-		return "", err
-	}
-	resp, err := haclient.DoWith(ctx, dialer, target, http.MethodPost, "/api/auth", header, strings.NewReader(string(reqBody)))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("login rejected (%d): %s", resp.StatusCode, snippet(body))
-	}
-	var out struct {
-		Session struct {
-			Valid bool   `json:"valid"`
-			SID   string `json:"sid"`
-		} `json:"session"`
-	}
-	if err := json.Unmarshal(body, &out); err != nil {
-		return "", fmt.Errorf("decode login response: %w", err)
-	}
-	if !out.Session.Valid || out.Session.SID == "" {
-		return "", fmt.Errorf("login not valid: %s", snippet(body))
-	}
-	return out.Session.SID, nil
+	return &mcp.CallToolResult{Content: withServiceNote(svc, &mcp.TextContent{Text: text})}, nil, nil
 }

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -28,6 +28,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -44,6 +45,7 @@ import (
 
 	edgesv1alpha1 "github.com/faroshq/provider-edges/apis/v1alpha1"
 	sdktunnel "github.com/faroshq/provider-edges/internal/tunnel"
+	"github.com/faroshq/provider-edges/internal/svccatalog"
 )
 
 // providerPublicBase is the path prefix (behind the hub backend proxy) this
@@ -152,6 +154,23 @@ func runServe() error {
 	// tools across the tenant's connected KubernetesCluster edges AND the Home
 	// Assistant tools of every Ready home-assistant EdgeService.
 	mux.Handle("/mcp", tsrv.RootMCPHandler())
+
+	// Service catalog: the UI-facing form schema for every service type
+	// (svccatalog.All() — connection defaults, auth model + credential fields,
+	// scheme-lock/host-required hints). The portal fetches this at
+	// /services/providers/edges/catalog to render the add/configure-service form
+	// from data, so it never drifts from the backend's auth/probe knowledge.
+	mux.HandleFunc("/catalog", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-cache")
+		if err := json.NewEncoder(w).Encode(svccatalog.All()); err != nil {
+			log.Error(err, "encoding service catalog")
+		}
+	})
 
 	// Provider portal micro-frontend (embedded Vite bundle). The hub proxies
 	// /ui/providers/edges/* here; ProviderFrame injects <script src=".../main.js">

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -4,48 +4,50 @@ import { RefreshCw, Trash2, Plus, Boxes, ChevronRight, ChevronDown, Save, KeyRou
 import {
   listServices, createKubeEdgeService, deleteEdgeService,
   updateEdgeServiceInstructions, connectEdgeService, listEdges,
+  fetchServiceCatalog,
 } from './api'
+import type { CatalogEntry, CatalogCredentialField } from './api'
 import type { EdgeService, EdgeServiceDraft, Edge, ErrorResponse } from './types'
 
-// Service catalog — mirrors the backend svcCatalog (providers/edges/internal/
-// tunnel/svc_catalog.go) + Home Assistant. Each entry seeds the default port and
-// tells the operator what credential the service expects.
-interface ServicePreset { type: string; label: string; category: string; port: number; tokenHint: string }
-const PRESETS: ServicePreset[] = [
-  { type: 'home-assistant', label: 'Home Assistant', category: 'Home & IoT', port: 8123, tokenHint: 'Long-lived access token' },
-  { type: 'adguard', label: 'AdGuard Home', category: 'Network', port: 80, tokenHint: 'Web credentials as "username:password"' },
-  { type: 'pihole', label: 'Pi-hole', category: 'Network', port: 80, tokenHint: 'Web-interface password (Pi-hole v6)' },
-  { type: 'unifi-network', label: 'UniFi Network', category: 'Network', port: 443, tokenHint: 'UniFi OS local API key (X-API-KEY) — set scheme https, host = console IP' },
-  { type: 'unifi-protect', label: 'UniFi Protect', category: 'Network', port: 443, tokenHint: 'UniFi OS local API key (X-API-KEY) — set scheme https, host = console IP' },
-  { type: 'grafana', label: 'Grafana', category: 'Observability', port: 3000, tokenHint: 'Service-account / API token' },
-  { type: 'grafana-loki', label: 'Grafana Loki', category: 'Observability', port: 3100, tokenHint: 'Bearer token (optional)' },
-  { type: 'prometheus', label: 'Prometheus', category: 'Observability', port: 9090, tokenHint: 'Bearer token (optional — often none)' },
-  { type: 'proxmox', label: 'Proxmox VE', category: 'Infra', port: 8006, tokenHint: 'API token "USER@REALM!ID=UUID" — set scheme https' },
-  { type: 'portainer', label: 'Portainer', category: 'Infra', port: 9000, tokenHint: 'Access token (X-API-Key)' },
-  { type: 'qbittorrent', label: 'qBittorrent', category: 'Media', port: 8080, tokenHint: 'WebUI credentials as "username:password"' },
-  { type: 'prowlarr', label: 'Prowlarr', category: 'Media', port: 9696, tokenHint: 'API key (Settings → General)' },
-  { type: 'sonarr', label: 'Sonarr', category: 'Media', port: 8989, tokenHint: 'API key (Settings → General)' },
-  { type: 'radarr', label: 'Radarr', category: 'Media', port: 7878, tokenHint: 'API key (Settings → General)' },
-  { type: 'jellyfin', label: 'Jellyfin', category: 'Media', port: 8096, tokenHint: 'API key (Dashboard → API Keys)' },
-  { type: 'plex', label: 'Plex', category: 'Media', port: 32400, tokenHint: 'X-Plex-Token' },
-  { type: 'generic', label: 'Generic (proxy only)', category: 'Other', port: 80, tokenHint: 'Bearer token (optional)' },
-]
-function presetFor(t?: string): ServicePreset | undefined {
-  return PRESETS.find((p) => p.type === t)
+// Service type catalog — fetched from the backend (svccatalog.All()) so the form
+// never drifts from the provider's auth/probe knowledge. Each entry seeds the
+// port/scheme and describes the credential fields the UI collects.
+const catalog = ref<CatalogEntry[]>([])
+function catalogFor(t?: string): CatalogEntry | undefined {
+  return catalog.value.find((c) => c.type === t)
 }
-// Presets grouped by category, preserving first-seen category order, for
-// <optgroup> rendering in the type dropdown.
-const PRESET_GROUPS = PRESETS.reduce<{ category: string; items: ServicePreset[] }[]>((groups, p) => {
-  let g = groups.find((x) => x.category === p.category)
-  if (!g) { g = { category: p.category, items: [] }; groups.push(g) }
-  g.items.push(p)
-  return groups
-}, [])
+// Types grouped by category (first-seen order) for <optgroup> rendering.
+const CATALOG_GROUPS = computed(() =>
+  catalog.value.reduce<{ category: string; items: CatalogEntry[] }[]>((groups, c) => {
+    const cat = c.category || 'Other'
+    let g = groups.find((x) => x.category === cat)
+    if (!g) { g = { category: cat, items: [] }; groups.push(g) }
+    g.items.push(c)
+    return groups
+  }, []),
+)
+// A one-entry fallback so the form still works if the catalog fetch fails.
+const GENERIC_FALLBACK: CatalogEntry = {
+  type: 'generic', displayName: 'Generic HTTP service', category: 'Other',
+  defaultPort: 80, defaultScheme: 'http', auth: 'bearer',
+  credential: { optional: true, packing: 'single', fields: [{ key: 'token', label: 'Bearer token (optional)', secret: true }] },
+}
+async function loadCatalog() {
+  try {
+    catalog.value = await fetchServiceCatalog()
+  } catch (e) {
+    error.value = (e as ErrorResponse)?.message ?? 'Failed to load service catalog'
+    if (!catalog.value.length) catalog.value = [GENERIC_FALLBACK]
+  }
+}
+// schemeLocked types (e.g. UniFi is always https) pin the scheme select.
+const createSchemeLocked = computed(() => !!catalogFor(draft.value.serviceType)?.schemeLocked)
 function onTypeChange() {
-  const p = presetFor(draft.value.serviceType)
-  if (p) draft.value.port = p.port
-  // UniFi OS speaks https (self-signed); default the scheme so it just works.
-  if (draft.value.serviceType.startsWith('unifi-')) draft.value.scheme = 'https'
+  const c = catalogFor(draft.value.serviceType)
+  if (c) {
+    if (c.defaultPort) draft.value.port = c.defaultPort
+    if (c.defaultScheme) draft.value.scheme = c.defaultScheme
+  }
   resetTargetMode()
 }
 
@@ -82,8 +84,10 @@ const selectedEdgeIsServer = computed(
 // (UniFi) and LinuxServer edges default to host; KubernetesCluster edges default
 // to a cluster Service. The user can override with the toggle.
 function resetTargetMode() {
-  const isLAN = draft.value.serviceType.startsWith('unifi-')
-  targetMode.value = selectedEdgeIsServer.value || isLAN ? 'host' : 'kube'
+  // Types flagged hostRequired live on the edge LAN (e.g. a UniFi console), not
+  // on the agent loopback, so they default to host addressing.
+  const needsHost = !!catalogFor(draft.value.serviceType)?.hostRequired
+  targetMode.value = selectedEdgeIsServer.value || needsHost ? 'host' : 'kube'
 }
 
 function toggleCreate() {
@@ -107,10 +111,12 @@ function applyHostUrl() {
   }
 }
 
-// Per-row expand for edit (instructions) + connect (token).
+// Per-row expand for edit (instructions) + connect (credentials).
 const expanded = ref<string | null>(null)
 const editInstructions = ref('')
-const editToken = ref('')
+// Credential inputs for the expanded row, keyed by field.key (e.g. "token", or
+// "username"/"password"). Packed into the single Secret "token" value on connect.
+const credInputs = ref<Record<string, string>>({})
 function toggle(s: EdgeService) {
   if (expanded.value === s.name) {
     expanded.value = null
@@ -118,7 +124,34 @@ function toggle(s: EdgeService) {
   }
   expanded.value = s.name
   editInstructions.value = s.instructions ?? ''
-  editToken.value = ''
+  credInputs.value = {}
+}
+
+// credFields returns the credential inputs to render for a service's type,
+// falling back to a single opaque token when the type is unknown.
+function credFields(s: EdgeService): CatalogCredentialField[] {
+  return catalogFor(s.serviceType)?.credential.fields ?? [{ key: 'token', label: 'token', secret: true }]
+}
+// packedCredential combines the credential inputs into the single string stored
+// as the Secret "token" (per the type's packing: "username:password" or the
+// single field verbatim).
+function packedCredential(s: EdgeService): string {
+  const cred = catalogFor(s.serviceType)?.credential
+  if (cred?.packing === 'userpass') {
+    const u = (credInputs.value['username'] ?? '').trim()
+    const p = credInputs.value['password'] ?? ''
+    return `${u}:${p}`
+  }
+  const key = credFields(s)[0]?.key ?? 'token'
+  return (credInputs.value[key] ?? '').trim()
+}
+// credFilled reports whether the required credential inputs are present.
+function credFilled(s: EdgeService): boolean {
+  const cred = catalogFor(s.serviceType)?.credential
+  if (cred?.packing === 'userpass') {
+    return !!(credInputs.value['username']?.trim() && credInputs.value['password'])
+  }
+  return !!packedCredential(s)
 }
 
 async function refresh() {
@@ -195,12 +228,13 @@ async function onSaveInstructions(s: EdgeService) {
 }
 
 async function onConnect(s: EdgeService) {
-  if (!editToken.value.trim()) return
+  const token = packedCredential(s)
+  if (!token) return
   busy.value = true
   error.value = null
   try {
-    await connectEdgeService(s.name, editToken.value.trim())
-    editToken.value = ''
+    await connectEdgeService(s.name, token)
+    credInputs.value = {}
     await refresh()
   } catch (e) {
     error.value = (e as ErrorResponse)?.message ?? 'Connect failed'
@@ -209,7 +243,10 @@ async function onConnect(s: EdgeService) {
   }
 }
 
-onMounted(refresh)
+onMounted(() => {
+  loadCatalog()
+  refresh()
+})
 const timer = setInterval(refresh, 10000)
 onUnmounted(() => clearInterval(timer))
 
@@ -256,14 +293,14 @@ function phaseClass(p?: string): string {
         <label class="fld" style="flex: 1;">
           <span class="lbl">Type</span>
           <select v-model="draft.serviceType" class="input" @change="onTypeChange">
-            <optgroup v-for="g in PRESET_GROUPS" :key="g.category" :label="g.category">
-              <option v-for="p in g.items" :key="p.type" :value="p.type">{{ p.label }}</option>
+            <optgroup v-for="g in CATALOG_GROUPS" :key="g.category" :label="g.category">
+              <option v-for="c in g.items" :key="c.type" :value="c.type">{{ c.displayName }}</option>
             </optgroup>
           </select>
         </label>
         <label class="fld" style="flex: 0 0 120px;">
           <span class="lbl">Scheme</span>
-          <select v-model="draft.scheme" class="input">
+          <select v-model="draft.scheme" class="input" :disabled="createSchemeLocked" :title="createSchemeLocked ? 'Fixed by the service type' : ''">
             <option value="http">http</option>
             <option value="https">https</option>
           </select>
@@ -288,8 +325,9 @@ function phaseClass(p?: string): string {
       <!-- Host: dial an address directly (loopback, or a LAN device like UniFi). -->
       <div v-if="targetMode === 'host'" class="row" style="gap: 12px; align-items: flex-start;">
         <label class="fld" style="flex: 1;">
-          <span class="lbl">Host (blank = agent loopback)</span>
+          <span class="lbl">Host {{ catalogFor(draft.serviceType)?.hostRequired ? '(required)' : '(blank = agent loopback)' }}</span>
           <input v-model="draft.host" class="input" @blur="applyHostUrl" placeholder="192.168.1.1, myui.example.com, or paste https://myui.example.com — blank = 127.0.0.1" />
+          <span v-if="catalogFor(draft.serviceType)?.hostHelp" class="muted" style="font-size: 12px; margin-top: 4px;">{{ catalogFor(draft.serviceType)?.hostHelp }}</span>
         </label>
       </div>
       <!-- Kubernetes Service: reach it by cluster DNS. -->
@@ -357,11 +395,15 @@ function phaseClass(p?: string): string {
                   <button class="btn primary" :disabled="busy" @click="onSaveInstructions(s)"><Save :size="14" /> Save instructions</button>
                 </div>
 
-                <div class="es-head">Access token</div>
-                <div class="muted" style="margin-bottom: 6px;">{{ presetFor(s.serviceType)?.tokenHint ?? 'Access token' }} — makes the service Ready. Stored as a Secret, never on the agent host.</div>
-                <div class="row" style="gap: 8px;">
-                  <input v-model="editToken" type="password" class="input" style="flex: 1;" placeholder="token" />
-                  <button class="btn" :disabled="busy || !editToken.trim()" @click="onConnect(s)"><KeyRound :size="14" /> {{ s.hasCredentials ? 'Update token' : 'Set token' }}</button>
+                <div class="es-head">Credentials</div>
+                <div class="muted" style="margin-bottom: 6px;">{{ catalogFor(s.serviceType)?.credential.hint ?? 'Credential' }} — makes the service Ready. Stored as a Secret, never on the agent host.</div>
+                <div class="row" style="gap: 8px; align-items: flex-end;">
+                  <label v-for="f in credFields(s)" :key="f.key" class="fld" style="flex: 1;">
+                    <span class="lbl">{{ f.label }}</span>
+                    <input v-model="credInputs[f.key]" :type="f.secret ? 'password' : 'text'" class="input" :placeholder="f.label" />
+                    <span v-if="f.help" class="muted" style="font-size: 12px; margin-top: 4px;">{{ f.help }}</span>
+                  </label>
+                  <button class="btn" :disabled="busy || !credFilled(s)" @click="onConnect(s)"><KeyRound :size="14" /> {{ s.hasCredentials ? 'Update' : 'Set' }} credentials</button>
                 </div>
               </td>
             </tr>

--- a/providers/edges/portal/src/api.ts
+++ b/providers/edges/portal/src/api.ts
@@ -205,6 +205,57 @@ export async function probeEdge(name: string, type: EdgeType): Promise<EdgeProbe
   }
 }
 
+// ─── Service catalog ──────────────────────────────────────────────
+// The provider serves the service-type form schema (svccatalog.All()) at
+// /services/providers/edges/catalog so the UI renders the add/configure-service
+// form from data instead of a hand-maintained mirror. Same origin as the portal;
+// the hub backend proxy forwards /services/providers/edges/* to the provider.
+
+// CatalogCredentialField is one input the form collects for a service's
+// credential (mirrors svccatalog.CredentialField).
+export interface CatalogCredentialField {
+  key: string
+  label: string
+  help?: string
+  secret?: boolean
+}
+// CatalogCredential is how the form collects the credential and how the fields
+// pack into the single Secret "token" value (mirrors svccatalog.CredentialModel).
+export interface CatalogCredential {
+  optional?: boolean
+  packing?: 'single' | 'userpass'
+  fields?: CatalogCredentialField[]
+  hint?: string
+}
+// CatalogEntry is the UI-facing subset of svccatalog.Definition.
+export interface CatalogEntry {
+  type: string
+  displayName: string
+  description?: string
+  category?: string
+  defaultPort?: number
+  defaultScheme?: string
+  schemeLocked?: boolean
+  hostRequired?: boolean
+  hostHelp?: string
+  auth: string
+  authParam?: string
+  credential: CatalogCredential
+}
+
+// fetchServiceCatalog returns every service type's form descriptor. It is static
+// provider metadata (not tenant-scoped), so it is fetched directly from the
+// provider backend rather than through the GraphQL gateway.
+export async function fetchServiceCatalog(): Promise<CatalogEntry[]> {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
+  const res = await fetch('/services/providers/edges/catalog', { credentials: 'same-origin', headers })
+  if (!res.ok) {
+    throw <ErrorResponse>{ reason: 'HTTPError', message: (await res.text()) || res.statusText }
+  }
+  return (await res.json()) as CatalogEntry[]
+}
+
 // ─── Services (EdgeService) ───────────────────────────────────────
 // Cluster-scoped services on an edge host (e.g. Home Assistant on a
 // LinuxServer). Discovery materializes them; the user attaches a token to make


### PR DESCRIPTION
Makes a Service's spec.instructions reliably reach the model, plus the svccatalog refactor and Services UI work.

Instructions end-to-end:
1. agents provider reads each MCP server's initialize instructions and injects them as a system message (MCPSession.Instructions -> buildToolset -> assembleTurnCtx).
2. edges echoes spec.instructions into every tool RESULT (withServiceNote in mcp_service.go; HA + catalog text/image). Reaches ANY MCP client (internal + external) at use time, independent of how clients treat server-level initialize instructions.

Also: svccatalog package (Definition/Tool + auth extracted from tunnel); Services UI details/edit panel + status conditions table + targeting decoupled from edge kind + host accepts a URL.

Edges + agents modules + portal build/vet clean.

Generated with Claude Code.