### PR TITLE
feat(agents): add a Chat button to each agent card on the agents list

### DIFF
--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -1050,6 +1050,9 @@ export class AgentsElement extends HTMLElement {
               <span>${ntrig} trigger${ntrig === 1 ? '' : 's'}</span>
               <span>${chan ? '📣 ' + escapeHTML(chan) : 'no channel'}</span>
             </div>
+            <div class="agents-card-actions">
+              <button class="agents-card-chat" data-chat="${escapeHTML(a.metadata.name)}">💬 Chat</button>
+            </div>
           </article>`
       })
       .join('')
@@ -1078,6 +1081,15 @@ export class AgentsElement extends HTMLElement {
   }
   private _wireHome(): void {
     this.querySelectorAll<HTMLElement>('.agents-card[data-agent]').forEach((el) => el.addEventListener('click', () => this._selectAgent(el.dataset.agent!)))
+    // Explicit Chat button on each card: opens the agent straight on its chat
+    // tab. Stops propagation so it reads as its own action (the whole card is
+    // also clickable and lands on the same place).
+    this.querySelectorAll<HTMLButtonElement>('.agents-card-chat[data-chat]').forEach((el) =>
+      el.addEventListener('click', (e) => {
+        e.stopPropagation()
+        this._selectAgent(el.dataset.chat!) // _selectAgent already opens the chat tab
+      }),
+    )
     this.querySelectorAll<HTMLElement>('[data-shared]').forEach((el) => el.addEventListener('click', () => this._openShared(el.dataset.shared as SharedView)))
     const nf = this.querySelector<HTMLFormElement>('.agents-card-new')
     nf?.addEventListener('submit', (e) => {

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -55,6 +55,18 @@ kedge-provider-agents .agents-card-foot {
   display: flex; flex-wrap: wrap; gap: 4px 12px; font-size: 11px; color: var(--color-text-muted, inherit);
   border-top: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.06)); padding-top: 10px;
 }
+kedge-provider-agents .agents-card-actions { display: flex; gap: 8px; }
+kedge-provider-agents .agents-card-chat {
+  flex: 1; padding: 8px 12px; font-size: 13px; font-weight: 600; cursor: pointer;
+  border-radius: 10px; border: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.06));
+  background: var(--color-accent-subtle, rgba(109, 79, 224, 0.1));
+  color: var(--color-accent, #6d4fe0);
+  transition: background 0.12s, border-color 0.12s;
+}
+kedge-provider-agents .agents-card-chat:hover {
+  border-color: var(--color-accent, #6d4fe0);
+  background: var(--color-accent, #6d4fe0); color: #fff;
+}
 /* new-agent card: a dashed tile with an inline create form */
 kedge-provider-agents .agents-card-new {
   border-style: dashed; align-items: stretch; justify-content: center; gap: 12px; cursor: default;


### PR DESCRIPTION
## Why

On the agents home grid (where all agents are listed), the only way to open an agent was to click the card body — no visible affordance for the primary action (chatting with the agent).

## What

Adds an explicit **💬 Chat** button to each agent card. It opens the agent straight on its chat tab (via the existing `_selectAgent`, which already defaults to the chat tab). `stopPropagation` keeps it a distinct action; clicking anywhere else on the card still lands on the same place.

- `element.ts`: button in the card template + wiring in `_wireHome`.
- `style.css`: accent-styled button matching the existing card design tokens.

## Test plan

- `vite build` clean (portal `dist` is built in CI, not committed).
- Manual: agents list → each card shows a Chat button → clicking it opens that agent's chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)