### PR TITLE
[1/5] fix(cli): re-login keeps the workspace selected with kedge use

### DIFF
--- a/pkg/cli/cmd/login.go
+++ b/pkg/cli/cmd/login.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -261,6 +262,18 @@ func mergeKubeconfig(kubeconfigBytes []byte) error {
 
 	// Merge: overwrite clusters, contexts, and auth infos from the new config.
 	for k, v := range newConfig.Clusters {
+		// Re-login always points the cluster at the home workspace. When the
+		// user previously switched workspaces with `kedge use` on the same
+		// hub, keep that selection — only credentials and TLS settings are
+		// refreshed. Logging into a different hub still takes the new URL.
+		if prev := existingConfig.Clusters[k]; prev != nil && strings.Contains(prev.Server, "/clusters/") {
+			prevBase, prevCluster := apiurl.SplitBaseAndCluster(prev.Server)
+			newBase, newCluster := apiurl.SplitBaseAndCluster(v.Server)
+			if prevBase == newBase && prevCluster != newCluster {
+				v.Server = prev.Server
+				fmt.Printf("Keeping previously selected workspace: %s\n", prev.Server)
+			}
+		}
 		existingConfig.Clusters[k] = v
 	}
 	for k, v := range newConfig.AuthInfos {

--- a/pkg/cli/cmd/login_test.go
+++ b/pkg/cli/cmd/login_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// loginKubeconfig mimics what the hub's auth handler returns on login: the
+// "kedge" cluster pointing at the user's home workspace.
+func loginKubeconfig(t *testing.T, server string) []byte {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters["kedge"] = &clientcmdapi.Cluster{Server: server}
+	cfg.AuthInfos["user-abc"] = &clientcmdapi.AuthInfo{Token: "tok"}
+	cfg.Contexts["kedge"] = &clientcmdapi.Context{Cluster: "kedge", AuthInfo: "user-abc"}
+	cfg.CurrentContext = "kedge"
+	out, err := clientcmd.Write(*cfg)
+	if err != nil {
+		t.Fatalf("writing kubeconfig: %v", err)
+	}
+	return out
+}
+
+func writeKubeconfigFile(t *testing.T, path, server string) {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters["kedge"] = &clientcmdapi.Cluster{Server: server}
+	cfg.AuthInfos["user-abc"] = &clientcmdapi.AuthInfo{Token: "old"}
+	cfg.Contexts["kedge"] = &clientcmdapi.Context{Cluster: "kedge", AuthInfo: "user-abc"}
+	cfg.CurrentContext = "kedge"
+	if err := clientcmd.WriteToFile(*cfg, path); err != nil {
+		t.Fatalf("writing kubeconfig file: %v", err)
+	}
+}
+
+func mergedServer(t *testing.T, path string) string {
+	t.Helper()
+	cfg, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("loading merged kubeconfig: %v", err)
+	}
+	cluster := cfg.Clusters["kedge"]
+	if cluster == nil {
+		t.Fatalf("merged kubeconfig has no kedge cluster")
+	}
+	return cluster.Server
+}
+
+func TestMergeKubeconfigPreservesWorkspaceSelection(t *testing.T) {
+	tests := []struct {
+		name       string
+		existing   string // server in the pre-existing kubeconfig; "" = no file
+		incoming   string // server in the login response
+		wantServer string
+	}{
+		{
+			name:       "relogin same hub keeps kedge use selection",
+			existing:   "https://console-dev.faros.sh/clusters/jcb49sm6dkg85xwg",
+			incoming:   "https://console-dev.faros.sh/clusters/home111",
+			wantServer: "https://console-dev.faros.sh/clusters/jcb49sm6dkg85xwg",
+		},
+		{
+			name:       "different hub takes the new server",
+			existing:   "https://console-dev.faros.sh/clusters/jcb49sm6dkg85xwg",
+			incoming:   "https://console.faros.sh/clusters/home111",
+			wantServer: "https://console.faros.sh/clusters/home111",
+		},
+		{
+			name:       "fresh login takes the new server",
+			existing:   "",
+			incoming:   "https://console-dev.faros.sh/clusters/home111",
+			wantServer: "https://console-dev.faros.sh/clusters/home111",
+		},
+		{
+			name:       "existing server without cluster path takes the new server",
+			existing:   "https://console-dev.faros.sh",
+			incoming:   "https://console-dev.faros.sh/clusters/home111",
+			wantServer: "https://console-dev.faros.sh/clusters/home111",
+		},
+		{
+			name:       "same workspace stays put",
+			existing:   "https://console-dev.faros.sh/clusters/home111",
+			incoming:   "https://console-dev.faros.sh/clusters/home111",
+			wantServer: "https://console-dev.faros.sh/clusters/home111",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config")
+			t.Setenv("KUBECONFIG", path)
+			if tc.existing != "" {
+				writeKubeconfigFile(t, path, tc.existing)
+			}
+			if err := mergeKubeconfig(loginKubeconfig(t, tc.incoming)); err != nil {
+				t.Fatalf("mergeKubeconfig: %v", err)
+			}
+			if got := mergedServer(t, path); got != tc.wantServer {
+				t.Errorf("kedge cluster server = %q, want %q", got, tc.wantServer)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`kedge login` merged the hub's kubeconfig verbatim, which always points the `kedge` cluster at the home workspace — clobbering whatever `/clusters/<id>` the user had switched to with `kedge use`. Re-logging in silently dropped you back into the home workspace:

```
❯ kedge login --hub-url https://console-dev.faros.sh
Login successful! ...
❯ k get pods
error: the server doesn't have a resource type "pods"   # wrong workspace again
```

Now, when re-logging into the **same hub**, the previously selected workspace server URL is preserved (with a `Keeping previously selected workspace: …` notice) and only credentials/TLS settings are refreshed. Logging into a **different hub** still takes the new server, so there's no stale cross-hub selection.

## Changes

- `mergeKubeconfig` compares the existing and incoming cluster entries via `apiurl.SplitBaseAndCluster`: same base + different cluster path → keep the old server.
- Added `login_test.go` covering re-login same hub, different hub, fresh login, no cluster path, and same workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)