### PR TITLE
fix(agents): Chat button lands on chat tab, not the flow editor

### DIFF
--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -1087,7 +1087,10 @@ export class AgentsElement extends HTMLElement {
     this.querySelectorAll<HTMLButtonElement>('.agents-card-chat[data-chat]').forEach((el) =>
       el.addEventListener('click', (e) => {
         e.stopPropagation()
-        this._selectAgent(el.dataset.chat!) // _selectAgent already opens the chat tab
+        // Land on the chat tab, not the flow editor: the detail renders flow
+        // whenever _agentView is 'flow' (its default), regardless of _agentTab.
+        this._agentView = 'list'
+        this._selectAgent(el.dataset.chat!) // sets _agentTab = 'chat' and renders
       }),
     )
     this.querySelectorAll<HTMLElement>('[data-shared]').forEach((el) => el.addEventListener('click', () => this._openShared(el.dataset.shared as SharedView)))


### PR DESCRIPTION
## Why

Follow-up to #456. The new per-card **💬 Chat** button opened the **flow editor** instead of the chat.

The agent detail renders the flow diagram whenever `_agentView === 'flow'` (its default) — *regardless* of `_agentTab`:

```ts
const flow = this._agentView === 'flow'
const listBody = flow ? '' : this._agentTab === 'chat' ? this._renderChat(a) : …
```

`_selectAgent` sets `_agentTab = 'chat'` but never touches `_agentView`, so the button landed on flow.

## Fix

Set `_agentView = 'list'` before selecting, mirroring the existing "Open chat" affordance (`[data-openchat]`), which already sets both `_agentView='list'` and `_agentTab='chat'`. One line in the button's click handler.

## Test plan

- `vite build` clean.
- Manual: agents list → card Chat button → now opens the agent's **chat**, not the flow diagram. Clicking the card body still opens the flow editor as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)