### PR TITLE
fix(edges): remove the broken UniFi Protect events tool

### DIFF
--- a/providers/edges/internal/svccatalog/catalog.go
+++ b/providers/edges/internal/svccatalog/catalog.go
@@ -410,7 +410,7 @@ var catalog = map[string]Definition{
 	},
 	"unifi-protect": {
 		Type: "unifi-protect", DisplayName: "UniFi Protect", Category: "Network",
-		Description: "UniFi OS console — cameras, snapshots, events.",
+		Description: "UniFi OS console — cameras and snapshots.",
 		DefaultPort: 443, DefaultScheme: "https", SchemeLocked: true,
 		HostRequired: true, HostHelp: "The UniFi console address, e.g. 192.168.1.1.",
 		Auth: AuthAPIKeyHeader, AuthParam: "X-API-KEY",
@@ -418,12 +418,12 @@ var catalog = map[string]Definition{
 		ProbePath: "/proxy/protect/integration/v1/cameras", ProbeMode: ProbeValidate,
 		Instructions: "The snapshot tool captures a live frame on demand, so it depends on the camera's current state. " +
 			"Battery- or power-managed cameras (notably G4/G5 doorbells) drop to standby and their snapshot may return a 500 \"UNKNOWN_ERROR\" until they wake — this is UniFi Protect's response, not a credential or connectivity fault. " +
-			"On a snapshot 500, retry the same camera a couple of times (waking it usually succeeds), or fall back to the events tool and use the most recent event's camera/thumbnail. " +
-			"Snapshots are returned as images you can view directly. Omit highQuality unless you specifically need full resolution — it makes the doorbell 500 more likely.",
+			"On a snapshot 500, retry the same camera a couple of times (waking it usually succeeds), or take a snapshot from another camera covering the same area. " +
+			"Snapshots are returned as images you can view directly. Omit highQuality unless you specifically need full resolution — it makes the doorbell 500 more likely. " +
+			"There is no event-history tool: UniFi Protect's Integration API delivers events only over a WebSocket (/subscribe/events), not as a REST list, so recent motion/ring/smart-detect events cannot be queried here. Use the cameras and snapshot tools to observe current state.",
 		Tools: []Tool{
 			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
-			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}). Live capture: may 500 on a sleeping doorbell — retry or use events.", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
-			{"events", "Recent Protect events (motion/person/vehicle). Query: start,end (ms epoch), types.", http.MethodGet, "/proxy/protect/integration/v1/events"},
+			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}). Live capture: may 500 on a sleeping doorbell — retry or try another camera.", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
 		},
 	},
 	"generic": {


### PR DESCRIPTION
## Why

Calling the UniFi Protect `events` tool returns:

```
404 NOT_FOUND: Entity 'endpoint' not found
GET /integration/v1/events
```

UniFi Protect's **Integration API v1 has no REST events list**. Events are delivered **only over a WebSocket** (`/proxy/protect/integration/v1/subscribe/events`), which a one-shot HTTP proxy tool can't consume. So the `events` tool never worked — and, worse, the guidance I added earlier (and the `snapshot` tool description) told the model to *"fall back to the events tool"*, sending it to a dead endpoint.

## What

- **Remove** the `events` tool from the `unifi-protect` catalog entry.
- **Correct the guidance**: the snapshot fallback is now "retry, or take a snapshot from another camera covering the same area." The instructions now state plainly that event history isn't queryable here (websocket-only), so the model stops trying.
- Tidy the type `Description` ("cameras and snapshots") and the `snapshot` tool blurb.

## Follow-up (not in this PR)

A real events capability would need a WebSocket-backed subscription tool (persistent stream → recent-events buffer), which doesn't fit the current one-shot HTTP tool model. Filing separately if wanted. The legacy internal API (`/proxy/protect/api/events?start=&end=&types=`) *does* offer a REST list, but it authenticates differently from the integration `X-API-KEY` and would likely 401 — untested, so intentionally not used here.

## Test plan

- `go build` + `go vet` clean on `providers/edges/internal/svccatalog`.
- The `events` tool no longer registers, so agents won't attempt the 404 endpoint; the instructions no longer reference it.

Sources on the API shape: [UI community — Protect API subscribe endpoints](https://community.ui.com/questions/How-to-use-Protect-API-subscribe-endpoints/b97ca438-6326-48e2-877a-464bd4084075), [hjdhjd/unifi-protect](https://github.com/hjdhjd/unifi-protect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)