### PR TITLE
feat(edges): dedicated service edit page + per-provider catalog info

### DIFF
--- a/providers/edges/internal/svccatalog/catalog.go
+++ b/providers/edges/internal/svccatalog/catalog.go
@@ -90,12 +90,14 @@ type CredentialModel struct {
 	Hint string `json:"hint,omitempty"`
 }
 
-// Tool is one HTTP operation exposed as an MCP tool. Not serialized to the UI.
+// Tool is one HTTP operation exposed as an MCP tool. Name + Desc are serialized
+// to the UI (so the portal can show what an AI agent can do with this service);
+// Method + Path are backend-only.
 type Tool struct {
-	Name   string
-	Desc   string
-	Method string
-	Path   string
+	Name   string `json:"name"`
+	Desc   string `json:"description,omitempty"`
+	Method string `json:"-"`
+	Path   string `json:"-"`
 }
 
 // ProbeMode selects how the validation reconciler interprets the probe result.
@@ -153,11 +155,14 @@ type Definition struct {
 	// ProbeMode selects how the probe status is interpreted (default validate
 	// when a ProbePath is set, reachable otherwise).
 	ProbeMode ProbeMode `json:"-"`
-	// Handcoded marks types whose MCP tools live in Go rather than in Tools
-	// (Home Assistant). Such a type still "has tools" for discovery purposes.
+	// Handcoded marks types whose MCP tools are executed by hand-written Go
+	// (Home Assistant) rather than driven by Tools. A Handcoded type may still
+	// list Tools for display only (the UI shows them; they are not registered by
+	// the data-driven registrar — see IsDataDriven).
 	Handcoded bool `json:"-"`
-	// Tools are the data-driven MCP operations exposed for this type.
-	Tools []Tool `json:"-"`
+	// Tools are the MCP operations exposed for this type. Serialized to the UI
+	// (name + description) so the portal can show what the agent can do.
+	Tools []Tool `json:"tools,omitempty"`
 }
 
 // singleField is a helper for the common "one opaque token" credential.
@@ -189,6 +194,14 @@ var catalog = map[string]Definition{
 		},
 		ProbePath: "/api/config", ProbeMode: ProbeValidate,
 		Handcoded: true,
+		// Display-only: Home Assistant's tools are executed by hand-written Go
+		// (mcp_service.go), not the data-driven registrar (Handcoded excludes it
+		// from IsDataDriven). Listed here so the UI shows what the agent can do.
+		Tools: []Tool{
+			{Name: "states", Desc: "List entity states (lights, sensors, switches…)."},
+			{Name: "get_state", Desc: "Read one entity's state by entity_id."},
+			{Name: "call_service", Desc: "Call a service, e.g. turn a light on/off or open a cover."},
+		},
 	},
 	"qbittorrent": {
 		Type: "qbittorrent", DisplayName: "qBittorrent", Category: "Media",
@@ -429,12 +442,13 @@ func HasTools(t string) bool {
 	return ok && (d.Handcoded || len(d.Tools) > 0)
 }
 
-// IsDataDriven reports whether a type's MCP tools come from Definition.Tools
-// (i.e. driven by the catalog registrar, not hand-coded). Replaces the old
-// catalogServiceType.
+// IsDataDriven reports whether a type's MCP tools are driven by the catalog
+// registrar (Definition.Tools) rather than hand-coded. Handcoded types (Home
+// Assistant) are excluded even when they list Tools for display. Replaces the
+// old catalogServiceType.
 func IsDataDriven(t string) bool {
 	d, ok := catalog[t]
-	return ok && len(d.Tools) > 0
+	return ok && !d.Handcoded && len(d.Tools) > 0
 }
 
 // All returns every definition, sorted by category then display name — the

--- a/providers/edges/portal/src/ServiceEdit.vue
+++ b/providers/edges/portal/src/ServiceEdit.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { ArrowLeft, Save, KeyRound } from 'lucide-vue-next'
+import { updateEdgeService, connectEdgeService } from './api'
+import type { CatalogEntry, CatalogCredentialField, EdgeServiceEdit } from './api'
+import type { EdgeService, Edge, ErrorResponse } from './types'
+
+// A dedicated per-service page: provider info (from the catalog) + editable
+// configuration + credentials + status. Reached from the Services list via the
+// Edit button; emits back/saved so the list can close it and refresh.
+const props = defineProps<{ service: EdgeService; catalog: CatalogEntry[]; edges: Edge[] }>()
+const emit = defineEmits<{ back: []; saved: [] }>()
+
+const busy = ref(false)
+const error = ref<string | null>(null)
+
+// Editable config, seeded from the service.
+const form = ref<EdgeServiceEdit>({
+  serviceType: props.service.serviceType,
+  scheme: props.service.scheme || 'http',
+  port: props.service.port,
+  host: props.service.host ?? '',
+  targetNamespace: props.service.targetNamespace ?? '',
+  targetName: props.service.targetName ?? '',
+})
+const instructions = ref(props.service.instructions ?? '')
+const targetMode = ref<'host' | 'kube'>(props.service.host ? 'host' : props.service.targetName ? 'kube' : 'host')
+
+// The catalog entry for the currently-selected type drives the info panel,
+// scheme lock, host hints and credential fields.
+const entry = computed(() => props.catalog.find((c) => c.type === form.value.serviceType))
+const schemeLocked = computed(() => !!entry.value?.schemeLocked)
+const edgeIsServer = computed(() => props.edges.find((e) => e.name === props.service.edgeName)?.type === 'server')
+
+function onTypeChange() {
+  const c = entry.value
+  if (!c) return
+  if (c.defaultPort) form.value.port = c.defaultPort
+  if (c.defaultScheme) form.value.scheme = c.defaultScheme
+  if (c.hostRequired) targetMode.value = 'host'
+}
+
+// Human labels for the auth badge.
+const AUTH_LABELS: Record<string, string> = {
+  bearer: 'Bearer token',
+  apiKeyHeader: 'API key (header)',
+  apiKeyQuery: 'API key (query)',
+  basic: 'Basic auth',
+  proxmox: 'Proxmox API token',
+  pihole: 'Session login',
+  qbittorrent: 'Session login',
+  none: 'No auth',
+}
+function authLabel(a?: string): string {
+  return AUTH_LABELS[a ?? ''] ?? a ?? '—'
+}
+
+async function onSaveConfig() {
+  busy.value = true
+  error.value = null
+  try {
+    const byHost = targetMode.value === 'host'
+    await updateEdgeService(props.service.name, {
+      serviceType: form.value.serviceType,
+      scheme: form.value.scheme,
+      port: Number(form.value.port) || props.service.port,
+      host: byHost ? form.value.host?.trim() || undefined : undefined,
+      targetNamespace: form.value.targetNamespace,
+      targetName: byHost ? '' : form.value.targetName,
+      instructions: instructions.value,
+    })
+    emit('saved')
+  } catch (e) {
+    error.value = (e as ErrorResponse)?.message ?? 'Save failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+// ── Credentials ────────────────────────────────────────────────────
+// Inputs keyed by field.key; packed into the single Secret "token" value per the
+// type's packing (mirrors Services.vue's create-form logic).
+const credInputs = ref<Record<string, string>>({})
+const credFields = computed<CatalogCredentialField[]>(
+  () => entry.value?.credential.fields ?? [{ key: 'token', label: 'token', secret: true }],
+)
+function packedCredential(): string {
+  const cred = entry.value?.credential
+  if (cred?.packing === 'userpass') {
+    const u = (credInputs.value['username'] ?? '').trim()
+    const p = credInputs.value['password'] ?? ''
+    return `${u}:${p}`
+  }
+  const key = credFields.value[0]?.key ?? 'token'
+  return (credInputs.value[key] ?? '').trim()
+}
+const credFilled = computed(() => {
+  const cred = entry.value?.credential
+  if (cred?.packing === 'userpass') return !!(credInputs.value['username']?.trim() && credInputs.value['password'])
+  return !!packedCredential()
+})
+async function onSaveCreds() {
+  const token = packedCredential()
+  if (!token) return
+  busy.value = true
+  error.value = null
+  try {
+    await connectEdgeService(props.service.name, token)
+    credInputs.value = {}
+    emit('saved')
+  } catch (e) {
+    error.value = (e as ErrorResponse)?.message ?? 'Connect failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+function statusClass(v?: string): string {
+  return v === 'True' ? 'ok' : v === 'False' ? 'down' : 'pending'
+}
+function phaseClass(p?: string): string {
+  return p === 'Ready' ? 'ok' : p === 'Unreachable' ? 'down' : 'pending'
+}
+function age(ts?: string): string {
+  if (!ts) return ''
+  const secs = Math.max(0, Math.floor((Date.now() - new Date(ts).getTime()) / 1000))
+  if (secs < 60) return `${secs}s`
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h`
+  return `${Math.floor(secs / 86400)}d`
+}
+</script>
+
+<template>
+  <div class="edges-app">
+    <header class="edges-header">
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <button class="icon" title="Back to services" @click="emit('back')"><ArrowLeft :size="16" /></button>
+        <div>
+          <h1>{{ service.name }} <span class="status" :class="phaseClass(service.phase)">{{ service.phase || 'Pending' }}</span></h1>
+          <p>{{ entry?.displayName ?? service.serviceType }}<span v-if="entry?.description"> — {{ entry.description }}</span></p>
+        </div>
+      </div>
+    </header>
+
+    <div v-if="error" class="banner error">{{ error }}</div>
+
+    <!-- Provider info (from the catalog) -->
+    <div class="wiz-card" style="margin-bottom: 16px;">
+      <div class="es-head">Provider info</div>
+      <div class="row" style="gap: 28px; flex-wrap: wrap;">
+        <div>
+          <span class="lbl">Auth</span>
+          <div><span class="pill">{{ authLabel(entry?.auth) }}</span></div>
+        </div>
+        <div>
+          <span class="lbl">Default port</span>
+          <div class="mono">{{ entry?.defaultPort ?? '—' }}</div>
+        </div>
+        <div>
+          <span class="lbl">Scheme</span>
+          <div class="mono">{{ entry?.defaultScheme ?? 'http' }}{{ entry?.schemeLocked ? ' (fixed)' : '' }}</div>
+        </div>
+        <div>
+          <span class="lbl">Reached via</span>
+          <div class="mono">{{ entry?.hostRequired ? 'LAN host (required)' : 'Agent loopback' }}</div>
+        </div>
+      </div>
+      <div v-if="entry?.tools?.length" style="margin-top: 14px;">
+        <span class="lbl">Exposed AI tools</span>
+        <ul style="margin: 6px 0 0; padding-left: 18px;">
+          <li v-for="t in entry.tools" :key="t.name" style="margin: 2px 0;">
+            <span class="mono">{{ t.name }}</span><span v-if="t.description" class="muted"> — {{ t.description }}</span>
+          </li>
+        </ul>
+      </div>
+      <div v-else class="muted" style="margin-top: 8px; font-size: 12px;">Proxy-only — this service exposes no AI tools.</div>
+    </div>
+
+    <!-- Configuration -->
+    <div class="wiz-card" style="margin-bottom: 16px;">
+      <div class="es-head">Configuration</div>
+      <div class="row" style="gap: 12px; align-items: flex-start;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Type</span>
+          <select v-model="form.serviceType" class="input" @change="onTypeChange">
+            <option v-for="c in catalog" :key="c.type" :value="c.type">{{ c.displayName }}</option>
+          </select>
+        </label>
+        <label class="fld" style="flex: 0 0 120px;">
+          <span class="lbl">Scheme</span>
+          <select v-model="form.scheme" class="input" :disabled="schemeLocked" :title="schemeLocked ? 'Fixed by the service type' : ''">
+            <option value="http">http</option>
+            <option value="https">https</option>
+          </select>
+        </label>
+        <label class="fld" style="flex: 0 0 120px;">
+          <span class="lbl">Port</span>
+          <input v-model="form.port" type="number" min="1" max="65535" class="input" />
+        </label>
+      </div>
+      <div class="row" style="gap: 16px; margin: 6px 0;">
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+          <input type="radio" value="host" v-model="targetMode" /> Host / IP
+        </label>
+        <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;" :style="{ opacity: edgeIsServer ? 0.5 : 1 }">
+          <input type="radio" value="kube" v-model="targetMode" :disabled="edgeIsServer" /> Kubernetes Service
+        </label>
+      </div>
+      <div v-if="targetMode === 'host'" class="row" style="gap: 12px;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Host {{ entry?.hostRequired ? '(required)' : '(blank = agent loopback)' }}</span>
+          <input v-model="form.host" class="input" placeholder="192.168.1.1, myui.example.com" />
+          <span v-if="entry?.hostHelp" class="muted" style="font-size: 12px; margin-top: 4px;">{{ entry.hostHelp }}</span>
+        </label>
+      </div>
+      <div v-else class="row" style="gap: 12px;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Target namespace</span>
+          <input v-model="form.targetNamespace" class="input" placeholder="home" />
+        </label>
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Target service name</span>
+          <input v-model="form.targetName" class="input" placeholder="home-assistant" />
+        </label>
+      </div>
+      <label class="fld" style="margin-top: 8px;">
+        <span class="lbl">AI instructions (optional)</span>
+        <textarea v-model="instructions" class="input" rows="3" placeholder="Describe this service's entities/rooms so the AI knows your setup."></textarea>
+      </label>
+      <div class="wiz-actions">
+        <button class="btn primary" :disabled="busy" @click="onSaveConfig"><Save :size="14" /> Save configuration</button>
+      </div>
+    </div>
+
+    <!-- Credentials -->
+    <div class="wiz-card" style="margin-bottom: 16px;">
+      <div class="es-head">Credentials</div>
+      <div class="muted" style="margin-bottom: 8px;">{{ entry?.credential.hint ?? 'Credential' }} — makes the service Ready. Stored as a Secret, never on the agent host.</div>
+      <div class="row" style="gap: 8px; align-items: flex-end;">
+        <label v-for="f in credFields" :key="f.key" class="fld" style="flex: 1;">
+          <span class="lbl">{{ f.label }}</span>
+          <input v-model="credInputs[f.key]" :type="f.secret ? 'password' : 'text'" class="input" :placeholder="f.label" />
+          <span v-if="f.help" class="muted" style="font-size: 12px; margin-top: 4px;">{{ f.help }}</span>
+        </label>
+        <button class="btn" :disabled="busy || !credFilled" @click="onSaveCreds"><KeyRound :size="14" /> {{ service.hasCredentials ? 'Update' : 'Set' }} credentials</button>
+      </div>
+    </div>
+
+    <!-- Status -->
+    <div class="wiz-card">
+      <div class="es-head">Status <span class="status" :class="phaseClass(service.phase)">{{ service.phase || 'Pending' }}</span></div>
+      <div v-if="service.url" class="muted mono" style="margin-bottom: 8px; font-size: 12px;">{{ service.url }}</div>
+      <table v-if="service.conditions.length" class="edges-table" style="font-size: 12px;">
+        <thead><tr><th>Condition</th><th>Status</th><th>Reason</th><th>Message</th><th>Age</th></tr></thead>
+        <tbody>
+          <tr v-for="c in service.conditions" :key="c.type">
+            <td class="name">{{ c.type }}</td>
+            <td><span class="status" :class="statusClass(c.status)">{{ c.status }}</span></td>
+            <td class="mono muted">{{ c.reason || '—' }}</td>
+            <td class="muted">{{ c.message || '—' }}</td>
+            <td class="mono muted">{{ age(c.lastTransitionTime) }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div v-else class="muted">No conditions reported yet.</div>
+    </div>
+  </div>
+</template>

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { RefreshCw, Trash2, Plus, Boxes, ChevronRight, ChevronDown, Save, KeyRound } from 'lucide-vue-next'
+import { RefreshCw, Trash2, Plus, Boxes, Pencil } from 'lucide-vue-next'
 import {
-  listServices, createKubeEdgeService, deleteEdgeService,
-  updateEdgeServiceInstructions, connectEdgeService, listEdges,
+  listServices, createKubeEdgeService, deleteEdgeService, listEdges,
   fetchServiceCatalog,
 } from './api'
-import type { CatalogEntry, CatalogCredentialField } from './api'
+import type { CatalogEntry } from './api'
 import type { EdgeService, EdgeServiceDraft, Edge, ErrorResponse } from './types'
+import ServiceEdit from './ServiceEdit.vue'
 
 // Service type catalog — fetched from the backend (svccatalog.All()) so the form
 // never drifts from the provider's auth/probe knowledge. Each entry seeds the
@@ -111,47 +111,19 @@ function applyHostUrl() {
   }
 }
 
-// Per-row expand for edit (instructions) + connect (credentials).
-const expanded = ref<string | null>(null)
-const editInstructions = ref('')
-// Credential inputs for the expanded row, keyed by field.key (e.g. "token", or
-// "username"/"password"). Packed into the single Secret "token" value on connect.
-const credInputs = ref<Record<string, string>>({})
-function toggle(s: EdgeService) {
-  if (expanded.value === s.name) {
-    expanded.value = null
-    return
-  }
-  expanded.value = s.name
-  editInstructions.value = s.instructions ?? ''
-  credInputs.value = {}
+// Edit opens a dedicated per-service page (ServiceEdit.vue) that hosts the
+// provider info, config, credentials and status. Held as local state (no shell
+// router), the same way App.vue drives the Edges Detail view.
+const editing = ref<EdgeService | null>(null)
+function openEdit(s: EdgeService) {
+  editing.value = s
 }
-
-// credFields returns the credential inputs to render for a service's type,
-// falling back to a single opaque token when the type is unknown.
-function credFields(s: EdgeService): CatalogCredentialField[] {
-  return catalogFor(s.serviceType)?.credential.fields ?? [{ key: 'token', label: 'token', secret: true }]
-}
-// packedCredential combines the credential inputs into the single string stored
-// as the Secret "token" (per the type's packing: "username:password" or the
-// single field verbatim).
-function packedCredential(s: EdgeService): string {
-  const cred = catalogFor(s.serviceType)?.credential
-  if (cred?.packing === 'userpass') {
-    const u = (credInputs.value['username'] ?? '').trim()
-    const p = credInputs.value['password'] ?? ''
-    return `${u}:${p}`
-  }
-  const key = credFields(s)[0]?.key ?? 'token'
-  return (credInputs.value[key] ?? '').trim()
-}
-// credFilled reports whether the required credential inputs are present.
-function credFilled(s: EdgeService): boolean {
-  const cred = catalogFor(s.serviceType)?.credential
-  if (cred?.packing === 'userpass') {
-    return !!(credInputs.value['username']?.trim() && credInputs.value['password'])
-  }
-  return !!packedCredential(s)
+// After a save in the edit page, refresh the list and re-seed the open page from
+// the fresh object so status/conditions update in place.
+async function onEditSaved() {
+  const name = editing.value?.name
+  await refresh()
+  if (name) editing.value = services.value.find((s) => s.name === name) ?? null
 }
 
 async function refresh() {
@@ -214,35 +186,6 @@ async function onDelete(s: EdgeService) {
   }
 }
 
-async function onSaveInstructions(s: EdgeService) {
-  busy.value = true
-  error.value = null
-  try {
-    await updateEdgeServiceInstructions(s.name, editInstructions.value)
-    await refresh()
-  } catch (e) {
-    error.value = (e as ErrorResponse)?.message ?? 'Save failed'
-  } finally {
-    busy.value = false
-  }
-}
-
-async function onConnect(s: EdgeService) {
-  const token = packedCredential(s)
-  if (!token) return
-  busy.value = true
-  error.value = null
-  try {
-    await connectEdgeService(s.name, token)
-    credInputs.value = {}
-    await refresh()
-  } catch (e) {
-    error.value = (e as ErrorResponse)?.message ?? 'Connect failed'
-  } finally {
-    busy.value = false
-  }
-}
-
 onMounted(() => {
   loadCatalog()
   refresh()
@@ -256,7 +199,15 @@ function phaseClass(p?: string): string {
 </script>
 
 <template>
-  <div class="edges-app">
+  <ServiceEdit
+    v-if="editing"
+    :service="editing"
+    :catalog="catalog"
+    :edges="edges"
+    @back="editing = null"
+    @saved="onEditSaved"
+  />
+  <div v-else class="edges-app">
     <header class="edges-header">
       <div>
         <h1>Services</h1>
@@ -363,51 +314,28 @@ function phaseClass(p?: string): string {
       <table class="edges-table">
         <thead>
           <tr>
-            <th></th>
             <th>Name</th>
             <th>Edge</th>
             <th>Type</th>
             <th>Target</th>
             <th>Status</th>
-            <th>Token</th>
+            <th>Creds</th>
             <th></th>
           </tr>
         </thead>
         <tbody>
-          <template v-for="s in services" :key="s.name">
-            <tr class="clickable" @click="toggle(s)">
-              <td><component :is="expanded === s.name ? ChevronDown : ChevronRight" :size="14" /></td>
-              <td class="name">{{ s.name }}</td>
-              <td class="muted">{{ s.edgeName || '—' }}</td>
-              <td class="mono muted">{{ s.serviceType || '—' }}</td>
-              <td class="mono muted">{{ s.targetNamespace ? s.targetNamespace + '/' : '' }}{{ s.targetName || '—' }}:{{ s.port || '' }}</td>
-              <td><span class="status" :class="phaseClass(s.phase)">{{ s.phase || 'Pending' }}</span></td>
-              <td>{{ s.hasCredentials ? '✓' : '—' }}</td>
-              <td class="actions">
-                <button class="icon danger" title="Delete" @click.stop="onDelete(s)"><Trash2 :size="14" /></button>
-              </td>
-            </tr>
-            <tr v-if="expanded === s.name" class="detail-row">
-              <td colspan="8">
-                <div class="es-head">AI instructions</div>
-                <textarea v-model="editInstructions" class="input" rows="4" placeholder="Describe this service's entities/rooms so the AI knows your setup."></textarea>
-                <div class="wiz-actions" style="margin: 8px 0 16px;">
-                  <button class="btn primary" :disabled="busy" @click="onSaveInstructions(s)"><Save :size="14" /> Save instructions</button>
-                </div>
-
-                <div class="es-head">Credentials</div>
-                <div class="muted" style="margin-bottom: 6px;">{{ catalogFor(s.serviceType)?.credential.hint ?? 'Credential' }} — makes the service Ready. Stored as a Secret, never on the agent host.</div>
-                <div class="row" style="gap: 8px; align-items: flex-end;">
-                  <label v-for="f in credFields(s)" :key="f.key" class="fld" style="flex: 1;">
-                    <span class="lbl">{{ f.label }}</span>
-                    <input v-model="credInputs[f.key]" :type="f.secret ? 'password' : 'text'" class="input" :placeholder="f.label" />
-                    <span v-if="f.help" class="muted" style="font-size: 12px; margin-top: 4px;">{{ f.help }}</span>
-                  </label>
-                  <button class="btn" :disabled="busy || !credFilled(s)" @click="onConnect(s)"><KeyRound :size="14" /> {{ s.hasCredentials ? 'Update' : 'Set' }} credentials</button>
-                </div>
-              </td>
-            </tr>
-          </template>
+          <tr v-for="s in services" :key="s.name" class="clickable" @click="openEdit(s)">
+            <td class="name">{{ s.name }}</td>
+            <td class="muted">{{ s.edgeName || '—' }}</td>
+            <td class="mono muted">{{ catalogFor(s.serviceType)?.displayName || s.serviceType || '—' }}</td>
+            <td class="mono muted">{{ s.host || (s.targetNamespace ? s.targetNamespace + '/' : '') + (s.targetName || '—') }}:{{ s.port || '' }}</td>
+            <td><span class="status" :class="phaseClass(s.phase)">{{ s.phase || 'Pending' }}</span></td>
+            <td>{{ s.hasCredentials ? '✓' : '—' }}</td>
+            <td class="actions">
+              <button class="icon" title="Edit" @click.stop="openEdit(s)"><Pencil :size="14" /></button>
+              <button class="icon danger" title="Delete" @click.stop="onDelete(s)"><Trash2 :size="14" /></button>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/providers/edges/portal/src/api.ts
+++ b/providers/edges/portal/src/api.ts
@@ -227,6 +227,12 @@ export interface CatalogCredential {
   fields?: CatalogCredentialField[]
   hint?: string
 }
+// CatalogTool is one MCP operation the service exposes to AI agents (name +
+// description; mirrors svccatalog.Tool's UI fields).
+export interface CatalogTool {
+  name: string
+  description?: string
+}
 // CatalogEntry is the UI-facing subset of svccatalog.Definition.
 export interface CatalogEntry {
   type: string
@@ -241,6 +247,7 @@ export interface CatalogEntry {
   auth: string
   authParam?: string
   credential: CatalogCredential
+  tools?: CatalogTool[]
 }
 
 // fetchServiceCatalog returns every service type's form descriptor. It is static
@@ -343,6 +350,43 @@ export async function updateEdgeServiceInstructions(name: string, instructions: 
        edges_kedge_faros_sh { v1alpha1 { updateService(name: $name, object: $object) { metadata { name } } } }
      }`,
     { name, object: { metadata: { name }, spec: { instructions } } },
+  )
+}
+
+// EdgeServiceEdit is the editable subset of a Service's spec (edgeRef is fixed
+// at creation).
+export interface EdgeServiceEdit {
+  serviceType?: string
+  scheme?: string
+  port?: number
+  host?: string
+  targetNamespace?: string
+  targetName?: string
+  instructions?: string
+}
+
+// updateEdgeService merge-patches the editable spec fields. host and targetRef
+// are mutually exclusive — the unused one is cleared (null/empty) so switching
+// target mode takes effect.
+export async function updateEdgeService(name: string, e: EdgeServiceEdit): Promise<void> {
+  const byHost = !!e.host?.trim()
+  const spec: Record<string, unknown> = {
+    type: e.serviceType,
+    scheme: e.scheme,
+    port: e.port,
+    instructions: e.instructions ?? '',
+    host: byHost ? e.host!.trim() : '',
+    targetRef: byHost
+      ? null
+      : e.targetName?.trim()
+        ? { namespace: e.targetNamespace?.trim() || 'default', name: e.targetName.trim() }
+        : null,
+  }
+  await graphql(
+    `mutation UpdateService($name: String!, $object: EdgesKedgeFarosShV1alpha1Service_Input!) {
+       edges_kedge_faros_sh { v1alpha1 { updateService(name: $name, object: $object) { metadata { name } } } }
+     }`,
+    { name, object: { metadata: { name }, spec } },
   )
 }
 


### PR DESCRIPTION
## What

Adds a dedicated per-service **edit page** and surfaces per-provider info from the service catalog, following up on #447 (which landed the `svccatalog` refactor + `/catalog` endpoint).

### UI
- **Edit button** on each row in the Services list opens a dedicated page ([`ServiceEdit.vue`](providers/edges/portal/src/ServiceEdit.vue)) instead of the old inline expand row. Hosted as a local sub-view (same pattern as the Edges `Detail.vue`) — no shell/router changes.
- The page shows, all driven by the catalog:
  - **Provider info** — auth badge (Bearer / API key / Session login…), default port/scheme (+ "fixed" for scheme-locked types like UniFi), whether it's reached via LAN host or agent loopback, and **the MCP tools the agent gets** (e.g. unifi-protect → `cameras`, `snapshot`, `events`).
  - **Configuration** — editable type/scheme/port + host-vs-kube target, catalog-aware (scheme lock, host help, port re-seed on type change).
  - **Credentials** — dynamic fields per type (username+password vs API key vs token), packed into the Secret correctly.
  - **Status** — phase + full conditions table + proxy URL.

### Backend
- `svccatalog.Tool` now serializes `name` + `description`, so `/catalog` carries each type's tools. Home Assistant gets display-only tools; `IsDataDriven` is guarded by `!Handcoded` so HA's hand-coded execution path is unaffected.
- Portal re-adds `updateEdgeService` and a `CatalogTool` type.

## Test
- `go build ./...`, `go test ./internal/{svccatalog,tunnel,servicectrl}/` green; added a catalog-JSON-shape assertion locally (tools/credential/scheme-lock/host-required present).
- Portal `vue-tsc` + vite build green.

## Deploy note
Needs the edges provider image rebuilt/redeployed — the portal is `go:embed`ed and `/catalog` is a backend route; the deployed UI won't show any of this until the new pod runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)