### PR TITLE
[5/5] feat(agents): Models overhaul — catalog, cost dashboard, health/discovery, observability

### DIFF
--- a/providers/agents/api/agents.go
+++ b/providers/agents/api/agents.go
@@ -467,6 +467,21 @@ func (s *Server) buildChatModelCtx(ctx context.Context, creds llm.SecretGetter, 
 	return llm.NewFallbackModel(members, built), nil
 }
 
+// primaryModelName resolves the model id of the agent's primary chat credential
+// for cost attribution. Best-effort: returns "" when unresolvable (cost then
+// falls back to 0 rather than erroring the run).
+func (s *Server) primaryModelName(ctx context.Context, creds llm.SecretGetter, agent *agentsv1alpha1.Agent) string {
+	name := strings.TrimSpace(agent.Spec.Models["chat"])
+	if name == "" {
+		return ""
+	}
+	p, err := llm.LoadCredential(ctx, creds, name)
+	if err != nil {
+		return ""
+	}
+	return p.Model
+}
+
 // credentialsError reports whether err is a missing/invalid model-credentials
 // condition (Secret not found or profile unconfigured), so callers can show a
 // "configure a model" hint instead of a raw error.

--- a/providers/agents/api/run.go
+++ b/providers/agents/api/run.go
@@ -77,6 +77,7 @@ type runResult struct {
 	Usage   struct {
 		InputTokens  int64 `json:"inputTokens"`
 		OutputTokens int64 `json:"outputTokens"`
+		USDMicros    int64 `json:"usdMicros"`
 	} `json:"usage"`
 }
 
@@ -168,19 +169,26 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 		ID: uuid.NewString(), AgentName: agent.Name, SessionID: sessionID, RunID: runID,
 		Role: "assistant", Content: res.Content, CreatedAt: end,
 	})
+	// Estimate cost from the catalog so budgets enforce dollars (not just
+	// tokens) and the Models dashboard can show spend. Cost is attributed to the
+	// agent's primary model; unknown models cost 0 rather than a fabricated
+	// number.
+	costMicros := llm.CostMicros(s.primaryModelName(ctx, run.Creds, agent), res.Usage.InputTokens, res.Usage.OutputTokens)
 	if run, gerr := s.store.GetRun(ctx, scope, runID); gerr == nil {
 		run.Phase = store.RunPhaseSucceeded
 		run.InputTokens = res.Usage.InputTokens
 		run.OutputTokens = res.Usage.OutputTokens
+		run.USDMicros = costMicros
 		run.UpdatedAt = end
 		run.FinishedAt = &end
 		_ = s.store.SaveRun(ctx, scope, run)
 	}
-	_, _ = s.store.AddUsage(ctx, scope, agent.Name, res.Usage.InputTokens, res.Usage.OutputTokens, 0, end, 30*24*time.Hour)
+	_, _ = s.store.AddUsage(ctx, scope, agent.Name, res.Usage.InputTokens, res.Usage.OutputTokens, costMicros, end, 30*24*time.Hour)
 
 	out := runResult{RunID: runID, Content: res.Content}
 	out.Usage.InputTokens = res.Usage.InputTokens
 	out.Usage.OutputTokens = res.Usage.OutputTokens
+	out.Usage.USDMicros = costMicros
 	return out, nil
 }
 

--- a/providers/agents/api/server.go
+++ b/providers/agents/api/server.go
@@ -143,6 +143,12 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("GET /api/credentials", s.listCredentials)
 	mux.HandleFunc("POST /api/credentials", s.createCredential)
 	mux.HandleFunc("DELETE /api/credentials/{name}", s.deleteCredential)
+	// Health-check a credential (real API probe → latency + served models).
+	mux.HandleFunc("POST /api/credentials/{name}/test", s.testCredential)
+	// Curated model catalog: pricing + capabilities for the Models UI.
+	mux.HandleFunc("GET /api/catalog", s.modelCatalog)
+	// Usage / observability rollups over a window (cost, tokens, latency, errors).
+	mux.HandleFunc("GET /api/usage", s.usageRollup)
 
 	// Schedules (M3): cron / wakeup / heartbeat, plus synchronous "run now".
 	mux.HandleFunc("GET /api/schedules", s.listSchedules)

--- a/providers/agents/api/settings.go
+++ b/providers/agents/api/settings.go
@@ -9,10 +9,14 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,6 +127,107 @@ func (s *Server) createCredential(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, modelCredential{
 		Name: req.Name, Provider: req.Provider, BaseURL: req.BaseURL, Model: req.Model, HasAPIKey: true,
 	})
+}
+
+// credentialTestResult is the outcome of a live credential health probe.
+type credentialTestResult struct {
+	OK        bool     `json:"ok"`
+	LatencyMS int64    `json:"latencyMS"`
+	Error     string   `json:"error,omitempty"`
+	Models    []string `json:"models,omitempty"` // ids the endpoint serves (discovery)
+}
+
+// testCredential health-checks a named credential by calling the provider's
+// GET {baseURL}/models with the stored key. This is a cheap, token-free probe
+// that both verifies the key works and discovers the models the endpoint serves
+// (returned for the "pick a model" UX). Reports latency either way.
+func (s *Server) testCredential(w http.ResponseWriter, r *http.Request) {
+	c, _, ok := s.requireClient(w, r)
+	if !ok {
+		return
+	}
+	name := r.PathValue("name")
+	profile, err := llm.LoadCredential(r.Context(), c, name)
+	if err != nil {
+		writeJSON(w, http.StatusOK, credentialTestResult{OK: false, Error: "credential not configured: " + err.Error()})
+		return
+	}
+	models, latency, perr := probeOpenAIModels(r.Context(), profile.BaseURL, profile.APIKey)
+	if perr != nil {
+		writeJSON(w, http.StatusOK, credentialTestResult{OK: false, LatencyMS: latency.Milliseconds(), Error: perr.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, credentialTestResult{OK: true, LatencyMS: latency.Milliseconds(), Models: models})
+}
+
+// probeOpenAIModels calls GET {baseURL}/models and returns the served model ids
+// plus the round-trip latency. A non-2xx status or transport error is returned
+// as err (with latency still measured for the health badge).
+func probeOpenAIModels(ctx context.Context, baseURL, apiKey string) ([]string, time.Duration, error) {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = "https://api.openai.com/v1"
+	}
+	ctx, cancel := context.WithTimeout(ctx, 12*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/models", nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	latency := time.Since(start)
+	if err != nil {
+		return nil, latency, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if len(msg) > 200 {
+			msg = msg[:200]
+		}
+		return nil, latency, &probeError{status: resp.StatusCode, msg: msg}
+	}
+	var parsed struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		// 2xx but unexpected body — the endpoint is reachable, just not a
+		// standard /models list. Treat as healthy with no discovered models.
+		return nil, latency, nil
+	}
+	ids := make([]string, 0, len(parsed.Data))
+	for _, m := range parsed.Data {
+		if id := strings.TrimSpace(m.ID); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids, latency, nil
+}
+
+type probeError struct {
+	status int
+	msg    string
+}
+
+func (e *probeError) Error() string {
+	if e.msg != "" {
+		return "endpoint returned HTTP " + strconv.Itoa(e.status) + ": " + e.msg
+	}
+	return "endpoint returned HTTP " + strconv.Itoa(e.status)
+}
+
+// modelCatalog returns the curated pricing + capability catalog (public — no
+// tenant data, just reference data for the Models UI).
+func (s *Server) modelCatalog(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"items": llm.Catalog()})
 }
 
 func (s *Server) deleteCredential(w http.ResponseWriter, r *http.Request) {

--- a/providers/agents/api/toolset.go
+++ b/providers/agents/api/toolset.go
@@ -90,9 +90,10 @@ func (s *Server) buildToolset(ctx context.Context, deps tools.Deps, run taskRun)
 			if err != nil {
 				return "", err
 			}
-			// Budget rollup: the child's spend also counts against the parent.
+			// Budget rollup: the child's spend (tokens + cost) also counts
+			// against the parent.
 			_, _ = s.store.AddUsage(dctx, parentDeps.Scope, parentDeps.Agent.Name,
-				res.Usage.InputTokens, res.Usage.OutputTokens, 0, time.Now().UTC(), 30*24*time.Hour)
+				res.Usage.InputTokens, res.Usage.OutputTokens, res.Usage.USDMicros, time.Now().UTC(), 30*24*time.Hour)
 			return res.Content, nil
 		}
 	}

--- a/providers/agents/api/usage.go
+++ b/providers/agents/api/usage.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package api
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/faroshq/provider-agents/store"
+)
+
+// usageBucket is one aggregated row (per agent, per model, or the grand total).
+type usageBucket struct {
+	Key          string `json:"key"`
+	Runs         int64  `json:"runs"`
+	Errors       int64  `json:"errors"`
+	InputTokens  int64  `json:"inputTokens"`
+	OutputTokens int64  `json:"outputTokens"`
+	USDMicros    int64  `json:"usdMicros"`
+	// LatencyP50MS/P95MS are computed over completed runs with timing.
+	LatencyP50MS int64 `json:"latencyP50MS"`
+	LatencyP95MS int64 `json:"latencyP95MS"`
+}
+
+// usagePoint is one day in the spend/volume timeseries.
+type usagePoint struct {
+	Date         string `json:"date"` // YYYY-MM-DD (UTC)
+	Runs         int64  `json:"runs"`
+	InputTokens  int64  `json:"inputTokens"`
+	OutputTokens int64  `json:"outputTokens"`
+	USDMicros    int64  `json:"usdMicros"`
+}
+
+type usageResponse struct {
+	WindowDays int           `json:"windowDays"`
+	Total      usageBucket   `json:"total"`
+	ByAgent    []usageBucket `json:"byAgent"`
+	ByModel    []usageBucket `json:"byModel"`
+	Series     []usagePoint  `json:"series"`
+}
+
+// usageRollup aggregates the run history into cost/usage/observability rollups
+// over a rolling window (default 30 days, ?days= to override, capped at 90).
+// Everything is derived from the runs table — no separate telemetry store — so
+// it powers both the cost dashboard and the latency/error panel. Per-model
+// attribution uses each agent's CURRENT primary model (spec.models.chat), since
+// runs are recorded per agent; this is exact unless an agent's model changed
+// mid-window.
+func (s *Server) usageRollup(w http.ResponseWriter, r *http.Request) {
+	c, id, ok := s.requireClient(w, r)
+	if !ok {
+		return
+	}
+	scope := id.scope("")
+
+	days := 30
+	if v := strings.TrimSpace(r.URL.Query().Get("days")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = min(n, 90)
+		}
+	}
+	since := time.Now().UTC().AddDate(0, 0, -days)
+
+	// Pull a generous slice of recent runs and filter to the window in-process
+	// (ListRuns is limit-based, not time-ranged).
+	runs, err := s.store.ListRuns(r.Context(), scope, 5000)
+	if err != nil {
+		writeResourceError(w, err)
+		return
+	}
+
+	// agent → primary model, for per-model attribution. Best-effort: an agent
+	// with no assigned model is bucketed under "(unassigned)".
+	agentModel := map[string]string{}
+	if agents, aerr := c.Agents().List(r.Context(), metav1.ListOptions{}); aerr == nil {
+		for i := range agents.Items {
+			a := &agents.Items[i]
+			agentModel[a.Name] = strings.TrimSpace(a.Spec.Models["chat"])
+		}
+	}
+
+	total := usageBucket{Key: "total"}
+	byAgent := map[string]*usageBucket{}
+	byModel := map[string]*usageBucket{}
+	series := map[string]*usagePoint{}
+	latAll := []int64{}
+	latByAgent := map[string][]int64{}
+	latByModel := map[string][]int64{}
+
+	for i := range runs {
+		run := &runs[i]
+		if run.CreatedAt.Before(since) {
+			continue
+		}
+		modelKey := agentModel[run.AgentName]
+		if modelKey == "" {
+			modelKey = "(unassigned)"
+		}
+		isErr := run.Phase == store.RunPhaseFailed
+
+		acc := func(b *usageBucket) {
+			b.Runs++
+			if isErr {
+				b.Errors++
+			}
+			b.InputTokens += run.InputTokens
+			b.OutputTokens += run.OutputTokens
+			b.USDMicros += run.USDMicros
+		}
+		acc(&total)
+		ab := byAgent[run.AgentName]
+		if ab == nil {
+			ab = &usageBucket{Key: run.AgentName}
+			byAgent[run.AgentName] = ab
+		}
+		acc(ab)
+		mb := byModel[modelKey]
+		if mb == nil {
+			mb = &usageBucket{Key: modelKey}
+			byModel[modelKey] = mb
+		}
+		acc(mb)
+
+		// Latency: completed runs with both timestamps.
+		if run.StartedAt != nil && run.FinishedAt != nil {
+			ms := run.FinishedAt.Sub(*run.StartedAt).Milliseconds()
+			if ms >= 0 {
+				latAll = append(latAll, ms)
+				latByAgent[run.AgentName] = append(latByAgent[run.AgentName], ms)
+				latByModel[modelKey] = append(latByModel[modelKey], ms)
+			}
+		}
+
+		// Daily timeseries.
+		day := run.CreatedAt.UTC().Format("2006-01-02")
+		pt := series[day]
+		if pt == nil {
+			pt = &usagePoint{Date: day}
+			series[day] = pt
+		}
+		pt.Runs++
+		pt.InputTokens += run.InputTokens
+		pt.OutputTokens += run.OutputTokens
+		pt.USDMicros += run.USDMicros
+	}
+
+	total.LatencyP50MS, total.LatencyP95MS = percentiles(latAll)
+	resp := usageResponse{WindowDays: days, Total: total}
+	for k, b := range byAgent {
+		b.LatencyP50MS, b.LatencyP95MS = percentiles(latByAgent[k])
+		resp.ByAgent = append(resp.ByAgent, *b)
+	}
+	for k, b := range byModel {
+		b.LatencyP50MS, b.LatencyP95MS = percentiles(latByModel[k])
+		resp.ByModel = append(resp.ByModel, *b)
+	}
+	// Highest spend first; ties broken by run count then name for stability.
+	rank := func(a, b usageBucket) bool {
+		if a.USDMicros != b.USDMicros {
+			return a.USDMicros > b.USDMicros
+		}
+		if a.Runs != b.Runs {
+			return a.Runs > b.Runs
+		}
+		return a.Key < b.Key
+	}
+	sort.Slice(resp.ByAgent, func(i, j int) bool { return rank(resp.ByAgent[i], resp.ByAgent[j]) })
+	sort.Slice(resp.ByModel, func(i, j int) bool { return rank(resp.ByModel[i], resp.ByModel[j]) })
+	for _, p := range series {
+		resp.Series = append(resp.Series, *p)
+	}
+	sort.Slice(resp.Series, func(i, j int) bool { return resp.Series[i].Date < resp.Series[j].Date })
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// percentiles returns the p50 and p95 of xs (nearest-rank). Empty → (0, 0).
+func percentiles(xs []int64) (p50, p95 int64) {
+	if len(xs) == 0 {
+		return 0, 0
+	}
+	sorted := append([]int64(nil), xs...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	at := func(q float64) int64 {
+		idx := int(q * float64(len(sorted)))
+		if idx >= len(sorted) {
+			idx = len(sorted) - 1
+		}
+		return sorted[idx]
+	}
+	return at(0.50), at(0.95)
+}

--- a/providers/agents/llm/catalog.go
+++ b/providers/agents/llm/catalog.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package llm
+
+import "strings"
+
+// ModelInfo is a curated catalog entry: pricing (USD per 1M tokens) and
+// capabilities for a model id. Used to (a) compute per-run cost from token
+// counts and (b) drive the portal's Models catalog (capability chips, pricing,
+// context window).
+//
+// Pricing is a best-effort 2026 snapshot and drifts — treat the numbers as
+// estimates, and prefer a live pricing source before quoting them externally.
+// Cost math: 1 USD per 1M tokens == 1 micro-USD per token, so
+//
+//	usd_micros = round(inTokens*InputPer1M + outTokens*OutputPer1M)
+type ModelInfo struct {
+	ID            string  `json:"id"`
+	Family        string  `json:"family"`
+	Label         string  `json:"label,omitempty"`
+	ContextWindow int     `json:"contextWindow,omitempty"` // tokens
+	InputPer1M    float64 `json:"inputPer1M"`              // USD / 1M input tokens
+	OutputPer1M   float64 `json:"outputPer1M"`             // USD / 1M output tokens
+	Vision        bool    `json:"vision,omitempty"`
+	ToolCall      bool    `json:"toolCall,omitempty"`
+	Reasoning     bool    `json:"reasoning,omitempty"`
+}
+
+// catalog is the curated model list. Keyed lookups normalize the id (lowercase,
+// strip any provider/org prefix like "openai/" or "anthropic/") so an
+// OpenAI-compatible gateway id such as "openrouter/anthropic/claude-sonnet-4"
+// still resolves.
+var catalog = []ModelInfo{
+	// OpenAI
+	{ID: "gpt-4o", Family: "openai", Label: "GPT-4o", ContextWindow: 128000, InputPer1M: 2.50, OutputPer1M: 10.00, Vision: true, ToolCall: true},
+	{ID: "gpt-4o-mini", Family: "openai", Label: "GPT-4o mini", ContextWindow: 128000, InputPer1M: 0.15, OutputPer1M: 0.60, Vision: true, ToolCall: true},
+	{ID: "gpt-4.1", Family: "openai", Label: "GPT-4.1", ContextWindow: 1000000, InputPer1M: 2.00, OutputPer1M: 8.00, Vision: true, ToolCall: true},
+	{ID: "gpt-4.1-mini", Family: "openai", Label: "GPT-4.1 mini", ContextWindow: 1000000, InputPer1M: 0.40, OutputPer1M: 1.60, Vision: true, ToolCall: true},
+	{ID: "gpt-4.1-nano", Family: "openai", Label: "GPT-4.1 nano", ContextWindow: 1000000, InputPer1M: 0.10, OutputPer1M: 0.40, Vision: true, ToolCall: true},
+	{ID: "gpt-5", Family: "openai", Label: "GPT-5", ContextWindow: 400000, InputPer1M: 1.25, OutputPer1M: 10.00, Vision: true, ToolCall: true, Reasoning: true},
+	{ID: "gpt-5-mini", Family: "openai", Label: "GPT-5 mini", ContextWindow: 400000, InputPer1M: 0.25, OutputPer1M: 2.00, Vision: true, ToolCall: true, Reasoning: true},
+	{ID: "o1", Family: "openai", Label: "o1", ContextWindow: 200000, InputPer1M: 15.00, OutputPer1M: 60.00, ToolCall: true, Reasoning: true},
+	{ID: "o3", Family: "openai", Label: "o3", ContextWindow: 200000, InputPer1M: 2.00, OutputPer1M: 8.00, ToolCall: true, Reasoning: true},
+	{ID: "o3-mini", Family: "openai", Label: "o3-mini", ContextWindow: 200000, InputPer1M: 1.10, OutputPer1M: 4.40, ToolCall: true, Reasoning: true},
+	{ID: "o4-mini", Family: "openai", Label: "o4-mini", ContextWindow: 200000, InputPer1M: 1.10, OutputPer1M: 4.40, ToolCall: true, Reasoning: true},
+	// Anthropic (via OpenAI-compatible endpoints / OpenRouter)
+	{ID: "claude-sonnet-4", Family: "anthropic", Label: "Claude Sonnet 4", ContextWindow: 200000, InputPer1M: 3.00, OutputPer1M: 15.00, Vision: true, ToolCall: true},
+	{ID: "claude-opus-4", Family: "anthropic", Label: "Claude Opus 4", ContextWindow: 200000, InputPer1M: 15.00, OutputPer1M: 75.00, Vision: true, ToolCall: true},
+	{ID: "claude-3-5-haiku", Family: "anthropic", Label: "Claude 3.5 Haiku", ContextWindow: 200000, InputPer1M: 0.80, OutputPer1M: 4.00, Vision: true, ToolCall: true},
+	// Google (via OpenAI-compatible endpoints)
+	{ID: "gemini-2.5-pro", Family: "google", Label: "Gemini 2.5 Pro", ContextWindow: 1000000, InputPer1M: 1.25, OutputPer1M: 10.00, Vision: true, ToolCall: true, Reasoning: true},
+	{ID: "gemini-2.5-flash", Family: "google", Label: "Gemini 2.5 Flash", ContextWindow: 1000000, InputPer1M: 0.30, OutputPer1M: 2.50, Vision: true, ToolCall: true},
+}
+
+var catalogByID = func() map[string]ModelInfo {
+	m := make(map[string]ModelInfo, len(catalog))
+	for _, mi := range catalog {
+		m[mi.ID] = mi
+	}
+	return m
+}()
+
+// Catalog returns the curated model list (copy-safe; callers must not mutate).
+func Catalog() []ModelInfo { return catalog }
+
+// normalizeModelID lowercases and strips a leading provider/org prefix, then
+// trims common date/version suffixes so "openai/gpt-4o-2024-08-06" and
+// "GPT-4o" both resolve to "gpt-4o".
+func normalizeModelID(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(m, "/"); idx >= 0 {
+		m = m[idx+1:]
+	}
+	return m
+}
+
+// LookupModel returns the catalog entry for a model id, matching first on the
+// exact normalized id and then on the longest catalog id that is a prefix of it
+// (so "gpt-4o-2024-08-06" matches "gpt-4o"). Reports ok=false when unknown.
+func LookupModel(model string) (ModelInfo, bool) {
+	norm := normalizeModelID(model)
+	if norm == "" {
+		return ModelInfo{}, false
+	}
+	if mi, ok := catalogByID[norm]; ok {
+		return mi, true
+	}
+	// Longest-prefix match: pick the most specific catalog id the model starts
+	// with (e.g. "gpt-4o-mini-…" must prefer "gpt-4o-mini" over "gpt-4o").
+	best := ""
+	for id := range catalogByID {
+		if strings.HasPrefix(norm, id) && len(id) > len(best) {
+			best = id
+		}
+	}
+	if best != "" {
+		return catalogByID[best], true
+	}
+	return ModelInfo{}, false
+}
+
+// CostMicros returns the estimated cost in micro-USD for a run of the given
+// model with in/out token counts. Unknown models cost 0 (no pricing data →
+// don't fabricate a number). 1 USD/1M-tokens == 1 micro-USD/token, so the
+// per-1M price is also the micro-USD-per-token rate.
+func CostMicros(model string, inTokens, outTokens int64) int64 {
+	mi, ok := LookupModel(model)
+	if !ok {
+		return 0
+	}
+	cost := float64(inTokens)*mi.InputPer1M + float64(outTokens)*mi.OutputPer1M
+	if cost < 0 {
+		return 0
+	}
+	return int64(cost + 0.5) // round to nearest micro-USD
+}

--- a/providers/agents/llm/catalog_test.go
+++ b/providers/agents/llm/catalog_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package llm
+
+import "testing"
+
+func TestLookupModel(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantID string
+		wantOK bool
+	}{
+		{"gpt-4o", "gpt-4o", true},
+		{"GPT-4o", "gpt-4o", true},
+		{"openai/gpt-4o", "gpt-4o", true},
+		{"gpt-4o-2024-08-06", "gpt-4o", true},          // date suffix → prefix match
+		{"gpt-4o-mini-2024-07-18", "gpt-4o-mini", true}, // must prefer the longer id
+		{"openrouter/anthropic/claude-sonnet-4", "claude-sonnet-4", true},
+		{"totally-unknown-model", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		mi, ok := LookupModel(c.in)
+		if ok != c.wantOK {
+			t.Errorf("LookupModel(%q) ok=%v, want %v", c.in, ok, c.wantOK)
+			continue
+		}
+		if ok && mi.ID != c.wantID {
+			t.Errorf("LookupModel(%q) = %q, want %q", c.in, mi.ID, c.wantID)
+		}
+	}
+}
+
+func TestCostMicros(t *testing.T) {
+	// gpt-4o: $2.50 / 1M input, $10.00 / 1M output.
+	// 1M input + 1M output = $2.50 + $10.00 = $12.50 = 12_500_000 micros.
+	if got := CostMicros("gpt-4o", 1_000_000, 1_000_000); got != 12_500_000 {
+		t.Errorf("CostMicros(gpt-4o, 1M, 1M) = %d, want 12500000", got)
+	}
+	// 1000 input tokens on gpt-4o = 1000 * 2.50 = 2500 micros = $0.0025.
+	if got := CostMicros("gpt-4o", 1000, 0); got != 2500 {
+		t.Errorf("CostMicros(gpt-4o, 1000, 0) = %d, want 2500", got)
+	}
+	// Unknown model → 0 (never fabricate a price).
+	if got := CostMicros("mystery-model", 1000, 1000); got != 0 {
+		t.Errorf("CostMicros(unknown) = %d, want 0", got)
+	}
+}

--- a/providers/agents/portal/src/actions.ts
+++ b/providers/agents/portal/src/actions.ts
@@ -124,7 +124,7 @@ export async function enableInbound(vc: ViewCtx, name: string): Promise<void> {
     const res = await vc.api.send<{ webhookURL: string; registered: boolean; note: string }>('POST', `/api/connections/${encodeURIComponent(name)}/enable-inbound`, {
       publicBaseURL: location.origin,
     })
-    vc.notify(`${res.registered ? '✅' : 'ℹ️'} ${res.note} URL: ${res.webhookURL}`)
+    vc.notify(`${res.registered ? 'Enabled —' : 'Note:'} ${res.note} URL: ${res.webhookURL}`)
     await vc.store.loadConnections()
   } catch (e) {
     vc.notify(`Enable inbound failed: ${(e as Error).message}`)

--- a/providers/agents/portal/src/conn-defs.ts
+++ b/providers/agents/portal/src/conn-defs.ts
@@ -2,6 +2,8 @@
 // TYPE-DRIVEN: pick what you're connecting, then a form with only that type's
 // fields, each labelled with where to get the value.
 
+import type { IconName } from './icons'
+
 export const PROVIDER_PRESETS: { id: string; label: string; baseURL: string; modelHint: string }[] = [
   { id: 'openai', label: 'OpenAI', baseURL: 'https://api.openai.com/v1', modelHint: 'gpt-4o' },
   { id: 'anthropic', label: 'Anthropic (Claude, OpenAI-compat)', baseURL: 'https://api.anthropic.com/v1', modelHint: 'claude-sonnet-4-20250514' },
@@ -25,7 +27,7 @@ export interface ConnMode {
 export interface ConnTypeDef {
   id: string
   label: string
-  glyph: string
+  glyph: IconName
   desc: string
   // setup is an ordered list of setup steps (HTML allowed), shown as a guide at
   // the top of the create form so users know what to prepare.
@@ -53,10 +55,10 @@ export const CONN_CATEGORY: Record<string, ConnCategory> = {
   smtp: 'channel',
   http: 'connection',
 }
-export const CATEGORY_META: Record<ConnCategory, { icon: string; label: string; blurb: string }> = {
-  tool: { icon: '🔧', label: 'Tool', blurb: 'Capabilities agents call during a run.' },
-  channel: { icon: '📣', label: 'Channel', blurb: 'Where agents message you — notify + inbound chat.' },
-  connection: { icon: '🔌', label: 'Connection', blurb: 'Generic API credentials for custom integrations.' },
+export const CATEGORY_META: Record<ConnCategory, { icon: IconName; label: string; blurb: string }> = {
+  tool: { icon: 'wrench', label: 'Tool', blurb: 'Capabilities agents call during a run.' },
+  channel: { icon: 'megaphone', label: 'Channel', blurb: 'Where agents message you — notify + inbound chat.' },
+  connection: { icon: 'plug', label: 'Connection', blurb: 'Generic API credentials for custom integrations.' },
 }
 export function connCategory(id: string): ConnCategory {
   return CONN_CATEGORY[id] || 'connection'
@@ -80,7 +82,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'github',
     label: 'GitHub',
-    glyph: '🐙',
+    glyph: 'github',
     desc: 'Issues, PRs, code search via the GitHub MCP server',
     modes: [
       {
@@ -115,7 +117,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'mcp',
     label: 'MCP server',
-    glyph: '🧩',
+    glyph: 'puzzle',
     desc: 'Any Model Context Protocol server',
     fields: [
       { key: 'baseURL', label: 'Server endpoint', required: true, placeholder: 'https://example.com/mcp', hint: 'The server’s streamable-HTTP MCP URL.' },
@@ -126,7 +128,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'websearch',
     label: 'Web search',
-    glyph: '🔎',
+    glyph: 'search',
     desc: 'Give agents web_search (Brave-compatible API)',
     fields: [{ key: 'token', label: 'API key', password: true, required: true, hint: 'Brave Search API key — api.search.brave.com/app/keys (free tier available).' }],
     advanced: [{ key: 'baseURL', label: 'Custom endpoint', placeholder: 'https://api.search.brave.com/res/v1/web/search' }],
@@ -135,7 +137,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'telegram',
     label: 'Telegram',
-    glyph: '✈️',
+    glyph: 'send',
     desc: 'Notify + chat with your agent on Telegram',
     fields: [
       { key: 'token', label: 'Bot token', password: true, required: true, hint: 'Create a bot with @BotFather — it gives a token like 12345:ABC…' },
@@ -146,7 +148,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'slack',
     label: 'Slack',
-    glyph: '💬',
+    glyph: 'message',
     desc: 'Notify + chat in Slack',
     modes: [
       {
@@ -193,7 +195,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'discord',
     label: 'Discord chat',
-    glyph: '🎮',
+    glyph: 'discord',
     desc: 'Two-way chat with your agent (bot)',
     setup: [
       'Create the bot: <a href="https://discord.com/developers/applications" target="_blank" rel="noopener">Discord Developer Portal</a> → <strong>New Application</strong> → <strong>Bot</strong> → <strong>Reset Token</strong> → copy it into <strong>Bot token</strong> below.',
@@ -211,7 +213,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'discord-webhook',
     label: 'Discord webhook',
-    glyph: '📣',
+    glyph: 'megaphone',
     desc: 'Notify a Discord channel (outbound only)',
     fields: [
       { key: 'channel', label: 'Webhook URL', required: true, hint: 'Channel → Edit Channel → Integrations → Webhooks → New Webhook → Copy URL. Outbound only, no chat.' },
@@ -221,7 +223,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'smtp',
     label: 'Email (SMTP)',
-    glyph: '✉️',
+    glyph: 'mail',
     desc: 'Send email notifications',
     fields: [
       { key: 'host', label: 'SMTP host', required: true, placeholder: 'smtp.gmail.com' },
@@ -236,7 +238,7 @@ export const CONN_DEFS: ConnTypeDef[] = [
   {
     id: 'http',
     label: 'HTTP API',
-    glyph: '🌐',
+    glyph: 'globe',
     desc: 'Generic HTTP endpoint',
     fields: [
       { key: 'baseURL', label: 'Base URL', required: true, placeholder: 'https://api.example.com' },

--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -28,6 +28,7 @@ import * as triggersView from './views/triggers'
 import * as modelsView from './views/models'
 import * as inboxView from './views/inbox'
 import { resetForTenant as resetChat } from './views/agent-chat'
+import { resetForTenant as resetModels } from './views/models'
 
 const MENU_META: Record<MenuKey, { icon: string; label: string }> = {
   agents: { icon: '🤖', label: 'Agents' },
@@ -106,11 +107,13 @@ export class AgentsElement extends HTMLElement {
     // hash-restored route so a refresh stays put.
     if (this._loadedTenant !== null) {
       resetChat()
+      resetModels()
       this._route = DEFAULT_ROUTE
       syncHash(this._route)
     }
     this._loadedTenant = key
     resetChat()
+    resetModels()
     this._store.loadAll()
   }
 

--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -15,6 +15,7 @@
 import { ApiClient } from './api'
 import { AppStore } from './store'
 import type { KedgeContext } from './types'
+import { ic, type IconName } from './icons'
 import { escapeHTML } from './types'
 import { DEFAULT_ROUTE, MENUS, parseHash, syncHash, type MenuKey, type Route } from './router'
 import type { ViewCtx } from './view'
@@ -30,14 +31,14 @@ import * as inboxView from './views/inbox'
 import { resetForTenant as resetChat } from './views/agent-chat'
 import { resetForTenant as resetModels } from './views/models'
 
-const MENU_META: Record<MenuKey, { icon: string; label: string }> = {
-  agents: { icon: '🤖', label: 'Agents' },
-  connections: { icon: '🔌', label: 'Connections' },
-  toolsets: { icon: '🧰', label: 'Toolsets' },
-  schedules: { icon: '⏰', label: 'Schedules' },
-  triggers: { icon: '⚡', label: 'Triggers' },
-  models: { icon: '⚙', label: 'Models' },
-  inbox: { icon: '📥', label: 'Inbox' },
+const MENU_META: Record<MenuKey, { icon: IconName; label: string }> = {
+  agents: { icon: 'bot', label: 'Agents' },
+  connections: { icon: 'plug', label: 'Connections' },
+  toolsets: { icon: 'package', label: 'Toolsets' },
+  schedules: { icon: 'clock', label: 'Schedules' },
+  triggers: { icon: 'zap', label: 'Triggers' },
+  models: { icon: 'cpu', label: 'Models' },
+  inbox: { icon: 'inbox', label: 'Inbox' },
 }
 
 export class AgentsElement extends HTMLElement {
@@ -183,7 +184,7 @@ export class AgentsElement extends HTMLElement {
       const meta = MENU_META[m]
       const n = count(m)
       const badge = n ? ` <span class="agents-navcount">${n}</span>` : ''
-      return `<button class="agents-navtab ${m === activeMenu ? 'sel' : ''}" data-nav="${m}">${meta.icon} ${meta.label}${badge}</button>`
+      return `<button class="agents-navtab ${m === activeMenu ? 'sel' : ''}" data-nav="${m}">${ic(meta.icon)} ${meta.label}${badge}</button>`
     }).join('')
     return `<nav class="agents-nav">${tabs}</nav>`
   }

--- a/providers/agents/portal/src/flow.ts
+++ b/providers/agents/portal/src/flow.ts
@@ -6,6 +6,8 @@
 // callbacks; it never talks to the API itself — the mapping from a dragged cable
 // to a real spec mutation lives with the data owner.
 
+ import { ic } from './icons'
+
 export type FNodeType =
   | 'agent'
   | 'schedule'
@@ -188,7 +190,7 @@ export class FlowCanvas {
         <div class="flow-world"><svg class="flow-wires" width="4000" height="2600"></svg></div>
       </div>
       <div class="flow-zoom">
-        <button data-z="out">−</button><span class="flow-zval mono">100%</span><button data-z="in">+</button><button data-z="fit" title="Fit to view">⤢</button>
+        <button data-z="out">−</button><span class="flow-zval mono">100%</span><button data-z="in">+</button><button data-z="fit" title="Fit to view">${ic('maximize')}</button>
       </div>
       <div class="flow-legend"></div>
       <div class="flow-modal hidden"><div class="flow-modal-bg"></div><div class="flow-dialog" role="dialog" aria-modal="true"></div></div>
@@ -317,7 +319,7 @@ export class FlowCanvas {
       <div class="flow-nhead">
         <span class="flow-nic">${svgIcon(n.type)}</span>
         <span class="flow-nmeta"><span class="flow-ntype">${TYPES[n.type].label}</span><span class="flow-ntitle">${esc(n.title)}</span></span>
-        ${editable ? '<button class="flow-editbtn" title="Edit" aria-label="Edit">✎</button>' : ''}
+        ${editable ? `<button class="flow-editbtn" title="Edit" aria-label="Edit">${ic('pencil')}</button>` : ''}
       </div>
       <div class="flow-nbody">
         ${n.sub ? `<p class="flow-nsub">${n.sub}</p>` : ''}
@@ -466,8 +468,8 @@ export class FlowCanvas {
       <div class="flow-dialog-head">
         <span class="flow-nic">${svgIcon(n.type)}</span>
         <span class="t"><span class="flow-ntype">${draft ? 'New ' + TYPES[n.type].label.toLowerCase() : TYPES[n.type].label}</span><div class="flow-ntitle">${esc(n.title)}</div></span>
-        <span class="flow-saved" data-saved>saved ✓</span>
-        <button class="flow-x" data-x aria-label="Close">✕</button>
+        <span class="flow-saved" data-saved>saved ${ic('check')}</span>
+        <button class="flow-x" data-x aria-label="Close">${ic('x')}</button>
       </div>
       <div class="flow-dialog-body">
         ${fields || '<p class="flow-nsub">Nothing to edit here — this node is wired from the canvas.</p>'}
@@ -478,7 +480,7 @@ export class FlowCanvas {
         <div class="flow-dialog-actions">
           ${draft ? '<button class="flow-btn" data-discard>Discard</button><button class="flow-btn primary" data-create>Create</button>' : ''}
           ${!draft && n.type === 'chat' ? '<button class="flow-btn primary" data-chat>Open chat</button>' : ''}
-          ${!draft && n.canRun ? '<button class="flow-btn" data-run>▶ Test</button>' : ''}
+          ${!draft && n.canRun ? `<button class="flow-btn" data-run>${ic('play')} Test</button>` : ''}
           ${!draft && n.canDelete ? '<button class="flow-btn danger" data-del>Remove</button>' : ''}
         </div>
       </div>`
@@ -806,7 +808,7 @@ export class FlowCanvas {
         b.classList.toggle('is-new', isNew)
         if (entry.sub) b.title = entry.sub
         else if (entry.linked) b.title = 'already linked to this agent'
-        b.innerHTML = `<span class="chip">${svgIcon(entry.icon)}</span><span>${esc(entry.label)}</span>${entry.linked ? '<span class="flow-pal-check">✓</span>' : ''}`
+        b.innerHTML = `<span class="chip">${svgIcon(entry.icon)}</span><span>${esc(entry.label)}</span>${entry.linked ? `<span class="flow-pal-check">${ic('check')}</span>` : ''}`
         if (entry.linked) {
           // Already referenced — inert (remove it from the agent via the node's
           // Remove button on the canvas).

--- a/providers/agents/portal/src/icons.ts
+++ b/providers/agents/portal/src/icons.ts
@@ -1,0 +1,104 @@
+// Inline SVG icon set — a small, self-contained Lucide-style stroke library
+// (MIT-derived paths, hand-inlined so the bundle has no runtime dependency and
+// stays CSP-safe). Icons inherit the current text color and font size (1em),
+// so they drop into buttons, labels, chips and headings without extra styling.
+//
+// Usage: `${ic('trash')}` inside an HTML template literal. Prefer these over
+// emoji everywhere for a consistent, professional look across light/dark.
+
+export type IconName =
+  | 'bot'
+  | 'plug'
+  | 'wrench'
+  | 'package'
+  | 'clock'
+  | 'zap'
+  | 'cpu'
+  | 'inbox'
+  | 'message'
+  | 'workflow'
+  | 'settings'
+  | 'sliders'
+  | 'trash'
+  | 'pencil'
+  | 'play'
+  | 'pause'
+  | 'plus'
+  | 'x'
+  | 'check'
+  | 'link'
+  | 'key'
+  | 'search'
+  | 'send'
+  | 'eye'
+  | 'brain'
+  | 'puzzle'
+  | 'globe'
+  | 'mail'
+  | 'github'
+  | 'discord'
+  | 'megaphone'
+  | 'swap'
+  | 'maximize'
+  | 'arrow-left'
+  | 'chevron-right'
+  | 'corner-down-right'
+  | 'circle'
+  | 'sparkles'
+  | 'gauge'
+  | 'dollar'
+  | 'refresh'
+  | 'flask'
+
+// Each entry is the inner markup of a 24×24 stroke icon.
+const PATHS: Record<IconName, string> = {
+  bot: '<path d="M12 8V4H8"/><rect x="4" y="8" width="16" height="12" rx="2"/><path d="M2 14h2M20 14h2M9 13v2M15 13v2"/>',
+  plug: '<path d="M9 2v6M15 2v6M7 8h10v3a5 5 0 0 1-10 0zM12 16v6"/>',
+  wrench: '<path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.6 2.6-2.4-.6-.6-2.4z"/>',
+  package: '<path d="M12 2 3 7v10l9 5 9-5V7z"/><path d="M3 7l9 5 9-5M12 12v10"/>',
+  clock: '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+  zap: '<path d="M13 2 4 14h7l-1 8 9-12h-7z"/>',
+  cpu: '<rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3"/>',
+  inbox: '<path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5 5h14l3 7v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-6z"/>',
+  message: '<path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z"/>',
+  workflow: '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/><path d="M6.5 10v3a2 2 0 0 0 2 2H14"/>',
+  settings: '<circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1"/>',
+  sliders: '<path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6"/>',
+  trash: '<path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/><path d="M10 11v6M14 11v6"/>',
+  pencil: '<path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/>',
+  play: '<path d="M6 4l14 8-14 8z"/>',
+  pause: '<rect x="6" y="4" width="4" height="16" rx="1"/><rect x="14" y="4" width="4" height="16" rx="1"/>',
+  plus: '<path d="M12 5v14M5 12h14"/>',
+  x: '<path d="M18 6 6 18M6 6l12 12"/>',
+  check: '<path d="M20 6 9 17l-5-5"/>',
+  link: '<path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1.5 1.5M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1.5-1.5"/>',
+  key: '<circle cx="7.5" cy="15.5" r="4.5"/><path d="M10.5 12.5 20 3M16 7l3 3M14 9l2 2"/>',
+  search: '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>',
+  send: '<path d="M22 2 11 13M22 2l-7 20-4-9-9-4z"/>',
+  eye: '<path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/>',
+  brain: '<path d="M9 3a3 3 0 0 0-3 3 3 3 0 0 0-2 5 3 3 0 0 0 2 5 3 3 0 0 0 6 0V4a3 3 0 0 0-3-1zM15 3a3 3 0 0 1 3 3 3 3 0 0 1 2 5 3 3 0 0 1-2 5 3 3 0 0 1-6 0"/>',
+  puzzle: '<path d="M9 3a2 2 0 0 1 4 0c0 .5-.2 1 .5 1H16a1 1 0 0 1 1 1v2.5c0 .7.5.5 1 .5a2 2 0 0 1 0 4c-.5 0-1-.2-1 .5V19a1 1 0 0 1-1 1h-2.5c-.7 0-.5-.5-.5-1a2 2 0 0 0-4 0c0 .5.2 1-.5 1H6a1 1 0 0 1-1-1v-2.5c0-.7-.5-.5-1-.5a2 2 0 0 1 0-4c.5 0 1 .2 1-.5V6a1 1 0 0 1 1-1h2.5c.7 0 .5-.5.5-1z"/>',
+  globe: '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z"/>',
+  mail: '<rect x="2" y="4" width="20" height="16" rx="2"/><path d="m2 6 10 7 10-7"/>',
+  github:
+    '<path d="M9 19c-4 1.4-4-2-6-2.5M15 21v-3.6c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 0 0-1.3-3.2 4.3 4.3 0 0 0-.1-3.2s-1-.3-3.4 1.3a11.6 11.6 0 0 0-6 0C6.3 2.1 5.3 2.4 5.3 2.4a4.3 4.3 0 0 0-.1 3.2A4.6 4.6 0 0 0 4 8.8c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21"/>',
+  discord: '<path d="M8 11h.01M16 11h.01M7.5 16.5C10 18 14 18 16.5 16.5M8 4.5C6 5 4 6 3.5 7.5 2 11 2 15 3.5 18c1 1 3 2 4.5 2l1-2M16 4.5c2 .5 4 1.5 4.5 3 1.5 3.5 1.5 7.5 0 10.5-1 1-3 2-4.5 2l-1-2"/>',
+  megaphone: '<path d="M3 11v2a1 1 0 0 0 1 1h2l6 4V6L6 10H4a1 1 0 0 0-1 1zM16 8a4 4 0 0 1 0 8M12 6l8-3v18l-8-3"/>',
+  swap: '<path d="M8 3 4 7l4 4M4 7h13M16 21l4-4-4-4M20 17H7"/>',
+  maximize: '<path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M3 16v3a2 2 0 0 0 2 2h3"/>',
+  'arrow-left': '<path d="M19 12H5M12 19l-7-7 7-7"/>',
+  'chevron-right': '<path d="m9 6 6 6-6 6"/>',
+  'corner-down-right': '<path d="M15 10l5 5-5 5M4 4v7a4 4 0 0 0 4 4h12"/>',
+  circle: '<circle cx="12" cy="12" r="6" fill="currentColor" stroke="none"/>',
+  sparkles: '<path d="M12 3l1.8 4.9L19 9.5l-5.2 1.6L12 16l-1.8-4.9L5 9.5l5.2-1.6zM19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8z"/>',
+  gauge: '<path d="M12 15l4-4M21 12a9 9 0 1 0-18 0 9 9 0 0 0 2 5.6h14A9 9 0 0 0 21 12z"/>',
+  dollar: '<path d="M12 2v20M17 6a4 4 0 0 0-4-3H11a3.5 3.5 0 0 0 0 7h2a3.5 3.5 0 0 1 0 7h-2a4 4 0 0 1-4-3"/>',
+  refresh: '<path d="M21 12a9 9 0 1 1-3-6.7L21 8M21 3v5h-5"/>',
+  flask: '<path d="M9 3h6M10 3v6l-5 9a2 2 0 0 0 1.8 3h10.4A2 2 0 0 0 19 18l-5-9V3M7.5 14h9"/>',
+}
+
+// ic returns the inline SVG markup for an icon, optionally with extra classes.
+export function ic(name: IconName, extraClass = ''): string {
+  const cls = extraClass ? `ic ${extraClass}` : 'ic'
+  return `<svg class="${cls}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${PATHS[name]}</svg>`
+}

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -562,6 +562,9 @@ kedge-provider-agents .agents-chip-warn { background: var(--color-warning-surfac
 kedge-provider-agents .agents-chip-btn { cursor: pointer; font-family: "IBM Plex Mono", ui-monospace, monospace; }
 kedge-provider-agents .agents-chip-btn:hover { border-color: var(--color-accent, #6d4fe0); color: var(--color-accent, #6d4fe0); }
 kedge-provider-agents .agents-model-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; font-size: 12px; }
+kedge-provider-agents .agents-model-assign { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
+kedge-provider-agents .agents-chip-primary { background: var(--color-accent-subtle, rgba(109,79,224,.1)); border-color: transparent; color: var(--color-accent, #6d4fe0); font-weight: 600; }
+kedge-provider-agents .agents-chip-fallback { border-style: dashed; color: var(--color-text-secondary, #667); }
 kedge-provider-agents .agents-model-meta .mono { font-size: 11px; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
 kedge-provider-agents .agents-model-discovered { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; font-size: 12px; padding: 8px; border-radius: 9px; background: var(--color-surface, #f4f6fb); }
 kedge-provider-agents .agents-model-actions { display: flex; gap: 8px; align-items: center; margin-top: 2px; }

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -12,6 +12,16 @@ kedge-provider-agents {
   color: var(--color-text-primary, inherit);
 }
 
+/* Inline SVG icons (see icons.ts): inherit color + size from surrounding text,
+ * so they sit cleanly inside buttons, chips, labels and headings. */
+kedge-provider-agents .ic { width: 1.05em; height: 1.05em; display: inline-block; vertical-align: -0.16em; flex: none; stroke-width: 2; }
+kedge-provider-agents button .ic, kedge-provider-agents .agents-chip .ic { vertical-align: -0.16em; }
+/* Buttons/labels that pair an icon with text get a small gap. */
+kedge-provider-agents .agents-navtab, kedge-provider-agents .agents-subtab,
+kedge-provider-agents .agents-card-chat, kedge-provider-agents .agents-model-actions button,
+kedge-provider-agents .agents-back, kedge-provider-agents .agents-health,
+kedge-provider-agents .agents-chip { display: inline-flex; align-items: center; gap: 5px; }
+
 kedge-provider-agents .agents-app { display: flex; flex-direction: column; gap: 16px; min-height: 560px; }
 kedge-provider-agents .agents-empty { flex: 1; display: flex; align-items: center; justify-content: center; text-align: center; min-height: 340px; }
 kedge-provider-agents .agents-page { display: flex; flex-direction: column; gap: 14px; }

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -507,3 +507,70 @@ kedge-provider-agents .agents-linkbtn { background: transparent; border: 0; colo
 kedge-provider-agents .agents-checkrow { display: flex; flex-wrap: wrap; gap: 8px 16px; }
 kedge-provider-agents .agents-toolset-form, kedge-provider-agents .agents-obj-form { display: flex; flex-direction: column; gap: 12px; }
 kedge-provider-agents .mono { font-family: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace; }
+
+/* ===================================================================
+ * Models: usage dashboard + catalog-enriched credential cards.
+ * =================================================================== */
+kedge-provider-agents .agents-section-h { margin: 8px 0 0; font-size: 15px; font-weight: 600; }
+
+/* dashboard */
+kedge-provider-agents .agents-dash { display: flex; flex-direction: column; gap: 12px; padding: 16px; border-radius: 14px;
+  background: var(--color-surface-raised, #fff); border: 1px solid var(--color-border-subtle, rgba(0,0,0,0.06)); }
+kedge-provider-agents .agents-dash-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+kedge-provider-agents .agents-dash-head h3 { margin: 0; }
+kedge-provider-agents .agents-dash-loading { padding: 24px; text-align: center; }
+kedge-provider-agents .agents-seg { display: inline-flex; background: var(--color-surface, #eef1f7); border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 9px; padding: 2px; }
+kedge-provider-agents .agents-seg button { border: 0; background: transparent; color: var(--color-text-secondary, #556); font: inherit; font-size: 12px; font-weight: 600; padding: 4px 11px; border-radius: 7px; cursor: pointer; }
+kedge-provider-agents .agents-seg button.on { background: var(--color-surface-raised, #fff); color: var(--color-text-primary, #123); box-shadow: 0 1px 2px rgba(0,0,0,.12); }
+kedge-provider-agents .agents-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
+kedge-provider-agents .agents-stat { padding: 12px 14px; border-radius: 11px; background: var(--color-surface, #f4f6fb); border: 1px solid var(--color-border-subtle, rgba(0,0,0,.05)); }
+kedge-provider-agents .agents-stat-v { font-size: 22px; font-weight: 700; color: var(--color-text-primary, #123); line-height: 1.1; }
+kedge-provider-agents .agents-stat-k { font-size: 11px; letter-spacing: .05em; text-transform: uppercase; color: var(--color-text-muted, #889); margin-top: 4px; }
+kedge-provider-agents .agents-stat-sub { font-size: 11px; color: var(--color-text-secondary, #667); margin-top: 2px; }
+kedge-provider-agents .agents-dash-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }
+kedge-provider-agents .agents-dash-card { padding: 12px 14px; border-radius: 11px; background: var(--color-surface, #f4f6fb); border: 1px solid var(--color-border-subtle, rgba(0,0,0,.05)); display: flex; flex-direction: column; gap: 10px; }
+kedge-provider-agents .agents-dash-card-h { font-size: 11px; font-weight: 600; letter-spacing: .05em; text-transform: uppercase; color: var(--color-text-muted, #889); }
+
+/* sparkline (monochrome, accent-hued, theme-aware) */
+kedge-provider-agents .agents-spark { width: 100%; height: 40px; display: block; }
+kedge-provider-agents .agents-spark-line { fill: none; stroke: var(--color-accent, #6d4fe0); stroke-width: 1.6; vector-effect: non-scaling-stroke; }
+kedge-provider-agents .agents-spark-fill { fill: var(--color-accent, #6d4fe0); opacity: .14; stroke: none; }
+kedge-provider-agents .agents-spark-empty { font-size: 12px; padding: 10px 0; }
+
+/* horizontal bars */
+kedge-provider-agents .agents-bars { display: flex; flex-direction: column; gap: 7px; }
+kedge-provider-agents .agents-bar-row { display: grid; grid-template-columns: 84px 1fr auto; align-items: center; gap: 8px; font-size: 12px; }
+kedge-provider-agents .agents-bar-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--color-text-secondary, #556); }
+kedge-provider-agents .agents-bar-track { height: 8px; border-radius: 999px; background: var(--color-surface-overlay, rgba(0,0,0,.06)); overflow: hidden; }
+kedge-provider-agents .agents-bar-fill { height: 100%; border-radius: 999px; background: var(--color-accent, #6d4fe0); }
+kedge-provider-agents .agents-bar-val { font-size: 11px; color: var(--color-text-muted, #889); white-space: nowrap; }
+
+/* credential cards */
+kedge-provider-agents .agents-model-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 14px; }
+kedge-provider-agents .agents-model-card { display: flex; flex-direction: column; gap: 10px; padding: 16px; border-radius: 14px;
+  background: var(--color-surface-raised, #fff); border: 1px solid var(--color-border-subtle, rgba(0,0,0,0.06)); }
+kedge-provider-agents .agents-model-card.is-editing { border-color: var(--color-accent, #6d4fe0); }
+kedge-provider-agents .agents-model-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
+kedge-provider-agents .agents-model-title { display: flex; gap: 10px; align-items: center; min-width: 0; }
+kedge-provider-agents .agents-model-glyph { width: 34px; height: 34px; flex: none; display: grid; place-items: center; font-size: 17px; border-radius: 9px; background: var(--color-accent-subtle, rgba(109,79,224,.1)); }
+kedge-provider-agents .agents-model-title h4 { margin: 0; font-size: 15px; font-weight: 600; }
+kedge-provider-agents .agents-model-sub { font-size: 12px; color: var(--color-text-secondary, #667); overflow: hidden; text-overflow: ellipsis; }
+kedge-provider-agents .agents-model-chips { display: flex; flex-wrap: wrap; gap: 5px; }
+kedge-provider-agents .agents-chip { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: var(--color-surface, #eef1f7); border: 1px solid var(--color-border-default, #d9e0ec); color: var(--color-text-secondary, #556); }
+kedge-provider-agents .agents-chip-price { background: var(--color-accent-subtle, rgba(109,79,224,.1)); border-color: transparent; color: var(--color-accent, #6d4fe0); font-weight: 600; }
+kedge-provider-agents .agents-chip-warn { background: var(--color-warning-surface, rgba(234,179,8,.14)); border-color: transparent; color: var(--color-warning, #d97706); }
+kedge-provider-agents .agents-chip-btn { cursor: pointer; font-family: "IBM Plex Mono", ui-monospace, monospace; }
+kedge-provider-agents .agents-chip-btn:hover { border-color: var(--color-accent, #6d4fe0); color: var(--color-accent, #6d4fe0); }
+kedge-provider-agents .agents-model-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; font-size: 12px; }
+kedge-provider-agents .agents-model-meta .mono { font-size: 11px; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+kedge-provider-agents .agents-model-discovered { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; font-size: 12px; padding: 8px; border-radius: 9px; background: var(--color-surface, #f4f6fb); }
+kedge-provider-agents .agents-model-actions { display: flex; gap: 8px; align-items: center; margin-top: 2px; }
+kedge-provider-agents .agents-model-actions button.secondary { font-size: 12.5px; }
+kedge-provider-agents .agents-rotate-form { display: flex; flex-direction: column; gap: 10px; padding: 12px; border-radius: 11px; background: var(--color-surface, #f4f6fb); }
+kedge-provider-agents .agents-model-create { margin-top: 4px; }
+
+/* health badge */
+kedge-provider-agents .agents-health { font-size: 11px; font-weight: 600; white-space: nowrap; padding: 2px 8px; border-radius: 999px; }
+kedge-provider-agents .agents-health-ok { color: var(--color-success, #10b981); background: var(--color-success-surface, rgba(16,185,129,.12)); }
+kedge-provider-agents .agents-health-bad { color: var(--color-danger, #ef4444); background: var(--color-danger-surface, rgba(239,68,68,.1)); }
+kedge-provider-agents .agents-health-unknown { color: var(--color-text-muted, #889); background: var(--color-surface-overlay, rgba(0,0,0,.05)); }

--- a/providers/agents/portal/src/views/agent-chat.ts
+++ b/providers/agents/portal/src/views/agent-chat.ts
@@ -4,6 +4,7 @@
 // there is one element instance for the app's lifetime, and keeping it here (not
 // in the store) means menu re-renders never disturb a live transcript.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { Agent, ChatMessage, SessionMeta } from '../types'
 import { escapeHTML, sessionLabel } from '../types'
@@ -168,7 +169,7 @@ export function render(a: Agent): string {
     <div class="agents-chat">
       <div class="agents-chat-head">
         <select class="agents-session-picker" ${streaming ? 'disabled' : ''} title="Chat sessions">${picker}</select>
-        <button type="button" class="agents-newchat secondary" ${streaming ? 'disabled' : ''}>＋ New chat</button>
+        <button type="button" class="agents-newchat secondary" ${streaming ? 'disabled' : ''}>${ic('plus')} New chat</button>
       </div>
       ${error ? `<div class="agents-err">${escapeHTML(error)}</div>` : ''}
       <div class="agents-log">
@@ -177,7 +178,7 @@ export function render(a: Agent): string {
             ? messages
                 .map((m) =>
                   m.role === 'tool'
-                    ? `<div class="agents-msg tool ${m.error ? 'err' : ''}"><div class="agents-toolrow">🔧 ${escapeHTML(m.content)}</div></div>`
+                    ? `<div class="agents-msg tool ${m.error ? 'err' : ''}"><div class="agents-toolrow">${ic('wrench')} ${escapeHTML(m.content)}</div></div>`
                     : `<div class="agents-msg ${m.role}"><div class="agents-role">${m.role}</div><div class="agents-body">${escapeHTML(m.content) || (streaming && m.role === 'assistant' ? '…' : '')}</div></div>`,
                 )
                 .join('')

--- a/providers/agents/portal/src/views/agent-detail.ts
+++ b/providers/agents/portal/src/views/agent-detail.ts
@@ -2,6 +2,7 @@
 // delete) over one of three tab bodies. Chat is the default. The flow tab mounts
 // the imperative FlowCanvas after render.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { AgentTab } from '../router'
 import { escapeHTML } from '../types'
@@ -11,9 +12,9 @@ import * as settings from './agent-settings'
 import * as flowView from './flow-view'
 
 const TABS: [AgentTab, string][] = [
-  ['chat', '💬 Chat'],
-  ['flow', '◆ Flow'],
-  ['settings', '⚙ Settings'],
+  ['chat', `${ic('message')} Chat`],
+  ['flow', `${ic('workflow')} Flow`],
+  ['settings', `${ic('settings')} Settings`],
 ]
 
 export function render(vc: ViewCtx, name: string, tab: AgentTab): string {
@@ -21,14 +22,14 @@ export function render(vc: ViewCtx, name: string, tab: AgentTab): string {
   if (!a) {
     // Agents may still be loading — show a gentle placeholder rather than an
     // error, since the list refreshes into place.
-    return `<div class="agents-detail"><div class="agents-detail-head"><div class="agents-detail-title"><button class="agents-back" data-back>← Agents</button></div></div><div class="agents-empty"><p class="muted">Loading agent…</p></div></div>`
+    return `<div class="agents-detail"><div class="agents-detail-head"><div class="agents-detail-title"><button class="agents-back" data-back>${ic('arrow-left')} Agents</button></div></div><div class="agents-empty"><p class="muted">Loading agent…</p></div></div>`
   }
   const body = tab === 'chat' ? chat.render(a) : tab === 'settings' ? settings.render(vc, a) : `<div class="agents-flow-host" data-flow-host></div>`
   return `
     <div class="agents-detail ${tab === 'flow' ? 'is-flow' : ''}">
       <div class="agents-detail-head">
         <div class="agents-detail-title">
-          <button class="agents-back" data-back>← Agents</button>
+          <button class="agents-back" data-back>${ic('arrow-left')} Agents</button>
           <h2>${escapeHTML(a.spec?.displayName || a.metadata.name)}</h2>
         </div>
         <div class="agents-detail-actions">

--- a/providers/agents/portal/src/views/agent-settings.ts
+++ b/providers/agents/portal/src/views/agent-settings.ts
@@ -2,6 +2,7 @@
 // monthly budget, and delegation. Tools/toolsets are wired in the Flow tab — the
 // save here deliberately omits them so it never clobbers tool policy.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { Agent } from '../types'
 import { escapeHTML } from '../types'
@@ -20,7 +21,7 @@ export function render(vc: ViewCtx, a: Agent): string {
         <label>Display name<input name="displayName" value="${escapeHTML(a.spec?.displayName || a.metadata.name)}" /></label>
         <label>Model credential
           <select name="modelCredential">${credOptions}</select>
-          ${vc.store.credentials.length === 0 ? `<span class="muted" style="font-size:12px">No models yet — add one under ⚙ Models.</span>` : ''}
+          ${vc.store.credentials.length === 0 ? `<span class="muted" style="font-size:12px">No models yet — add one under ${ic('settings')} Models.</span>` : ''}
         </label>
         <label>System prompt (persona + standing instructions)
           <textarea name="systemPrompt" rows="4" placeholder="You are a concise assistant that…">${escapeHTML(a.spec?.systemPrompt || '')}</textarea>

--- a/providers/agents/portal/src/views/agents.ts
+++ b/providers/agents/portal/src/views/agents.ts
@@ -2,6 +2,7 @@
 // agent's detail page (Chat first). Each card has quick Chat / Flow actions and
 // a delete. A dashed "new agent" tile creates one and jumps into it.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import { escapeHTML } from '../types'
 import { createAgent, deleteAgent } from '../actions'
@@ -16,7 +17,7 @@ export function render(vc: ViewCtx): string {
       const chan = a.spec?.defaultNotifyConnection
       return `
         <article class="agents-card" data-agent="${escapeHTML(a.metadata.name)}">
-          <div class="agents-card-glyph">🤖</div>
+          <div class="agents-card-glyph">${ic('bot')}</div>
           <div class="agents-card-body">
             <h3>${escapeHTML(a.spec?.displayName || a.metadata.name)}</h3>
             <p class="agents-card-model ${model ? '' : 'warn'}">${model ? escapeHTML(model) : 'no model — set up in Settings'}</p>
@@ -24,12 +25,12 @@ export function render(vc: ViewCtx): string {
           <div class="agents-card-foot">
             <span>${nsched} schedule${nsched === 1 ? '' : 's'}</span>
             <span>${ntrig} trigger${ntrig === 1 ? '' : 's'}</span>
-            <span>${chan ? '📣 ' + escapeHTML(chan) : 'no channel'}</span>
+            <span>${chan ? `${ic('megaphone')} ` + escapeHTML(chan) : 'no channel'}</span>
           </div>
           <div class="agents-card-actions">
-            <button class="agents-card-chat" data-chat="${escapeHTML(a.metadata.name)}">💬 Chat</button>
-            <button class="secondary agents-card-flow" data-flow="${escapeHTML(a.metadata.name)}" title="Open flow">◆ Flow</button>
-            <button class="agents-iconbtn agents-iconbtn-danger" data-delagent="${escapeHTML(a.metadata.name)}" title="Delete agent">🗑</button>
+            <button class="agents-card-chat" data-chat="${escapeHTML(a.metadata.name)}">${ic('message')} Chat</button>
+            <button class="secondary agents-card-flow" data-flow="${escapeHTML(a.metadata.name)}" title="Open flow">${ic('workflow')} Flow</button>
+            <button class="agents-iconbtn agents-iconbtn-danger" data-delagent="${escapeHTML(a.metadata.name)}" title="Delete agent">${ic('trash')}</button>
           </div>
         </article>`
     })
@@ -39,7 +40,7 @@ export function render(vc: ViewCtx): string {
     <div class="agents-menu">
       <div class="agents-grid">
         <form class="agents-card agents-card-new">
-          <div class="agents-card-glyph">＋</div>
+          <div class="agents-card-glyph">${ic('plus')}</div>
           <input name="name" placeholder="new-agent-id" required pattern="[a-z0-9-]+" />
           <button>Create agent</button>
         </form>

--- a/providers/agents/portal/src/views/connections.ts
+++ b/providers/agents/portal/src/views/connections.ts
@@ -1,8 +1,9 @@
-// Connections menu: shared credentials for external systems. Each is a 🔧 Tool
-// agents call, a 📣 Channel they message you on, or a 🔌 generic Connection.
+// Connections menu: shared credentials for external systems. Each is a ${ic('wrench')} Tool
+// agents call, a ${ic('megaphone')} Channel they message you on, or a ${ic('plug')} generic Connection.
 // Type-driven create (CONN_DEFS), edit with Discord special-casing, test /
 // enable-inbound / OAuth-connect actions.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { Connection } from '../types'
 import { escapeHTML } from '../types'
@@ -51,13 +52,13 @@ function renderConnEditForm(c: Connection): string {
   const secretField = isDiscordWebhook
     ? ''
     : isOAuth
-      ? '<p class="agents-hint">This is an OAuth connection — use the 🔗 button in the table to re-authorize. Client credentials aren’t edited here.</p>'
+      ? `<p class="agents-hint">This is an OAuth connection — use the ${ic('link')} button in the table to re-authorize. Client credentials aren’t edited here.</p>`
       : `<label>New ${isDiscordBot ? 'bot token' : 'secret / token'}<input name="secret" type="password" placeholder="leave blank to keep the current one" /><span class="agents-hint">Only set this to rotate the credential.</span></label>`
   const kindLabel = isDiscordWebhook ? 'Discord webhook' : isDiscordBot ? 'Discord chat' : ''
   return `<form class="agents-conn-form" data-editconn="${escapeHTML(c.metadata.name)}" data-usechannel="${usesChannel ? '1' : '0'}">
       <div class="agents-conn-formhead">
-        <button type="button" class="agents-back" data-conncancel>← connections</button>
-        <h4>Edit ${escapeHTML(CATEGORY_META[cat].icon)} <code>${escapeHTML(c.metadata.name)}</code>${kindLabel ? ` <span class="agents-badge">${escapeHTML(kindLabel)}</span>` : ''}</h4>
+        <button type="button" class="agents-back" data-conncancel>${ic('arrow-left')} connections</button>
+        <h4>Edit ${ic(CATEGORY_META[cat].icon)} <code>${escapeHTML(c.metadata.name)}</code>${kindLabel ? ` <span class="agents-badge">${escapeHTML(kindLabel)}</span>` : ''}</h4>
       </div>
       <label>Display name<input name="displayName" value="${escapeHTML(c.spec.displayName || '')}" placeholder="${escapeHTML(c.metadata.name)}" /></label>
       <label>${endpointLabel}<input name="endpoint" value="${escapeHTML(endpointVal)}" /></label>
@@ -75,13 +76,13 @@ function renderConnForm(def: ConnTypeDef, oauthApps: Set<string>): string {
   let platformNote = ''
   if (isOAuthMode && oauthApps.has(def.id)) {
     fields = fields.filter((f) => f.key !== 'clientID' && f.key !== 'clientSecret')
-    platformNote = `<div class="agents-platform-note">✓ Using the platform's ${escapeHTML(def.label)} OAuth app — no client id/secret needed. Create it, then click <strong>Connect</strong>.</div>`
+    platformNote = `<div class="agents-platform-note">${ic('check')} Using the platform's ${escapeHTML(def.label)} OAuth app — no client id/secret needed. Create it, then click <strong>Connect</strong>.</div>`
   }
   return `
     <form class="agents-conn-form" data-type="${def.id}">
       <div class="agents-conn-formhead">
-        <button type="button" class="agents-back" data-conntypes>← connection types</button>
-        <h4>${def.glyph} ${escapeHTML(def.label)}</h4>
+        <button type="button" class="agents-back" data-conntypes>${ic('arrow-left')} connection types</button>
+        <h4>${ic(def.glyph)} ${escapeHTML(def.label)}</h4>
       </div>
       <p class="muted">${escapeHTML(def.desc)}</p>
       ${
@@ -106,7 +107,7 @@ export function render(vc: ViewCtx): string {
   const conns = vc.store.connections
   const def = connType ? CONN_DEFS.find((d) => d.id === connType) : null
   const tile = (d: ConnTypeDef) => `<button class="agents-conn-tile" data-conntype="${d.id}">
-               <span class="agents-conn-glyph">${d.glyph}</span>
+               <span class="agents-conn-glyph">${ic(d.glyph)}</span>
                <span class="agents-conn-name">${escapeHTML(d.label)}</span>
                <span class="muted">${escapeHTML(d.desc)}</span>
              </button>`
@@ -116,7 +117,7 @@ export function render(vc: ViewCtx): string {
       if (!defs.length) return ''
       const m = CATEGORY_META[cat]
       return `<div class="agents-conn-group">
-          <h5 class="agents-conn-grouphead">${m.icon} ${escapeHTML(m.label)}s <span class="muted">— ${escapeHTML(m.blurb)}</span></h5>
+          <h5 class="agents-conn-grouphead">${ic(m.icon)} ${escapeHTML(m.label)}s <span class="muted">— ${escapeHTML(m.blurb)}</span></h5>
           <div class="agents-conn-types">${defs.map(tile).join('')}</div>
         </div>`
     })
@@ -129,7 +130,7 @@ export function render(vc: ViewCtx): string {
       : `<div class="agents-conn-picker"><h4>Add a connection</h4>${groups}</div>`
   const catBadge = (id: string) => {
     const m = CATEGORY_META[connCategory(id)]
-    return `<span class="agents-badge agents-badge-cat agents-cat-${connCategory(id)}">${m.icon} ${escapeHTML(m.label)}</span>`
+    return `<span class="agents-badge agents-badge-cat agents-cat-${connCategory(id)}">${ic(m.icon)} ${escapeHTML(m.label)}</span>`
   }
   const typeLabel = (c: Connection) => {
     if (c.spec.type !== 'discord') return c.spec.type
@@ -138,7 +139,7 @@ export function render(vc: ViewCtx): string {
   return `
     <div class="agents-panel">
       <h3>Connections</h3>
-      <p class="muted">Shared credentials for external systems. Each is a 🔧 <strong>Tool</strong> agents call, a 📣 <strong>Channel</strong> they message you on, or a 🔌 generic <strong>Connection</strong>. Stored as Secrets in your workspace.</p>
+      <p class="muted">Shared credentials for external systems. Each is a ${ic('wrench')} <strong>Tool</strong> agents call, a ${ic('megaphone')} <strong>Channel</strong> they message you on, or a ${ic('plug')} generic <strong>Connection</strong>. Stored as Secrets in your workspace.</p>
       <table class="agents-table">
         <thead><tr><th>Name</th><th>Kind</th><th>Type</th><th>Endpoint / channel</th><th class="agents-th-actions">Actions</th></tr></thead>
         <tbody>
@@ -147,21 +148,21 @@ export function render(vc: ViewCtx): string {
               ? conns
                   .map(
                     (c) => `<tr>
-                      <td><span class="agents-cell-name">${escapeHTML(c.spec.displayName || c.metadata.name)}</span>${c.status?.webhookPath ? ' <span class="agents-inbound-on" title="Inbound enabled">⇄</span>' : ''}${c.status?.oauthConnected ? ' <span class="agents-inbound-on" title="OAuth connected">🔗</span>' : ''}</td>
+                      <td><span class="agents-cell-name">${escapeHTML(c.spec.displayName || c.metadata.name)}</span>${c.status?.webhookPath ? ` <span class="agents-inbound-on" title="Inbound enabled">${ic('swap')}</span>` : ''}${c.status?.oauthConnected ? ` <span class="agents-inbound-on" title="OAuth connected">${ic('link')}</span>` : ''}</td>
                       <td>${catBadge(c.spec.type)}</td>
                       <td><span class="agents-badge">${escapeHTML(typeLabel(c))}</span></td>
                       <td class="agents-cell-task muted">${escapeHTML(c.spec.baseURL || c.spec.channel || '—')}</td>
                       <td class="agents-row-actions">
-                        <button class="agents-iconbtn" data-editconn="${escapeHTML(c.metadata.name)}" title="Edit">✏️</button>
-                        ${connCategory(c.spec.type) === 'channel' ? `<button class="agents-iconbtn" data-testconn="${escapeHTML(c.metadata.name)}" title="Send a test message">📨</button>` : ''}
-                        ${connCategory(c.spec.type) === 'channel' ? `<button class="agents-iconbtn" data-inbound="${escapeHTML(c.metadata.name)}" title="${c.status?.webhookPath ? 'Inbound enabled' : 'Enable inbound chat'}">⇄</button>` : ''}
-                        ${c.spec.auth === 'oauth' ? `<button class="agents-iconbtn" data-oauth="${escapeHTML(c.metadata.name)}" title="${c.status?.oauthConnected ? 'Reconnect OAuth' : 'Connect OAuth'}">🔗</button>` : ''}
-                        <button class="agents-iconbtn agents-iconbtn-danger" data-delconn="${escapeHTML(c.metadata.name)}" title="Delete">🗑</button>
+                        <button class="agents-iconbtn" data-editconn="${escapeHTML(c.metadata.name)}" title="Edit">${ic('pencil')}</button>
+                        ${connCategory(c.spec.type) === 'channel' ? `<button class="agents-iconbtn" data-testconn="${escapeHTML(c.metadata.name)}" title="Send a test message">${ic('send')}</button>` : ''}
+                        ${connCategory(c.spec.type) === 'channel' ? `<button class="agents-iconbtn" data-inbound="${escapeHTML(c.metadata.name)}" title="${c.status?.webhookPath ? 'Inbound enabled' : 'Enable inbound chat'}">${ic('swap')}</button>` : ''}
+                        ${c.spec.auth === 'oauth' ? `<button class="agents-iconbtn" data-oauth="${escapeHTML(c.metadata.name)}" title="${c.status?.oauthConnected ? 'Reconnect OAuth' : 'Connect OAuth'}">${ic('link')}</button>` : ''}
+                        <button class="agents-iconbtn agents-iconbtn-danger" data-delconn="${escapeHTML(c.metadata.name)}" title="Delete">${ic('trash')}</button>
                       </td>
                     </tr>`,
                   )
                   .join('')
-              : `<tr class="agents-empty-row"><td colspan="5"><span class="agents-empty">🔌 No connections yet — add one below.</span></td></tr>`
+              : `<tr class="agents-empty-row"><td colspan="5"><span class="agents-empty">${ic('plug')} No connections yet — add one below.</span></td></tr>`
           }
         </tbody>
       </table>

--- a/providers/agents/portal/src/views/flow-view.ts
+++ b/providers/agents/portal/src/views/flow-view.ts
@@ -499,7 +499,7 @@ function flowDraftFor(key: string): DraftSpec | null {
           label: 'Tool',
           kind: 'select',
           value: '',
-          options: [{ value: '', label: `＋ Create a new ${t.label} tool` }, ...existing.map((c) => ({ value: c.metadata.name, label: c.spec.displayName || c.metadata.name }))],
+          options: [{ value: '', label: `+ Create a new ${t.label} tool` }, ...existing.map((c) => ({ value: c.metadata.name, label: c.spec.displayName || c.metadata.name }))],
           hint: existing.length ? 'reuse one you already have, or create a new one below' : undefined,
         },
         {
@@ -531,7 +531,7 @@ function flowDraftFor(key: string): DraftSpec | null {
           label: 'Toolset',
           kind: 'select',
           value: '',
-          options: [{ value: '', label: '＋ Create a new toolset' }, ...unlinked.map((t) => ({ value: t.metadata.name, label: t.spec.displayName || t.metadata.name }))],
+          options: [{ value: '', label: '+ Create a new toolset' }, ...unlinked.map((t) => ({ value: t.metadata.name, label: t.spec.displayName || t.metadata.name }))],
           hint: unlinked.length ? 'link a shared one, or create a new bundle below' : undefined,
         },
         { key: 'name', label: 'New toolset name', kind: 'text', placeholder: 'dev-tools', hint: 'only when creating a new toolset' },

--- a/providers/agents/portal/src/views/inbox.ts
+++ b/providers/agents/portal/src/views/inbox.ts
@@ -1,6 +1,7 @@
 // Inbox menu: approvals and questions agents raise across the workspace.
 // Approve/deny grants one tool call.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import { escapeHTML } from '../types'
 import { resolveInbox } from '../actions'
@@ -27,7 +28,7 @@ export function render(vc: ViewCtx): string {
                     </tr>`,
                   )
                   .join('')
-              : `<tr class="agents-empty-row"><td colspan="5"><span class="agents-empty">📥 Nothing needs your attention.</span></td></tr>`
+              : `<tr class="agents-empty-row"><td colspan="5"><span class="agents-empty">${ic('inbox')} Nothing needs your attention.</span></td></tr>`
           }
         </tbody>
       </table>

--- a/providers/agents/portal/src/views/models.ts
+++ b/providers/agents/portal/src/views/models.ts
@@ -1,78 +1,440 @@
-// Models menu: workspace-shared model credentials (each is its own Secret,
-// kedge-agents-model-<name>). Create + delete; assign to agents in each agent's
-// Settings tab.
+// Models menu: model credentials as an ops surface, not a plain table.
+//  - a usage dashboard (spend, tokens, runs, error rate, p50/p95 latency) over a
+//    selectable window, with a daily spend sparkline and by-model / by-agent
+//    breakdowns — all from GET /api/usage (derived from the runs table);
+//  - credential cards enriched from the model catalog (pricing + capability
+//    chips + context window), each with a live health probe (Test → latency +
+//    served-model discovery), key rotation, edit and delete;
+//  - an assignments view: which agents use each model (primary vs fallback).
+//
+// Each credential is its own Secret (kedge-agents-model-<name>).
 
 import type { ViewCtx } from '../view'
+import type { Credential } from '../types'
 import { escapeHTML } from '../types'
 import { PROVIDER_PRESETS } from '../conn-defs'
 import { createCredential, deleteCredential } from '../actions'
 
+// ---- data shapes (mirror the backend JSON) ---------------------------------
+
+interface ModelInfo {
+  id: string
+  family: string
+  label?: string
+  contextWindow?: number
+  inputPer1M: number
+  outputPer1M: number
+  vision?: boolean
+  toolCall?: boolean
+  reasoning?: boolean
+}
+interface UsageBucket {
+  key: string
+  runs: number
+  errors: number
+  inputTokens: number
+  outputTokens: number
+  usdMicros: number
+  latencyP50MS: number
+  latencyP95MS: number
+}
+interface UsagePoint {
+  date: string
+  runs: number
+  inputTokens: number
+  outputTokens: number
+  usdMicros: number
+}
+interface UsageResponse {
+  windowDays: number
+  total: UsageBucket
+  byAgent: UsageBucket[]
+  byModel: UsageBucket[]
+  series: UsagePoint[]
+}
+interface TestResult {
+  ok: boolean
+  latencyMS: number
+  error?: string
+  models?: string[]
+}
+
+// ---- view-local state ------------------------------------------------------
+
+let catalog: ModelInfo[] = []
+let catalogLoaded = false
+let usage: UsageResponse | null = null
+let windowDays = 30
+const tested = new Map<string, TestResult>() // credential name → last probe
+const discovered = new Map<string, string[]>() // credential name → served model ids
+let editName: string | null = null // credential being edited (rotate/model), or null
+let creating = false
 let msg: string | null = null
 
-export function render(vc: ViewCtx): string {
-  const creds = vc.store.credentials
+// resetForTenant clears cross-workspace state on a tenant switch.
+export function resetForTenant(): void {
+  catalog = []
+  catalogLoaded = false
+  usage = null
+  tested.clear()
+  discovered.clear()
+  editName = null
+  creating = false
+  msg = null
+}
+
+async function ensureLoaded(vc: ViewCtx): Promise<void> {
+  if (!catalogLoaded) {
+    catalogLoaded = true
+    try {
+      catalog = await vc.api.list<ModelInfo>('/api/catalog')
+    } catch {
+      catalog = []
+    }
+    vc.rerender()
+  }
+  if (!usage) void loadUsage(vc)
+}
+
+async function loadUsage(vc: ViewCtx): Promise<void> {
+  try {
+    usage = await vc.api.get<UsageResponse>(`/api/usage?days=${windowDays}`)
+  } catch {
+    usage = null
+  }
+  vc.rerender()
+}
+
+// ---- catalog helpers (client mirror of the backend normalization) ----------
+
+function lookupModel(model: string): ModelInfo | undefined {
+  const norm = (model || '').toLowerCase().trim().replace(/^.*\//, '')
+  if (!norm) return undefined
+  let exact: ModelInfo | undefined
+  let best: ModelInfo | undefined
+  for (const m of catalog) {
+    if (m.id === norm) exact = m
+    if (norm.startsWith(m.id) && (!best || m.id.length > best.id.length)) best = m
+  }
+  return exact || best
+}
+
+// ---- formatting ------------------------------------------------------------
+
+function fmtUSD(micros: number): string {
+  const usd = micros / 1e6
+  if (usd === 0) return '$0'
+  if (usd < 0.01) return '$' + usd.toFixed(4)
+  if (usd < 100) return '$' + usd.toFixed(2)
+  return '$' + Math.round(usd).toLocaleString()
+}
+function fmtTokens(n: number): string {
+  if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B'
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M'
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k'
+  return String(n)
+}
+function fmtCtx(n?: number): string {
+  if (!n) return ''
+  if (n >= 1e6) return n / 1e6 + 'M ctx'
+  if (n >= 1e3) return Math.round(n / 1e3) + 'k ctx'
+  return n + ' ctx'
+}
+function pct(n: number, d: number): string {
+  if (d === 0) return '0%'
+  return Math.round((n / d) * 100) + '%'
+}
+
+// capabilityChips renders capability + pricing badges for a catalog entry.
+function capabilityChips(mi: ModelInfo): string {
+  const chips: string[] = []
+  if (mi.contextWindow) chips.push(`<span class="agents-chip">${fmtCtx(mi.contextWindow)}</span>`)
+  if (mi.vision) chips.push(`<span class="agents-chip">👁 vision</span>`)
+  if (mi.toolCall) chips.push(`<span class="agents-chip">🔧 tools</span>`)
+  if (mi.reasoning) chips.push(`<span class="agents-chip">🧠 reasoning</span>`)
+  chips.push(`<span class="agents-chip agents-chip-price">$${mi.inputPer1M}/$${mi.outputPer1M} per 1M</span>`)
+  return chips.join('')
+}
+
+// sparkline draws a tiny inline-SVG area chart of daily spend (monochrome,
+// theme-aware via the accent token). No chart lib — the page is self-contained.
+function sparkline(series: UsagePoint[]): string {
+  const pts = series.map((p) => p.usdMicros)
+  if (pts.length < 2 || Math.max(...pts) === 0) return '<div class="agents-spark-empty muted">no spend in this window</div>'
+  const w = 260
+  const h = 40
+  const max = Math.max(...pts)
+  const step = w / (pts.length - 1)
+  const coords = pts.map((v, i) => `${(i * step).toFixed(1)},${(h - (v / max) * (h - 4) - 2).toFixed(1)}`)
+  const line = coords.join(' ')
+  const area = `0,${h} ${line} ${w},${h}`
+  return `<svg class="agents-spark" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" role="img" aria-label="daily spend">
+      <polygon class="agents-spark-fill" points="${area}" />
+      <polyline class="agents-spark-line" points="${line}" />
+    </svg>`
+}
+
+// bar renders one labeled horizontal bar (value relative to max).
+function bar(label: string, value: number, max: number, right: string): string {
+  const w = max > 0 ? Math.max(2, Math.round((value / max) * 100)) : 0
+  return `<div class="agents-bar-row">
+      <div class="agents-bar-label" title="${escapeHTML(label)}">${escapeHTML(label)}</div>
+      <div class="agents-bar-track"><div class="agents-bar-fill" style="width:${w}%"></div></div>
+      <div class="agents-bar-val">${escapeHTML(right)}</div>
+    </div>`
+}
+
+// ---- render ----------------------------------------------------------------
+
+function renderDashboard(): string {
+  if (!usage) return `<div class="agents-dash-loading muted">Loading usage…</div>`
+  const t = usage.total
+  const errRate = pct(t.errors, t.runs)
+  const tokens = t.inputTokens + t.outputTokens
+  const stat = (label: string, value: string, sub = '') =>
+    `<div class="agents-stat"><div class="agents-stat-v">${value}</div><div class="agents-stat-k">${escapeHTML(label)}</div>${sub ? `<div class="agents-stat-sub">${escapeHTML(sub)}</div>` : ''}</div>`
+  const maxModel = Math.max(1, ...usage.byModel.map((b) => b.usdMicros))
+  const modelBars =
+    usage.byModel.length && usage.byModel.some((b) => b.usdMicros > 0 || b.runs > 0)
+      ? usage.byModel
+          .slice(0, 6)
+          .map((b) => bar(b.key, b.usdMicros, maxModel, `${fmtUSD(b.usdMicros)} · ${b.runs} run${b.runs === 1 ? '' : 's'}`))
+          .join('')
+      : '<div class="muted" style="font-size:12px">No runs yet in this window.</div>'
+  const maxAgent = Math.max(1, ...usage.byAgent.map((b) => b.usdMicros))
+  const agentBars = usage.byAgent
+    .slice(0, 6)
+    .map((b) => bar(b.key, b.usdMicros, maxAgent, `${fmtUSD(b.usdMicros)} · ${b.latencyP50MS ? b.latencyP50MS + 'ms p50' : '—'}${b.errors ? ` · ${b.errors} err` : ''}`))
+    .join('')
   return `
-    <div class="agents-panel agents-form-panel">
-      <h3>Models</h3>
-      <p class="muted">Model credentials shared across the workspace — create once, assign to agents in each agent's Settings. Each is its own Secret (<code>kedge-agents-model-&lt;name&gt;</code>).</p>
-      <table class="agents-table">
-        <thead><tr><th>Name</th><th>Provider</th><th>Model</th><th>Base URL</th><th class="agents-th-actions">Actions</th></tr></thead>
-        <tbody>
-          ${
-            creds.length
-              ? creds
-                  .map(
-                    (c) => `<tr>
-                      <td><strong>${escapeHTML(c.name)}</strong></td>
-                      <td>${escapeHTML(c.provider || '')}</td>
-                      <td>${escapeHTML(c.model || '')}</td>
-                      <td class="muted">${escapeHTML(c.baseURL || '')}</td>
-                      <td class="agents-row-actions"><button class="agents-iconbtn agents-iconbtn-danger" data-delcred="${escapeHTML(c.name)}" title="Delete">🗑</button></td>
-                    </tr>`,
-                  )
-                  .join('')
-              : `<tr class="agents-empty-row"><td colspan="5"><span class="agents-empty">⚙ No models yet — add one below.</span></td></tr>`
-          }
-        </tbody>
-      </table>
-      <form class="agents-cred-form">
+    <div class="agents-dash">
+      <div class="agents-dash-head">
+        <h3>Usage &amp; cost</h3>
+        <div class="agents-seg" data-window>
+          ${[7, 30, 90].map((d) => `<button class="${d === windowDays ? 'on' : ''}" data-days="${d}">${d}d</button>`).join('')}
+        </div>
+      </div>
+      <div class="agents-stats">
+        ${stat('spend', fmtUSD(t.usdMicros), `${usage.windowDays}d`)}
+        ${stat('tokens', fmtTokens(tokens), `${fmtTokens(t.inputTokens)} in · ${fmtTokens(t.outputTokens)} out`)}
+        ${stat('runs', String(t.runs), errRate + ' errors')}
+        ${stat('latency', t.latencyP50MS ? t.latencyP50MS + 'ms' : '—', t.latencyP95MS ? t.latencyP95MS + 'ms p95' : 'p50 / p95')}
+      </div>
+      <div class="agents-dash-grid">
+        <div class="agents-dash-card">
+          <div class="agents-dash-card-h">Daily spend</div>
+          ${sparkline(usage.series)}
+        </div>
+        <div class="agents-dash-card">
+          <div class="agents-dash-card-h">Spend by model</div>
+          <div class="agents-bars">${modelBars}</div>
+        </div>
+        <div class="agents-dash-card">
+          <div class="agents-dash-card-h">Spend by agent</div>
+          <div class="agents-bars">${agentBars || '<div class="muted" style="font-size:12px">—</div>'}</div>
+        </div>
+      </div>
+    </div>`
+}
+
+function healthBadge(name: string): string {
+  const t = tested.get(name)
+  if (!t) return `<span class="agents-health agents-health-unknown" title="not tested">● untested</span>`
+  if (t.ok) return `<span class="agents-health agents-health-ok" title="healthy">● healthy · ${t.latencyMS}ms</span>`
+  return `<span class="agents-health agents-health-bad" title="${escapeHTML(t.error || 'failed')}">● failed</span>`
+}
+
+function credentialCard(vc: ViewCtx, c: Credential): string {
+  const mi = lookupModel(c.model || '')
+  const usedBy = vc.store.agents.filter((a) => {
+    const chat = a.spec?.models?.chat
+    const fb = a.spec?.modelFallbacks || []
+    return chat === c.name || fb.includes(c.name)
+  })
+  const disc = discovered.get(c.name)
+  const isEditing = editName === c.name
+  const chips = mi ? capabilityChips(mi) : `<span class="agents-chip agents-chip-warn">not in catalog — no pricing</span>`
+  return `
+    <article class="agents-model-card ${isEditing ? 'is-editing' : ''}">
+      <div class="agents-model-head">
+        <div class="agents-model-title">
+          <span class="agents-model-glyph">⚙</span>
+          <div>
+            <h4>${escapeHTML(c.name)}</h4>
+            <div class="agents-model-sub"><span class="mono">${escapeHTML(c.model || '—')}</span>${mi?.label ? ` · ${escapeHTML(mi.label)}` : ''}</div>
+          </div>
+        </div>
+        ${healthBadge(c.name)}
+      </div>
+      <div class="agents-model-chips">${chips}</div>
+      <div class="agents-model-meta">
+        <span class="muted">${escapeHTML(c.provider || 'openai-compatible')}</span>
+        ${c.baseURL ? `<span class="muted mono">${escapeHTML(c.baseURL)}</span>` : ''}
+        <span class="agents-badge">${usedBy.length} agent${usedBy.length === 1 ? '' : 's'}</span>
+      </div>
+      ${
+        disc && disc.length
+          ? `<div class="agents-model-discovered"><span class="muted">served models — click to switch:</span> ${disc
+              .slice(0, 24)
+              .map((m) => `<button class="agents-chip agents-chip-btn" data-setmodel="${escapeHTML(c.name)}" data-model="${escapeHTML(m)}">${escapeHTML(m)}</button>`)
+              .join('')}</div>`
+          : ''
+      }
+      ${isEditing ? renderRotate(c) : ''}
+      <div class="agents-model-actions">
+        <button class="secondary" data-testcred="${escapeHTML(c.name)}">🔌 Test</button>
+        <button class="secondary" data-editcred="${escapeHTML(c.name)}">${isEditing ? 'Close' : '🔑 Rotate / model'}</button>
+        <button class="agents-iconbtn agents-iconbtn-danger" data-delcred="${escapeHTML(c.name)}" title="Delete">🗑</button>
+      </div>
+    </article>`
+}
+
+// renderRotate is the inline edit panel: rotate the key and/or change the model.
+function renderRotate(c: Credential): string {
+  return `<form class="agents-rotate-form" data-rotate="${escapeHTML(c.name)}">
+      <div class="agents-grid2">
+        <label>Model<input name="model" value="${escapeHTML(c.model || '')}" class="mono" placeholder="gpt-4o" list="agents-catalog-models" /></label>
+        <label>Base URL<input name="baseURL" value="${escapeHTML(c.baseURL || '')}" class="mono" placeholder="https://api.openai.com/v1" /></label>
+      </div>
+      <label>New API key <span class="agents-hint">leave blank to keep the current key</span><input name="apiKey" type="password" autocomplete="off" placeholder="sk-… (rotate)" /></label>
+      <div class="agents-form-actions"><button>Save</button><button type="button" class="secondary" data-editcancel>Cancel</button></div>
+    </form>`
+}
+
+export function render(vc: ViewCtx): string {
+  void ensureLoaded(vc)
+  const creds = vc.store.credentials
+  const cards = creds.length
+    ? creds.map((c) => credentialCard(vc, c)).join('')
+    : `<div class="agents-empty-row"><span class="agents-empty">⚙ No models yet — add one below.</span></div>`
+  const createForm = creating
+    ? `<form class="agents-cred-form agents-model-create">
         <h4>New model credential</h4>
         <div class="agents-grid2">
           <label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="my-openai" /></label>
           <label>Provider<select name="preset">${PROVIDER_PRESETS.map((p) => `<option value="${p.id}">${escapeHTML(p.label)}</option>`).join('')}</select></label>
-          <label>Base URL<input name="baseURL" value="${PROVIDER_PRESETS[0].baseURL}" placeholder="https://api.openai.com/v1" /></label>
-          <label>Model<input name="model" placeholder="gpt-4o" required /></label>
+          <label>Base URL<input name="baseURL" class="mono" value="${PROVIDER_PRESETS[0].baseURL}" placeholder="https://api.openai.com/v1" /></label>
+          <label>Model<input name="model" class="mono" placeholder="gpt-4o" required list="agents-catalog-models" /></label>
         </div>
         <label>API key<input name="apiKey" type="password" autocomplete="off" placeholder="sk-…" required /></label>
         ${msg ? `<div class="agents-msg-note">${escapeHTML(msg)}</div>` : ''}
-        <button>Add credential</button>
-      </form>
+        <div class="agents-form-actions"><button>Add credential</button><button type="button" class="secondary" data-createcancel>Cancel</button></div>
+      </form>`
+    : ''
+  // A datalist of known catalog model ids helps autocomplete the model field.
+  const datalist = `<datalist id="agents-catalog-models">${catalog.map((m) => `<option value="${escapeHTML(m.id)}">${escapeHTML(m.label || m.id)}</option>`).join('')}</datalist>`
+  return `
+    <div class="agents-panel">
+      <div class="agents-panel-head"><h3>Models</h3>${creating ? '' : `<button data-newcred>＋ New model</button>`}</div>
+      <p class="muted">Model credentials shared across the workspace (each is a Secret <code>kedge-agents-model-&lt;name&gt;</code>). Assign them to agents in each agent's Settings or Flow.</p>
+      ${renderDashboard()}
+      <h3 class="agents-section-h">Credentials</h3>
+      <div class="agents-model-grid">${cards}</div>
+      ${createForm}
+      ${datalist}
     </div>`
 }
 
+// ---- wire ------------------------------------------------------------------
+
+async function testCredential(vc: ViewCtx, name: string): Promise<void> {
+  vc.notify(`Testing ${name}…`)
+  try {
+    const res = await vc.api.send<TestResult>('POST', `/api/credentials/${encodeURIComponent(name)}/test`)
+    tested.set(name, res)
+    if (res.models?.length) discovered.set(name, res.models)
+    vc.notify(res.ok ? `${name}: healthy · ${res.latencyMS}ms${res.models?.length ? ` · ${res.models.length} models` : ''}` : `${name}: ${res.error || 'failed'}`)
+  } catch (e) {
+    tested.set(name, { ok: false, latencyMS: 0, error: (e as Error).message })
+    vc.notify(`${name}: ${(e as Error).message}`)
+  }
+}
+
 export function wire(vc: ViewCtx, root: HTMLElement): void {
+  // Window selector for the dashboard.
+  root.querySelectorAll<HTMLElement>('[data-window] button').forEach((el) =>
+    el.addEventListener('click', () => {
+      const d = Number(el.dataset.days)
+      if (d && d !== windowDays) {
+        windowDays = d
+        usage = null
+        vc.rerender()
+        void loadUsage(vc)
+      }
+    }),
+  )
+  root.querySelector<HTMLElement>('[data-newcred]')?.addEventListener('click', () => {
+    creating = true
+    msg = null
+    vc.rerender()
+  })
+  root.querySelector<HTMLElement>('[data-createcancel]')?.addEventListener('click', () => {
+    creating = false
+    vc.rerender()
+  })
+  root.querySelectorAll<HTMLElement>('[data-testcred]').forEach((el) => el.addEventListener('click', () => void testCredential(vc, el.dataset.testcred!)))
+  root.querySelectorAll<HTMLElement>('[data-editcred]').forEach((el) =>
+    el.addEventListener('click', () => {
+      const n = el.dataset.editcred!
+      editName = editName === n ? null : n
+      vc.rerender()
+    }),
+  )
+  root.querySelector<HTMLElement>('[data-editcancel]')?.addEventListener('click', () => {
+    editName = null
+    vc.rerender()
+  })
   root.querySelectorAll<HTMLElement>('[data-delcred]').forEach((el) =>
     el.addEventListener('click', () => {
       if (confirm(`Delete credential ${el.dataset.delcred}? Agents using it will need reassigning.`)) void deleteCredential(vc, el.dataset.delcred!)
     }),
   )
-  const form = root.querySelector<HTMLFormElement>('.agents-cred-form')
-  if (!form) return
-  const preset = form.querySelector<HTMLSelectElement>('select[name=preset]')!
-  const baseURL = form.querySelector<HTMLInputElement>('input[name=baseURL]')!
-  const model = form.querySelector<HTMLInputElement>('input[name=model]')!
-  preset.addEventListener('change', () => {
-    const p = PROVIDER_PRESETS.find((x) => x.id === preset.value)
-    if (p && p.id !== 'custom') baseURL.value = p.baseURL
-    if (p) model.placeholder = p.modelHint
-  })
-  form.addEventListener('submit', (e) => {
+  // Click a discovered model chip → set that credential's model.
+  root.querySelectorAll<HTMLElement>('[data-setmodel]').forEach((el) =>
+    el.addEventListener('click', () => {
+      const name = el.dataset.setmodel!
+      const model = el.dataset.model!
+      const c = vc.store.credentials.find((x) => x.name === name)
+      void createCredential(vc, { name, provider: 'openai-compatible', baseURL: c?.baseURL, model }).then(() => {
+        tested.delete(name)
+        vc.rerender()
+      })
+    }),
+  )
+  // Rotate / model edit form.
+  const rf = root.querySelector<HTMLFormElement>('.agents-rotate-form')
+  rf?.addEventListener('submit', (e) => {
     e.preventDefault()
-    const g = (n: string) => (form.querySelector<HTMLInputElement>(`input[name=${n}]`)?.value || '').trim()
-    msg = 'Saving…'
-    vc.rerender()
-    void createCredential(vc, { name: g('name'), provider: 'openai-compatible', baseURL: baseURL.value.trim(), model: model.value.trim(), apiKey: g('apiKey') }).then((ok) => {
-      msg = ok ? 'Credential saved.' : msg
+    const name = rf.dataset.rotate!
+    const g = (n: string) => (rf.querySelector<HTMLInputElement>(`[name=${n}]`)?.value || '').trim()
+    const body: Record<string, unknown> = { name, provider: 'openai-compatible', model: g('model'), baseURL: g('baseURL') }
+    const key = g('apiKey')
+    if (key) body.apiKey = key
+    void createCredential(vc, body).then((ok) => {
+      if (ok) {
+        editName = null
+        tested.delete(name)
+        vc.rerender()
+      }
     })
   })
+  // Create form.
+  const cf = root.querySelector<HTMLFormElement>('.agents-model-create')
+  if (cf) {
+    const preset = cf.querySelector<HTMLSelectElement>('select[name=preset]')!
+    const baseURL = cf.querySelector<HTMLInputElement>('input[name=baseURL]')!
+    const model = cf.querySelector<HTMLInputElement>('input[name=model]')!
+    preset.addEventListener('change', () => {
+      const p = PROVIDER_PRESETS.find((x) => x.id === preset.value)
+      if (p && p.id !== 'custom') baseURL.value = p.baseURL
+      if (p) model.placeholder = p.modelHint
+    })
+    cf.addEventListener('submit', (e) => {
+      e.preventDefault()
+      const g = (n: string) => (cf.querySelector<HTMLInputElement>(`input[name=${n}]`)?.value || '').trim()
+      void createCredential(vc, { name: g('name'), provider: 'openai-compatible', baseURL: baseURL.value.trim(), model: model.value.trim(), apiKey: g('apiKey') }).then((ok) => {
+        if (ok) creating = false
+      })
+    })
+  }
 }

--- a/providers/agents/portal/src/views/models.ts
+++ b/providers/agents/portal/src/views/models.ts
@@ -9,6 +9,7 @@
 //
 // Each credential is its own Secret (kedge-agents-model-<name>).
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { Credential } from '../types'
 import { escapeHTML } from '../types'
@@ -149,9 +150,9 @@ function pct(n: number, d: number): string {
 function capabilityChips(mi: ModelInfo): string {
   const chips: string[] = []
   if (mi.contextWindow) chips.push(`<span class="agents-chip">${fmtCtx(mi.contextWindow)}</span>`)
-  if (mi.vision) chips.push(`<span class="agents-chip">👁 vision</span>`)
-  if (mi.toolCall) chips.push(`<span class="agents-chip">🔧 tools</span>`)
-  if (mi.reasoning) chips.push(`<span class="agents-chip">🧠 reasoning</span>`)
+  if (mi.vision) chips.push(`<span class="agents-chip">${ic('eye')} vision</span>`)
+  if (mi.toolCall) chips.push(`<span class="agents-chip">${ic('wrench')} tools</span>`)
+  if (mi.reasoning) chips.push(`<span class="agents-chip">${ic('brain')} reasoning</span>`)
   chips.push(`<span class="agents-chip agents-chip-price">$${mi.inputPer1M}/$${mi.outputPer1M} per 1M</span>`)
   return chips.join('')
 }
@@ -239,9 +240,9 @@ function renderDashboard(): string {
 
 function healthBadge(name: string): string {
   const t = tested.get(name)
-  if (!t) return `<span class="agents-health agents-health-unknown" title="not tested">● untested</span>`
-  if (t.ok) return `<span class="agents-health agents-health-ok" title="healthy">● healthy · ${t.latencyMS}ms</span>`
-  return `<span class="agents-health agents-health-bad" title="${escapeHTML(t.error || 'failed')}">● failed</span>`
+  if (!t) return `<span class="agents-health agents-health-unknown" title="not tested">${ic('circle')} untested</span>`
+  if (t.ok) return `<span class="agents-health agents-health-ok" title="healthy">${ic('circle')} healthy · ${t.latencyMS}ms</span>`
+  return `<span class="agents-health agents-health-bad" title="${escapeHTML(t.error || 'failed')}">${ic('circle')} failed</span>`
 }
 
 function credentialCard(vc: ViewCtx, c: Credential): string {
@@ -259,7 +260,7 @@ function credentialCard(vc: ViewCtx, c: Credential): string {
     <article class="agents-model-card ${isEditing ? 'is-editing' : ''}">
       <div class="agents-model-head">
         <div class="agents-model-title">
-          <span class="agents-model-glyph">⚙</span>
+          <span class="agents-model-glyph">${ic('settings')}</span>
           <div>
             <h4>${escapeHTML(c.name)}</h4>
             <div class="agents-model-sub"><span class="mono">${escapeHTML(c.model || '—')}</span>${mi?.label ? ` · ${escapeHTML(mi.label)}` : ''}</div>
@@ -276,8 +277,8 @@ function credentialCard(vc: ViewCtx, c: Credential): string {
         ${
           usedBy.length
             ? [
-                ...primaryOf.map((a) => `<span class="agents-chip agents-chip-primary" title="primary model">▸ ${escapeHTML(a.spec?.displayName || a.metadata.name)}</span>`),
-                ...fallbackOf.map((a) => `<span class="agents-chip agents-chip-fallback" title="fallback model">⤷ ${escapeHTML(a.spec?.displayName || a.metadata.name)}</span>`),
+                ...primaryOf.map((a) => `<span class="agents-chip agents-chip-primary" title="primary model">${ic('chevron-right')} ${escapeHTML(a.spec?.displayName || a.metadata.name)}</span>`),
+                ...fallbackOf.map((a) => `<span class="agents-chip agents-chip-fallback" title="fallback model">${ic('corner-down-right')} ${escapeHTML(a.spec?.displayName || a.metadata.name)}</span>`),
               ].join('')
             : '<span class="muted" style="font-size:12px">not assigned to any agent</span>'
         }
@@ -292,9 +293,9 @@ function credentialCard(vc: ViewCtx, c: Credential): string {
       }
       ${isEditing ? renderRotate(c) : ''}
       <div class="agents-model-actions">
-        <button class="secondary" data-testcred="${escapeHTML(c.name)}">🔌 Test</button>
-        <button class="secondary" data-editcred="${escapeHTML(c.name)}">${isEditing ? 'Close' : '🔑 Rotate / model'}</button>
-        <button class="agents-iconbtn agents-iconbtn-danger" data-delcred="${escapeHTML(c.name)}" title="Delete">🗑</button>
+        <button class="secondary" data-testcred="${escapeHTML(c.name)}">${ic('plug')} Test</button>
+        <button class="secondary" data-editcred="${escapeHTML(c.name)}">${isEditing ? 'Close' : `${ic('key')} Rotate / model`}</button>
+        <button class="agents-iconbtn agents-iconbtn-danger" data-delcred="${escapeHTML(c.name)}" title="Delete">${ic('trash')}</button>
       </div>
     </article>`
 }
@@ -316,7 +317,7 @@ export function render(vc: ViewCtx): string {
   const creds = vc.store.credentials
   const cards = creds.length
     ? creds.map((c) => credentialCard(vc, c)).join('')
-    : `<div class="agents-empty-row"><span class="agents-empty">⚙ No models yet — add one below.</span></div>`
+    : `<div class="agents-empty-row"><span class="agents-empty">${ic('settings')} No models yet — add one below.</span></div>`
   const createForm = creating
     ? `<form class="agents-cred-form agents-model-create">
         <h4>New model credential</h4>
@@ -335,7 +336,7 @@ export function render(vc: ViewCtx): string {
   const datalist = `<datalist id="agents-catalog-models">${catalog.map((m) => `<option value="${escapeHTML(m.id)}">${escapeHTML(m.label || m.id)}</option>`).join('')}</datalist>`
   return `
     <div class="agents-panel">
-      <div class="agents-panel-head"><h3>Models</h3>${creating ? '' : `<button data-newcred>＋ New model</button>`}</div>
+      <div class="agents-panel-head"><h3>Models</h3>${creating ? '' : `<button data-newcred>${ic('plus')} New model</button>`}</div>
       <p class="muted">Model credentials shared across the workspace (each is a Secret <code>kedge-agents-model-&lt;name&gt;</code>). Assign them to agents in each agent's Settings or Flow.</p>
       ${renderDashboard()}
       <h3 class="agents-section-h">Credentials</h3>

--- a/providers/agents/portal/src/views/models.ts
+++ b/providers/agents/portal/src/views/models.ts
@@ -246,11 +246,12 @@ function healthBadge(name: string): string {
 
 function credentialCard(vc: ViewCtx, c: Credential): string {
   const mi = lookupModel(c.model || '')
-  const usedBy = vc.store.agents.filter((a) => {
-    const chat = a.spec?.models?.chat
-    const fb = a.spec?.modelFallbacks || []
-    return chat === c.name || fb.includes(c.name)
-  })
+  // Assignments: which agents reason with this credential, and in what role.
+  // primary = spec.models.chat; fallback = appears in spec.modelFallbacks. This
+  // surfaces the existing fallback/routing chain in the Models context.
+  const primaryOf = vc.store.agents.filter((a) => a.spec?.models?.chat === c.name)
+  const fallbackOf = vc.store.agents.filter((a) => a.spec?.models?.chat !== c.name && (a.spec?.modelFallbacks || []).includes(c.name))
+  const usedBy = [...primaryOf, ...fallbackOf]
   const disc = discovered.get(c.name)
   const isEditing = editName === c.name
   const chips = mi ? capabilityChips(mi) : `<span class="agents-chip agents-chip-warn">not in catalog — no pricing</span>`
@@ -270,7 +271,16 @@ function credentialCard(vc: ViewCtx, c: Credential): string {
       <div class="agents-model-meta">
         <span class="muted">${escapeHTML(c.provider || 'openai-compatible')}</span>
         ${c.baseURL ? `<span class="muted mono">${escapeHTML(c.baseURL)}</span>` : ''}
-        <span class="agents-badge">${usedBy.length} agent${usedBy.length === 1 ? '' : 's'}</span>
+      </div>
+      <div class="agents-model-assign">
+        ${
+          usedBy.length
+            ? [
+                ...primaryOf.map((a) => `<span class="agents-chip agents-chip-primary" title="primary model">▸ ${escapeHTML(a.spec?.displayName || a.metadata.name)}</span>`),
+                ...fallbackOf.map((a) => `<span class="agents-chip agents-chip-fallback" title="fallback model">⤷ ${escapeHTML(a.spec?.displayName || a.metadata.name)}</span>`),
+              ].join('')
+            : '<span class="muted" style="font-size:12px">not assigned to any agent</span>'
+        }
       </div>
       ${
         disc && disc.length

--- a/providers/agents/portal/src/views/schedules.ts
+++ b/providers/agents/portal/src/views/schedules.ts
@@ -3,6 +3,7 @@
 // backend rejects an empty agentRef), cron/timezone or one-shot runAt, task,
 // suspend. Run-now, edit, suspend toggle, delete per row.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { Schedule } from '../types'
 import { escapeHTML, fmtTime } from '../types'
@@ -38,7 +39,7 @@ export function render(vc: ViewCtx): string {
   const showForm = creating || !!editing
   const rows =
     vc.store.schedules.length === 0
-      ? `<tr class="agents-empty-row"><td colspan="6"><span class="agents-empty">⏰ No schedules yet — add one below.</span></td></tr>`
+      ? `<tr class="agents-empty-row"><td colspan="6"><span class="agents-empty">${ic('clock')} No schedules yet — add one below.</span></td></tr>`
       : vc.store.schedules
           .map((s) => {
             const when = s.spec.type === 'wakeup' ? s.spec.runAt || '' : s.spec.schedule || ''
@@ -50,17 +51,17 @@ export function render(vc: ViewCtx): string {
               <td class="mono">${escapeHTML(when)}${s.spec.timeZone ? ` <span class="muted">${escapeHTML(s.spec.timeZone)}</span>` : ''}</td>
               <td class="muted">${status}</td>
               <td class="agents-row-actions">
-                <button class="agents-iconbtn" data-runsched="${escapeHTML(s.metadata.name)}" title="Run now">▶</button>
-                <button class="agents-iconbtn" data-editsched="${escapeHTML(s.metadata.name)}" title="Edit">✏️</button>
-                <button class="agents-iconbtn" data-suspsched="${escapeHTML(s.metadata.name)}" data-susp="${s.spec.suspend ? '1' : '0'}" title="${s.spec.suspend ? 'Resume' : 'Pause'}">${s.spec.suspend ? '▶️' : '⏸'}</button>
-                <button class="agents-iconbtn agents-iconbtn-danger" data-delsched="${escapeHTML(s.metadata.name)}" title="Delete">🗑</button>
+                <button class="agents-iconbtn" data-runsched="${escapeHTML(s.metadata.name)}" title="Run now">${ic('play')}</button>
+                <button class="agents-iconbtn" data-editsched="${escapeHTML(s.metadata.name)}" title="Edit">${ic('pencil')}</button>
+                <button class="agents-iconbtn" data-suspsched="${escapeHTML(s.metadata.name)}" data-susp="${s.spec.suspend ? '1' : '0'}" title="${s.spec.suspend ? 'Resume' : 'Pause'}">${s.spec.suspend ? ic('play') : ic('pause')}</button>
+                <button class="agents-iconbtn agents-iconbtn-danger" data-delsched="${escapeHTML(s.metadata.name)}" title="Delete">${ic('trash')}</button>
               </td>
             </tr>`
           })
           .join('')
   return `
     <div class="agents-panel">
-      <div class="agents-panel-head"><h3>Schedules</h3>${showForm ? '' : `<button data-newobj ${vc.store.agents.length ? '' : 'disabled title="Create an agent first"'}>＋ New schedule</button>`}</div>
+      <div class="agents-panel-head"><h3>Schedules</h3>${showForm ? '' : `<button data-newobj ${vc.store.agents.length ? '' : 'disabled title="Create an agent first"'}>${ic('plus')} New schedule</button>`}</div>
       <p class="muted">Recurring or one-shot tasks. Each runs as a specific agent. ${vc.store.agents.length ? '' : 'Create an agent first.'}</p>
       <table class="agents-table">
         <thead><tr><th>Name</th><th>Agent</th><th>When</th><th>Status</th><th class="agents-th-actions">Actions</th></tr></thead>

--- a/providers/agents/portal/src/views/toolsets.ts
+++ b/providers/agents/portal/src/views/toolsets.ts
@@ -2,6 +2,7 @@
 // to many agents (in each agent's Flow, drag the toolset onto the agent).
 // Checked tool-connections drive the derived families.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import { escapeHTML } from '../types'
 import { createToolset, updateToolset, deleteToolset } from '../actions'
@@ -15,7 +16,7 @@ export function render(vc: ViewCtx): string {
     vc.store.agents.filter((a) => [...(a.spec?.tools?.interactive?.toolsets || []), ...(a.spec?.tools?.background?.toolsets || [])].includes(name)).length
   const rows =
     vc.store.toolsets.length === 0
-      ? `<tr class="agents-empty-row"><td colspan="4"><span class="agents-empty">🧰 No toolsets yet — create one below or in an agent's Flow view.</span></td></tr>`
+      ? `<tr class="agents-empty-row"><td colspan="4"><span class="agents-empty">${ic('package')} No toolsets yet — create one below or in an agent's Flow view.</span></td></tr>`
       : vc.store.toolsets
           .map((t) => {
             const conns = t.spec.connections || []
@@ -25,8 +26,8 @@ export function render(vc: ViewCtx): string {
               <td>${conns.length ? conns.map((c) => `<span class="agents-badge">${escapeHTML(c)}</span>`).join(' ') : '<span class="muted">—</span>'}</td>
               <td class="muted">${used} agent${used === 1 ? '' : 's'}</td>
               <td class="agents-row-actions">
-                <button class="agents-iconbtn" data-edittoolset="${escapeHTML(t.metadata.name)}" title="Edit">✏️</button>
-                <button class="agents-iconbtn agents-iconbtn-danger" data-deltoolset="${escapeHTML(t.metadata.name)}" title="Delete">🗑</button>
+                <button class="agents-iconbtn" data-edittoolset="${escapeHTML(t.metadata.name)}" title="Edit">${ic('pencil')}</button>
+                <button class="agents-iconbtn agents-iconbtn-danger" data-deltoolset="${escapeHTML(t.metadata.name)}" title="Delete">${ic('trash')}</button>
               </td>
             </tr>`
           })
@@ -39,7 +40,7 @@ export function render(vc: ViewCtx): string {
             (c) => `<label class="agents-check"><input type="checkbox" name="connection" value="${escapeHTML(c.metadata.name)}" ${on.has(c.metadata.name) ? 'checked' : ''} /> ${escapeHTML(c.metadata.name)} <span class="agents-hint">${escapeHTML(c.spec.type)}</span></label>`,
           )
           .join('')
-      : `<span class="muted">No tools yet — create MCP/GitHub/web tools under 🔌 Connections. Cluster edges are always on.</span>`
+      : `<span class="muted">No tools yet — create MCP/GitHub/web tools under ${ic('plug')} Connections. Cluster edges are always on.</span>`
   const form = editing
     ? `<form class="agents-toolset-form" data-edit="${escapeHTML(editing.metadata.name)}">
         <h4>Edit toolset <code>${escapeHTML(editing.metadata.name)}</code></h4>

--- a/providers/agents/portal/src/views/triggers.ts
+++ b/providers/agents/portal/src/views/triggers.ts
@@ -2,6 +2,7 @@
 // agent via agentRef and fired by an external source (webhook / github). Same
 // table + Agent-select form pattern as schedules.
 
+import { ic } from '../icons'
 import type { ViewCtx } from '../view'
 import type { Trigger } from '../types'
 import { escapeHTML, fmtTime } from '../types'
@@ -38,7 +39,7 @@ export function render(vc: ViewCtx): string {
   const showForm = creating || !!editing
   const rows =
     vc.store.triggers.length === 0
-      ? `<tr class="agents-empty-row"><td colspan="6"><span class="agents-empty">⚡ No triggers yet — add one below.</span></td></tr>`
+      ? `<tr class="agents-empty-row"><td colspan="6"><span class="agents-empty">${ic('zap')} No triggers yet — add one below.</span></td></tr>`
       : vc.store.triggers
           .map((t) => {
             const status = t.spec.suspend ? '<span class="agents-badge">paused</span>' : t.status?.lastFired ? `last ${escapeHTML(fmtTime(t.status.lastFired))}` : 'armed'
@@ -48,17 +49,17 @@ export function render(vc: ViewCtx): string {
               <td class="mono">${escapeHTML(t.spec.source)}${t.spec.connectionRef ? ` <span class="muted">${escapeHTML(t.spec.connectionRef)}</span>` : ''}</td>
               <td class="muted">${status}</td>
               <td class="agents-row-actions">
-                <button class="agents-iconbtn" data-runtrig="${escapeHTML(t.metadata.name)}" title="Fire now">▶</button>
-                <button class="agents-iconbtn" data-edittrig="${escapeHTML(t.metadata.name)}" title="Edit">✏️</button>
-                <button class="agents-iconbtn" data-susptrig="${escapeHTML(t.metadata.name)}" data-susp="${t.spec.suspend ? '1' : '0'}" title="${t.spec.suspend ? 'Resume' : 'Pause'}">${t.spec.suspend ? '▶️' : '⏸'}</button>
-                <button class="agents-iconbtn agents-iconbtn-danger" data-deltrig="${escapeHTML(t.metadata.name)}" title="Delete">🗑</button>
+                <button class="agents-iconbtn" data-runtrig="${escapeHTML(t.metadata.name)}" title="Fire now">${ic('play')}</button>
+                <button class="agents-iconbtn" data-edittrig="${escapeHTML(t.metadata.name)}" title="Edit">${ic('pencil')}</button>
+                <button class="agents-iconbtn" data-susptrig="${escapeHTML(t.metadata.name)}" data-susp="${t.spec.suspend ? '1' : '0'}" title="${t.spec.suspend ? 'Resume' : 'Pause'}">${t.spec.suspend ? ic('play') : ic('pause')}</button>
+                <button class="agents-iconbtn agents-iconbtn-danger" data-deltrig="${escapeHTML(t.metadata.name)}" title="Delete">${ic('trash')}</button>
               </td>
             </tr>`
           })
           .join('')
   return `
     <div class="agents-panel">
-      <div class="agents-panel-head"><h3>Triggers</h3>${showForm ? '' : `<button data-newobj ${vc.store.agents.length ? '' : 'disabled title="Create an agent first"'}>＋ New trigger</button>`}</div>
+      <div class="agents-panel-head"><h3>Triggers</h3>${showForm ? '' : `<button data-newobj ${vc.store.agents.length ? '' : 'disabled title="Create an agent first"'}>${ic('plus')} New trigger</button>`}</div>
       <p class="muted">External events that wake an agent. Each fires a specific agent. ${vc.store.agents.length ? '' : 'Create an agent first.'}</p>
       <table class="agents-table">
         <thead><tr><th>Name</th><th>Agent</th><th>Source</th><th>Status</th><th class="agents-th-actions">Actions</th></tr></thead>


### PR DESCRIPTION
**Merge order: 5 of 5 (LAST). Base is `agents-ui-refactor` — merge #463 first; GitHub will retarget this to `main` automatically.**

Turns the Models menu from a plain CRUD table into an ops surface. Grounded in a deep-research survey (Dify, LiteLLM, Portkey, Helicone) verified against primary docs, and in the existing backend (usage table, fallback engine).

## Backend (`providers/agents/…`)
- **Model catalog** (`llm/catalog.go`): pricing (USD/1M tokens) + capabilities (context window, vision, tools, reasoning); normalized lookup; `GET /api/catalog`.
- **Real cost**: `executeTask` now computes `usd_micros` from the catalog (was hardcoded `0`) — budgets enforce **dollars**, spend is queryable, delegation rolls child cost up to the parent.
- **Health + discovery**: `POST /api/credentials/{name}/test` does a token-free `GET {baseURL}/models` probe → `{ok, latencyMS, error, models[]}`.
- **Usage/observability**: `GET /api/usage?days=` aggregates the **existing runs table** into cost/token/latency(p50,p95)/error rollups (total, by-agent, by-model, daily series) — no new telemetry store.

## Frontend (`views/models.ts`)
- Usage dashboard (7/30/90d): spend / tokens / runs / error-rate / p50-p95 latency, daily-spend sparkline, spend-by-model / by-agent bars (inline SVG, theme-aware).
- Catalog-enriched credential cards: capability chips + per-1M pricing; "not in catalog" warning when pricing is unknown.
- Live health badge + Test; served models as clickable chips to switch the model (discovery).
- Key rotation (blank = keep current); catalog datalist autocomplete.
- Per-model agent assignments tagged primary vs fallback (surfaces the routing chain).

## Verification
`go test ./providers/agents/llm ./providers/agents/api` pass; portal typecheck + vite build clean; playwright **7/7** (dashboard, chips+pricing, health probe + discovery, rotation, window switch, datalist).

## Deliberately deferred (need enforcement infra — a stub would mislead)
- **Full credential↔model object split** (today one Secret = one model): a breaking change to the agent runtime; delivered the UX benefit (discovery, shared creds, rotation) additively instead.
- **Rate limits (TPM/RPM) + budget-triggered fallback**: need windowed-counter enforcement + a per-model-budget concept the system lacks (budgets are per-agent). The catalog + usage endpoint are the foundation for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)