### PR TITLE
feat(edges,agents): backend-default service instructions, snapshot retry, and image analysis

### DIFF
--- a/providers/agents/engine/engine.go
+++ b/providers/agents/engine/engine.go
@@ -14,6 +14,7 @@ package engine
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -57,10 +58,34 @@ type Tool struct {
 	Params     map[string]Param
 	JSONSchema map[string]any
 	// Exec runs the tool with the model-provided JSON arguments and returns
-	// the observation fed back to the model. An error is also fed back (as an
-	// error observation) rather than aborting the run.
+	// the text observation fed back to the model. An error is also fed back (as
+	// an error observation) rather than aborting the run. Set this for text-only
+	// tools; tools that can return images set ExecRich instead.
 	Exec func(ctx context.Context, argsJSON string) (string, error)
+	// ExecRich, when non-nil, is used in preference to Exec and may return
+	// images (e.g. a camera snapshot) alongside text. The engine feeds the text
+	// back as the tool observation and the images as a follow-up user message so
+	// vision-capable models can actually see them.
+	ExecRich func(ctx context.Context, argsJSON string) (Observation, error)
 }
+
+// ToolImage is binary image output from a tool (e.g. a UniFi Protect camera
+// snapshot), carried back to the model as vision input. Data is the raw,
+// un-encoded image bytes; the engine base64-encodes them for the model.
+type ToolImage struct {
+	MIMEType string // e.g. "image/jpeg"; defaults to image/jpeg when empty
+	Data     []byte
+}
+
+// Observation is a rich tool result: a text observation plus any images.
+type Observation struct {
+	Text   string
+	Images []ToolImage
+}
+
+// maxTurnImages caps how many tool-returned images are fed back to the model in
+// a single turn, so a fan-out of snapshot calls can't blow the token budget.
+const maxTurnImages = 8
 
 // ToolEvent reports a tool invocation to the caller (for SSE/UI + audit).
 type ToolEvent struct {
@@ -155,8 +180,13 @@ func (e *Engine) StreamTurnWithTools(
 		}
 
 		// Feed the assistant's tool-call message back, then execute each call
-		// and append its observation.
+		// and append its observation. Images returned by tools are collected and
+		// appended once, after all tool messages: the OpenAI wire format requires
+		// each tool_call to be answered by a contiguous tool message, and image
+		// content must ride on a user message (a tool-role message can't carry
+		// it), so the images become a single follow-up user turn.
 		in = append(in, full)
+		var turnImages []ToolImage
 		for _, tc := range full.ToolCalls {
 			name := tc.Function.Name
 			args := tc.Function.Arguments
@@ -164,12 +194,30 @@ func (e *Engine) StreamTurnWithTools(
 			var result string
 			var failed bool
 			if tool, ok := byName[name]; ok {
-				out, execErr := tool.Exec(ctx, args)
-				if execErr != nil {
-					result = "error: " + execErr.Error()
+				switch {
+				case tool.ExecRich != nil:
+					obs, execErr := tool.ExecRich(ctx, args)
+					if execErr != nil {
+						result = "error: " + execErr.Error()
+						failed = true
+					} else {
+						result = obs.Text
+						turnImages = append(turnImages, obs.Images...)
+						if result == "" && len(obs.Images) > 0 {
+							result = fmt.Sprintf("[returned %d image(s); shown below]", len(obs.Images))
+						}
+					}
+				case tool.Exec != nil:
+					out, execErr := tool.Exec(ctx, args)
+					if execErr != nil {
+						result = "error: " + execErr.Error()
+						failed = true
+					} else {
+						result = out
+					}
+				default:
+					result = fmt.Sprintf("error: tool %q has no executor", name)
 					failed = true
-				} else {
-					result = out
 				}
 			} else {
 				result = fmt.Sprintf("error: unknown tool %q", name)
@@ -179,6 +227,9 @@ func (e *Engine) StreamTurnWithTools(
 				onTool(ToolEvent{Name: name, Args: args, Result: result, Err: failed, Duration: time.Since(started)})
 			}
 			in = append(in, schema.ToolMessage(result, tc.ID, schema.WithToolName(name)))
+		}
+		if msg := imageUserMessage(turnImages); msg != nil {
+			in = append(in, msg)
 		}
 	}
 
@@ -284,6 +335,42 @@ func einoDataType(t string) schema.DataType {
 	default:
 		return schema.String
 	}
+}
+
+// imageUserMessage builds a synthetic user turn carrying tool-returned images
+// as vision input, or nil when there are none. Images beyond maxTurnImages are
+// dropped with a note so the truncation is honest rather than silent.
+func imageUserMessage(imgs []ToolImage) *schema.Message {
+	if len(imgs) == 0 {
+		return nil
+	}
+	note := "Images returned by the preceding tool call(s):"
+	if len(imgs) > maxTurnImages {
+		note += fmt.Sprintf(" (showing the first %d of %d)", maxTurnImages, len(imgs))
+		imgs = imgs[:maxTurnImages]
+	}
+	parts := []schema.MessageInputPart{{Type: schema.ChatMessagePartTypeText, Text: note}}
+	for _, img := range imgs {
+		if len(img.Data) == 0 {
+			continue
+		}
+		b64 := base64.StdEncoding.EncodeToString(img.Data)
+		mime := img.MIMEType
+		if mime == "" {
+			mime = "image/jpeg"
+		}
+		parts = append(parts, schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+			Image: &schema.MessageInputImage{
+				MessagePartCommon: schema.MessagePartCommon{Base64Data: &b64, MIMEType: mime},
+				Detail:            schema.ImageURLDetailAuto,
+			},
+		})
+	}
+	if len(parts) == 1 { // text note only: every image was empty
+		return nil
+	}
+	return &schema.Message{Role: schema.User, UserInputMultiContent: parts}
 }
 
 func toEino(msgs []Message) []*schema.Message {

--- a/providers/agents/engine/engine_test.go
+++ b/providers/agents/engine/engine_test.go
@@ -89,6 +89,7 @@ func (m *toolMockModel) WithTools(tools []*schema.ToolInfo) (einomodel.ToolCalli
 
 func (m *toolMockModel) Stream(_ context.Context, in []*schema.Message, _ ...einomodel.Option) (*schema.StreamReader[*schema.Message], error) {
 	m.calls++
+	m.gotIn = in
 	for _, msg := range in {
 		if msg.Role == schema.Tool {
 			m.sawToolMsg = true
@@ -151,6 +152,66 @@ func TestStreamTurnWithTools_ExecutesToolAndContinues(t *testing.T) {
 	if res.Usage.OutputTokens != 6 {
 		t.Fatalf("usage %+v", res.Usage)
 	}
+}
+
+func TestStreamTurnWithTools_ExecRichFeedsImageAsUserMessage(t *testing.T) {
+	m := &toolMockModel{}
+	png := []byte{0x89, 0x50, 0x4e, 0x47} // arbitrary bytes; content is opaque here
+
+	_, err := New().StreamTurnWithTools(context.Background(), m,
+		[]Message{{Role: RoleUser, Content: "snapshot please"}},
+		[]Tool{{
+			Name: "get_weather", Desc: "returns a snapshot",
+			Params: map[string]Param{"city": {Type: "string", Desc: "city", Required: true}},
+			ExecRich: func(_ context.Context, _ string) (Observation, error) {
+				return Observation{Images: []ToolImage{{MIMEType: "image/jpeg", Data: png}}}, nil
+			},
+		}},
+		8, nil, nil)
+	if err != nil {
+		t.Fatalf("StreamTurnWithTools: %v", err)
+	}
+	// m.gotIn holds the SECOND model call's input: it must include a synthetic
+	// user message carrying the image as vision input, right after the tool msg.
+	var imgMsg *schema.Message
+	for _, msg := range m.gotIn {
+		if msg.Role == schema.User && len(msg.UserInputMultiContent) > 0 {
+			imgMsg = msg
+		}
+	}
+	if imgMsg == nil {
+		t.Fatalf("no image user message fed back; got roles %v", rolesOf(m.gotIn))
+	}
+	var haveImage bool
+	for _, p := range imgMsg.UserInputMultiContent {
+		if p.Type == schema.ChatMessagePartTypeImageURL && p.Image != nil && p.Image.Base64Data != nil {
+			haveImage = true
+			if p.Image.MIMEType != "image/jpeg" {
+				t.Fatalf("image MIME = %q, want image/jpeg", p.Image.MIMEType)
+			}
+		}
+	}
+	if !haveImage {
+		t.Fatal("image user message had no base64 image part")
+	}
+	// The tool message itself must still carry a non-empty text observation.
+	var toolText string
+	for _, msg := range m.gotIn {
+		if msg.Role == schema.Tool {
+			toolText = msg.Content
+		}
+	}
+	if strings.TrimSpace(toolText) == "" {
+		t.Fatal("tool observation text was empty (should note images shown below)")
+	}
+}
+
+func rolesOf(msgs []*schema.Message) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, string(m.Role))
+	}
+	return out
 }
 
 func TestStreamTurnWithTools_UnknownToolReportsError(t *testing.T) {

--- a/providers/agents/tools/mcp.go
+++ b/providers/agents/tools/mcp.go
@@ -109,37 +109,45 @@ func ConnectMCPEndpoint(ctx context.Context, endpoint, bearer, prefix string, in
 			Name:       full,
 			Desc:       clip(t.Description, 1000),
 			JSONSchema: js,
-			Exec: func(ctx context.Context, argsJSON string) (string, error) {
+			// Rich executor: MCP tools can return images (e.g. a UniFi Protect
+			// snapshot), which the engine feeds to vision-capable models.
+			ExecRich: func(ctx context.Context, argsJSON string) (engine.Observation, error) {
 				var args map[string]any
 				if argsJSON != "" {
 					if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
-						return "", fmt.Errorf("invalid arguments: %w", err)
+						return engine.Observation{}, fmt.Errorf("invalid arguments: %w", err)
 					}
 				}
 				res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: toolName, Arguments: args})
 				if err != nil {
-					return "", err
+					return engine.Observation{}, err
 				}
-				text := mcpResultText(res)
+				text, images := mcpResultParts(res)
 				if res.IsError {
-					return "", fmt.Errorf("%s", clip(text, 2000))
+					return engine.Observation{}, fmt.Errorf("%s", clip(text, 2000))
 				}
-				return clip(text, webFetchMaxReturn), nil
+				return engine.Observation{Text: clip(text, webFetchMaxReturn), Images: images}, nil
 			},
 		})
 	}
 	return out, nil
 }
 
-func mcpResultText(res *mcp.CallToolResult) string {
+// mcpResultParts splits an MCP tool result into its concatenated text and any
+// image content (raw bytes + MIME type) for vision-capable models.
+func mcpResultParts(res *mcp.CallToolResult) (string, []engine.ToolImage) {
 	var b strings.Builder
+	var imgs []engine.ToolImage
 	for _, c := range res.Content {
-		if tc, ok := c.(*mcp.TextContent); ok {
+		switch tc := c.(type) {
+		case *mcp.TextContent:
 			b.WriteString(tc.Text)
 			b.WriteString("\n")
+		case *mcp.ImageContent:
+			imgs = append(imgs, engine.ToolImage{MIMEType: tc.MIMEType, Data: tc.Data})
 		}
 	}
-	return strings.TrimSpace(b.String())
+	return strings.TrimSpace(b.String()), imgs
 }
 
 // bearerTransport injects the connection token as a Bearer Authorization

--- a/providers/edges/internal/svccatalog/catalog.go
+++ b/providers/edges/internal/svccatalog/catalog.go
@@ -163,6 +163,15 @@ type Definition struct {
 	// Tools are the MCP operations exposed for this type. Serialized to the UI
 	// (name + description) so the portal can show what the agent can do.
 	Tools []Tool `json:"tools,omitempty"`
+
+	// Instructions is backend-authored default guidance for AI clients about
+	// this service type: quirks, gotchas, and recommended tool sequences (e.g.
+	// "doorbell snapshots can transiently 500 — retry, or fall back to events").
+	// It is composed into the MCP endpoint's "initialize" instructions ahead of
+	// any operator-authored spec.instructions, which extend or override it. Not
+	// user-provided — edit it here in the catalog — but serialized so the portal
+	// can display it as the default context an agent already has.
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // singleField is a helper for the common "one opaque token" credential.
@@ -407,9 +416,13 @@ var catalog = map[string]Definition{
 		Auth: AuthAPIKeyHeader, AuthParam: "X-API-KEY",
 		Credential: CredentialModel{Packing: PackSingle, Fields: singleField("apiKey", "API key", "UniFi OS → Control Plane → Integrations → create a local API key."), Hint: "A UniFi OS local API key (same key works for Network + Protect)."},
 		ProbePath: "/proxy/protect/integration/v1/cameras", ProbeMode: ProbeValidate,
+		Instructions: "The snapshot tool captures a live frame on demand, so it depends on the camera's current state. " +
+			"Battery- or power-managed cameras (notably G4/G5 doorbells) drop to standby and their snapshot may return a 500 \"UNKNOWN_ERROR\" until they wake — this is UniFi Protect's response, not a credential or connectivity fault. " +
+			"On a snapshot 500, retry the same camera a couple of times (waking it usually succeeds), or fall back to the events tool and use the most recent event's camera/thumbnail. " +
+			"Snapshots are returned as images you can view directly. Omit highQuality unless you specifically need full resolution — it makes the doorbell 500 more likely.",
 		Tools: []Tool{
 			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
-			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}).", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
+			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}). Live capture: may 500 on a sleeping doorbell — retry or use events.", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
 			{"events", "Recent Protect events (motion/person/vehicle). Query: start,end (ms epoch), types.", http.MethodGet, "/proxy/protect/integration/v1/events"},
 		},
 	},
@@ -433,6 +446,13 @@ func Get(t string) (Definition, bool) {
 func IsKnown(t string) bool {
 	_, ok := catalog[t]
 	return ok
+}
+
+// DefaultInstructions returns the backend-authored default agent guidance for a
+// service type, or "" if the type is unknown or has none. Callers compose it
+// into the MCP instructions ahead of the operator's spec.instructions.
+func DefaultInstructions(t string) string {
+	return catalog[t].Instructions
 }
 
 // HasTools reports whether a type exposes any MCP tools (data-driven or the

--- a/providers/edges/internal/tunnel/mcp_root.go
+++ b/providers/edges/internal/tunnel/mcp_root.go
@@ -111,11 +111,20 @@ func (p *Server) buildRootMCPServer(ctx context.Context, cluster, token string, 
 			"Service, tools named \"<service>_*\" (e.g. a Home Assistant service \"ha\" gives ha_states/ha_call_service; a qBittorrent service \"qb\" gives qb_torrents/qb_add).",
 		cluster,
 	)
-	// Append each registered service's own instructions so operator-authored
-	// context (entity naming, indexer prefs, safety notes) reaches the model.
+	// Append each registered service's guidance so backend-authored defaults
+	// (type quirks, tool sequences) and operator-authored context (entity naming,
+	// indexer prefs, safety notes) reach the model. The catalog default comes
+	// first; the operator's spec.instructions extends or overrides it.
 	for _, h := range toRegister {
+		var parts []string
+		if def := strings.TrimSpace(svccatalog.DefaultInstructions(h.reg.view.Spec.Type)); def != "" {
+			parts = append(parts, def)
+		}
 		if extra := strings.TrimSpace(h.reg.view.Spec.Instructions); extra != "" {
-			instructions += fmt.Sprintf("\n\nService %q (type %q, tools \"%s*\"):\n%s", h.reg.name, h.reg.view.Spec.Type, h.prefix, extra)
+			parts = append(parts, extra)
+		}
+		if len(parts) > 0 {
+			instructions += fmt.Sprintf("\n\nService %q (type %q, tools \"%s*\"):\n%s", h.reg.name, h.reg.view.Spec.Type, h.prefix, strings.Join(parts, "\n\n"))
 		}
 	}
 

--- a/providers/edges/internal/tunnel/mcp_service.go
+++ b/providers/edges/internal/tunnel/mcp_service.go
@@ -72,6 +72,11 @@ func (p *Server) buildServiceMCPServer(cluster, name, kcpToken string, svc *serv
 			"The call_service tool actuates physical devices — treat it with care.",
 		name, svc.Spec.Type, cluster,
 	)
+	// Backend-authored default guidance for the type (quirks, tool sequences),
+	// then the operator's own spec.instructions, which extend or override it.
+	if def := strings.TrimSpace(svccatalog.DefaultInstructions(svc.Spec.Type)); def != "" {
+		instructions += "\n\n" + def
+	}
 	if extra := strings.TrimSpace(svc.Spec.Instructions); extra != "" {
 		instructions += "\n\n" + extra
 	}

--- a/providers/edges/internal/tunnel/svc_catalog.go
+++ b/providers/edges/internal/tunnel/svc_catalog.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -125,14 +126,42 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 		path += "?" + q.Encode()
 	}
 
-	resp, err := haclient.DoWith(ctx, dialer, target, tool.Method, path, header, bodyReader)
-	if err != nil {
-		return toolErr(err.Error()), nil, nil
+	// Idempotent reads (GET with no body) are retried on a 5xx: some upstreams —
+	// notably UniFi Protect doorbell snapshots, which capture a live frame and
+	// 500 while the camera is waking — succeed on a second attempt. Anything with
+	// a body (POST actions) is sent once so we never repeat a side effect.
+	retryable := tool.Method == http.MethodGet && bodyReader == nil
+	var resp *http.Response
+	var respBody []byte
+	const maxAttempts = 3
+	for attempt := 1; ; attempt++ {
+		var err error
+		resp, err = haclient.DoWith(ctx, dialer, target, tool.Method, path, header, bodyReader)
+		if err != nil {
+			return toolErr(err.Error()), nil, nil
+		}
+		respBody, _ = io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+		resp.Body.Close() //nolint:errcheck
+		if retryable && resp.StatusCode >= 500 && attempt < maxAttempts {
+			select {
+			case <-ctx.Done():
+				return toolErr(ctx.Err().Error()), nil, nil
+			case <-time.After(time.Duration(attempt) * 400 * time.Millisecond):
+			}
+			continue
+		}
+		break
 	}
-	defer resp.Body.Close() //nolint:errcheck
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 	if resp.StatusCode >= 400 {
-		return toolErr(fmt.Sprintf("%s returned %d: %s", def.DisplayName, resp.StatusCode, snippet(respBody))), nil, nil
+		msg := fmt.Sprintf("%s returned %d: %s", def.DisplayName, resp.StatusCode, snippet(respBody))
+		// On a persistent upstream error, surface the type's default guidance so
+		// the model knows the sanctioned fallback (e.g. Protect: use events).
+		if resp.StatusCode >= 500 {
+			if hint := strings.TrimSpace(def.Instructions); hint != "" {
+				msg += "\n\nGuidance: " + hint
+			}
+		}
+		return toolErr(msg), nil, nil
 	}
 	// Binary image responses (e.g. a UniFi Protect camera snapshot) are returned
 	// as MCP image content so the model can actually see them.


### PR DESCRIPTION
## Why

Checking UniFi Protect snapshots through the agents interface surfaced three gaps:
1. The G4 Doorbell Pro `snapshot` tool returned `500 UNKNOWN_ERROR` while other cameras worked — a UniFi-side live-capture quirk (doorbells sleep), not our bug, but nothing told the agent that or retried.
2. That "retry / use events" knowledge lived nowhere the model could see it.
3. Even when a snapshot came back, the JPEG was **silently dropped** before any vision model — so the agent couldn't actually look at the image.

## What

**edges — backend-default instructions**
- New `Definition.Instructions`: backend-authored, type-level agent guidance composed into the MCP endpoint's `initialize` instructions **ahead of** the operator's `spec.instructions` (which still extends/overrides it). Serialized in `/catalog` so the portal can show it.
- Authored `unifi-protect` guidance: snapshot is a live capture; doorbells 500 while asleep; retry or fall back to `events`.

**edges — snapshot retry**
- Idempotent (GET, bodyless) catalog tool calls retry up to 3× on a 5xx with a ctx-cancellable backoff, so a waking doorbell self-heals. POST actions never repeat. A persistent 5xx now appends the type's guidance to the error.

**agents — image analysis**
- `engine.Tool` gains an optional `ExecRich` returning `Observation{Text, Images}`. The tool loop collects images and appends them as **one synthetic user turn** after the tool messages (OpenAI can't carry images on a tool-role message), capped at 8/turn with honest truncation. Text-only `Exec` tools are unchanged.
- The MCP wrapper extracts `mcp.ImageContent` and feeds it back as Eino base64 image parts (`UserInputMultiContent`), so vision-capable models can see a camera snapshot. PNG/WebP/etc. work — the upstream MIME type is threaded through, not assumed.

## Not included

App-studio: its MCP surface (infrastructure/databricks) emits no images and never touches the edges endpoint, so wiring vision there would be latent dead code. Deferred until an image-emitting tool lands there.

## Notes / follow-ups

- Reaching a real model requires a **vision-capable** tenant-configured model ID; a text-only model will ignore the image parts.
- Possible follow-up: replace the empty-MIME `image/jpeg` default in `imageUserMessage` with an `http.DetectContentType` sniff (only matters if a future tool returns image bytes with no MIME).

## Test plan

- `go build` + `go vet` clean on both providers (`providers/edges`, `providers/agents`).
- New engine test asserts an `ExecRich` image observation becomes a synthetic user message carrying a base64 image part, and the tool message keeps a non-empty text observation. Existing engine tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)