### PR TITLE
[2/5] fix(provider-sdk): prune stale APIExport resources in init-owned groups

### DIFF
--- a/provider-sdk/install/install.go
+++ b/provider-sdk/install/install.go
@@ -245,8 +245,9 @@ func ApplySchemasFromDir(ctx context.Context, cl dynamic.Interface, dir string) 
 //
 // Merge, don't clobber: spec.resources has multiple writers (this init step,
 // plus any runtime controller that mints per-object entries, e.g. the
-// infrastructure templates virtual storage). Only entries this step owns
-// (keyed by group+name) are upserted; the rest are preserved.
+// infrastructure templates virtual storage). Entries in the API groups this
+// step owns are fully reconciled — upserted, and stale ones (renamed/removed
+// resources) pruned. Entries in other groups are preserved untouched.
 func ApplyAPIExport(ctx context.Context, cl dynamic.Interface, exportName string, schemaNames []string, claims []PermissionClaim) error {
 	resources := make([]any, 0, len(schemaNames))
 	for _, n := range schemaNames {
@@ -444,33 +445,45 @@ func applyUnstructured(ctx context.Context, cl dynamic.Interface, gvr schema.Gro
 }
 
 // mergeAPIExportResources upserts the owned entries (keyed by group+name) into
-// existing, preserving every existing entry not owned. Owned entries win and
-// come first for deterministic output.
+// existing. Owned entries win and come first for deterministic output.
+//
+// Within the API groups init owns (the groups its schema files declare), the
+// owned set is authoritative: a pre-existing entry in an owned group whose
+// name is no longer owned is a leftover from a renamed/removed resource
+// (e.g. agentruns → runs) and is pruned. Entries in foreign groups are
+// preserved — those belong to runtime writers (e.g. the infrastructure
+// templates controller minting per-template entries in per-template groups).
 func mergeAPIExportResources(existing, owned []any) []any {
-	key := func(r any) (string, bool) {
+	parse := func(r any) (group, name string, ok bool) {
 		m, ok := r.(map[string]any)
 		if !ok {
-			return "", false
+			return "", "", false
 		}
-		group, _ := m["group"].(string)
-		name, _ := m["name"].(string)
-		return group + "/" + name, true
+		group, _ = m["group"].(string)
+		name, _ = m["name"].(string)
+		return group, name, true
 	}
 	ownedKeys := make(map[string]struct{}, len(owned))
+	ownedGroups := make(map[string]struct{}, len(owned))
 	for _, r := range owned {
-		if k, ok := key(r); ok {
-			ownedKeys[k] = struct{}{}
+		if group, name, ok := parse(r); ok {
+			ownedKeys[group+"/"+name] = struct{}{}
+			ownedGroups[group] = struct{}{}
 		}
 	}
 	out := make([]any, 0, len(owned)+len(existing))
 	out = append(out, owned...)
 	for _, r := range existing {
-		k, ok := key(r)
+		group, name, ok := parse(r)
 		if !ok {
 			out = append(out, r)
 			continue
 		}
-		if _, isOwned := ownedKeys[k]; isOwned {
+		if _, isOwned := ownedKeys[group+"/"+name]; isOwned {
+			continue
+		}
+		if _, groupOwned := ownedGroups[group]; groupOwned {
+			// Stale entry in an init-owned group — prune.
 			continue
 		}
 		out = append(out, r)

--- a/provider-sdk/install/install_test.go
+++ b/provider-sdk/install/install_test.go
@@ -40,6 +40,7 @@ func TestMergeAPIExportResources(t *testing.T) {
 	}
 	existing := []any{
 		res("code.kedge.faros.sh", "connections"),         // owned → replaced
+		res("code.kedge.faros.sh", "coderepos"),           // stale in owned group → pruned
 		res("infrastructure.kedge.faros.sh", "templates"), // foreign → preserved
 		"unparseable", // kept verbatim
 	}
@@ -59,11 +60,17 @@ func TestMergeAPIExportResources(t *testing.T) {
 	if m, ok := out[1].(map[string]any); !ok || m["name"] != "repositories" {
 		t.Errorf("out[1] = %v, want owned repositories second", out[1])
 	}
-	// foreign templates preserved (not dropped by the connections overlap)
-	foundTemplates, foundUnparseable := false, false
+	// foreign templates preserved (not dropped by the connections overlap);
+	// stale coderepos in the owned group pruned
+	foundTemplates, foundUnparseable, foundStale := false, false, false
 	for _, r := range out {
-		if m, ok := r.(map[string]any); ok && m["name"] == "templates" {
-			foundTemplates = true
+		if m, ok := r.(map[string]any); ok {
+			switch m["name"] {
+			case "templates":
+				foundTemplates = true
+			case "coderepos":
+				foundStale = true
+			}
 		}
 		if s, ok := r.(string); ok && s == "unparseable" {
 			foundUnparseable = true
@@ -74,5 +81,8 @@ func TestMergeAPIExportResources(t *testing.T) {
 	}
 	if !foundUnparseable {
 		t.Error("unparseable entry was dropped")
+	}
+	if foundStale {
+		t.Error("stale 'coderepos' entry in an owned group was not pruned")
 	}
 }


### PR DESCRIPTION
## Summary

Provider `init` (`sdkinstall.ApplyAPIExport`) merged `APIExport.spec.resources` by upserting the schemas it owns and **preserving everything else**. When a resource is renamed or removed between deploys, the dead entry lingered in the APIExport forever, and every new tenant `APIBinding` kept projecting the dead kind.

The agents provider hit exactly this — its `agentruns / agentschedules / agenttriggers` were renamed to `runs / schedules / triggers`, but the old prefixed entries stayed in the live APIExport:

```
$ kubectl get apiexport agents.kedge.faros.sh -o ...
agents connections runs schedules toolsets triggers   # wanted
agentruns agentschedules agenttriggers                 # stale, never pruned
```

## Fix

Treat the API groups `init` owns (those declared by its schema files) as authoritative:

- Within an **owned group**, an existing entry whose name is no longer owned is **pruned**.
- Entries in **foreign groups** are still preserved untouched — runtime writers (e.g. the infrastructure templates controller minting per-template entries in per-template groups) are unaffected.

Extended `TestMergeAPIExportResources` to cover a stale entry in an owned group (pruned) alongside the existing foreign-group and unparseable-entry preservation cases.

## Note on already-bound tenants

kcp's APIBinding reconciler only ever **upserts** `status.boundResources` from the current export — it never prunes. So tenants already bound keep the dead kinds in their binding until it is recreated. This PR fixes new binds and provider re-inits going forward; existing bindings need a separate one-off cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)