### PR TITLE
fix(edges): stop MCP tool server panicking on catalog services + surface edge agent version

### DIFF
--- a/providers/edges/controller_manager.go
+++ b/providers/edges/controller_manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -103,6 +104,13 @@ func startEdgeControllerManager(ctx context.Context, config *rest.Config, tsrv *
 	})
 
 	opts := edgectrl.Options{HubExternalURL: hubExternalURL, HubCAData: hubCAData, DevMode: devMode}
+	// Drive the UpgradeAvailable condition off the hub's /version endpoint. A
+	// single cache is shared across both kinds' version reconcilers so many edges
+	// cost one periodic hub lookup, not one per edge. Skipped without a hub URL
+	// (dev/healthz-only), leaving the condition untouched.
+	if hubExternalURL != "" {
+		opts.LatestAgentVersion = edgectrl.NewHubVersionCache(hubExternalURL, hubCAData, 10*time.Minute).Get
+	}
 	// One set of token/RBAC/lifecycle controllers per kind, on the shared
 	// multicluster manager. Both kinds share the single tunnel ConnManager (keyed
 	// by resource/cluster/name), so the lifecycle reconciler's tunnel-liveness

--- a/providers/edges/internal/edgeapi/types.go
+++ b/providers/edges/internal/edgeapi/types.go
@@ -40,6 +40,13 @@ const (
 // via the bootstrap join token.
 const ConnectionConditionRegistered = "Registered"
 
+// ConnectionConditionUpgradeAvailable is set True by the version reconciler when
+// the agent's reported status.agentVersion is older than the hub's current
+// release. The condition message carries the target version ("upgrade available
+// to <version>.") so the portal can render upgrade instructions without a
+// separate lookup.
+const ConnectionConditionUpgradeAvailable = "UpgradeAvailable"
+
 // AnnotationRegenerateJoinToken, set on a connectable resource, instructs the
 // token reconciler to mint a fresh bootstrap join token.
 const AnnotationRegenerateJoinToken = "edges.kedge.faros.sh/regenerate-join-token"

--- a/providers/edges/internal/edgectrl/setup.go
+++ b/providers/edges/internal/edgectrl/setup.go
@@ -17,6 +17,8 @@ limitations under the License.
 package edgectrl
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	edgeapi "github.com/faroshq/provider-edges/internal/edgeapi"
@@ -28,6 +30,10 @@ type Options struct {
 	HubExternalURL string
 	HubCAData      []byte
 	DevMode        bool
+	// LatestAgentVersion yields the hub's current release version. When set, the
+	// version reconciler maintains the UpgradeAvailable condition by comparing it
+	// against each edge's reported status.agentVersion. Nil disables the check.
+	LatestAgentVersion func(context.Context) (string, error)
 }
 
 // SetupControllers registers the token, RBAC, and lifecycle reconcilers for one
@@ -48,6 +54,11 @@ func SetupControllers(
 	}
 	if err := SetupRBACWithManager(mgr, gvr, kind, newObj, opts.HubExternalURL, opts.HubCAData, opts.DevMode); err != nil {
 		return err
+	}
+	if opts.LatestAgentVersion != nil {
+		if err := SetupVersionWithManager(mgr, gvr, newObj, opts.LatestAgentVersion); err != nil {
+			return err
+		}
 	}
 	return SetupLifecycleWithManager(mgr, gvr, newObj, connManager)
 }

--- a/providers/edges/internal/edgectrl/version_reconciler.go
+++ b/providers/edges/internal/edgectrl/version_reconciler.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edgectrl
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	edgeapi "github.com/faroshq/provider-edges/internal/edgeapi"
+
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+)
+
+const (
+	// versionCheckInterval is the steady-state requeue cadence for re-evaluating
+	// an edge's agent version against the hub release.
+	versionCheckInterval = 10 * time.Minute
+	// versionRetryInterval is the shorter requeue used when the hub version could
+	// not be fetched, so a transient hub outage doesn't stall upgrade detection
+	// for a full check interval.
+	versionRetryInterval = 2 * time.Minute
+)
+
+// HubVersionCache fetches the hub's current release from its unauthenticated
+// /version endpoint and caches it for a TTL, so the per-edge version reconcilers
+// (one per kind, potentially many edges) share a single upstream lookup rather
+// than hammering the hub on every reconcile.
+type HubVersionCache struct {
+	url    string
+	client *http.Client
+	ttl    time.Duration
+
+	mu      sync.Mutex
+	version string
+	fetched time.Time
+}
+
+// NewHubVersionCache builds a cache pointed at hubExternalURL + "/version". When
+// caData is provided it is trusted for the TLS handshake (the hub serves the
+// front-proxy CA, same as the RBAC reconciler's agent-kubeconfig generation).
+func NewHubVersionCache(hubExternalURL string, caData []byte, ttl time.Duration) *HubVersionCache {
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if len(caData) > 0 {
+		pool := x509.NewCertPool()
+		if pool.AppendCertsFromPEM(caData) {
+			tlsCfg.RootCAs = pool
+		}
+	}
+	return &HubVersionCache{
+		url:    strings.TrimRight(hubExternalURL, "/") + "/version",
+		client: &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsCfg}},
+		ttl:    ttl,
+	}
+}
+
+// Get returns the hub's release version, refetching when the cached value is
+// stale. On a fetch error the previous fetch time is left untouched so the next
+// call retries rather than serving a stale value indefinitely.
+func (h *HubVersionCache) Get(ctx context.Context) (string, error) {
+	h.mu.Lock()
+	if h.version != "" && time.Since(h.fetched) < h.ttl {
+		v := h.version
+		h.mu.Unlock()
+		return v, nil
+	}
+	h.mu.Unlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching hub version: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("hub /version returned %s", resp.Status)
+	}
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
+		return "", fmt.Errorf("decoding hub version: %w", err)
+	}
+
+	h.mu.Lock()
+	h.version = body.Version
+	h.fetched = time.Now()
+	h.mu.Unlock()
+	return body.Version, nil
+}
+
+// VersionReconciler compares each connectable's reported agent version against
+// the hub release and maintains the UpgradeAvailable condition.
+type VersionReconciler struct {
+	mgr    mcmanager.Manager
+	newObj func() edgeapi.Connectable
+	latest func(context.Context) (string, error)
+}
+
+// SetupVersionWithManager registers the version controller for one connectable
+// kind. latest yields the hub's current release version (typically a cached
+// HubVersionCache.Get).
+func SetupVersionWithManager(mgr mcmanager.Manager, gvr schema.GroupVersionResource, newObj func() edgeapi.Connectable, latest func(context.Context) (string, error)) error {
+	r := &VersionReconciler{mgr: mgr, newObj: newObj, latest: latest}
+	return mcbuilder.ControllerManagedBy(mgr).
+		Named("version-" + gvr.Resource).
+		For(newObj()).
+		Complete(r)
+}
+
+// Reconcile keeps the UpgradeAvailable condition in sync with the agent-vs-hub
+// version delta. It only writes status when the condition actually changes, so a
+// steady state costs one periodic Get (usually cache-served) and no API writes.
+func (r *VersionReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
+	logger := klog.FromContext(ctx).WithValues("edge", req.Name, "cluster", req.ClusterName)
+
+	cl, err := r.mgr.GetCluster(ctx, req.ClusterName)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("getting cluster %s: %w", req.ClusterName, err)
+	}
+	c := cl.GetClient()
+
+	edge := r.newObj()
+	if err := c.Get(ctx, req.NamespacedName, edge); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	cs := edge.GetConnectionStatus()
+
+	// Nothing to compare until the agent has heartbeated a version at least once.
+	if cs.AgentVersion == "" {
+		return ctrl.Result{RequeueAfter: versionCheckInterval}, nil
+	}
+
+	latest, err := r.latest(ctx)
+	if err != nil {
+		// A transient hub-version fetch failure must not flap the condition;
+		// leave it as-is and retry sooner than the steady-state interval.
+		logger.V(2).Info("could not determine hub version, skipping upgrade check", "err", err)
+		return ctrl.Result{RequeueAfter: versionRetryInterval}, nil
+	}
+
+	desired := upgradeCondition(cs.AgentVersion, latest)
+	existing := meta.FindStatusCondition(cs.Conditions, edgeapi.ConnectionConditionUpgradeAvailable)
+	if existing != nil &&
+		existing.Status == desired.Status &&
+		existing.Reason == desired.Reason &&
+		existing.Message == desired.Message {
+		return ctrl.Result{RequeueAfter: versionCheckInterval}, nil
+	}
+
+	meta.SetStatusCondition(&cs.Conditions, desired)
+	if err := c.Status().Update(ctx, edge); err != nil {
+		return ctrl.Result{}, fmt.Errorf("updating upgrade condition: %w", err)
+	}
+	logger.Info("Updated upgrade condition", "status", desired.Status, "agentVersion", cs.AgentVersion, "hubVersion", latest)
+	return ctrl.Result{RequeueAfter: versionCheckInterval}, nil
+}
+
+// upgradeCondition builds the desired UpgradeAvailable condition. The True
+// message embeds the target version in a "upgrade available to <version>."
+// suffix the portal parses to render upgrade commands.
+func upgradeCondition(agentVersion, hubVersion string) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               edgeapi.ConnectionConditionUpgradeAvailable,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+	if agentOutdated(agentVersion, hubVersion) {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "NewVersionAvailable"
+		cond.Message = fmt.Sprintf("Agent is running %s; upgrade available to %s.", agentVersion, hubVersion)
+	} else {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "UpToDate"
+		cond.Message = fmt.Sprintf("Agent is running the current release (%s).", agentVersion)
+	}
+	return cond
+}
+
+// agentOutdated reports whether the agent should be upgraded: both versions must
+// be known, neither may be the placeholder "dev" build, and they must differ.
+// Mirrors the portal's historical isAgentOutdated so behaviour is unchanged.
+func agentOutdated(agentVersion, hubVersion string) bool {
+	if agentVersion == "" || hubVersion == "" {
+		return false
+	}
+	if agentVersion == "dev" || hubVersion == "dev" {
+		return false
+	}
+	return agentVersion != hubVersion
+}

--- a/providers/edges/internal/tunnel/svc_catalog.go
+++ b/providers/edges/internal/tunnel/svc_catalog.go
@@ -51,9 +51,9 @@ func snippet(b []byte) string {
 // catToolInput is the single, generic tool input. A tool's description tells the
 // model which of these to fill; reads typically need none.
 type catToolInput struct {
-	Query map[string]string `json:"query,omitempty" jsonschema:"description=Optional query-string parameters, e.g. {\"query\":\"ubuntu\"} for a search."`
-	Form  map[string]string `json:"form,omitempty" jsonschema:"description=Optional form fields for form-encoded APIs (qBittorrent actions), e.g. {\"urls\":\"magnet:?...\"}."`
-	Body  string            `json:"body,omitempty" jsonschema:"description=Optional raw JSON request body for JSON POST/PUT actions."`
+	Query map[string]string `json:"query,omitempty" jsonschema:"Optional query-string parameters, e.g. {\"query\":\"ubuntu\"} for a search."`
+	Form  map[string]string `json:"form,omitempty" jsonschema:"Optional form fields for form-encoded APIs (qBittorrent actions), e.g. {\"urls\":\"magnet:?...\"}."`
+	Body  string            `json:"body,omitempty" jsonschema:"Optional raw JSON request body for JSON POST/PUT actions."`
 }
 
 // registerCatalogTools installs the MCP tools for a catalog service type.

--- a/providers/edges/portal/src/Detail.vue
+++ b/providers/edges/portal/src/Detail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { ArrowLeft, RefreshCw, Trash2, CircleDot, Server, Boxes, Copy, Check, TerminalSquare, Home, Plug, Plus } from 'lucide-vue-next'
+import { ArrowLeft, RefreshCw, Trash2, CircleDot, Server, Boxes, Copy, Check, TerminalSquare, Home, Plug, Plus, ArrowUpCircle, ChevronDown, ChevronUp } from 'lucide-vue-next'
 import { getEdge, deleteEdge, listEdgeServices, connectEdgeService, createKubeEdgeService, deleteEdgeService } from './api'
 import type { EdgeDetail, EdgeService, EdgeType, ErrorResponse } from './types'
 
@@ -56,6 +56,33 @@ async function copy(text: string, field: string) {
     setTimeout(() => (copied.value = null), 2000)
   } catch { /* clipboard denied */ }
 }
+
+// ─── Upgrade ─────────────────────────────────────────────────────────
+// The version reconciler stamps an UpgradeAvailable condition (status True)
+// when the agent is behind the hub release, embedding the target version in the
+// message ("upgrade available to <version>."). We read that condition rather
+// than comparing versions client-side.
+const showUpgrade = ref(false)
+const upgradeCond = computed(() =>
+  edge.value?.conditions.find((c) => c.type === 'UpgradeAvailable' && c.status === 'True'),
+)
+const upgradeAvailable = computed(() => !!upgradeCond.value)
+const targetVersion = computed(() => {
+  const m = upgradeCond.value?.message?.match(/upgrade available to (\S+?)\.?$/)
+  return m?.[1] ?? 'latest'
+})
+const upgradeCliCommand = computed(() => `kedge agent upgrade ${props.name}`)
+const upgradeHelmSnippet = computed(
+  () => `helm upgrade kedge-agent oci://ghcr.io/faroshq/charts/kedge-agent \\
+  --namespace kedge-agent \\
+  --reuse-values \\
+  --set agent.image.tag=${targetVersion.value}`,
+)
+const upgradeServerSnippet = computed(
+  () => `curl -fsSL https://github.com/faroshq/kedge/releases/latest/download/kubectl-kedge_linux_amd64.tar.gz | tar xz
+sudo mv kubectl-kedge /usr/local/bin/kedge
+sudo systemctl restart kedge-agent-${props.name}`,
+)
 
 // ─── Services ────────────────────────────────────────────────────────
 // Server edges: discovered by the agent. Kube edges: declared here (a cluster
@@ -197,7 +224,15 @@ function rel(ts?: string): string {
             <CircleDot :size="12" /> {{ edge.connected ? 'Connected' : (edge.phase || 'Disconnected') }}
           </span>
         </div>
-        <div class="field"><span class="lbl">Agent version</span><span class="mono">{{ edge.agentVersion || '—' }}</span></div>
+        <div class="field">
+          <span class="lbl">Agent version</span>
+          <span class="row" style="gap: 6px;">
+            <span class="mono">{{ edge.agentVersion || '—' }}</span>
+            <span v-if="upgradeAvailable" class="status down" :title="upgradeCond?.message">
+              <ArrowUpCircle :size="11" /> Upgrade
+            </span>
+          </span>
+        </div>
         <div class="field"><span class="lbl">Hostname</span><span class="mono">{{ edge.hostname || '—' }}</span></div>
         <div class="field"><span class="lbl">Last heartbeat</span><span>{{ rel(edge.lastHeartbeatTime) }}</span></div>
         <div class="field"><span class="lbl">Created</span><span>{{ rel(edge.creationTimestamp) }}</span></div>
@@ -209,6 +244,54 @@ function rel(ts?: string): string {
         <h3>Labels</h3>
         <div class="chips">
           <span v-for="(v, k) in edge.labels" :key="k" class="pill">{{ k }}={{ v }}</span>
+        </div>
+      </div>
+
+      <!-- Upgrade available: agent behind the hub release (UpgradeAvailable condition). -->
+      <div v-if="upgradeAvailable" class="section">
+        <div class="banner warn" style="display: flex; align-items: center; justify-content: space-between; gap: 10px;">
+          <span class="row" style="gap: 6px;">
+            <ArrowUpCircle :size="14" />
+            {{ upgradeCond?.message || 'A newer agent version is available.' }}
+          </span>
+          <button class="btn sm" @click="showUpgrade = !showUpgrade">
+            {{ showUpgrade ? 'Hide' : 'Show' }} commands
+            <component :is="showUpgrade ? ChevronUp : ChevronDown" :size="14" />
+          </button>
+        </div>
+
+        <div v-if="showUpgrade" style="margin-top: 12px; display: flex; flex-direction: column; gap: 12px;">
+          <!-- Kubernetes: CLI or Helm. -->
+          <template v-if="type === 'kubernetes'">
+            <div class="snippet">
+              <div class="snippet-head"><span>Option A — CLI</span>
+                <button class="copy" @click="copy(upgradeCliCommand, 'up-cli')">
+                  <component :is="copied === 'up-cli' ? Check : Copy" :size="12" /> {{ copied === 'up-cli' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
+              <pre>{{ upgradeCliCommand }}</pre>
+            </div>
+            <div class="snippet">
+              <div class="snippet-head"><span>Option B — Helm</span>
+                <button class="copy" @click="copy(upgradeHelmSnippet, 'up-helm')">
+                  <component :is="copied === 'up-helm' ? Check : Copy" :size="12" /> {{ copied === 'up-helm' ? 'Copied' : 'Copy' }}
+                </button>
+              </div>
+              <pre>{{ upgradeHelmSnippet }}</pre>
+            </div>
+          </template>
+
+          <!-- Server: replace the binary and restart the unit. -->
+          <div v-else class="snippet">
+            <div class="snippet-head"><span>Replace binary and restart</span>
+              <button class="copy" @click="copy(upgradeServerSnippet, 'up-srv')">
+                <component :is="copied === 'up-srv' ? Check : Copy" :size="12" /> {{ copied === 'up-srv' ? 'Copied' : 'Copy' }}
+              </button>
+            </div>
+            <pre>{{ upgradeServerSnippet }}</pre>
+          </div>
+
+          <p class="muted" style="font-size: 11px;">After upgrading, the agent reports its new version on the next heartbeat and this notice clears.</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Context

Came out of debugging a **"UniFi Protect edge service unreachable"** report. The console itself was healthy the whole time (direct curl returned `200` with all 6 cameras on Protect `v7.1.87`); the failures were all on our side. Two fixes.

## 1. MCP tool server panic on every catalog service (the real blocker)

The edges provider was panic-looping while registering catalog tools:

```
panic: AddTool: tool "unify-protect_cameras": input schema:
  ForType(tunnel.catToolInput): tag must not begin with 'WORD='
  provider-edges/internal/tunnel/svc_catalog.go:67
```

`catToolInput`'s `jsonschema` struct tags used the `description=...` convention. But **jsonschema-go v0.4.3** uses the *entire tag verbatim* as the description and explicitly rejects any tag beginning with `WORD=` (`disallowedPrefixRegexp = ^[^ \t\n]*=`) — precisely to catch this old convention. So `mcp.AddTool` panicked → HTTP 500 on the MCP endpoint → assistants could not list cameras or call **any** catalog tool (not just UniFi — every catalog service shares `catToolInput`).

Fix: drop the `description=` prefix from the three tags so the tag is the plain description. Verified with `jsonschema.For[catToolInput]` (now infers cleanly; previously returned the `WORD=` error).

## 2. Surface the edge agent version

Adds `version_reconciler.go` (+ wiring through `controller_manager.go` / `setup.go`, a field on the edge API type, and the portal `Detail.vue` view) so the running agent's version is visible. This directly addresses the *first* symptom in the same investigation: an outdated agent returned `403 "svc target host not permitted"` and there was no way to see the agent was stale — now there is.

## Testing

- `go build ./...` and `go vet` clean for the provider.
- Schema inference for `catToolInput` verified via `jsonschema.For`.
- Direct curl through the (upgraded) agent → console returns `200` for `/proxy/protect/integration/v1/cameras`, confirming the tunnel data path; this PR unblocks exposing that through MCP.

## Release

Version is git-tag driven (`providers/edges/v*`). Tag `providers/edges/v0.0.16` to be cut by the maintainer after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)