### PR TITLE
feat(portal): "Precision Flat" retheme + shared cross-provider UI recipes

### DIFF
--- a/portal/index.html
+++ b/portal/index.html
@@ -1,22 +1,28 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" class="light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kedge Portal</title>
     <script>
-      // Apply theme before first paint to prevent flash
+      // Apply theme before first paint to prevent flash. Light is the hard
+      // fallback: any failure (no matchMedia, thrown error) renders light,
+      // which matches the CSS base in main.css.
       (function() {
-        var t = localStorage.getItem('kedge-theme') || 'system';
-        var d = t === 'system'
-          ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-          : t;
-        document.documentElement.className = d;
+        try {
+          var t = localStorage.getItem('kedge-theme') || 'system';
+          var prefersDark = window.matchMedia
+            && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var d = t === 'system' ? (prefersDark ? 'dark' : 'light') : t;
+          document.documentElement.className = d;
+        } catch (e) {
+          document.documentElement.className = 'light';
+        }
       })();
     </script>
   </head>
-  <body class="bg-surface text-text-primary antialiased noise">
+  <body class="bg-surface text-text-primary antialiased">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -8,6 +8,9 @@
       "name": "kedge-portal",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/archivo": "^5.3.0",
+        "@fontsource-variable/instrument-sans": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@urql/vue": "^1.4.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
@@ -555,6 +558,33 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/archivo": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/archivo/-/archivo-5.3.0.tgz",
+      "integrity": "sha512-HogK8FJelrD1o7TlZlkIVtHgc20bO5PZRWE7mUeUTdMN055alznQV6/00J00IBeu8FQAH4s3zW9UJNvKExXf+g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/instrument-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/instrument-sans/-/instrument-sans-5.3.0.tgz",
+      "integrity": "sha512-u4gKbDBTNFGkg997tfQn3eHOhHuquWUFTRT/rwzuKtrxX5P2ekfs2x+LgBPP4P32+cC+vUwF1Cr+IdRoPQbrGw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@interactjs/types": {
       "version": "1.10.27",

--- a/portal/package.json
+++ b/portal/package.json
@@ -9,6 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource-variable/archivo": "^5.3.0",
+    "@fontsource-variable/instrument-sans": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@urql/vue": "^1.4.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/portal/src/assets/kedge-ui.css
+++ b/portal/src/assets/kedge-ui.css
@@ -1,0 +1,199 @@
+/*
+ * kedge-ui — shared component recipes for the whole portal surface.
+ *
+ * WHY THIS FILE EXISTS
+ * Every provider micro-frontend (including the self-contained code / kuery /
+ * app-studio bundles) renders inside the HOST portal's light DOM, so any class
+ * defined here reaches all of them — the same mechanism that already lets the
+ * global `.live-dot` rule style provider StatusBadge copies. These are the
+ * canonical "Precision Flat" recipes; host components and providers should use
+ * the `k-*` classes instead of re-deriving card / table / badge / button
+ * styling in eight separate stylesheets.
+ *
+ * Colour ONLY through the semantic tokens defined in main.css
+ * (var(--color-*)). Never hardcode hex here — it would not adapt to the
+ * light/dark toggle. Radii: cards 12px, controls 8px, pills full.
+ */
+
+/* ── Eyebrow / KPI ────────────────────────────────────────────────────────
+ * Small uppercase tracked label + big expanded numeral (KPI recipe). */
+.k-eyebrow {
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-secondary);
+}
+.k-kpi {
+  font-family: var(--font-display);
+  font-stretch: 125%;
+  letter-spacing: -0.01em;
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 1.1;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Card ─────────────────────────────────────────────────────────────────*/
+.k-card {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  box-shadow: 0 1px 2px rgba(17, 19, 34, 0.04);
+}
+html.dark .k-card {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+.k-card--flat {
+  box-shadow: none;
+}
+
+/* ── Table ────────────────────────────────────────────────────────────────
+ * Rounded surface card wrapper + 10px/600 uppercase headers + 13px rows with
+ * an accent-tinted hover. Wrap a <table> in `.k-table` (or apply to a card). */
+.k-table {
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 12px;
+  background: var(--color-surface-raised);
+}
+.k-table table {
+  min-width: 100%;
+  border-collapse: collapse;
+}
+.k-table thead tr {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.k-table th {
+  padding: 12px 20px;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-muted);
+}
+.k-table tbody tr {
+  border-bottom: 1px solid var(--color-border-subtle);
+  transition: background 0.15s ease;
+}
+.k-table tbody tr:last-child {
+  border-bottom: 0;
+}
+.k-table tbody tr.is-interactive {
+  cursor: pointer;
+}
+.k-table tbody tr.is-interactive:hover {
+  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
+}
+.k-table td {
+  padding: 12px 20px;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  transition: color 0.1s ease;
+}
+.k-table tbody tr.is-interactive:hover td {
+  color: var(--color-text-primary);
+}
+/* Data-like cells (names, ids, timestamps, emails). */
+.k-cell-mono {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+/* ── Badge / status pill ──────────────────────────────────────────────────*/
+.k-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 9999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.k-badge--success { background: var(--color-success-subtle); color: var(--color-success); }
+.k-badge--warning { background: var(--color-warning-subtle); color: var(--color-warning); }
+.k-badge--danger  { background: var(--color-danger-subtle);  color: var(--color-danger); }
+.k-badge--muted   { background: var(--color-surface-overlay); color: var(--color-text-muted); }
+.k-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: currentColor;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────────*/
+.k-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.k-btn:disabled {
+  pointer-events: none;
+  opacity: 0.4;
+}
+.k-btn--primary {
+  background: var(--color-accent);
+  color: #fff;
+}
+.k-btn--primary:hover {
+  background: var(--color-accent-hover);
+}
+.k-btn--ghost {
+  background: var(--color-surface-overlay);
+  border-color: var(--color-border-default);
+  color: var(--color-text-primary);
+}
+.k-btn--ghost:hover {
+  background: var(--color-surface-hover);
+  border-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+.k-btn--danger {
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+}
+.k-btn--danger:hover {
+  background: color-mix(in srgb, var(--color-danger) 18%, transparent);
+}
+
+/* ── Input ────────────────────────────────────────────────────────────────*/
+.k-input {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-surface-overlay);
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.k-input::placeholder {
+  color: var(--color-text-muted);
+}
+.k-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle);
+}
+
+/* ── grid-layout-plus drag placeholder (default is a red block) ────────────*/
+.vgl-item--placeholder {
+  background: var(--color-accent-subtle) !important;
+  border: 1px dashed color-mix(in srgb, var(--color-accent) 40%, transparent) !important;
+  border-radius: 12px !important;
+  opacity: 1 !important;
+}

--- a/portal/src/assets/main.css
+++ b/portal/src/assets/main.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./kedge-ui.css";
 
 /*
  * Some built-in providers ship their UI as separate Vite bundles under
@@ -14,192 +15,103 @@
  */
 @source "../../../providers/infrastructure/portal/src/**/*.{vue,ts}";
 
+/*
+ * Theme tokens. LIGHT is the base (in @theme) and is what renders in every
+ * degraded path (JS off, matchMedia missing). DARK is an override applied by
+ * theme.ts toggling `html.dark`. Exactly one of `.light`/`.dark` is always set.
+ *
+ * NOTE: no Tailwind `dark:` variant is used anywhere in the portal or the
+ * providers. If one is ever introduced, add:
+ *   @custom-variant dark (&:where(.dark, .dark *));
+ * because Tailwind v4 defaults the `dark:` variant to prefers-color-scheme,
+ * which would ignore the explicit class-based toggle.
+ */
 @theme {
-  --color-surface: #06060b;
-  --color-surface-raised: #0d0d14;
-  --color-surface-overlay: #14141f;
-  --color-surface-hover: #1a1a28;
-  --color-border-subtle: rgba(255, 255, 255, 0.04);
-  --color-border-default: rgba(255, 255, 255, 0.08);
-  --color-accent: #7c5bf5;
-  --color-accent-hover: #9b85f7;
-  --color-accent-subtle: rgba(124, 91, 245, 0.1);
-  --color-accent-glow: rgba(124, 91, 245, 0.25);
-  --color-text-primary: #eeeef3;
-  --color-text-secondary: #7e7e96;
-  --color-text-muted: #44445a;
-  --color-success: #34d399;
-  --color-success-subtle: rgba(52, 211, 153, 0.1);
-  --color-warning: #fbbf24;
-  --color-warning-subtle: rgba(251, 191, 36, 0.1);
-  --color-danger: #f87171;
-  --color-danger-subtle: rgba(248, 113, 113, 0.1);
+  --font-sans: "Instrument Sans Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Archivo Variable", "Instrument Sans Variable", ui-sans-serif, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* ── Light (base) ── */
+  --color-surface: #f5f6fa;
+  --color-surface-raised: #ffffff;
+  --color-surface-overlay: #eef0f6;
+  --color-surface-hover: #e9e9f2;
+  --color-border-subtle: #ecebf4;
+  --color-border-default: #e5e4f0;
+  --color-accent: #6d4fe0;
+  --color-accent-hover: #5a3fd4;
+  --color-accent-subtle: rgba(109, 79, 224, 0.08);
+  --color-accent-glow: rgba(109, 79, 224, 0.14);
+  --color-text-primary: #111322;
+  --color-text-secondary: #5a5d72;
+  --color-text-muted: #9092a9;
+  --color-success: #0fa36b;
+  --color-success-subtle: #e7f8f0;
+  --color-warning: #c77d0a;
+  --color-warning-subtle: #fdf3e2;
+  --color-danger: #dc3d43;
+  --color-danger-subtle: #fdebec;
 }
 
-/* ── Light mode overrides ── */
-html.light {
-  --color-surface: #f5f7fa;
-  --color-surface-raised: #ffffff;
-  --color-surface-overlay: #eef1f6;
-  --color-surface-hover: #e2e6ed;
-  --color-border-subtle: rgba(0, 0, 0, 0.06);
-  --color-border-default: rgba(0, 0, 0, 0.1);
-  --color-accent: #6d4fe0;
-  --color-accent-hover: #5b3fd0;
-  --color-accent-subtle: rgba(109, 79, 224, 0.08);
-  --color-accent-glow: rgba(109, 79, 224, 0.15);
-  --color-text-primary: #0f172a;
-  --color-text-secondary: #64748b;
-  --color-text-muted: #94a3b8;
-  --color-success: #10b981;
-  --color-success-subtle: rgba(16, 185, 129, 0.1);
-  --color-warning: #d97706;
-  --color-warning-subtle: rgba(217, 119, 6, 0.08);
-  --color-danger: #ef4444;
-  --color-danger-subtle: rgba(239, 68, 68, 0.08);
+/* ── Dark override (flat ink, no glass) ── */
+html.dark {
+  --color-surface: #0b0c11;
+  --color-surface-raised: #12131b;
+  --color-surface-overlay: #181926;
+  --color-surface-hover: #1e1f2e;
+  --color-border-subtle: rgba(255, 255, 255, 0.06);
+  --color-border-default: rgba(255, 255, 255, 0.1);
+  --color-accent: #7c5bf5;
+  --color-accent-hover: #9b85f7;
+  --color-accent-subtle: rgba(124, 91, 245, 0.12);
+  --color-accent-glow: rgba(124, 91, 245, 0.2);
+  --color-text-primary: #eeeef3;
+  --color-text-secondary: #7e7e96;
+  --color-text-muted: #565870;
+  --color-success: #34d399;
+  --color-success-subtle: rgba(52, 211, 153, 0.12);
+  --color-warning: #fbbf24;
+  --color-warning-subtle: rgba(251, 191, 36, 0.12);
+  --color-danger: #f87171;
+  --color-danger-subtle: rgba(248, 113, 113, 0.12);
 }
 
 body {
   background-color: var(--color-surface);
   color: var(--color-text-primary);
+  font-family: var(--font-sans);
   font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 }
 
-/* ── Dot grid background ── */
-.dot-grid {
-  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
-  background-size: 24px 24px;
-}
-html.light .dot-grid {
-  background-image: radial-gradient(circle, rgba(0, 0, 0, 0.04) 1px, transparent 1px);
-}
-
-/* ── Cross grid ── */
-.cross-grid {
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px);
-  background-size: 80px 80px;
-}
-html.light .cross-grid {
-  background-image:
-    linear-gradient(rgba(0, 0, 0, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.025) 1px, transparent 1px);
+/*
+ * Display face (Söhne-Breit role). Archivo's width axis expanded to its max
+ * (125%) — used for page titles, KPI numerals and the KEDGE wordmark.
+ * `font-stretch` drives the wdth axis on the variable font; if a target
+ * browser mishandles it, swap to `font-variation-settings: "wdth" 125`.
+ */
+.type-display {
+  font-family: var(--font-display);
+  font-stretch: 125%;
+  letter-spacing: -0.01em;
 }
 
-/* ── Glass panel ── */
-.glass {
-  background: rgba(13, 13, 20, 0.6);
-  backdrop-filter: blur(24px) saturate(1.5);
-  -webkit-backdrop-filter: blur(24px) saturate(1.5);
-  border: 1px solid rgba(255, 255, 255, 0.04);
+/* ──────────────────────────────────────────────────────────────────────────
+ * Signature background — fine wavy contour lines. Used sparingly: login,
+ * auth callback, empty states, page hero areas. Two data-URIs because a data
+ * URI can't read a CSS var; the tile is seamless on both axes (wave period
+ * 120px over the 240px tile; lines spaced 48px).
+ * ────────────────────────────────────────────────────────────────────────── */
+.contour-grid {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240' viewBox='0 0 240 240'%3E%3Cg fill='none' stroke='%236d4fe0' stroke-opacity='0.06' stroke-width='1'%3E%3Cpath d='M0 24 Q30 12 60 24 T120 24 T180 24 T240 24'/%3E%3Cpath d='M0 72 Q30 84 60 72 T120 72 T180 72 T240 72'/%3E%3Cpath d='M0 120 Q30 108 60 120 T120 120 T180 120 T240 120'/%3E%3Cpath d='M0 168 Q30 180 60 168 T120 168 T180 168 T240 168'/%3E%3Cpath d='M0 216 Q30 204 60 216 T120 216 T180 216 T240 216'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 240px 240px;
 }
-html.light .glass {
-  background: rgba(255, 255, 255, 0.7);
-  border-color: rgba(0, 0, 0, 0.06);
+html.dark .contour-grid {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240' viewBox='0 0 240 240'%3E%3Cg fill='none' stroke='%237c5bf5' stroke-opacity='0.05' stroke-width='1'%3E%3Cpath d='M0 24 Q30 12 60 24 T120 24 T180 24 T240 24'/%3E%3Cpath d='M0 72 Q30 84 60 72 T120 72 T180 72 T240 72'/%3E%3Cpath d='M0 120 Q30 108 60 120 T120 120 T180 120 T240 120'/%3E%3Cpath d='M0 168 Q30 180 60 168 T120 168 T180 168 T240 168'/%3E%3Cpath d='M0 216 Q30 204 60 216 T120 216 T180 216 T240 216'/%3E%3C/g%3E%3C/svg%3E");
 }
-
-/* ── Border beam (animated light tracing border) ── */
-@keyframes border-beam {
-  0% { offset-distance: 0%; }
-  100% { offset-distance: 100%; }
-}
-.border-beam {
-  position: relative;
-  overflow: hidden;
-}
-.border-beam::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: conic-gradient(from var(--beam-angle, 0deg), transparent 0%, transparent 75%, rgba(124, 91, 245, 0.5) 85%, rgba(52, 211, 153, 0.4) 92%, transparent 100%);
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  animation: beam-rotate 4s linear infinite;
-  pointer-events: none;
-}
-html.light .border-beam::after {
-  background: conic-gradient(from var(--beam-angle, 0deg), transparent 0%, transparent 75%, rgba(109, 79, 224, 0.35) 85%, rgba(16, 185, 129, 0.3) 92%, transparent 100%);
-}
-@keyframes beam-rotate {
-  0% { --beam-angle: 0deg; }
-  100% { --beam-angle: 360deg; }
-}
-/* Fallback for browsers that don't support @property */
-@property --beam-angle {
-  syntax: "<angle>";
-  initial-value: 0deg;
-  inherits: false;
-}
-
-/* ── Card with hover glow ── */
-.card-glow {
-  position: relative;
-  border: 1px solid transparent;
-  background-clip: padding-box;
-}
-.card-glow::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  background: linear-gradient(135deg, rgba(124, 91, 245, 0.15), transparent 40%, transparent 60%, rgba(52, 211, 153, 0.1));
-  z-index: -1;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-.card-glow:hover::before {
-  opacity: 1;
-}
-html.light .card-glow::before {
-  background: linear-gradient(135deg, rgba(109, 79, 224, 0.1), transparent 40%, transparent 60%, rgba(16, 185, 129, 0.08));
-}
-
-/* ── 3D Tilt card (CSS-only perspective hover) ── */
-.tilt-card {
-  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease;
-  transform-style: preserve-3d;
-  perspective: 800px;
-}
-.tilt-card:hover {
-  transform: perspective(800px) rotateX(-2deg) rotateY(3deg) scale(1.02);
-  box-shadow: -4px 4px 24px rgba(124, 91, 245, 0.08), 0 0 0 1px rgba(124, 91, 245, 0.1);
-}
-html.light .tilt-card:hover {
-  box-shadow: -4px 4px 24px rgba(109, 79, 224, 0.06), 0 0 0 1px rgba(109, 79, 224, 0.08);
-}
-
-/* ── Glow ring ── */
-.glow-ring {
-  box-shadow: 0 0 0 0 rgba(124, 91, 245, 0);
-  transition: box-shadow 0.3s ease;
-}
-.glow-ring:focus,
-.glow-ring.active {
-  box-shadow: 0 0 0 3px rgba(124, 91, 245, 0.15), 0 0 20px rgba(124, 91, 245, 0.08);
-}
-html.light .glow-ring:focus,
-html.light .glow-ring.active {
-  box-shadow: 0 0 0 3px rgba(109, 79, 224, 0.12), 0 0 16px rgba(109, 79, 224, 0.06);
-}
-
-/* ── Gradient text ── */
-.text-gradient {
-  background: linear-gradient(135deg, #eeeef3 0%, #7c5bf5 50%, #34d399 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-html.light .text-gradient {
-  background: linear-gradient(135deg, #0f172a 0%, #6d4fe0 50%, #10b981 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
+/* Fade the pattern out toward the bottom for hero tops. */
+.contour-grid-fade {
+  -webkit-mask-image: linear-gradient(to bottom, black, transparent 70%);
+  mask-image: linear-gradient(to bottom, black, transparent 70%);
 }
 
 /* ── Stagger animation ── */
@@ -211,16 +123,21 @@ html.light .text-gradient {
   animation: stagger-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
 
-/* ── Pulse glow ── */
-@keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
-  50% { box-shadow: 0 0 8px 2px currentColor; opacity: 0.6; }
+/* ──────────────────────────────────────────────────────────────────────────
+ * Live status dot. Consumed globally by host StatusBadge AND by the
+ * self-contained providers' own StatusBadge copies (app-studio, code,
+ * databricks) via the light DOM — NEVER delete this selector. Softened from
+ * the old glowing pulse to a quiet opacity pulse.
+ * ────────────────────────────────────────────────────────────────────────── */
+@keyframes live-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 .live-dot {
-  animation: pulse-glow 2.5s ease-in-out infinite;
+  animation: live-pulse 2.5s ease-in-out infinite;
 }
 
-/* ── Shimmer ── */
+/* ── Shimmer (skeleton loading) ── */
 @keyframes shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
@@ -231,24 +148,20 @@ html.light .text-gradient {
   animation: shimmer 1.8s ease-in-out infinite;
 }
 
-/* ── Floating island dock ── */
+/* ──────────────────────────────────────────────────────────────────────────
+ * Floating island dock — flat raised card (no glass/backdrop-filter).
+ * ────────────────────────────────────────────────────────────────────────── */
 .island {
-  background: rgba(13, 13, 20, 0.85);
-  backdrop-filter: blur(32px) saturate(1.6);
-  -webkit-backdrop-filter: blur(32px) saturate(1.6);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-default);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(255, 255, 255, 0.02) inset,
-    0 -4px 12px rgba(124, 91, 245, 0.04);
+    0 1px 2px rgba(17, 19, 34, 0.04),
+    0 8px 24px rgba(17, 19, 34, 0.08);
 }
-html.light .island {
-  background: rgba(255, 255, 255, 0.85);
-  border-color: rgba(0, 0, 0, 0.08);
+html.dark .island {
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.08),
-    0 0 0 1px rgba(0, 0, 0, 0.02) inset,
-    0 -4px 12px rgba(109, 79, 224, 0.04);
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 8px 24px rgba(0, 0, 0, 0.5);
 }
 
 /* ── Island nav item ── */
@@ -269,22 +182,12 @@ html.light .island {
   height: 4px;
   border-radius: 50%;
   background: var(--color-accent);
-  box-shadow: 0 0 8px var(--color-accent);
 }
 
-/* ── Energy line ── */
-@keyframes energy-flow {
-  0% { background-position: 0% 0%; }
-  100% { background-position: 200% 0%; }
-}
+/* ── Progress / divider line (flat, accent) ── */
 .energy-line {
-  background: linear-gradient(90deg, transparent, rgba(124, 91, 245, 0.3), rgba(52, 211, 153, 0.2), transparent);
-  background-size: 200% 100%;
-  animation: energy-flow 4s linear infinite;
-}
-html.light .energy-line {
-  background: linear-gradient(90deg, transparent, rgba(109, 79, 224, 0.2), rgba(16, 185, 129, 0.15), transparent);
-  background-size: 200% 100%;
+  background: var(--color-accent);
+  border-radius: 9999px;
 }
 
 /* ── Bento grid ── */
@@ -324,36 +227,19 @@ html.light .energy-line {
   }
 }
 
-/* ── Noise ── */
-.noise::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.012;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  z-index: 9999;
-}
-
 /* ── Scrollbar ── */
 ::-webkit-scrollbar { width: 4px; height: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(124, 91, 245, 0.12); border-radius: 10px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(124, 91, 245, 0.25); }
+::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
 
 /* ── Selection ── */
 ::selection {
-  background: rgba(124, 91, 245, 0.3);
-  color: #fff;
-}
-html.light ::selection {
-  color: #0f172a;
-}
-
-/* ── Floating label ── */
-.float-label {
-  writing-mode: vertical-rl;
-  text-orientation: mixed;
-  transform: rotate(180deg);
-  letter-spacing: 0.2em;
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  color: var(--color-text-primary);
 }

--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -348,14 +348,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <div class="cross-grid relative flex h-screen bg-surface" :class="layoutClass" :style="layoutInsetsStyle">
-    <!-- Ambient orbs -->
-    <div class="pointer-events-none fixed inset-0 overflow-hidden">
-      <div class="absolute -top-40 left-1/3 h-80 w-80 rounded-full bg-accent/4 blur-[160px]" />
-      <div class="absolute bottom-1/3 right-1/4 h-64 w-64 rounded-full bg-success/3 blur-[140px]" />
-      <div class="absolute top-1/2 left-3/4 h-48 w-48 rounded-full bg-accent/3 blur-[120px]" />
-    </div>
-
+  <div class="relative flex h-screen bg-surface" :class="layoutClass" :style="layoutInsetsStyle">
     <!-- Edge snap hint overlays -->
     <Transition name="fade">
       <div v-if="nearEdge === 'left'" class="fixed inset-y-0 left-0 z-[60] w-48 rounded-r-xl bg-accent/10 border-r-2 border-accent/40" />
@@ -374,7 +367,7 @@ watchEffect(() => {
     <aside
       v-if="isVerticalDock"
       ref="dockedRef"
-      class="relative z-50 flex h-full w-48 flex-shrink-0 flex-col overflow-hidden border-border-subtle bg-surface-raised/80 py-3 px-2 backdrop-blur-xl"
+      class="relative z-50 flex h-full w-48 flex-shrink-0 flex-col overflow-hidden border-border-default bg-surface-raised py-3 px-2"
       :class="dockState.mode === 'left' ? 'order-first border-r' : 'order-last border-l'"
     >
       <!-- Drag handle + Logo -->
@@ -385,13 +378,10 @@ watchEffect(() => {
         >
           <GripVertical class="h-3 w-3" :stroke-width="2" />
         </div>
-        <div class="relative flex h-7 w-7 items-center justify-center">
-          <div class="absolute inset-0 rounded-lg bg-accent/20 blur-md" />
-          <div class="relative flex h-7 w-7 items-center justify-center rounded-lg border border-accent/25 bg-surface-overlay/80">
-            <Hexagon class="h-3.5 w-3.5 text-accent" :stroke-width="2.5" />
-          </div>
+        <div class="flex h-7 w-7 items-center justify-center rounded-lg border border-border-default bg-surface-overlay">
+          <Hexagon class="h-3.5 w-3.5 text-accent" :stroke-width="2.5" />
         </div>
-        <span class="text-[11px] font-bold tracking-tight text-text-primary">KEDGE</span>
+        <span class="type-display text-[11px] font-bold tracking-[0.08em] text-text-primary">KEDGE</span>
         <div class="flex items-center gap-0.5 rounded-full border border-success/20 bg-success-subtle px-1.5 py-px">
           <Zap class="h-2 w-2 text-success" :stroke-width="2.5" fill="currentColor" />
           <span class="text-[7px] font-semibold uppercase tracking-widest text-success">Live</span>
@@ -599,7 +589,7 @@ watchEffect(() => {
     <nav
       v-if="isHorizontalDock"
       ref="dockedRef"
-      class="relative z-50 flex w-full flex-shrink-0 items-center gap-1.5 border-border-subtle bg-surface-raised/80 px-4 py-1.5 backdrop-blur-xl"
+      class="relative z-50 flex w-full flex-shrink-0 items-center gap-1.5 border-border-default bg-surface-raised px-4 py-1.5"
       :class="dockState.mode === 'top' ? 'order-first border-b' : 'order-last border-t'"
     >
       <!-- Drag handle -->
@@ -614,13 +604,10 @@ watchEffect(() => {
 
       <!-- Logo -->
       <div class="flex items-center gap-1.5 px-1">
-        <div class="relative flex h-6 w-6 items-center justify-center">
-          <div class="absolute inset-0 rounded-md bg-accent/20 blur-md" />
-          <div class="relative flex h-6 w-6 items-center justify-center rounded-md border border-accent/25 bg-surface-overlay/80">
-            <Hexagon class="h-3 w-3 text-accent" :stroke-width="2.5" />
-          </div>
+        <div class="flex h-6 w-6 items-center justify-center rounded-md border border-border-default bg-surface-overlay">
+          <Hexagon class="h-3 w-3 text-accent" :stroke-width="2.5" />
         </div>
-        <span class="text-[11px] font-bold tracking-tight text-text-primary">KEDGE</span>
+        <span class="type-display text-[11px] font-bold tracking-[0.08em] text-text-primary">KEDGE</span>
         <div class="flex items-center gap-0.5 rounded-full border border-success/20 bg-success-subtle px-1.5 py-px">
           <Zap class="h-2 w-2 text-success" :stroke-width="2.5" fill="currentColor" />
           <span class="text-[8px] font-semibold uppercase tracking-widest text-success">Live</span>
@@ -740,7 +727,6 @@ watchEffect(() => {
       :class="mainClass"
       :style="mainStyle"
     >
-      <div class="dot-grid pointer-events-none absolute inset-0 opacity-40" />
       <!--
         Keying the slot on auth.clusterName forces the active page to
         unmount + remount when the user switches workspace or org. The
@@ -779,7 +765,7 @@ watchEffect(() => {
       }"
       :style="floatStyle"
     >
-      <div class="island flex max-w-[calc(100vw-2rem)] items-center gap-1 rounded-2xl px-2 py-1.5">
+      <div class="island flex max-w-[calc(100vw-2rem)] items-center gap-1 rounded-xl px-2 py-1.5">
         <div
           class="island-nav flex h-8 w-5 cursor-grab items-center justify-center rounded-lg text-text-muted/30 transition-colors hover:text-text-muted"
           :class="{ 'cursor-grabbing': isDragging }"
@@ -791,13 +777,10 @@ watchEffect(() => {
         <div class="mx-0.5 h-5 w-px bg-border-default/40" />
 
         <div class="flex items-center gap-1.5 px-1.5">
-          <div class="relative flex h-6 w-6 items-center justify-center">
-            <div class="absolute inset-0 rounded-md bg-accent/20 blur-md" />
-            <div class="relative flex h-6 w-6 items-center justify-center rounded-md border border-accent/25 bg-surface-overlay/80 backdrop-blur">
-              <Hexagon class="h-3 w-3 text-accent" :stroke-width="2.5" />
-            </div>
+          <div class="flex h-6 w-6 items-center justify-center rounded-md border border-border-default bg-surface-overlay">
+            <Hexagon class="h-3 w-3 text-accent" :stroke-width="2.5" />
           </div>
-          <span class="text-[11px] font-bold tracking-tight text-text-primary">KEDGE</span>
+          <span class="type-display text-[11px] font-bold tracking-[0.08em] text-text-primary">KEDGE</span>
           <div class="flex items-center gap-0.5 rounded-full border border-success/20 bg-success-subtle px-1.5 py-px">
             <Zap class="h-2 w-2 text-success" :stroke-width="2.5" fill="currentColor" />
             <span class="text-[8px] font-semibold uppercase tracking-widest text-success">Live</span>

--- a/portal/src/components/CliQuickstartModal.vue
+++ b/portal/src/components/CliQuickstartModal.vue
@@ -76,7 +76,7 @@ const releasesURL = 'https://github.com/faroshq/kedge/releases/latest'
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
       @click.self="$emit('close')"
     >
-      <div class="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-2xl border border-border-subtle bg-surface-raised shadow-2xl">
+      <div class="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl border border-border-subtle bg-surface-raised shadow-2xl">
         <!-- Header (terminal-style) -->
         <div class="flex items-center justify-between border-b border-border-subtle bg-surface-overlay/60 px-4 py-2.5">
           <div class="flex items-center gap-2">

--- a/portal/src/components/ConfirmDialog.vue
+++ b/portal/src/components/ConfirmDialog.vue
@@ -23,7 +23,7 @@ useEscapeKey(() => emit('cancel'))
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       @click.self="emit('cancel')"
     >
-      <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
+      <div class="w-full max-w-md rounded-xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
         <div class="flex items-start justify-between gap-4">
           <div class="flex items-start gap-3">
             <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-danger/20 bg-danger-subtle">

--- a/portal/src/components/ControlPlaneProvisioning.vue
+++ b/portal/src/components/ControlPlaneProvisioning.vue
@@ -61,7 +61,7 @@ const overBudget = computed(() => props.attempts >= 15)
 </script>
 
 <template>
-  <div class="cross-grid fixed inset-0 z-[200] flex items-center justify-center bg-surface">
+  <div class="contour-grid fixed inset-0 z-[200] flex items-center justify-center bg-surface">
     <!-- Ambient glow, matching the login / auth-callback takeovers -->
     <div class="pointer-events-none fixed inset-0 overflow-hidden">
       <div class="absolute -top-40 left-1/2 h-96 w-[500px] -translate-x-1/2 rounded-full bg-accent/5 blur-[160px]" />
@@ -71,8 +71,8 @@ const overBudget = computed(() => props.attempts >= 15)
     <div class="relative flex w-full max-w-md flex-col items-center px-6">
       <!-- Pulsing hex mark -->
       <div class="relative flex h-16 w-16 items-center justify-center">
-        <div class="absolute inset-0 animate-pulse rounded-2xl bg-accent/20 blur-lg" />
-        <div class="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-accent/25 bg-surface-overlay">
+        <div class="absolute inset-0 animate-pulse rounded-xl bg-accent/20 blur-lg" />
+        <div class="relative flex h-16 w-16 items-center justify-center rounded-xl border border-accent/25 bg-surface-overlay">
           <Hexagon class="h-8 w-8 animate-spin text-accent" style="animation-duration: 3s" :stroke-width="2" />
         </div>
       </div>
@@ -86,8 +86,8 @@ const overBudget = computed(() => props.attempts >= 15)
       </p>
 
       <!-- Step list -->
-      <div class="border-beam mt-7 w-full rounded-2xl">
-        <ul class="space-y-1 rounded-2xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur">
+      <div class="mt-7 w-full rounded-xl border border-border-default shadow-sm">
+        <ul class="space-y-1 rounded-xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur">
           <li
             v-for="(step, i) in steps"
             :key="step.label"

--- a/portal/src/components/DashboardTile.vue
+++ b/portal/src/components/DashboardTile.vue
@@ -141,7 +141,7 @@ onBeforeUnmount(() => {
        this cell so it leaves no gap in the layout. -->
   <div
     v-if="loadState !== 'no-tile'"
-    class="relative flex h-full flex-col overflow-hidden rounded-2xl border bg-surface-raised/80 p-5 backdrop-blur"
+    class="relative flex h-full flex-col overflow-hidden rounded-xl border bg-surface-raised/80 p-5 backdrop-blur"
     :class="editMode ? 'cursor-move border-accent/40 ring-1 ring-accent/30' : 'border-border-subtle'"
   >
     <!-- Remove affordance — only in edit mode. `tile-no-drag` keeps the

--- a/portal/src/components/FirstWorkspaceWizard.vue
+++ b/portal/src/components/FirstWorkspaceWizard.vue
@@ -64,8 +64,8 @@ async function handleCreate() {
       </div>
     </div>
 
-    <div class="border-beam rounded-2xl">
-      <div class="space-y-5 rounded-2xl border border-border-subtle bg-surface-raised/80 p-6 backdrop-blur">
+    <div class="rounded-xl border border-border-default shadow-sm">
+      <div class="space-y-5 rounded-xl border border-border-subtle bg-surface-raised/80 p-6 backdrop-blur">
         <div
           v-if="error"
           class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger"

--- a/portal/src/components/ResourceTable.vue
+++ b/portal/src/components/ResourceTable.vue
@@ -23,7 +23,7 @@ function onRowClick(row: Record<string, unknown>) {
 </script>
 
 <template>
-  <div class="overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised/80 backdrop-blur">
+  <div class="k-table">
     <!-- Error -->
     <div v-if="error" class="flex items-center gap-2 p-4 text-[13px] text-danger">
       <AlertCircle class="h-4 w-4 shrink-0" :stroke-width="1.75" />
@@ -43,33 +43,22 @@ function onRowClick(row: Record<string, unknown>) {
     </div>
 
     <!-- Table -->
-    <table v-else class="min-w-full">
+    <table v-else>
       <thead>
-        <tr class="border-b border-border-subtle">
-          <th
-            v-for="col in columns"
-            :key="col.key"
-            class="px-5 py-3 text-left text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted"
-          >
-            {{ col.label }}
-          </th>
+        <tr>
+          <th v-for="col in columns" :key="col.key">{{ col.label }}</th>
         </tr>
       </thead>
       <tbody>
         <tr
           v-for="(row, i) in rows"
           :key="i"
-          class="stagger-item group border-b border-border-subtle transition-all duration-150 last:border-b-0"
-          :class="interactive ? 'cursor-pointer hover:bg-accent/[0.03]' : ''"
+          class="stagger-item"
+          :class="interactive ? 'is-interactive' : ''"
           :style="{ animationDelay: `${i * 35}ms` }"
           @click="onRowClick(row)"
         >
-          <td
-            v-for="col in columns"
-            :key="col.key"
-            class="whitespace-nowrap px-5 py-3 text-[13px] text-text-secondary transition-colors duration-100"
-            :class="interactive ? 'group-hover:text-text-primary' : ''"
-          >
+          <td v-for="col in columns" :key="col.key">
             <slot :name="col.key" :value="row[col.key]" :row="row">
               {{ row[col.key] }}
             </slot>

--- a/portal/src/components/StatusBadge.vue
+++ b/portal/src/components/StatusBadge.vue
@@ -13,59 +13,51 @@ const props = withDefaults(
   { connected: null, tone: null },
 )
 
-const toneConfig: Record<Tone, { bg: string; text: string; dot: string; glow: string }> = {
-  success: { bg: 'bg-success-subtle', text: 'text-success', dot: 'bg-success', glow: 'text-success' },
-  warning: { bg: 'bg-warning-subtle', text: 'text-warning', dot: 'bg-warning', glow: 'text-warning' },
-  danger: { bg: 'bg-danger-subtle', text: 'text-danger', dot: 'bg-danger', glow: 'text-danger' },
-  muted: { bg: 'bg-surface-overlay', text: 'text-text-muted', dot: 'bg-text-muted', glow: 'text-text-muted' },
+const toneConfig: Record<Tone, { cls: string; icon: typeof CheckCircle }> = {
+  success: { cls: 'k-badge--success', icon: CheckCircle },
+  warning: { cls: 'k-badge--warning', icon: Clock },
+  danger: { cls: 'k-badge--danger', icon: AlertTriangle },
+  muted: { cls: 'k-badge--muted', icon: Circle },
 }
 
 const config = computed(() => {
   if (props.connected === false)
-    return { bg: 'bg-danger-subtle', text: 'text-danger', icon: XCircle, dot: 'bg-danger', glow: 'text-danger' }
+    return { cls: 'k-badge--danger', icon: XCircle }
 
-  if (props.tone) {
-    const tone = toneConfig[props.tone]
-    return { ...tone, icon: props.tone === 'danger' ? AlertTriangle : props.tone === 'warning' ? Clock : props.tone === 'success' ? CheckCircle : Circle }
-  }
+  if (props.tone) return toneConfig[props.tone]
 
   switch (props.status?.toLowerCase()) {
     case 'ready':
     case 'succeeded':
     case 'committed':
-      return { bg: 'bg-success-subtle', text: 'text-success', icon: CheckCircle, dot: 'bg-success', glow: 'text-success' }
+    case 'active':
+      return { cls: 'k-badge--success', icon: CheckCircle }
     case 'scheduling':
     case 'pending':
     case 'provisioning':
     case 'running':
     case 'status unavailable':
-      return { bg: 'bg-warning-subtle', text: 'text-warning', icon: Clock, dot: 'bg-warning', glow: 'text-warning' }
-    case 'active':
-      return { bg: 'bg-success-subtle', text: 'text-success', icon: CheckCircle, dot: 'bg-success', glow: 'text-success' }
+      return { cls: 'k-badge--warning', icon: Clock }
     case 'terminating':
     case 'failed':
     case 'error':
     case 'repository missing':
     case 'connection missing':
-      return { bg: 'bg-danger-subtle', text: 'text-danger', icon: AlertTriangle, dot: 'bg-danger', glow: 'text-danger' }
+      return { cls: 'k-badge--danger', icon: AlertTriangle }
     default:
-      return { bg: 'bg-surface-overlay', text: 'text-text-muted', icon: Circle, dot: 'bg-text-muted', glow: 'text-text-muted' }
+      return { cls: 'k-badge--muted', icon: Circle }
   }
 })
 </script>
 
 <template>
-  <span
-    class="inline-flex items-center gap-1.5 rounded-full border border-current/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide transition-colors duration-150"
-    :class="[config.bg, config.text]"
-  >
+  <span class="k-badge" :class="config.cls">
     <span class="relative flex h-1.5 w-1.5">
       <span
         v-if="status?.toLowerCase() === 'ready' && connected !== false"
-        class="live-dot absolute inline-flex h-full w-full rounded-full"
-        :class="config.glow"
+        class="live-dot k-badge__dot absolute inline-flex h-full w-full"
       />
-      <span class="relative inline-flex h-1.5 w-1.5 rounded-full" :class="config.dot" />
+      <span class="k-badge__dot relative inline-flex" />
     </span>
     {{ status }}
   </span>

--- a/portal/src/components/TerminalDock.vue
+++ b/portal/src/components/TerminalDock.vue
@@ -292,8 +292,8 @@ onUnmounted(() => {
 <template>
   <div
     v-if="store.isVisible && store.sessions.length > 0"
-    class="terminal-dock fixed z-40 flex flex-col border-t border-border-subtle bg-surface-raised/95 shadow-[0_-8px_24px_-8px_rgba(0,0,0,0.4)] backdrop-blur"
-    :class="{ 'rounded-t-2xl': !store.panelState.isFullscreen }"
+    class="terminal-dock fixed z-40 flex flex-col border-t border-border-default bg-surface-raised shadow-[0_-8px_24px_-8px_rgba(0,0,0,0.5)]"
+    :class="{ 'rounded-t-xl': !store.panelState.isFullscreen }"
     :style="panelStyle"
   >
     <!-- Resize handle (top edge) -->
@@ -386,7 +386,7 @@ onUnmounted(() => {
     <!-- Content area -->
     <div
       v-if="!store.panelState.isMinimized"
-      class="panel-content relative min-h-0 flex-1 overflow-hidden bg-[#0a0a0f]"
+      class="panel-content relative min-h-0 flex-1 overflow-hidden bg-[#0b0c11]"
       :class="`layout-${store.panelState.splitLayout}`"
     >
       <template v-for="session in store.sessions" :key="session.id">
@@ -414,6 +414,34 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+/*
+ * The terminal is always a dark console, even on the light theme. Pin the dark
+ * palette as local CSS variables on the dock root so every token-driven child
+ * utility (bg-surface-*, text-text-*, border-*) inside resolves dark and the
+ * chrome reads as one intentional dark strip. Custom properties inherit, so the
+ * whole subtree picks these up.
+ */
+.terminal-dock {
+  --color-surface: #0b0c11;
+  --color-surface-raised: #12131b;
+  --color-surface-overlay: #181926;
+  --color-surface-hover: #1e1f2e;
+  --color-border-subtle: rgba(255, 255, 255, 0.06);
+  --color-border-default: rgba(255, 255, 255, 0.1);
+  --color-accent: #7c5bf5;
+  --color-accent-hover: #9b85f7;
+  --color-accent-subtle: rgba(124, 91, 245, 0.12);
+  --color-text-primary: #eeeef3;
+  --color-text-secondary: #7e7e96;
+  --color-text-muted: #565870;
+  --color-success: #34d399;
+  --color-success-subtle: rgba(52, 211, 153, 0.12);
+  --color-warning: #fbbf24;
+  --color-warning-subtle: rgba(251, 191, 36, 0.12);
+  --color-danger: #f87171;
+  --color-danger-subtle: rgba(248, 113, 113, 0.12);
+}
+
 .terminal-pane.hidden-pane {
   display: none !important;
 }

--- a/portal/src/components/TerminalInstance.vue
+++ b/portal/src/components/TerminalInstance.vue
@@ -52,13 +52,13 @@ async function initialize() {
   terminal = new Terminal({
     cursorBlink: true,
     fontSize: 13,
-    fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+    fontFamily: "'IBM Plex Mono', ui-monospace, Menlo, monospace",
     theme: {
-      background: '#0a0a0f',
+      background: '#0b0c11',
       foreground: '#c8c8d0',
       cursor: '#a78bfa',
       selectionBackground: '#a78bfa33',
-      black: '#0a0a0f',
+      black: '#0b0c11',
       red: '#f87171',
       green: '#34d399',
       yellow: '#fbbf24',
@@ -193,7 +193,7 @@ defineExpose({ resize, focusTerminal, clearTerminal, reconnect })
 </script>
 
 <template>
-  <div class="terminal-instance flex h-full w-full flex-col bg-[#0a0a0f]">
+  <div class="terminal-instance flex h-full w-full flex-col bg-[#0b0c11]">
     <div class="flex h-7 items-center justify-between gap-2 border-b border-border-subtle bg-surface-overlay/40 px-3 text-[10px] text-text-muted">
       <div class="flex items-center gap-1.5">
         <component

--- a/portal/src/components/UserProfileModal.vue
+++ b/portal/src/components/UserProfileModal.vue
@@ -30,7 +30,7 @@ async function copy(text: string, field: string) {
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
       @click.self="$emit('close')"
     >
-      <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised shadow-2xl">
+      <div class="w-full max-w-md rounded-xl border border-border-subtle bg-surface-raised shadow-2xl">
         <!-- Header -->
         <div class="flex items-center justify-between border-b border-border-subtle bg-surface-overlay/60 px-4 py-2.5">
           <div class="flex items-center gap-2">

--- a/portal/src/components/YamlViewer.vue
+++ b/portal/src/components/YamlViewer.vue
@@ -143,7 +143,7 @@ const collapseAll = () => {
         Collapse all
       </button>
     </div>
-    <div class="max-h-[500px] overflow-auto rounded-2xl border border-border-subtle bg-surface-overlay/60 py-3 pl-2 pr-5 font-mono text-[11px] leading-relaxed text-text-secondary backdrop-blur">
+    <div class="max-h-[500px] overflow-auto rounded-xl border border-border-subtle bg-surface-overlay/60 py-3 pl-2 pr-5 font-mono text-[11px] leading-relaxed text-text-secondary backdrop-blur">
       <div
         v-for="item in visible"
         :key="item.idx"

--- a/portal/src/main.ts
+++ b/portal/src/main.ts
@@ -4,6 +4,12 @@ import App from './App.vue'
 import { router } from './router'
 import { registerProviderRoutes } from './router/providers'
 import { initTheme } from './stores/theme'
+// Self-hosted webfonts. Imported before main.css so @font-face rules are
+// registered ahead of the stylesheet that references them.
+import '@fontsource-variable/instrument-sans' // UI / body
+import '@fontsource-variable/archivo/wdth.css' // display / KPI numerals (width axis)
+import '@fontsource/ibm-plex-mono/400.css' // data / mono
+import '@fontsource/ibm-plex-mono/500.css'
 import './assets/main.css'
 
 // Apply theme before mount to prevent flash

--- a/portal/src/pages/AuthCallback.vue
+++ b/portal/src/pages/AuthCallback.vue
@@ -49,13 +49,13 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="cross-grid relative flex min-h-screen items-center justify-center bg-surface">
+  <div class="contour-grid relative flex min-h-screen items-center justify-center bg-surface">
     <div class="pointer-events-none fixed inset-0 overflow-hidden">
       <div class="absolute -top-40 left-1/2 h-96 w-[500px] -translate-x-1/2 rounded-full bg-accent/5 blur-[160px]" />
     </div>
 
-    <div v-if="error" class="border-beam relative rounded-2xl">
-      <div class="rounded-2xl border border-border-subtle bg-surface-raised/80 p-8 text-center backdrop-blur">
+    <div v-if="error" class="relative rounded-xl border border-border-default shadow-sm">
+      <div class="rounded-xl border border-border-subtle bg-surface-raised/80 p-8 text-center backdrop-blur">
         <div class="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-danger/20 bg-danger-subtle">
           <AlertCircle class="h-5 w-5 text-danger" :stroke-width="1.75" />
         </div>
@@ -72,8 +72,8 @@ onMounted(() => {
 
     <div v-else class="relative flex flex-col items-center gap-5">
       <div class="relative flex h-16 w-16 items-center justify-center">
-        <div class="absolute inset-0 animate-pulse rounded-2xl bg-accent/20 blur-lg" />
-        <div class="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-accent/25 bg-surface-overlay">
+        <div class="absolute inset-0 animate-pulse rounded-xl bg-accent/20 blur-lg" />
+        <div class="relative flex h-16 w-16 items-center justify-center rounded-xl border border-accent/25 bg-surface-overlay">
           <Hexagon class="h-8 w-8 animate-spin text-accent" style="animation-duration: 3s" :stroke-width="2" />
         </div>
       </div>

--- a/portal/src/pages/LoginPage.vue
+++ b/portal/src/pages/LoginPage.vue
@@ -69,34 +69,24 @@ function handleOIDCLogin() {
 </script>
 
 <template>
-  <div class="cross-grid relative flex min-h-screen bg-surface">
+  <div class="contour-grid relative flex min-h-screen bg-surface">
     <!-- Theme toggle -->
     <button
-      class="fixed right-4 top-4 z-50 flex h-8 w-8 items-center justify-center rounded-lg border border-border-subtle bg-surface-raised/80 text-text-muted backdrop-blur transition-all hover:border-accent/30 hover:text-text-secondary"
+      class="fixed right-4 top-4 z-50 flex h-8 w-8 items-center justify-center rounded-lg border border-border-subtle bg-surface-raised text-text-muted transition-all hover:border-accent/30 hover:text-text-secondary"
       title="Toggle theme"
       @click="theme.toggle()"
     >
       <component :is="themeIcon" class="h-3.5 w-3.5" :stroke-width="1.75" />
     </button>
 
-    <!-- Ambient -->
-    <div class="pointer-events-none fixed inset-0 overflow-hidden">
-      <div class="absolute -top-40 left-1/2 h-96 w-[600px] -translate-x-1/2 rounded-full bg-accent/5 blur-[180px]" />
-      <div class="absolute bottom-0 right-1/3 h-72 w-72 rounded-full bg-success/3 blur-[140px]" />
-    </div>
-
     <!-- Left decorative panel (hidden on small) -->
     <div class="hidden flex-1 items-center justify-center lg:flex">
       <div class="relative">
-        <div class="absolute inset-0 rounded-3xl bg-accent/8 blur-2xl" />
-        <div class="dot-grid relative flex h-72 w-72 flex-col items-center justify-center rounded-3xl border border-border-subtle bg-surface-raised/50 backdrop-blur">
-          <div class="relative flex h-20 w-20 items-center justify-center">
-            <div class="absolute inset-0 rounded-2xl bg-accent/20 blur-lg" />
-            <div class="relative flex h-20 w-20 items-center justify-center rounded-2xl border border-accent/25 bg-surface-overlay">
-              <Hexagon class="h-10 w-10 text-accent" :stroke-width="1.5" />
-            </div>
+        <div class="relative flex h-72 w-72 flex-col items-center justify-center rounded-3xl border border-border-default bg-surface-raised shadow-sm">
+          <div class="relative flex h-20 w-20 items-center justify-center rounded-xl border border-border-default bg-surface-overlay">
+            <Hexagon class="h-10 w-10 text-accent" :stroke-width="1.5" />
           </div>
-          <span class="text-gradient mt-6 text-2xl font-bold tracking-tight">KEDGE</span>
+          <span class="type-display mt-6 text-2xl font-bold tracking-tight text-text-primary">KEDGE</span>
           <span class="mt-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-text-muted">Command Center</span>
           <div class="energy-line mt-6 h-px w-24" />
         </div>
@@ -109,16 +99,15 @@ function handleOIDCLogin() {
         <!-- Mobile logo -->
         <div class="mb-8 text-center lg:hidden">
           <div class="relative mx-auto flex h-14 w-14 items-center justify-center">
-            <div class="absolute inset-0 rounded-xl bg-accent/20 blur-md" />
-            <div class="relative flex h-14 w-14 items-center justify-center rounded-xl border border-accent/20 bg-surface-overlay">
+            <div class="relative flex h-14 w-14 items-center justify-center rounded-xl border border-border-default bg-surface-overlay">
               <Hexagon class="h-7 w-7 text-accent" :stroke-width="2" />
             </div>
           </div>
-          <h1 class="text-gradient mt-4 text-xl font-bold">KEDGE</h1>
+          <h1 class="type-display mt-4 text-xl font-bold text-text-primary">KEDGE</h1>
         </div>
 
-        <div class="border-beam rounded-2xl">
-          <div class="space-y-5 rounded-2xl border border-border-subtle bg-surface-raised/80 p-7 backdrop-blur">
+        <div class="rounded-xl border border-border-default shadow-sm">
+          <div class="space-y-5 rounded-xl bg-surface-raised p-7">
             <div>
               <h2 class="text-[15px] font-semibold text-text-primary">Sign in</h2>
               <p class="mt-0.5 text-[12px] text-text-muted">Authenticate to access your cluster</p>
@@ -133,7 +122,7 @@ function handleOIDCLogin() {
             <!-- OIDC -->
             <button
               v-if="auth.authMode === 'both' || auth.authMode === 'oidc'"
-              class="group flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-[13px] font-semibold text-white transition-all duration-200 hover:bg-accent-hover hover:shadow-lg hover:shadow-accent/20 active:scale-[0.98]"
+              class="group flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-[13px] font-semibold text-white transition-all duration-200 hover:bg-accent-hover active:scale-[0.98]"
               @click="handleOIDCLogin"
             >
               <ShieldCheck class="h-4 w-4 transition-transform duration-200 group-hover:scale-110" :stroke-width="2" />
@@ -163,8 +152,8 @@ function handleOIDCLogin() {
               <div>
                 <label for="token" class="mb-1 block text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Bearer Token</label>
                 <div
-                  class="glow-ring flex items-center gap-2 rounded-xl border bg-surface-overlay/60 px-3 py-2.5 backdrop-blur transition-all duration-200"
-                  :class="inputFocused ? 'active border-accent/40' : 'border-border-default'"
+                  class="flex items-center gap-2 rounded-lg border bg-surface-overlay px-3 py-2.5 transition-all duration-200"
+                  :class="inputFocused ? 'border-accent ring-[3px] ring-accent/15' : 'border-border-default'"
                 >
                   <KeyRound class="h-3.5 w-3.5 shrink-0 text-text-muted transition-colors" :class="{ 'text-accent': inputFocused }" :stroke-width="1.75" />
                   <input
@@ -181,7 +170,7 @@ function handleOIDCLogin() {
               <button
                 type="submit"
                 :disabled="!tokenInput || auth.loading"
-                class="group flex w-full items-center justify-center gap-2 rounded-xl border border-border-default bg-surface-overlay/60 px-4 py-2.5 text-[12px] font-semibold text-text-primary backdrop-blur transition-all duration-200 hover:border-accent/30 hover:bg-surface-hover active:scale-[0.98] disabled:pointer-events-none disabled:opacity-30"
+                class="group flex w-full items-center justify-center gap-2 rounded-lg border border-border-default bg-surface-overlay px-4 py-2.5 text-[12px] font-semibold text-text-primary transition-all duration-200 hover:border-accent/30 hover:bg-surface-hover active:scale-[0.98] disabled:pointer-events-none disabled:opacity-30"
               >
                 <Loader2
                   v-if="auth.loading"

--- a/portal/src/pages/NotFoundPage.vue
+++ b/portal/src/pages/NotFoundPage.vue
@@ -3,19 +3,19 @@ import { Hexagon, ArrowLeft } from 'lucide-vue-next'
 </script>
 
 <template>
-  <div class="cross-grid relative flex min-h-screen items-center justify-center bg-surface">
+  <div class="contour-grid relative flex min-h-screen items-center justify-center bg-surface">
     <div class="pointer-events-none fixed inset-0 overflow-hidden">
       <div class="absolute top-1/3 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-accent/4 blur-[140px]" />
     </div>
 
     <div class="relative text-center">
       <div class="relative mx-auto flex h-20 w-20 items-center justify-center">
-        <div class="absolute inset-0 rounded-2xl bg-accent/10 blur-lg" />
-        <div class="relative flex h-20 w-20 items-center justify-center rounded-2xl border border-border-subtle bg-surface-raised/80 backdrop-blur">
+        <div class="absolute inset-0 rounded-xl bg-accent/10 blur-lg" />
+        <div class="relative flex h-20 w-20 items-center justify-center rounded-xl border border-border-subtle bg-surface-raised">
           <Hexagon class="h-10 w-10 text-text-muted/15" :stroke-width="1" />
         </div>
       </div>
-      <h1 class="text-gradient mt-6 text-7xl font-bold tracking-tighter">404</h1>
+      <h1 class="type-display mt-6 text-7xl font-bold tracking-tighter text-text-primary">404</h1>
       <p class="mt-2 text-[13px] text-text-muted">This page doesn't exist</p>
       <router-link
         to="/"

--- a/portal/src/stores/theme.ts
+++ b/portal/src/stores/theme.ts
@@ -6,7 +6,15 @@ export type ThemeMode = 'light' | 'dark' | 'system'
 const STORAGE_KEY = 'kedge-theme'
 
 function getSystemTheme(): 'light' | 'dark' {
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  // Light is the hard fallback (matches the CSS base) when matchMedia is
+  // unavailable or throws.
+  try {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+  } catch {
+    return 'light'
+  }
 }
 
 function applyTheme(resolved: 'light' | 'dark') {
@@ -34,8 +42,8 @@ export const useThemeStore = defineStore('theme', () => {
   }
 
   // Listen for system theme changes
-  const mql = window.matchMedia('(prefers-color-scheme: dark)')
-  mql.addEventListener('change', () => {
+  const mql = window.matchMedia?.('(prefers-color-scheme: dark)')
+  mql?.addEventListener('change', () => {
     if (mode.value === 'system') {
       resolved.value = getSystemTheme()
       applyTheme(resolved.value)

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -215,7 +215,7 @@ kedge-provider-agents .agents-body { padding: 9px 12px; border-radius: 12px; whi
 kedge-provider-agents .agents-msg.user { align-items: flex-end; }
 kedge-provider-agents .agents-msg.user .agents-body { background: var(--color-accent-subtle, rgba(109, 79, 224, 0.1)); border: 1px solid var(--color-accent, transparent); }
 kedge-provider-agents .agents-toolrow {
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace; font-size: 11px;
   padding: 6px 10px; border-radius: 8px; word-break: break-all; max-width: 90%;
   background: var(--color-surface-overlay, rgba(0, 0, 0, 0.04));
   border-left: 2px solid var(--color-accent, #6d4fe0); color: var(--color-text-secondary, inherit);
@@ -228,7 +228,7 @@ kedge-provider-agents .agents-chat-form input { flex: 1; }
 kedge-provider-agents .muted { color: var(--color-text-muted, inherit); }
 kedge-provider-agents code {
   padding: 1px 5px; border-radius: 4px; font-size: 12px;
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
   background: var(--color-surface-overlay, rgba(0, 0, 0, 0.05)); color: var(--color-text-secondary, currentColor);
 }
 kedge-provider-agents .agents-err {
@@ -357,7 +357,7 @@ kedge-provider-agents .flow-nhead { display: flex; align-items: center; gap: 9px
 kedge-provider-agents .flow-nic { width: 28px; height: 28px; border-radius: 8px; flex: none; display: grid; place-items: center; background: var(--nc-soft); color: var(--nc); border: 1px solid var(--nc-line); }
 kedge-provider-agents .flow-nic svg { width: 16px; height: 16px; }
 kedge-provider-agents .flow-nmeta { min-width: 0; flex: 1; display: flex; flex-direction: column; }
-kedge-provider-agents .flow-ntype { font: 700 9.5px/1.4 ui-monospace, monospace; letter-spacing: .12em; text-transform: uppercase; color: var(--nc); }
+kedge-provider-agents .flow-ntype { font: 700 9.5px/1.4 "IBM Plex Mono", ui-monospace, monospace; letter-spacing: .12em; text-transform: uppercase; color: var(--nc); }
 kedge-provider-agents .flow-ntitle { font-size: 13.5px; font-weight: 600; color: var(--color-text-primary, #123); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 kedge-provider-agents .flow-node.core .flow-ntitle { font-size: 15px; }
 kedge-provider-agents .flow-nbody { padding: 0 11px 11px; }
@@ -380,7 +380,7 @@ kedge-provider-agents .flow-port.io-out { left: 100%; }
 kedge-provider-agents .flow-node:hover .flow-port { box-shadow: 0 0 0 3px color-mix(in srgb, var(--pc) 18%, transparent); }
 kedge-provider-agents .flow-port:hover, kedge-provider-agents .flow-port.drop { box-shadow: 0 0 0 5px color-mix(in srgb, var(--pc) 34%, transparent); transform: translate(-50%, -50%) scale(1.18); }
 kedge-provider-agents .flow-port.drop { background: var(--pc); }
-kedge-provider-agents .flow-port::after { content: attr(data-label); position: absolute; top: 50%; transform: translateY(-50%); font: 700 8.5px/1 ui-monospace, monospace; letter-spacing: .1em; text-transform: uppercase; color: var(--color-text-muted, #889); white-space: nowrap; pointer-events: none; opacity: 0; transition: opacity .12s; }
+kedge-provider-agents .flow-port::after { content: attr(data-label); position: absolute; top: 50%; transform: translateY(-50%); font: 700 8.5px/1 "IBM Plex Mono", ui-monospace, monospace; letter-spacing: .1em; text-transform: uppercase; color: var(--color-text-muted, #889); white-space: nowrap; pointer-events: none; opacity: 0; transition: opacity .12s; }
 kedge-provider-agents .flow-port.io-in::after { right: 20px; }
 kedge-provider-agents .flow-port.io-out::after { left: 20px; }
 kedge-provider-agents .flow-node:hover .flow-port::after, kedge-provider-agents .flow-node.sel .flow-port::after { opacity: 1; }
@@ -388,7 +388,7 @@ kedge-provider-agents .flow-node:hover .flow-port::after, kedge-provider-agents 
 /* palette rail */
 kedge-provider-agents .flow-rail { position: absolute; left: 12px; top: 12px; bottom: 12px; width: 66px; z-index: 5; display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 9px 6px; overflow-y: auto;
   background: color-mix(in srgb, var(--color-surface-raised, #fff) 86%, transparent); backdrop-filter: blur(8px); border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 14px; box-shadow: 0 8px 24px rgba(20,40,80,.10); }
-kedge-provider-agents .flow-rlab { font: 700 8.5px/1 ui-monospace, monospace; letter-spacing: .12em; text-transform: uppercase; color: var(--color-text-muted, #889); margin: 5px 0 1px; }
+kedge-provider-agents .flow-rlab { font: 700 8.5px/1 "IBM Plex Mono", ui-monospace, monospace; letter-spacing: .12em; text-transform: uppercase; color: var(--color-text-muted, #889); margin: 5px 0 1px; }
 kedge-provider-agents .flow-palnode { width: 54px; display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 7px 2px; border-radius: 10px; cursor: pointer; color: var(--color-text-secondary, #556); border: 1px solid transparent; background: transparent; font: inherit; }
 kedge-provider-agents .flow-palnode:hover { background: var(--color-surface, #eef1f7); border-color: var(--color-border-default, #d9e0ec); color: var(--color-text-primary, #123); }
 kedge-provider-agents .flow-palnode .chip { width: 30px; height: 30px; border-radius: 9px; display: grid; place-items: center; background: var(--nc-soft); color: var(--nc); border: 1px solid var(--nc-line); }
@@ -431,13 +431,13 @@ kedge-provider-agents .flow-dialog-foot { display: flex; align-items: center; ju
 kedge-provider-agents .flow-autonote { font-size: 11.5px; color: var(--color-text-muted, #889); }
 kedge-provider-agents .flow-dialog-actions { display: flex; gap: 8px; }
 kedge-provider-agents .flow-field { display: flex; flex-direction: column; gap: 5px; }
-kedge-provider-agents .flow-field > label { font: 700 10.5px/1.4 ui-monospace, monospace; letter-spacing: .08em; text-transform: uppercase; color: var(--color-text-muted, #889); }
+kedge-provider-agents .flow-field > label { font: 700 10.5px/1.4 "IBM Plex Mono", ui-monospace, monospace; letter-spacing: .08em; text-transform: uppercase; color: var(--color-text-muted, #889); }
 kedge-provider-agents .flow-field input, kedge-provider-agents .flow-field textarea, kedge-provider-agents .flow-field select { width: 100%; background: var(--color-surface, #f4f6fb); border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 9px; padding: 8px 10px; color: var(--color-text-primary, #123); font: inherit; font-size: 13px; }
 kedge-provider-agents .flow-field textarea { resize: vertical; min-height: 70px; font-size: 12.5px; }
-kedge-provider-agents .flow-field input.mono, kedge-provider-agents .flow-field textarea.mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+kedge-provider-agents .flow-field input.mono, kedge-provider-agents .flow-field textarea.mono { font-family: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace; }
 kedge-provider-agents .flow-field .hint { font-size: 11px; color: var(--color-text-muted, #889); }
 kedge-provider-agents .flow-static { font-size: 13px; color: var(--color-text-secondary, #556); padding: 2px 0; }
-kedge-provider-agents .flow-static.mono { font-family: ui-monospace, monospace; }
+kedge-provider-agents .flow-static.mono { font-family: "IBM Plex Mono", ui-monospace, monospace; }
 kedge-provider-agents .flow-chiprow { display: flex; flex-wrap: wrap; gap: 5px; }
 kedge-provider-agents .flow-chip { font-size: 12px; padding: 4px 10px; border-radius: 999px; background: var(--color-surface, #f4f6fb); border: 1px solid var(--color-border-default, #d9e0ec); color: var(--color-text-secondary, #556); cursor: pointer; }
 kedge-provider-agents .flow-chip.on { background: color-mix(in srgb, var(--nc) 15%, var(--color-surface-raised)); border-color: var(--nc-line); color: var(--nc); font-weight: 600; }
@@ -445,7 +445,7 @@ kedge-provider-agents .flow-wirelist { display: flex; flex-direction: column; ga
 kedge-provider-agents .flow-wireitem { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--color-text-secondary, #556); padding: 6px 9px; background: var(--color-surface, #f4f6fb); border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 8px; }
 kedge-provider-agents .flow-wireitem.muted { color: var(--color-text-muted, #889); }
 kedge-provider-agents .flow-wireitem .sw { width: 9px; height: 9px; border-radius: 50%; flex: none; }
-kedge-provider-agents .flow-wireitem .dir { color: var(--color-text-muted, #889); font: 700 10px/1 ui-monospace, monospace; }
+kedge-provider-agents .flow-wireitem .dir { color: var(--color-text-muted, #889); font: 700 10px/1 "IBM Plex Mono", ui-monospace, monospace; }
 kedge-provider-agents .flow-btn { border: 1px solid var(--color-border-default, #d9e0ec); background: var(--color-surface, #f4f6fb); color: var(--color-text-primary, #123); font: inherit; font-weight: 600; font-size: 12.5px; padding: 8px 14px; border-radius: 9px; cursor: pointer; }
 kedge-provider-agents .flow-btn:hover { border-color: var(--color-border-strong, #bbb); }
 kedge-provider-agents .flow-btn.primary { background: var(--color-accent, #0fb9a3); border-color: transparent; color: #fff; }
@@ -454,7 +454,7 @@ kedge-provider-agents .flow-btn.danger { color: var(--flow-output); }
 /* toast */
 kedge-provider-agents .flow-toast { position: absolute; left: 50%; bottom: 20px; transform: translateX(-50%) translateY(20px); z-index: 9; background: var(--color-text-primary, #123); color: var(--color-surface-raised, #fff); padding: 9px 15px; border-radius: 10px; font-size: 13px; font-weight: 550; opacity: 0; transition: all .25s; box-shadow: 0 12px 30px rgba(0,0,0,.3); pointer-events: none; max-width: 60%; text-align: center; }
 kedge-provider-agents .flow-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
-kedge-provider-agents .flow-root .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+kedge-provider-agents .flow-root .mono { font-family: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace; }
 
 /* drag-to-create: draggable palette items, drag ghost, draft nodes */
 kedge-provider-agents .flow-palnode.draggable { cursor: grab; touch-action: none; }
@@ -482,4 +482,4 @@ kedge-provider-agents .agents-ov-v.muted { color: var(--color-text-muted, #889);
 kedge-provider-agents .agents-ov-sub { margin-top: 5px; font-size: 12px; font-weight: 400; color: var(--color-text-muted, #889); }
 kedge-provider-agents .agents-checkrow { display: flex; flex-wrap: wrap; gap: 8px 16px; }
 kedge-provider-agents .agents-toolset-form { display: flex; flex-direction: column; gap: 12px; }
-kedge-provider-agents .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+kedge-provider-agents .mono { font-family: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace; }

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -4417,7 +4417,7 @@ function repositoryCommitFilesLabel(commit: ProjectRepositoryCommit): string {
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 px-4 py-6 backdrop-blur-sm"
       @click.self="closeSettings"
     >
-      <div class="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised shadow-2xl">
+      <div class="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-border-subtle bg-surface-raised shadow-2xl">
         <header class="flex items-center justify-between gap-3 border-b border-border-subtle bg-surface-overlay/60 px-4 py-3">
           <div class="min-w-0">
             <div class="flex items-center gap-2">

--- a/providers/app-studio/portal/src/components/ConfirmDialog.vue
+++ b/providers/app-studio/portal/src/components/ConfirmDialog.vue
@@ -23,7 +23,7 @@ useEscapeKey(() => emit('cancel'))
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       @click.self="emit('cancel')"
     >
-      <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
+      <div class="w-full max-w-md rounded-xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
         <div class="flex items-start justify-between gap-4">
           <div class="flex items-start gap-3">
             <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-danger/20 bg-danger-subtle">

--- a/providers/app-studio/portal/src/components/StatusBadge.vue
+++ b/providers/app-studio/portal/src/components/StatusBadge.vue
@@ -10,47 +10,44 @@ const props = withDefaults(
   { connected: null },
 )
 
+// Styling comes from the host-served shared recipe layer (kedge-ui.css:
+// .k-badge / .k-badge--*), so this badge matches the host and every other
+// provider without each build compiling its own utility classes.
 const config = computed(() => {
-  if (props.connected === false)
-    return { bg: 'bg-danger-subtle', text: 'text-danger', icon: XCircle, dot: 'bg-danger', glow: 'text-danger' }
+  if (props.connected === false) return { cls: 'k-badge--danger', icon: XCircle }
 
   switch (props.status?.toLowerCase()) {
     case 'ready':
     case 'succeeded':
     case 'committed':
-      return { bg: 'bg-success-subtle', text: 'text-success', icon: CheckCircle, dot: 'bg-success', glow: 'text-success' }
+    case 'active':
+      return { cls: 'k-badge--success', icon: CheckCircle }
     case 'scheduling':
     case 'pending':
     case 'provisioning':
     case 'running':
     case 'status unavailable':
-      return { bg: 'bg-warning-subtle', text: 'text-warning', icon: Clock, dot: 'bg-warning', glow: 'text-warning' }
-    case 'active':
-      return { bg: 'bg-success-subtle', text: 'text-success', icon: CheckCircle, dot: 'bg-success', glow: 'text-success' }
+      return { cls: 'k-badge--warning', icon: Clock }
     case 'terminating':
     case 'failed':
     case 'error':
     case 'repository missing':
     case 'connection missing':
-      return { bg: 'bg-danger-subtle', text: 'text-danger', icon: AlertTriangle, dot: 'bg-danger', glow: 'text-danger' }
+      return { cls: 'k-badge--danger', icon: AlertTriangle }
     default:
-      return { bg: 'bg-surface-overlay', text: 'text-text-muted', icon: Circle, dot: 'bg-text-muted', glow: 'text-text-muted' }
+      return { cls: 'k-badge--muted', icon: Circle }
   }
 })
 </script>
 
 <template>
-  <span
-    class="inline-flex items-center gap-1.5 rounded-full border border-current/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide transition-colors duration-150"
-    :class="[config.bg, config.text]"
-  >
+  <span class="k-badge" :class="config.cls">
     <span class="relative flex h-1.5 w-1.5">
       <span
         v-if="status?.toLowerCase() === 'ready' && connected !== false"
-        class="live-dot absolute inline-flex h-full w-full rounded-full"
-        :class="config.glow"
+        class="live-dot k-badge__dot absolute inline-flex h-full w-full"
       />
-      <span class="relative inline-flex h-1.5 w-1.5 rounded-full" :class="config.dot" />
+      <span class="k-badge__dot relative inline-flex" />
     </span>
     {{ status }}
   </span>

--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -9,7 +9,7 @@
 
 kedge-provider-code {
   display: block;
-  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-family: inherit;
   color: var(--color-text-primary, inherit);
 }
 
@@ -432,7 +432,7 @@ kedge-provider-code code {
   color: var(--color-text-secondary, currentColor);
   padding: 1px 5px;
   border-radius: 4px;
-  font-family: ui-monospace, Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 11px;
 }
 

--- a/providers/databricks/portal/src/style.css
+++ b/providers/databricks/portal/src/style.css
@@ -297,7 +297,7 @@ kedge-provider-databricks input:disabled {
 }
 
 kedge-provider-databricks .mono {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 kedge-provider-databricks .strong {
@@ -306,7 +306,7 @@ kedge-provider-databricks .strong {
 }
 
 kedge-provider-databricks code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 kedge-provider-databricks .props {

--- a/providers/edges/portal/src/style.css
+++ b/providers/edges/portal/src/style.css
@@ -11,16 +11,19 @@
  *     colours don't adapt to the light/dark theme and drift from the portal.
  *   - For an accent/state-tinted border or fill, mix a token with transparent
  *     via color-mix() (mirrors the portal's `border-accent/30` utilities).
- *   - Match the portal component recipes below: buttons = rounded-lg (8px),
- *     cards/tables = rounded-2xl (16px) surface-raised card, table headers =
- *     10px/600 uppercase tracking-wide text-muted, rows = 13px text-secondary
- *     with an accent-tinted hover. See portal/src/components/ResourceTable.vue,
- *     StatusBadge.vue and portal/src/assets/main.css for the source of truth.
+ *   - PREFER the shared recipe classes served by the host for cards, tables,
+ *     badges, buttons and inputs: .k-card, .k-table, .k-badge (+ --success/
+ *     --warning/--danger/--muted), .k-btn (+ --primary/--ghost/--danger),
+ *     .k-input, .k-eyebrow, .k-kpi. They live in portal/src/assets/kedge-ui.css
+ *     and reach this element through the light DOM, so use them instead of
+ *     re-deriving the styling here; local rules should cover only
+ *     edges-specific layout. Recipe shapes: cards/tables = 12px radius,
+ *     controls = 8px, table headers = 10px/600 uppercase muted, rows = 13px.
  */
 
 kedge-provider-edges {
   display: block;
-  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-family: inherit;
   color: var(--color-text-primary);
 }
 
@@ -57,7 +60,7 @@ kedge-provider-edges .input {
   width: 100%; box-sizing: border-box; padding: 8px 12px;
   border: 1px solid var(--color-border-default); border-radius: 8px;
   background: var(--color-surface-overlay); color: var(--color-text-primary);
-  font-family: ui-monospace, monospace; font-size: 12px; transition: border-color .15s;
+  font-family: "IBM Plex Mono", ui-monospace, monospace; font-size: 12px; transition: border-color .15s;
 }
 kedge-provider-edges .input:focus { outline: none; border-color: var(--color-accent); }
 kedge-provider-edges .input::placeholder { color: var(--color-text-muted); }
@@ -92,7 +95,7 @@ kedge-provider-edges .type small { color: var(--color-text-secondary); font-size
 /* ── Code snippets ── */
 kedge-provider-edges .snippet { border: 1px solid var(--color-border-subtle); border-radius: 12px; padding: 12px; background: var(--color-surface-raised); }
 kedge-provider-edges .snippet-head { display: flex; justify-content: space-between; align-items: center; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .12em; color: var(--color-text-muted); margin-bottom: 8px; }
-kedge-provider-edges .snippet pre { margin: 0; overflow-x: auto; background: var(--color-surface-overlay); border-radius: 8px; padding: 12px; font-family: ui-monospace, monospace; font-size: 11px; line-height: 1.6; color: var(--color-text-secondary); }
+kedge-provider-edges .snippet pre { margin: 0; overflow-x: auto; background: var(--color-surface-overlay); border-radius: 8px; padding: 12px; font-family: "IBM Plex Mono", ui-monospace, monospace; font-size: 11px; line-height: 1.6; color: var(--color-text-secondary); }
 kedge-provider-edges .copy { display: inline-flex; align-items: center; gap: 4px; background: none; border: none; color: var(--color-text-muted); cursor: pointer; font-size: 10px; font-weight: 500; }
 kedge-provider-edges .copy:hover { color: var(--color-accent); }
 kedge-provider-edges .copy:disabled { opacity: .4; cursor: default; }
@@ -104,7 +107,7 @@ kedge-provider-edges .banner.error { border: 1px solid color-mix(in srgb, var(--
 
 /* ── Misc text ── */
 kedge-provider-edges .row { display: flex; align-items: center; gap: 8px; }
-kedge-provider-edges .mono { font-family: ui-monospace, monospace; }
+kedge-provider-edges .mono { font-family: "IBM Plex Mono", ui-monospace, monospace; }
 kedge-provider-edges .muted { color: var(--color-text-secondary); }
 kedge-provider-edges .spin { animation: kedge-edges-spin 1s linear infinite; }
 @keyframes kedge-edges-spin { to { transform: rotate(360deg); } }
@@ -114,7 +117,7 @@ kedge-provider-edges .pad { padding: 20px 0; }
 kedge-provider-edges .empty { text-align: center; padding: 56px 0; color: var(--color-text-secondary); }
 kedge-provider-edges .empty svg { color: var(--color-text-muted); opacity: .5; }
 kedge-provider-edges .empty-title { margin-top: 12px; font-weight: 600; color: var(--color-text-primary); }
-kedge-provider-edges .empty code { font-family: ui-monospace, monospace; font-size: 12px; color: var(--color-text-primary); background: var(--color-surface-overlay); padding: 1px 5px; border-radius: 4px; }
+kedge-provider-edges .empty code { font-family: "IBM Plex Mono", ui-monospace, monospace; font-size: 12px; color: var(--color-text-primary); background: var(--color-surface-overlay); padding: 1px 5px; border-radius: 4px; }
 
 /* ── Table (mirrors portal ResourceTable card) ── */
 kedge-provider-edges .edges-table-wrap { overflow: hidden; border: 1px solid var(--color-border-subtle); border-radius: 16px; background: var(--color-surface-raised); }

--- a/providers/infrastructure/portal/src/components/ConfirmDialog.vue
+++ b/providers/infrastructure/portal/src/components/ConfirmDialog.vue
@@ -27,7 +27,7 @@ onUnmounted(() => window.removeEventListener('keydown', onKey))
       class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       @click.self="emit('cancel')"
     >
-      <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
+      <div class="w-full max-w-md rounded-xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
         <div class="flex items-start justify-between gap-4">
           <div class="flex items-start gap-3">
             <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-danger/20 bg-danger-subtle">

--- a/providers/infrastructure/portal/src/style.css
+++ b/providers/infrastructure/portal/src/style.css
@@ -10,7 +10,7 @@
 
 kedge-provider-infrastructure {
   display: block;
-  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-family: inherit;
   color: var(--color-text-primary, inherit);
 }
 
@@ -269,7 +269,7 @@ kedge-provider-infrastructure pre {
   border: 1px solid var(--color-border-subtle, transparent);
   border-radius: 8px;
   padding: 10px 12px;
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
   font-size: 11px;
   overflow-x: auto;
   white-space: pre-wrap;
@@ -280,7 +280,7 @@ kedge-provider-infrastructure code {
   color: var(--color-text-secondary, currentColor);
   padding: 1px 5px;
   border-radius: 4px;
-  font-family: ui-monospace, Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 11px;
 }
 

--- a/providers/infrastructure/portal/src/views/InstanceDetailPage.vue
+++ b/providers/infrastructure/portal/src/views/InstanceDetailPage.vue
@@ -117,7 +117,7 @@ async function executeDelete() {
         <div
           v-for="(group, gi) in view.detail"
           :key="gi"
-          class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised"
+          class="mb-5 overflow-hidden rounded-xl border border-border-subtle bg-surface-raised"
         >
           <div v-if="group.title" class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">
             {{ group.title }}
@@ -132,13 +132,13 @@ async function executeDelete() {
       </template>
 
       <!-- Values (raw fallback when the template defines no detail view) -->
-      <div v-else class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+      <div v-else class="mb-5 overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
         <div class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Values</div>
         <pre class="overflow-auto p-4 font-mono text-[12px] leading-relaxed text-text-secondary">{{ JSON.stringify(inst.values, null, 2) }}</pre>
       </div>
 
       <!-- Conditions -->
-      <div v-if="inst.conditions && inst.conditions.length" class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+      <div v-if="inst.conditions && inst.conditions.length" class="mb-5 overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
         <div class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Conditions</div>
         <table class="w-full border-collapse text-left">
           <thead>
@@ -161,7 +161,7 @@ async function executeDelete() {
       </div>
 
       <!-- Child resources -->
-      <div v-if="inst.children && inst.children.length" class="mb-5 overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+      <div v-if="inst.children && inst.children.length" class="mb-5 overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
         <div class="border-b border-border-subtle px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted">Child resources</div>
         <table class="w-full border-collapse text-left">
           <thead>

--- a/providers/infrastructure/portal/src/views/InstanceListPage.vue
+++ b/providers/infrastructure/portal/src/views/InstanceListPage.vue
@@ -134,7 +134,7 @@ onUnmounted(() => {
     </div>
 
     <!-- Table -->
-    <div class="overflow-hidden rounded-2xl border border-border-subtle bg-surface-raised">
+    <div class="overflow-hidden rounded-xl border border-border-subtle bg-surface-raised">
       <div v-if="loading" class="p-6 text-[12px] text-text-muted">Loading…</div>
       <div v-else-if="error" class="m-4 rounded-lg border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger">
         {{ error }}
@@ -211,7 +211,7 @@ onUnmounted(() => {
         class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
         @click.self="deleting ? null : (deleteConfirm = null)"
       >
-        <div class="w-full max-w-md rounded-2xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
+        <div class="w-full max-w-md rounded-xl border border-border-subtle bg-surface-raised p-6 shadow-2xl">
           <h3 class="text-[14px] font-bold text-text-primary">Delete instance?</h3>
           <p class="mt-2 text-[12px] text-text-muted">
             This permanently deletes

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -86,7 +86,7 @@ kedge-provider-kuery pre {
   border: 1px solid var(--color-border-subtle, transparent);
   border-radius: 8px;
   padding: 10px 12px;
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
   font-size: 11px;
   overflow-x: auto;
 }
@@ -96,7 +96,7 @@ kedge-provider-kuery code {
   color: var(--color-text-secondary, currentColor);
   padding: 1px 5px;
   border-radius: 4px;
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
   font-size: 11px;
 }
 
@@ -308,7 +308,7 @@ kedge-provider-kuery .pg-editor .CodeMirror {
 kedge-provider-kuery .pg-fallback {
   width: 100%;
   min-height: 360px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   padding: 8px;
   box-sizing: border-box;
@@ -323,7 +323,7 @@ kedge-provider-kuery .pg-result {
   border: 1px solid var(--color-border-subtle, rgba(127, 127, 127, 0.15));
   border-radius: 8px;
   background: var(--color-surface-base, rgba(0, 0, 0, 0.02));
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   white-space: pre-wrap;
   word-break: break-word;

--- a/providers/quickstart/portal/src/style.css
+++ b/providers/quickstart/portal/src/style.css
@@ -86,7 +86,7 @@ kedge-provider-quickstart pre {
   border: 1px solid var(--color-border-subtle, transparent);
   border-radius: 8px;
   padding: 10px 12px;
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
   font-size: 11px;
   overflow-x: auto;
 }
@@ -96,7 +96,7 @@ kedge-provider-quickstart code {
   color: var(--color-text-secondary, currentColor);
   padding: 1px 5px;
   border-radius: 4px;
-  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-family: "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
   font-size: 11px;
 }
 


### PR DESCRIPTION
Reshapes the portal from the dark-default violet glassmorphism look into a flat, precise, language — while keeping kedge's violet identity. Light-first, applied across the host **and all 8 provider micro-frontends**, plus a new shared component layer so providers stop drifting.

## What changed

**Palette — light-first**
- Light values are now the `@theme` base (pale `#f5f6fa` page, white cards, hairline borders, ink text, violet `#6d4fe0`); dark is a flat-ink `html.dark` override (`#0b0c11`, brighter `#7c5bf5`). No more glass/glow.
- Default flips to light with a hard fallback in `index.html` + `stores/theme.ts` (every degraded path renders light).

**Typography** — self-hosted via `@fontsource`
- Instrument Sans (UI/body), Archivo at `font-stretch:125%` for display/KPI/wordmark, IBM Plex Mono for data.
- Providers inherit them — removed three root `font-family` overrides (code/edges/infrastructure) that blocked inheritance; prepended IBM Plex Mono to every provider mono stack.

**Effects overhaul** (`main.css`)
- Deleted `.glass`, `.border-beam`, `.card-glow`, `.tilt-card`, `.glow-ring`, `.text-gradient`, `.dot-grid`, `.cross-grid`, `.noise`, ambient orbs.
- Restyled `.island`/`.energy-line`/`.live-dot` flat; added the signature `.contour-grid` wavy-line background (login, auth, hero, 404).

**Shared recipe layer — cross-provider unification**
- New `portal/src/assets/kedge-ui.css`: `.k-card / .k-table / .k-badge / .k-btn / .k-input / .k-eyebrow / .k-kpi`. Host-served, so it reaches every provider through the light DOM. `ResourceTable` + `StatusBadge` (host + app-studio) adopt it; the styling-contract comment now points future work here.

**Misc** — radii sweep (16→12px) across host + providers; terminal stays an intentional dark console on the light page.

## Verification
- Host portal **and all 8 provider portals build clean** (quickstart, kuery, infrastructure, edges, app-studio, agents, code, databricks).
- Residue grep: zero references to any deleted class; no `rounded-2xl` remaining.
- Every dark-violet value in the built CSS is correctly scoped (dark token block / always-dark terminal / contour SVG) — no light-mode leaks.
- Light + dark rendered from the real built CSS (fonts, tokens, recipes) and visually checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)