### PR TITLE
fix(edges): service edit shows empty host + surface upstream 403 body

### DIFF
--- a/providers/edges/internal/servicectrl/validation_reconciler.go
+++ b/providers/edges/internal/servicectrl/validation_reconciler.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -249,8 +250,17 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionTrue, "Ready", "service reachable and authenticated")
 		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
 			es.Status.Phase = "Unreachable"
-			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "Unauthorized",
-				fmt.Sprintf("service rejected the credentials (%d)", resp.StatusCode))
+			// Surface the upstream error body — it usually says WHY (e.g. UniFi
+			// "Invalid API Key" vs "API key lacks Protect access"), which is the
+			// difference between a bad key and a wrong endpoint/firmware.
+			detail := bodySnippet(resp.Body, 300)
+			logger.Info("service rejected the credentials", "type", es.Spec.Type,
+				"status", resp.StatusCode, "probePath", probePath, "upstream", detail)
+			msg := fmt.Sprintf("service rejected the credentials (%d)", resp.StatusCode)
+			if detail != "" {
+				msg += ": " + detail
+			}
+			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionFalse, "Unauthorized", msg)
 			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "Unauthorized",
 				"service reachable but rejected the credentials")
 		default:
@@ -263,6 +273,18 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 
 	logger.V(4).Info("validated service", "phase", es.Status.Phase, "type", es.Spec.Type)
 	return r.commit(ctx, c, orig, es, validationResyncInterval)
+}
+
+// bodySnippet reads up to a small cap from an upstream response body and trims
+// it to max runes for inclusion in a status condition / log — enough to surface
+// an API's "why" message without dumping a whole page.
+func bodySnippet(body io.Reader, max int) string {
+	b, _ := io.ReadAll(io.LimitReader(body, 4<<10))
+	s := strings.TrimSpace(string(b))
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
 }
 
 // commit writes status only when it changed, then requeues.

--- a/providers/edges/portal/src/api.ts
+++ b/providers/edges/portal/src/api.ts
@@ -279,6 +279,7 @@ interface RawEdgeService {
   spec?: {
     edgeRef?: { kind?: string; name?: string }
     targetRef?: { namespace?: string; name?: string } | null
+    host?: string
     type?: string
     scheme?: string
     port?: number
@@ -299,7 +300,7 @@ const EDGE_SVC_SEL = `
   spec {
     edgeRef { kind name }
     targetRef { namespace name }
-    type scheme port instructions authSecretRef { name namespace }
+    host type scheme port instructions authSecretRef { name namespace }
   }
   status { phase version installType url conditions { type status reason message lastTransitionTime } }
 `
@@ -312,6 +313,7 @@ function toEdgeService(it: RawEdgeService): EdgeService {
     edgeKind: it.spec?.edgeRef?.kind,
     targetNamespace: it.spec?.targetRef?.namespace,
     targetName: it.spec?.targetRef?.name,
+    host: it.spec?.host,
     serviceType: it.spec?.type,
     scheme: it.spec?.scheme,
     port: it.spec?.port,


### PR DESCRIPTION
#448 dropped `spec.host` from the service GraphQL selection + mapping in `api.ts`, so `EdgeService.host` came back `undefined` and `ServiceEdit.vue`'s host field rendered **empty** — e.g. a UniFi Protect service with `host: 192.168.1.1` showed blank on edit.

Restores `host` in three spots: `RawEdgeService.spec`, the `EDGE_SVC_SEL` selection, and `toEdgeService`. `scheme`/`port`/`type` were still mapped, so only host was affected.

Portal builds clean.

Generated with Claude Code.