### PR TITLE
feat(edges): WebSocket-backed UniFi Protect events (per-tenant store + subscriber)

### DIFF
--- a/providers/edges/controller_manager.go
+++ b/providers/edges/controller_manager.go
@@ -32,6 +32,7 @@ import (
 	mcmulticluster "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	edgectrl "github.com/faroshq/provider-edges/internal/edgectrl"
+	"github.com/faroshq/provider-edges/internal/events"
 	"github.com/faroshq/provider-edges/internal/scheduler"
 	"github.com/faroshq/provider-edges/internal/servicectrl"
 	"github.com/faroshq/provider-edges/internal/status"
@@ -50,6 +51,11 @@ var errControllerDisabled = errors.New("no kubeconfig available; edge controller
 // watches. By convention (provider-sdk) the slice name equals the APIExport
 // name — see sdkinstall.Bootstrap / EnsureAPIExportEndpointSlice.
 const endpointSliceName = apiExportName
+
+// eventsMaxAge bounds how long an edge event is retained in the in-memory store
+// (on top of the per-service count cap), so the "recent events" a tool returns
+// stay recent even for a quiet camera.
+const eventsMaxAge = 6 * time.Hour
 
 // startEdgeControllerManager builds the multicluster manager and starts the
 // edge token / RBAC / lifecycle reconcilers. connManager wires the lifecycle
@@ -139,6 +145,17 @@ func startEdgeControllerManager(ctx context.Context, config *rest.Config, tsrv *
 		return fmt.Errorf("Workload status aggregator: %w", err)
 	}
 
+	// Edge event subscribers (currently UniFi Protect): a per-tenant, per-service
+	// event store the validation reconciler feeds via WebSocket subscribers, and
+	// the MCP `events` tool reads. The in-memory store is bounded per service and
+	// sits behind an interface so it can be swapped for Redis once the provider
+	// scales past the revdial single-replica invariant. Both the writer (manager)
+	// and reader (tunnel Server) share the one store; subscriber goroutines live
+	// under ctx, so they stop on shutdown.
+	eventStore := events.NewMemoryStore(events.DefaultPerServiceCap, eventsMaxAge)
+	eventsMgr := events.NewManager(ctx, eventStore, ctrl.Log.WithName("edge-events"))
+	tsrv.SetEventStore(eventStore)
+
 	// EdgeService controllers (LinuxServer edges): the discovery reconciler
 	// pulls host services from each connected agent and materializes an
 	// EdgeService per service; the validation reconciler checks configured
@@ -146,6 +163,7 @@ func startEdgeControllerManager(ctx context.Context, config *rest.Config, tsrv *
 	// ConnManager for agent dials.
 	if err := servicectrl.SetupWithManager(mgr, connManager, servicectrl.Options{
 		EdgeProxyPublicPath: edgeProxyPublicPath,
+		Events:              eventsMgr,
 	}); err != nil {
 		return fmt.Errorf("EdgeService controllers: %w", err)
 	}

--- a/providers/edges/internal/events/event.go
+++ b/providers/edges/internal/events/event.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// Event is a normalized edge event, provider-agnostic in shape so the Store and
+// the MCP tool don't depend on UniFi specifics. Timestamps are absolute; the
+// original vendor payload is not retained (only the fields below are stored).
+type Event struct {
+	// ID is the vendor event id (best effort; may be empty).
+	ID string `json:"id,omitempty"`
+	// Type is the normalized event type, e.g. "motion", "ring", "smartDetect".
+	Type string `json:"type"`
+	// Start is when the event began.
+	Start time.Time `json:"start"`
+	// End is when the event ended, if known.
+	End time.Time `json:"end,omitempty"`
+	// CameraID is the source camera id, if the event is camera-scoped.
+	CameraID string `json:"cameraId,omitempty"`
+	// Score is the detection confidence (0–100), if reported.
+	Score int `json:"score,omitempty"`
+	// SmartTypes lists smart-detection classes (person, vehicle, package…),
+	// when the event carries them.
+	SmartTypes []string `json:"smartTypes,omitempty"`
+}
+
+// decodeUniFiFrame parses one UniFi Protect Integration API `/subscribe/events`
+// WebSocket message into zero or more normalized Events. It is deliberately
+// tolerant: the integration feed wraps event items in an envelope whose exact
+// field names have shifted across Protect versions, so we accept the common
+// spellings and skip anything we can't place rather than failing the stream.
+//
+// NOTE: the precise frame schema should be confirmed against a live console;
+// unrecognized shapes are returned as (nil, nil) so an unexpected message never
+// tears down the subscription.
+func decodeUniFiFrame(data []byte) ([]Event, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "pong" {
+		return nil, nil
+	}
+
+	// The feed may deliver a single object or an array of them.
+	var raw json.RawMessage = data
+	var arr []json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		arr = []json.RawMessage{raw}
+	}
+
+	var out []Event
+	for _, item := range arr {
+		ev, ok := decodeUniFiItem(item)
+		if ok {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+// uniFiEnvelope models the wrapper the integration feed may use: an action plus
+// the event nested under "item" or "data". When neither is present the event
+// fields are read from the message itself. Unknown fields are ignored.
+type uniFiEnvelope struct {
+	Action string          `json:"action,omitempty"`
+	Item   json.RawMessage `json:"item,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+type uniFiEventFields struct {
+	ID        string `json:"id,omitempty"`
+	EventType string `json:"type,omitempty"`
+	// Timestamps are epoch milliseconds in the Protect feed.
+	Start int64 `json:"start,omitempty"`
+	End   int64 `json:"end,omitempty"`
+	// Camera id under either "camera" or "cameraId".
+	Camera   string `json:"camera,omitempty"`
+	CameraID string `json:"cameraId,omitempty"`
+	Score    int    `json:"score,omitempty"`
+	// Smart-detect classes under either spelling.
+	SmartDetectTypes []string `json:"smartDetectTypes,omitempty"`
+	SmartTypes       []string `json:"smartTypes,omitempty"`
+}
+
+func decodeUniFiItem(item json.RawMessage) (Event, bool) {
+	var env uniFiEnvelope
+	_ = json.Unmarshal(item, &env) // best-effort: no wrapper is fine
+	// Read event fields from the nested payload when present, else the message.
+	payload := env.Item
+	if len(payload) == 0 {
+		payload = env.Data
+	}
+	if len(payload) == 0 {
+		payload = item
+	}
+	var fields uniFiEventFields
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return Event{}, false
+	}
+
+	typ := fields.EventType
+	if typ == "" {
+		return Event{}, false // not an event frame (e.g. a keep-alive/status)
+	}
+	cam := firstNonEmpty(fields.CameraID, fields.Camera)
+	smart := fields.SmartTypes
+	if len(smart) == 0 {
+		smart = fields.SmartDetectTypes
+	}
+	ev := Event{
+		ID:         fields.ID,
+		Type:       typ,
+		CameraID:   cam,
+		Score:      fields.Score,
+		SmartTypes: smart,
+	}
+	if fields.Start > 0 {
+		ev.Start = time.UnixMilli(fields.Start).UTC()
+	} else {
+		ev.Start = time.Now().UTC() // feed omitted a timestamp; stamp on receipt
+	}
+	if fields.End > 0 {
+		ev.End = time.UnixMilli(fields.End).UTC()
+	}
+	return ev, true
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/providers/edges/internal/events/event_test.go
+++ b/providers/edges/internal/events/event_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import "testing"
+
+func TestDecodeUniFiFrame_Inline(t *testing.T) {
+	// Epoch millis for a fixed instant.
+	const startMs = 1_700_000_000_000
+	data := []byte(`{"id":"e1","type":"smartDetectZone","start":1700000000000,"camera":"cam1","score":88,"smartDetectTypes":["person"]}`)
+	evs, err := decodeUniFiFrame(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("want 1 event, got %d", len(evs))
+	}
+	e := evs[0]
+	if e.ID != "e1" || e.Type != "smartDetectZone" || e.CameraID != "cam1" || e.Score != 88 {
+		t.Fatalf("bad decode: %+v", e)
+	}
+	if e.Start.UnixMilli() != startMs {
+		t.Fatalf("bad start: %v", e.Start)
+	}
+	if len(e.SmartTypes) != 1 || e.SmartTypes[0] != "person" {
+		t.Fatalf("bad smart types: %v", e.SmartTypes)
+	}
+}
+
+func TestDecodeUniFiFrame_NestedItemAndArray(t *testing.T) {
+	// An array of envelopes with the event nested under "item", using cameraId.
+	data := []byte(`[{"action":"add","item":{"id":"a","type":"motion","start":1700000000000,"cameraId":"c9"}},{"action":"add","item":{"id":"b","type":"ring","start":1700000001000,"camera":"c9"}}]`)
+	evs, err := decodeUniFiFrame(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events, got %d", len(evs))
+	}
+	if evs[0].Type != "motion" || evs[0].CameraID != "c9" {
+		t.Fatalf("bad first: %+v", evs[0])
+	}
+	if evs[1].Type != "ring" || evs[1].CameraID != "c9" {
+		t.Fatalf("bad second: %+v", evs[1])
+	}
+}
+
+func TestDecodeUniFiFrame_SkipsNonEvents(t *testing.T) {
+	// Keep-alive / status frames without a type must not produce events, and
+	// must not error (the stream keeps running).
+	for _, raw := range []string{`{"hello":"world"}`, `pong`, ``, `{}`} {
+		evs, err := decodeUniFiFrame([]byte(raw))
+		if err != nil {
+			t.Fatalf("%q errored: %v", raw, err)
+		}
+		if len(evs) != 0 {
+			t.Fatalf("%q produced events: %+v", raw, evs)
+		}
+	}
+}
+
+func TestDecodeUniFiFrame_StampsMissingTimestamp(t *testing.T) {
+	evs, err := decodeUniFiFrame([]byte(`{"type":"motion","camera":"c1"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("want 1, got %d", len(evs))
+	}
+	if evs[0].Start.IsZero() {
+		t.Fatal("expected a receipt timestamp when the feed omits start")
+	}
+}

--- a/providers/edges/internal/events/manager.go
+++ b/providers/edges/internal/events/manager.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+// Manager owns the set of running event subscribers, one per tenant+service
+// Key. The Service reconciler calls Ensure when a Service is Ready and Stop when
+// it is deleted or goes NotReady; Manager makes the running set match. All
+// subscriber goroutines are children of the base context passed to NewManager,
+// so they exit on provider shutdown.
+type Manager struct {
+	base   context.Context
+	store  Store
+	logger logr.Logger
+
+	mu   sync.Mutex
+	subs map[Key]*subHandle
+}
+
+// subHandle is one running subscriber, identified by pointer so a goroutine can
+// tell whether the slot it started still belongs to it.
+type subHandle struct{ cancel context.CancelFunc }
+
+// NewManager returns a Manager writing to store. base bounds every subscriber's
+// lifetime (typically the controller-manager context).
+func NewManager(base context.Context, store Store, logger logr.Logger) *Manager {
+	return &Manager{
+		base:   base,
+		store:  store,
+		logger: logger,
+		subs:   map[Key]*subHandle{},
+	}
+}
+
+// Store returns the backing store (for the MCP events tool to read).
+func (m *Manager) Store() Store { return m.store }
+
+// Ensure starts a subscriber for cfg.Key if one isn't already running. It is
+// idempotent: repeated calls for an already-running Key are no-ops, so the
+// reconciler can call it on every Ready reconcile without churn. Subscribers
+// resolve their dialer lazily, so an edge that isn't connected yet is handled by
+// the subscriber's own retry loop rather than needing a restart here.
+func (m *Manager) Ensure(cfg SubscriberConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, running := m.subs[cfg.Key]; running {
+		return
+	}
+	ctx, cancel := context.WithCancel(m.base)
+	handle := &subHandle{cancel: cancel}
+	m.subs[cfg.Key] = handle
+	cfg.Store = m.store
+	if cfg.Logger.GetSink() == nil {
+		cfg.Logger = m.logger
+	}
+	go func() {
+		runSubscriber(ctx, cfg) // returns only when ctx is cancelled
+		// Release our slot if it's still ours (base-context shutdown path; the
+		// Stop path already removed it under the lock).
+		m.mu.Lock()
+		if m.subs[cfg.Key] == handle {
+			delete(m.subs, cfg.Key)
+		}
+		m.mu.Unlock()
+	}()
+	m.logger.V(2).Info("events subscriber started", "cluster", cfg.Key.Cluster, "service", cfg.Key.Service)
+}
+
+// Stop cancels the subscriber for key (if any) and clears its stored events, so
+// a stopped stream leaves nothing stale behind for the MCP tool to read.
+func (m *Manager) Stop(ctx context.Context, key Key) {
+	m.mu.Lock()
+	handle := m.subs[key]
+	delete(m.subs, key)
+	m.mu.Unlock()
+	if handle != nil {
+		handle.cancel()
+		m.logger.V(2).Info("events subscriber stopped", "cluster", key.Cluster, "service", key.Service)
+	}
+	_ = m.store.Clear(ctx, key)
+}

--- a/providers/edges/internal/events/store.go
+++ b/providers/edges/internal/events/store.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package events collects edge event streams (currently UniFi Protect's
+// WebSocket event feed) into a per-tenant, per-service store that the MCP
+// `events` tool reads. Storage sits behind the Store interface so the default
+// bounded in-memory ring can be swapped for Redis (or another shared backend)
+// once the provider scales past the single replica that the revdial tunnel
+// currently pins each edge to.
+package events
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Key is the isolation scope for a stream of events: exactly one tenant
+// workspace (kcp logical cluster) and one Service. Every Store operation is
+// scoped by a Key, so events never leak across tenants, workspaces, or
+// services — the Cluster field is the hard tenant boundary.
+type Key struct {
+	// Cluster is the kcp logical cluster (tenant workspace) the Service lives in.
+	Cluster string
+	// Service is the Service.metadata.name.
+	Service string
+}
+
+// Filter narrows a List query. The zero value returns everything held for the
+// Key (up to the store's own bound), newest first.
+type Filter struct {
+	// Since, when set, drops events that started before it.
+	Since time.Time
+	// Types, when non-empty, keeps only events whose Type is in the set.
+	Types []string
+	// CameraID, when set, keeps only events from that camera.
+	CameraID string
+	// Limit caps the number of returned events (most recent first). 0 = no cap.
+	Limit int
+}
+
+// Store persists edge events per Key. Implementations MUST be safe for
+// concurrent use and MUST isolate events strictly by Key — a List for one Key
+// must never observe another Key's events. The default in-memory implementation
+// lives here; a Redis-backed implementation can satisfy the same contract for
+// multi-replica deployments (LPUSH/LTRIM per key with a TTL).
+type Store interface {
+	// Append records one event under key.
+	Append(ctx context.Context, key Key, ev Event) error
+	// List returns events for key matching filter, most recent first.
+	List(ctx context.Context, key Key, f Filter) ([]Event, error)
+	// Clear drops all events for key. Called when a subscriber stops (the
+	// Service was deleted or went NotReady) so a stopped stream leaves nothing
+	// stale behind.
+	Clear(ctx context.Context, key Key) error
+}
+
+// MemoryStore is the default Store: a bounded ring buffer per Key, held in the
+// provider process. It is the right fit while the revdial tunnel pins each edge
+// to a single replica (the subscriber that writes and the MCP tool that reads
+// share this process). Events are lost on a provider restart; the subscriber
+// resumes the stream on reconnect, so only the restart window is missed.
+type MemoryStore struct {
+	mu      sync.RWMutex
+	rings   map[Key]*ring
+	perKey  int           // max events retained per Key
+	maxAge  time.Duration // drop events older than this on read (0 = no age bound)
+	nowFunc func() time.Time
+}
+
+// DefaultPerServiceCap is the number of events retained per Service (per tenant
+// workspace) when the caller doesn't specify one — a hard bound so a busy camera
+// can't grow the in-memory store without limit.
+const DefaultPerServiceCap = 1000
+
+// NewMemoryStore returns a MemoryStore retaining up to perKey events per Key and
+// (when maxAge > 0) dropping events older than maxAge on read. A non-positive
+// perKey falls back to DefaultPerServiceCap.
+func NewMemoryStore(perKey int, maxAge time.Duration) *MemoryStore {
+	if perKey <= 0 {
+		perKey = DefaultPerServiceCap
+	}
+	return &MemoryStore{
+		rings:   map[Key]*ring{},
+		perKey:  perKey,
+		maxAge:  maxAge,
+		nowFunc: time.Now,
+	}
+}
+
+func (s *MemoryStore) Append(_ context.Context, key Key, ev Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r := s.rings[key]
+	if r == nil {
+		r = newRing(s.perKey)
+		s.rings[key] = r
+	}
+	r.push(ev)
+	return nil
+}
+
+func (s *MemoryStore) List(_ context.Context, key Key, f Filter) ([]Event, error) {
+	s.mu.RLock()
+	r := s.rings[key]
+	if r == nil {
+		s.mu.RUnlock()
+		return nil, nil
+	}
+	all := r.snapshot()
+	s.mu.RUnlock()
+
+	cutoff := time.Time{}
+	if s.maxAge > 0 {
+		cutoff = s.nowFunc().Add(-s.maxAge)
+	}
+	if f.Since.After(cutoff) {
+		cutoff = f.Since
+	}
+	var typeSet map[string]struct{}
+	if len(f.Types) > 0 {
+		typeSet = make(map[string]struct{}, len(f.Types))
+		for _, t := range f.Types {
+			typeSet[t] = struct{}{}
+		}
+	}
+
+	out := make([]Event, 0, len(all))
+	for _, ev := range all {
+		if !cutoff.IsZero() && ev.Start.Before(cutoff) {
+			continue
+		}
+		if typeSet != nil {
+			if _, ok := typeSet[ev.Type]; !ok {
+				continue
+			}
+		}
+		if f.CameraID != "" && ev.CameraID != f.CameraID {
+			continue
+		}
+		out = append(out, ev)
+	}
+	// Newest first.
+	sort.Slice(out, func(i, j int) bool { return out[i].Start.After(out[j].Start) })
+	if f.Limit > 0 && len(out) > f.Limit {
+		out = out[:f.Limit]
+	}
+	return out, nil
+}
+
+func (s *MemoryStore) Clear(_ context.Context, key Key) error {
+	s.mu.Lock()
+	delete(s.rings, key)
+	s.mu.Unlock()
+	return nil
+}
+
+// ring is a fixed-capacity FIFO overwriting the oldest entry when full.
+type ring struct {
+	buf   []Event
+	next  int
+	count int
+}
+
+func newRing(cap int) *ring { return &ring{buf: make([]Event, cap)} }
+
+func (r *ring) push(ev Event) {
+	r.buf[r.next] = ev
+	r.next = (r.next + 1) % len(r.buf)
+	if r.count < len(r.buf) {
+		r.count++
+	}
+}
+
+// snapshot returns the retained events in insertion order (oldest first).
+func (r *ring) snapshot() []Event {
+	out := make([]Event, 0, r.count)
+	start := 0
+	if r.count == len(r.buf) {
+		start = r.next // buffer is full; oldest is at next
+	}
+	for i := 0; i < r.count; i++ {
+		out = append(out, r.buf[(start+i)%len(r.buf)])
+	}
+	return out
+}

--- a/providers/edges/internal/events/store_test.go
+++ b/providers/edges/internal/events/store_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func ev(id, typ, cam string, t time.Time) Event {
+	return Event{ID: id, Type: typ, CameraID: cam, Start: t}
+}
+
+func TestMemoryStore_RingCapEvictsOldest(t *testing.T) {
+	s := NewMemoryStore(3, 0)
+	k := Key{Cluster: "c1", Service: "cam"}
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < 5; i++ {
+		if err := s.Append(context.Background(), k, ev(string(rune('a'+i)), "motion", "x", base.Add(time.Duration(i)*time.Second))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := s.List(context.Background(), k, Filter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 retained (cap), got %d", len(got))
+	}
+	// Newest first; the two oldest (a,b) were evicted, leaving e,d,c.
+	if got[0].ID != "e" || got[2].ID != "c" {
+		t.Fatalf("unexpected retained order: %v", ids(got))
+	}
+}
+
+func TestMemoryStore_IsolationByKey(t *testing.T) {
+	s := NewMemoryStore(10, 0)
+	now := time.Unix(1_700_000_000, 0)
+	a := Key{Cluster: "tenantA", Service: "cam"}
+	b := Key{Cluster: "tenantB", Service: "cam"} // same service name, different tenant
+	_ = s.Append(context.Background(), a, ev("a1", "motion", "x", now))
+	_ = s.Append(context.Background(), b, ev("b1", "ring", "y", now))
+
+	ga, _ := s.List(context.Background(), a, Filter{})
+	gb, _ := s.List(context.Background(), b, Filter{})
+	if len(ga) != 1 || ga[0].ID != "a1" {
+		t.Fatalf("tenantA leak/miss: %v", ids(ga))
+	}
+	if len(gb) != 1 || gb[0].ID != "b1" {
+		t.Fatalf("tenantB leak/miss: %v", ids(gb))
+	}
+}
+
+func TestMemoryStore_Filter(t *testing.T) {
+	s := NewMemoryStore(50, 0)
+	k := Key{Cluster: "c", Service: "cam"}
+	now := time.Unix(1_700_000_000, 0)
+	_ = s.Append(context.Background(), k, ev("old", "motion", "cam1", now.Add(-2*time.Hour)))
+	_ = s.Append(context.Background(), k, ev("m1", "motion", "cam1", now.Add(-10*time.Minute)))
+	_ = s.Append(context.Background(), k, ev("r1", "ring", "cam2", now.Add(-5*time.Minute)))
+
+	// Since drops the 2h-old event.
+	got, _ := s.List(context.Background(), k, Filter{Since: now.Add(-30 * time.Minute)})
+	if len(got) != 2 {
+		t.Fatalf("since: want 2, got %v", ids(got))
+	}
+	// Type filter.
+	got, _ = s.List(context.Background(), k, Filter{Types: []string{"ring"}})
+	if len(got) != 1 || got[0].ID != "r1" {
+		t.Fatalf("types: got %v", ids(got))
+	}
+	// Camera filter.
+	got, _ = s.List(context.Background(), k, Filter{CameraID: "cam1"})
+	if len(got) != 2 {
+		t.Fatalf("camera: want 2, got %v", ids(got))
+	}
+	// Limit, newest first.
+	got, _ = s.List(context.Background(), k, Filter{Limit: 1})
+	if len(got) != 1 || got[0].ID != "r1" {
+		t.Fatalf("limit: got %v", ids(got))
+	}
+}
+
+func TestMemoryStore_MaxAgeOnRead(t *testing.T) {
+	s := NewMemoryStore(50, time.Hour)
+	fixed := time.Unix(1_700_000_000, 0)
+	s.nowFunc = func() time.Time { return fixed }
+	k := Key{Cluster: "c", Service: "cam"}
+	_ = s.Append(context.Background(), k, ev("stale", "motion", "x", fixed.Add(-2*time.Hour)))
+	_ = s.Append(context.Background(), k, ev("fresh", "motion", "x", fixed.Add(-10*time.Minute)))
+	got, _ := s.List(context.Background(), k, Filter{})
+	if len(got) != 1 || got[0].ID != "fresh" {
+		t.Fatalf("maxAge: got %v", ids(got))
+	}
+}
+
+func TestMemoryStore_Clear(t *testing.T) {
+	s := NewMemoryStore(10, 0)
+	k := Key{Cluster: "c", Service: "cam"}
+	_ = s.Append(context.Background(), k, ev("a", "motion", "x", time.Unix(1, 0)))
+	_ = s.Clear(context.Background(), k)
+	got, _ := s.List(context.Background(), k, Filter{})
+	if len(got) != 0 {
+		t.Fatalf("clear: want 0, got %v", ids(got))
+	}
+}
+
+func ids(evs []Event) []string {
+	out := make([]string, len(evs))
+	for i, e := range evs {
+		out[i] = e.ID
+	}
+	return out
+}

--- a/providers/edges/internal/events/subscriber.go
+++ b/providers/edges/internal/events/subscriber.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/gorilla/websocket"
+
+	"github.com/faroshq/provider-edges/internal/haclient"
+)
+
+// wsPathUniFiEvents is the UniFi Protect Integration API events subscription,
+// reached through the agent's /svc reverse proxy (which bridges the upgrade to
+// the console, doing the TLS itself). The leading /svc prefix routes to the
+// agent's service proxy; the remainder is the console-local path.
+const wsPathUniFiEvents = "/svc/proxy/protect/integration/v1/subscribe/events"
+
+// SubscriberConfig configures one long-lived event subscription. The dialer is
+// resolved lazily on each (re)connect so an edge tunnel that flaps and
+// re-registers is picked up without restarting the subscriber.
+type SubscriberConfig struct {
+	// Key is the tenant+service scope events are stored under.
+	Key Key
+	// ResolveDialer returns the current tunnel dialer for the Service's edge, or
+	// (nil,false) when the edge isn't connected right now.
+	ResolveDialer func() (haclient.Dialer, bool)
+	// Target is the console address the agent dials (scheme/host/port).
+	Target haclient.Target
+	// Header carries the auth applied by the caller (svccatalog.Apply) — for
+	// UniFi that is X-API-KEY. It is copied onto the WS handshake request.
+	Header http.Header
+	// Store receives decoded events.
+	Store Store
+	// Logger is optional.
+	Logger logr.Logger
+}
+
+// runSubscriber holds the WS subscription open, decoding UniFi Protect event
+// frames into the store, and reconnecting with backoff until ctx is cancelled.
+// It returns only when ctx is done.
+func runSubscriber(ctx context.Context, cfg SubscriberConfig) {
+	const (
+		minBackoff = 1 * time.Second
+		maxBackoff = 30 * time.Second
+	)
+	backoff := minBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		connected := cfg.connectOnce(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if connected {
+			backoff = minBackoff // a successful session resets the backoff
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+// connectOnce opens one WS session and pumps frames until it errors or ctx is
+// cancelled. It reports whether the session connected (used to reset backoff).
+func (cfg SubscriberConfig) connectOnce(ctx context.Context) bool {
+	dialer, ok := cfg.ResolveDialer()
+	if !ok || dialer == nil {
+		return false // edge not connected right now; caller backs off and retries
+	}
+
+	wsDialer := &websocket.Dialer{
+		HandshakeTimeout: 15 * time.Second,
+		// Every connection rides a fresh tunnel dial to the agent; the agent
+		// bridges the upgrade to the console (and does the TLS), so no client
+		// TLS here. The addr is ignored — the tunnel decides the destination.
+		NetDialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+			return dialer.Dial(dialCtx)
+		},
+	}
+	header := http.Header{}
+	header.Set(haclient.SvcTargetHeader, cfg.Target.SvcTarget())
+	for k, vals := range cfg.Header {
+		for _, v := range vals {
+			header.Add(k, v)
+		}
+	}
+
+	conn, resp, err := wsDialer.DialContext(ctx, "ws://edge-agent"+wsPathUniFiEvents, header)
+	if err != nil {
+		if resp != nil {
+			cfg.Logger.V(2).Info("events subscribe handshake failed", "service", cfg.Key.Service, "status", resp.StatusCode)
+		} else {
+			cfg.Logger.V(2).Info("events subscribe dial failed", "service", cfg.Key.Service, "err", err.Error())
+		}
+		return false
+	}
+	defer conn.Close() //nolint:errcheck
+	cfg.Logger.V(2).Info("events subscription connected", "service", cfg.Key.Service, "cluster", cfg.Key.Cluster)
+
+	// Close the conn when ctx is cancelled so the read loop unblocks.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-stop:
+		}
+	}()
+
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return true // connected then dropped; reconnect
+		}
+		evs, derr := decodeUniFiFrame(data)
+		if derr != nil {
+			continue
+		}
+		for _, ev := range evs {
+			if err := cfg.Store.Append(ctx, cfg.Key, ev); err != nil {
+				cfg.Logger.V(3).Info("events store append failed", "service", cfg.Key.Service, "err", err.Error())
+			}
+		}
+	}
+}

--- a/providers/edges/internal/haclient/haclient.go
+++ b/providers/edges/internal/haclient/haclient.go
@@ -29,9 +29,14 @@ import (
 	"net/http"
 )
 
-// svcTargetHeader mirrors the agent-side constant (pkg/agent/tunnel). The agent
-// enforces that the target host is loopback.
-const svcTargetHeader = "X-Kedge-Svc-Target"
+// SvcTargetHeader mirrors the agent-side constant (pkg/agent/tunnel). The agent
+// enforces that the target host is loopback. Exported so out-of-package callers
+// that build their own tunnel requests (e.g. the events WebSocket subscriber)
+// set the same header.
+const SvcTargetHeader = "X-Kedge-Svc-Target"
+
+// svcTargetHeader is the internal spelling used throughout this package.
+const svcTargetHeader = SvcTargetHeader
 
 // Dialer opens a fresh connection to the edge agent over the reverse tunnel.
 // *revdial.Dialer satisfies this.

--- a/providers/edges/internal/servicectrl/setup.go
+++ b/providers/edges/internal/servicectrl/setup.go
@@ -21,6 +21,8 @@ package servicectrl
 
 import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+
+	"github.com/faroshq/provider-edges/internal/events"
 )
 
 // Options configures the servicectrl controllers.
@@ -29,6 +31,11 @@ type Options struct {
 	// backend proxy), e.g. /services/providers/edges/edgeproxy. Stamped into
 	// Service status.URL. Empty disables URL stamping.
 	EdgeProxyPublicPath string
+	// Events, when set, drives the per-Service event subscribers (currently
+	// UniFi Protect): the validation reconciler starts one when a Service is
+	// Ready and stops it when the Service is deleted or goes NotReady. Nil
+	// disables event subscriptions.
+	Events *events.Manager
 }
 
 // SetupWithManager registers both Service controllers on the multicluster
@@ -37,5 +44,5 @@ func SetupWithManager(mgr mcmanager.Manager, connManager ConnManager, opts Optio
 	if err := SetupDiscoveryWithManager(mgr, connManager); err != nil {
 		return err
 	}
-	return SetupValidationWithManager(mgr, connManager, opts.EdgeProxyPublicPath)
+	return SetupValidationWithManager(mgr, connManager, opts.EdgeProxyPublicPath, opts.Events)
 }

--- a/providers/edges/internal/servicectrl/validation_reconciler.go
+++ b/providers/edges/internal/servicectrl/validation_reconciler.go
@@ -43,6 +43,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	edgesv1alpha1 "github.com/faroshq/provider-edges/apis/v1alpha1"
+	"github.com/faroshq/provider-edges/internal/events"
 	"github.com/faroshq/provider-edges/internal/haclient"
 	"github.com/faroshq/provider-edges/internal/svccatalog"
 )
@@ -56,13 +57,15 @@ type ValidationReconciler struct {
 	mgr                 mcmanager.Manager
 	connManager         ConnManager
 	edgeProxyPublicPath string
+	// events, when non-nil, runs a per-Service event subscriber (UniFi Protect).
+	events *events.Manager
 }
 
 // SetupValidationWithManager registers the validation reconciler (For Service).
 // It also watches Secrets so an edited auth token is re-validated immediately,
 // rather than waiting up to validationResyncInterval for the next resync.
-func SetupValidationWithManager(mgr mcmanager.Manager, connManager ConnManager, edgeProxyPublicPath string) error {
-	r := &ValidationReconciler{mgr: mgr, connManager: connManager, edgeProxyPublicPath: edgeProxyPublicPath}
+func SetupValidationWithManager(mgr mcmanager.Manager, connManager ConnManager, edgeProxyPublicPath string, eventsMgr *events.Manager) error {
+	r := &ValidationReconciler{mgr: mgr, connManager: connManager, edgeProxyPublicPath: edgeProxyPublicPath, events: eventsMgr}
 	return mcbuilder.ControllerManagedBy(mgr).
 		Named("service-validation").
 		For(&edgesv1alpha1.Service{}).
@@ -113,6 +116,10 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 	es := &edgesv1alpha1.Service{}
 	if err := c.Get(ctx, req.NamespacedName, es); err != nil {
 		if apierrors.IsNotFound(err) {
+			// Service deleted: tear down its subscriber and drop its events.
+			if r.events != nil {
+				r.events.Stop(ctx, eventsKey(req))
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -120,14 +127,41 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 
 	orig := es.DeepCopy()
 
-	// Always keep status.URL current.
-	es.Status.URL = r.statusURL(string(req.ClusterName), es.Name)
-
 	// The catalog tells us how to probe this type: the health path, the auth
 	// style, and whether a 2xx proves the credential (ProbeValidate) or merely
 	// that the service is up (ProbeReachable). An unknown type falls back to a
-	// bare reachability probe on "/".
+	// bare reachability probe on "/". Declared here so the subscriber defer can
+	// reuse it for the auth header.
 	def, _ := svccatalog.Get(string(es.Spec.Type))
+
+	// Subscriber lifecycle: reconcile it on every return path from the captured
+	// final state. It only runs for a Ready UniFi Protect Service; every other
+	// outcome (not ready, wrong type, disabled) stops it and clears its events.
+	var (
+		subReady  bool
+		subDialer haclient.Dialer
+		subToken  string
+		subTarget haclient.Target
+	)
+	defer func() {
+		if r.events == nil || es.Spec.Type != edgesv1alpha1.ServiceTypeUniFiProtect {
+			return
+		}
+		key := eventsKey(req)
+		if subReady && subDialer != nil {
+			r.events.Ensure(events.SubscriberConfig{
+				Key:           key,
+				ResolveDialer: r.dialerResolver(connResource(es), string(req.ClusterName), es.Spec.EdgeRef.Name),
+				Target:        subTarget,
+				Header:        unifiAuthHeader(ctx, subDialer, subTarget, def, subToken),
+			})
+		} else {
+			r.events.Stop(ctx, key)
+		}
+	}()
+
+	// Always keep status.URL current.
+	es.Status.URL = r.statusURL(string(req.ClusterName), es.Name)
 
 	// No credentials → nothing to validate, unless the type is usable
 	// unauthenticated (e.g. Prometheus), in which case we still probe for
@@ -160,6 +194,8 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 		return r.commit(ctx, c, orig, es, 30*time.Second)
 	}
 
+	subDialer = dialer // captured for the subscriber defer
+
 	var token string
 	if es.Spec.AuthSecretRef != nil {
 		token, err = r.readToken(ctx, c, es)
@@ -169,6 +205,7 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 			return r.commit(ctx, c, orig, es, validationResyncInterval)
 		}
 	}
+	subToken = token
 
 	// Build the probe request and apply the type's auth. For the session-login
 	// kinds (qBittorrent/Pi-hole) Apply performs the login, so a failure here is
@@ -178,6 +215,7 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 		Host:   targetHost(es),
 		Port:   es.Spec.Port,
 	}
+	subTarget = target // captured for the subscriber defer
 	header := http.Header{}
 	query := url.Values{}
 	if err := svccatalog.Apply(ctx, dialer, target, def, token, header, query); err != nil {
@@ -225,6 +263,7 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 			break
 		}
 		es.Status.Phase = "Ready"
+		subReady = true
 		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionTrue, "Ready", "service reachable")
 		if token != "" && resp.StatusCode < http.StatusMultipleChoices {
 			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionTrue, "Validated", "credentials accepted by the service")
@@ -246,6 +285,7 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 				}
 			}
 			es.Status.Phase = "Ready"
+			subReady = true
 			setCondition(&es.Status.Conditions, "CredentialsValid", metav1.ConditionTrue, "Validated", "credentials accepted by the service")
 			setCondition(&es.Status.Conditions, "Ready", metav1.ConditionTrue, "Ready", "service reachable and authenticated")
 		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
@@ -273,6 +313,33 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 
 	logger.V(4).Info("validated service", "phase", es.Status.Phase, "type", es.Spec.Type)
 	return r.commit(ctx, c, orig, es, validationResyncInterval)
+}
+
+// eventsKey is the tenant+service scope events are stored and looked up under.
+func eventsKey(req mcreconcile.Request) events.Key {
+	return events.Key{Cluster: string(req.ClusterName), Service: req.Name}
+}
+
+// dialerResolver returns a closure that re-resolves the edge's tunnel dialer on
+// demand, so a subscriber survives an edge tunnel that drops and re-registers.
+func (r *ValidationReconciler) dialerResolver(resource, cluster, name string) func() (haclient.Dialer, bool) {
+	key := connKey(resource, cluster, name)
+	return func() (haclient.Dialer, bool) {
+		d, ok := r.connManager.Load(key)
+		if !ok || d == nil {
+			return nil, false
+		}
+		return d, true
+	}
+}
+
+// unifiAuthHeader builds the header the events WebSocket handshake needs, using
+// the same catalog Apply as the data-plane proxy (UniFi → X-API-KEY). Apply does
+// not dial for the API-key auth kind, so this is a pure header build.
+func unifiAuthHeader(ctx context.Context, dialer haclient.Dialer, target haclient.Target, def svccatalog.Definition, token string) http.Header {
+	h := http.Header{}
+	_ = svccatalog.Apply(ctx, dialer, target, def, token, h, url.Values{})
+	return h
 }
 
 // bodySnippet reads up to a small cap from an upstream response body and trims

--- a/providers/edges/internal/svccatalog/catalog.go
+++ b/providers/edges/internal/svccatalog/catalog.go
@@ -420,7 +420,7 @@ var catalog = map[string]Definition{
 			"Battery- or power-managed cameras (notably G4/G5 doorbells) drop to standby and their snapshot may return a 500 \"UNKNOWN_ERROR\" until they wake — this is UniFi Protect's response, not a credential or connectivity fault. " +
 			"On a snapshot 500, retry the same camera a couple of times (waking it usually succeeds), or take a snapshot from another camera covering the same area. " +
 			"Snapshots are returned as images you can view directly. Omit highQuality unless you specifically need full resolution — it makes the doorbell 500 more likely. " +
-			"There is no event-history tool: UniFi Protect's Integration API delivers events only over a WebSocket (/subscribe/events), not as a REST list, so recent motion/ring/smart-detect events cannot be queried here. Use the cameras and snapshot tools to observe current state.",
+			"The events tool returns recent motion/ring/smart-detect events captured from Protect's live WebSocket feed (the provider subscribes in the background and buffers them). It is a rolling recent-history buffer, not a full archive: it only holds events seen since the subscription connected, most recent first. To see who/what triggered a camera, query events and then snapshot that camera.",
 		Tools: []Tool{
 			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
 			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}). Live capture: may 500 on a sleeping doorbell — retry or try another camera.", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},

--- a/providers/edges/internal/svccatalog/catalog.go
+++ b/providers/edges/internal/svccatalog/catalog.go
@@ -410,7 +410,7 @@ var catalog = map[string]Definition{
 	},
 	"unifi-protect": {
 		Type: "unifi-protect", DisplayName: "UniFi Protect", Category: "Network",
-		Description: "UniFi OS console — cameras, snapshots, events.",
+		Description: "UniFi OS console — cameras and snapshots.",
 		DefaultPort: 443, DefaultScheme: "https", SchemeLocked: true,
 		HostRequired: true, HostHelp: "The UniFi console address, e.g. 192.168.1.1.",
 		Auth: AuthAPIKeyHeader, AuthParam: "X-API-KEY",
@@ -418,12 +418,12 @@ var catalog = map[string]Definition{
 		ProbePath: "/proxy/protect/integration/v1/cameras", ProbeMode: ProbeValidate,
 		Instructions: "The snapshot tool captures a live frame on demand, so it depends on the camera's current state. " +
 			"Battery- or power-managed cameras (notably G4/G5 doorbells) drop to standby and their snapshot may return a 500 \"UNKNOWN_ERROR\" until they wake — this is UniFi Protect's response, not a credential or connectivity fault. " +
-			"On a snapshot 500, retry the same camera a couple of times (waking it usually succeeds), or fall back to the events tool and use the most recent event's camera/thumbnail. " +
-			"Snapshots are returned as images you can view directly. Omit highQuality unless you specifically need full resolution — it makes the doorbell 500 more likely.",
+			"On a snapshot 500, retry the same camera a couple of times (waking it usually succeeds), or take a snapshot from another camera covering the same area. " +
+			"Snapshots are returned as images you can view directly. Omit highQuality unless you specifically need full resolution — it makes the doorbell 500 more likely. " +
+			"There is no event-history tool: UniFi Protect's Integration API delivers events only over a WebSocket (/subscribe/events), not as a REST list, so recent motion/ring/smart-detect events cannot be queried here. Use the cameras and snapshot tools to observe current state.",
 		Tools: []Tool{
 			{"cameras", "List Protect cameras (each camera's id, name, state).", http.MethodGet, "/proxy/protect/integration/v1/cameras"},
-			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}). Live capture: may 500 on a sleeping doorbell — retry or use events.", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
-			{"events", "Recent Protect events (motion/person/vehicle). Query: start,end (ms epoch), types.", http.MethodGet, "/proxy/protect/integration/v1/events"},
+			{"snapshot", "Current snapshot (JPEG) from a camera. Query {\"cameraId\":\"<id>\"} (optional {\"highQuality\":\"true\"}). Live capture: may 500 on a sleeping doorbell — retry or try another camera.", http.MethodGet, "/proxy/protect/integration/v1/cameras/{cameraId}/snapshot"},
 		},
 	},
 	"generic": {

--- a/providers/edges/internal/tunnel/server.go
+++ b/providers/edges/internal/tunnel/server.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
+	"github.com/faroshq/provider-edges/internal/events"
 	"github.com/faroshq/provider-edges/internal/kcpurl"
 )
 
@@ -116,8 +117,18 @@ type Server struct {
 	// authorizeFn performs delegated authn/authz against kcp; injectable for tests.
 	authorizeFn authorizeFnType
 
+	// eventStore, when set, backs the read side of edge event tools (the UniFi
+	// Protect `events` MCP tool). The write side (the WebSocket subscribers) is
+	// driven by the service reconciler through the same store. Nil disables the
+	// events tool. Set via SetEventStore from the controller manager.
+	eventStore events.Store
+
 	logger klog.Logger
 }
+
+// SetEventStore wires the read side of the events tools to the store the event
+// subscribers write to. Called once from the controller manager after New.
+func (s *Server) SetEventStore(store events.Store) { s.eventStore = store }
 
 // Config carries the inputs for New. Kinds is required (>=1, all sharing a
 // group+version); everything else is optional (nil KCPConfig is allowed for

--- a/providers/edges/internal/tunnel/svc_catalog.go
+++ b/providers/edges/internal/tunnel/svc_catalog.go
@@ -26,15 +26,18 @@ package tunnel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/faroshq/provider-edges/internal/events"
 	"github.com/faroshq/provider-edges/internal/haclient"
 	"github.com/faroshq/provider-edges/internal/svccatalog"
 )
@@ -72,6 +75,68 @@ func (p *Server) registerCatalogTools(srv *mcp.Server, prefix, cluster, kcpToken
 			return p.callCatalogTool(ctx, cluster, kcpToken, svc, dialer, def, tool, in)
 		})
 	}
+	// UniFi Protect events are not a REST endpoint — the provider subscribes to
+	// Protect's WebSocket feed in the background and buffers them per tenant+
+	// service. Expose that buffer as a tool when a store is wired.
+	if svc.Spec.Type == "unifi-protect" && p.eventStore != nil {
+		p.registerEdgeEventsTool(srv, prefix, cluster, svc)
+	}
+}
+
+// registerEdgeEventsTool exposes the per-tenant, per-service event buffer (fed
+// by the WebSocket subscribers) as a read-only MCP tool. Events are isolated by
+// events.Key{cluster, service}, so a caller only ever sees its own workspace's
+// events.
+func (p *Server) registerEdgeEventsTool(srv *mcp.Server, prefix, cluster string, svc *serviceView) {
+	name := svc.Name
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: prefix + "events",
+		Description: "UniFi Protect — recent camera events (motion/ring/smart-detect) from the live event stream, most recent first. " +
+			"All query params optional: {\"since\":\"30m\"} (a duration back from now), {\"types\":\"motion,ring\"}, {\"cameraId\":\"<id>\"}, {\"limit\":\"20\"}. " +
+			"Rolling recent buffer, not a full archive.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in catToolInput) (*mcp.CallToolResult, any, error) {
+		evs, err := p.eventStore.List(ctx, events.Key{Cluster: cluster, Service: name}, eventsFilterFromQuery(in.Query))
+		if err != nil {
+			return toolErr(err.Error()), nil, nil
+		}
+		if len(evs) == 0 {
+			return &mcp.CallToolResult{Content: withServiceNote(svc, &mcp.TextContent{Text: "no recent events buffered for this service"})}, nil, nil
+		}
+		b, err := json.Marshal(evs)
+		if err != nil {
+			return toolErr("encode events: " + err.Error()), nil, nil
+		}
+		return &mcp.CallToolResult{Content: withServiceNote(svc, &mcp.TextContent{Text: string(b)})}, nil, nil
+	})
+}
+
+// eventsFilterFromQuery maps the generic tool query params to an events.Filter.
+func eventsFilterFromQuery(q map[string]string) events.Filter {
+	var f events.Filter
+	if s := strings.TrimSpace(q["since"]); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			f.Since = time.Now().Add(-d)
+		}
+	}
+	if s := strings.TrimSpace(q["start"]); s != "" { // epoch millis, matches the old REST param
+		if ms, err := strconv.ParseInt(s, 10, 64); err == nil {
+			f.Since = time.UnixMilli(ms)
+		}
+	}
+	if s := strings.TrimSpace(q["types"]); s != "" {
+		for _, t := range strings.Split(s, ",") {
+			if t = strings.TrimSpace(t); t != "" {
+				f.Types = append(f.Types, t)
+			}
+		}
+	}
+	f.CameraID = strings.TrimSpace(q["cameraId"])
+	if s := strings.TrimSpace(q["limit"]); s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			f.Limit = n
+		}
+	}
+	return f
 }
 
 // callCatalogTool executes one catalog tool: resolve the token, apply the auth


### PR DESCRIPTION
## Why

Supersedes #458. UniFi Protect's Integration API has **no REST events list** — events come only over a WebSocket (`/subscribe/events`), so the old one-shot HTTP `events` tool 404'd. This replaces it with a real capability: the provider subscribes to the feed in the background and buffers events per tenant+service for the MCP `events` tool to read.

Design discussion (where it runs / where events are stored, given the agent is a slim proxy) drove the shape below.

## Architecture

- **The edge agent stays a dumb byte-pipe.** The WS subscription runs in the **provider** and rides the existing tunnel dialer; the agent already bridges `/svc` upgrade requests to the console (TLS and all), so no agent changes.
- **The subscriber lives in the process that holds the tunnel** (revdial pins each edge to one replica), and the MCP `events` tool reads the same in-process store — no cross-process coordination.

## What

- **`internal/events`** — the storage abstraction and everything feed-side:
  - `Store` interface (`Append`/`List`/`Clear`), strictly scoped by `Key{Cluster, Service}` — **per-tenant/workspace/service isolation** is the hard boundary (test: same service name in two tenants never cross-reads).
  - `MemoryStore`: a **bounded ring, default 1000 events/service** (+ a max-age), the default impl. The interface is deliberately shaped so a **Redis** backend (`LPUSH`/`LTRIM` per key + TTL) can drop in once we scale past the single-replica invariant.
  - Normalized `Event` model + a tolerant UniFi frame decoder (handles inline / nested `item` / arrays / epoch-ms; skips non-event frames without tearing down the stream).
  - `Subscriber` (WS over the tunnel dialer, reconnect w/ backoff, re-resolves the dialer so a flapping edge self-heals) and a `Manager` (one subscriber per Key; `Ensure`/`Stop`).
- **`servicectrl`** — the validation reconciler starts a subscriber when a UniFi Protect Service is **Ready** and stops it (clearing events) on **delete/NotReady**, via a defer that covers every return path.
- **`tunnel`** — the `events` MCP tool reads the store (`since`/`types`/`cameraId`/`limit`, newest first), isolated by `Key{cluster, service}`. Wired through `Server.SetEventStore`.
- **`controller_manager`** — builds the store + manager under the manager ctx (subscribers stop on shutdown) and shares the store with the tunnel Server.

## Scaling note (per your ask)

Storage is behind the `Store` interface precisely so multi-replica is a drop-in later: today's in-memory ring works because revdial forces single-replica; a Redis `Store` keyed by `{cluster}:{service}` satisfies the same contract when that changes. Nothing else in the feature knows how events are stored.

## Test plan

- `go build` + `go vet` clean across the provider.
- New unit tests: ring cap eviction, **cross-tenant isolation**, filters (since/types/camera/limit, newest-first), max-age, clear; decoder for inline/nested/array/epoch-ms and non-event skip.
- Note: the exact UniFi frame schema should be confirmed against a live console — the decoder is intentionally tolerant and keeps the stream alive on unrecognized shapes (called out in code).

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)