### PR TITLE
feat(agents): add a `wait` tool so agents can verify slow operations

### DIFF
--- a/providers/agents/tools/core.go
+++ b/providers/agents/tools/core.go
@@ -56,6 +56,32 @@ func Core(d Deps) []engine.Tool {
 func coreTools(d Deps) []engine.Tool {
 	return []engine.Tool{
 		{
+			Name: "wait",
+			Desc: "Pause for a few seconds before your next step, when an action needs time to take effect before you can verify it. Applies to any slow operation — a physical device finishing its motion (a gate, door, or cover), a service or container restarting, a deployment or provisioning settling, a job/build/query making progress, a state change propagating. Prefer a verify loop: act → wait → re-check (read state, poll status, take a snapshot, list results) → if not yet at the target state, act/wait/re-check again, until confirmed. Max 60 seconds per call.",
+			Params: map[string]engine.Param{
+				"seconds": {Type: "integer", Desc: "how long to wait, 1–60 seconds", Required: true},
+			},
+			Exec: func(ctx context.Context, argsJSON string) (string, error) {
+				args, err := parseArgs(argsJSON)
+				if err != nil {
+					return "", err
+				}
+				secs := argInt(args, "seconds")
+				if secs <= 0 {
+					secs = 5
+				}
+				if secs > 60 {
+					secs = 60
+				}
+				select {
+				case <-ctx.Done():
+					return "", ctx.Err()
+				case <-time.After(time.Duration(secs) * time.Second):
+				}
+				return fmt.Sprintf("waited %d seconds", secs), nil
+			},
+		},
+		{
 			Name: "memory_save",
 			Desc: "Save a durable memory note (title + body) you can recall in future conversations and runs.",
 			Params: map[string]engine.Param{

--- a/providers/agents/tools/tools.go
+++ b/providers/agents/tools/tools.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
 	"github.com/faroshq/provider-agents/llm"
@@ -85,6 +87,21 @@ func argString(args map[string]any, key string) string {
 		return v
 	}
 	return ""
+}
+
+// argInt reads an integer argument, tolerating the float64 that JSON numbers
+// decode to and a numeric string. Returns 0 when absent or unparseable.
+func argInt(args map[string]any, key string) int {
+	switch v := args[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case string:
+		n, _ := strconv.Atoi(strings.TrimSpace(v))
+		return n
+	}
+	return 0
 }
 
 func clip(s string, n int) string {


### PR DESCRIPTION
## Why

Observed with gate control: the agent sends `open_cover`, immediately snapshots, catches the gate **mid-motion** (half-open), and stops — reporting "can't confirm fully open" instead of waiting and re-checking. The same trap applies to any operation that takes time to take effect: a service/container restart, a deploy or provisioning settling, a long query or build.

The pieces for self-iteration were already there — the tool-call loop runs up to `maxIters` (16, configurable to 32), and (from #454) image results feed back to vision models. The missing primitive was a way to **wait for an action to take effect** before verifying it.

## What

Adds a `wait` tool to the core tool family:
- Bounded to **1–60s**, `ctx`-cancellable (never blocks a shutdown), defaults to 5s on a bad/zero value.
- Description is **operation-agnostic** and teaches the verify loop: *act → wait → re-check (read state, poll status, snapshot, list results) → if not yet at the target state, repeat until confirmed.* Device motion is one example among restarts/deploys/jobs/state propagation.
- New `argInt` helper (tolerates the float64 JSON numbers decode to, plus numeric strings).

## Not changed

`maxIters` and the image-feedback path were already sufficient; this is purely the missing "let it settle" primitive plus the loop nudge in the tool description.

## Test plan

- `go build` + `go vet` clean on `providers/agents`.
- Manual: an agent asked to "open the gate and confirm it's fully open" can now `open_cover` → `wait` → `snapshot` → repeat until the frame shows fully open.

Builds on #454 (image analysis), which is already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)