### PR TITLE
[3/5] fix(providers): stop the enable-provider provisioning race needing a manual refresh

### DIFF
--- a/pkg/hub/restapi/providers_enable.go
+++ b/pkg/hub/restapi/providers_enable.go
@@ -137,6 +137,19 @@ func (h *Handler) enableProvider(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// Precondition (checked BEFORE creating anything): a provider that requests
+	// edge-proxy access needs its WorkspaceCluster, which the catalog controller
+	// stamps only after it finishes provisioning the provider's sub-workspace.
+	// If Enable is clicked during that window the value is still empty. Refuse
+	// up front — before EnsureProviderAPIBinding — so a raced Enable is a clean
+	// no-op the client can retry, instead of leaving the APIBinding created but
+	// the edge-proxy grant missing (a partial enable). The "retry shortly"
+	// message is a retryable signal; the portal backs off and re-tries.
+	if prov.EdgeProxyAccess && prov.WorkspaceCluster == "" {
+		writeStatus(w, http.StatusConflict, "Conflict", "provider "+providerName+" requests edge proxy access but its workspace is not provisioned yet — retry shortly")
+		return
+	}
+
 	if err := h.mgr.bootstrapper.EnsureProviderAPIBinding(
 		r.Context(),
 		tc.OrgUUID,
@@ -153,15 +166,9 @@ func (h *Handler) enableProvider(w http.ResponseWriter, r *http.Request) {
 	// Providers that declared spec.edgeProxyAccess additionally get the
 	// "proxy"-on-edges grant in this workspace, bound to the provider SA's
 	// cluster-qualified identity (the Enable dialog surfaced the request —
-	// clicking Enable is the consent). WorkspaceCluster is resolved by the
-	// catalog controller during provisioning; a provider whose CatalogEntry
-	// hasn't finished provisioning can't meaningfully be enabled yet, so an
-	// empty value is an error rather than a silent skip.
+	// clicking Enable is the consent). WorkspaceCluster is guaranteed non-empty
+	// by the precheck above.
 	if prov.EdgeProxyAccess {
-		if prov.WorkspaceCluster == "" {
-			writeStatus(w, http.StatusConflict, "Conflict", "provider "+providerName+" requests edge proxy access but its workspace is not provisioned yet — retry shortly")
-			return
-		}
 		subject := identity.QualifiedServiceAccount(prov.WorkspaceCluster, providers.ProviderSANamespace, providers.ProviderSAName)
 		if err := h.mgr.bootstrapper.EnsureProviderEdgeProxyGrant(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, providerName, subject); err != nil {
 			writeStatus(w, http.StatusInternalServerError, "InternalError", "ensure edge-proxy grant: "+err.Error())

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -306,14 +306,27 @@ export const useProvidersStore = defineStore('providers', () => {
       acceptedClaims: accept.map((c) => ({ group: c.group ?? '', resource: c.resource })),
     }
     const url = `/api/orgs/${encodeURIComponent(t.orgUUID)}/workspaces/${encodeURIComponent(t.workspaceUUID)}/providers/${encodeURIComponent(p.name)}/enable`
-    const res = await authFetch(url, {
-      method: 'POST',
-      tenant: true,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!res.ok) {
+
+    // A provider that requests edge-proxy access can't be enabled until the
+    // catalog controller has provisioned its workspace, so an Enable clicked
+    // during that window returns 409 "retry shortly". That's a transient,
+    // retryable signal (the enable endpoint is idempotent), so back off and
+    // re-try a few times instead of surfacing an error the user has to clear
+    // with a manual page refresh. Non-409 failures are terminal — throw at once.
+    const backoffMs = [750, 1250, 1750, 2500, 3000] // ~9s total across 6 attempts
+    for (let attempt = 0; ; attempt++) {
+      const res = await authFetch(url, {
+        method: 'POST',
+        tenant: true,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (res.ok) break
       const detail = await res.text().catch(() => '')
+      if (res.status === 409 && attempt < backoffMs.length) {
+        await new Promise((r) => setTimeout(r, backoffMs[attempt]))
+        continue
+      }
       throw new Error(`enable ${p.name} failed: ${res.status} ${res.statusText} ${detail}`)
     }
     bindingNamesByProvider.value = { ...bindingNamesByProvider.value, [p.name]: p.name }


### PR DESCRIPTION
**Merge order: 3 of 5. Independent — can merge any time relative to #460/#461.**

## Problem
Enabling an edge-proxy provider (e.g. edges) right after registration intermittently returned `409 "workspace is not provisioned yet — retry shortly"`, and users had to refresh the page to get it to stick.

The 409 is by design — a provider that requests edge-proxy access needs its `Status.WorkspaceCluster`, which the catalog controller only stamps after provisioning the sub-workspace — but two things made it a papercut:

1. The portal treated the 409 as terminal and threw, so the "retry shortly" signal required a manual refresh.
2. The hub created the APIBinding **before** checking `WorkspaceCluster`, so a raced Enable left a partial state (binding created, edge-proxy grant missing).

## Fix
1. **Portal auto-retry** ([providers.ts](portal/src/stores/providers.ts)): honor the retryable contract — back off and re-try on 409 (~9s across 6 attempts); non-409 failures still throw immediately.
2. **Server reorder** ([providers_enable.go](pkg/hub/restapi/providers_enable.go)): move the `WorkspaceCluster == ""` precheck ahead of `EnsureProviderAPIBinding` so a raced Enable is a clean, side-effect-free no-op.

Verified: `go build ./pkg/hub/...` clean, `pkg/hub/restapi` tests pass, portal `vue-tsc` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)