### PR TITLE
fix(agents-portal): flow-mode drag, channel inbound/outbound clarity, form-based Wiring tab

### DIFF
--- a/providers/agents/portal/src/flow.ts
+++ b/providers/agents/portal/src/flow.ts
@@ -50,6 +50,13 @@ export interface FNode {
   canDelete?: boolean
   draft?: boolean // unsaved: shows a Create button instead of auto-save
   createKey?: string // palette key used to create this draft
+  // Channel nodes: the inbound (channel → agent) leg, shown as its own row in
+  // the modal so it's clear a linked channel talks both ways.
+  inbound?: {
+    state: 'auto' | 'on' | 'off' | 'unlinked' // auto = bot gateway, needs no toggle
+    canEnable: boolean // telegram/slack expose an enable-inbound action
+    note: string
+  }
 }
 
 // DraftSpec describes a new, unsaved node dropped from the palette: the fields
@@ -83,6 +90,8 @@ export interface FlowCallbacks {
   onDelete(nodeId: string): void
   onOpenChat(): void
   onToast(msg: string): void
+  // Turn on inbound chat for a channel node (telegram/slack webhook registration).
+  onEnableInbound(nodeId: string): void
   // draftFor returns the create-form spec for a "new:<key>" palette entry, or
   // null for keys that aren't standalone objects (chat/tools/notify/delegate).
   draftFor(key: string): DraftSpec | null
@@ -331,20 +340,21 @@ export class FlowCanvas {
     const p = this.pos.get(n.id) as Pos
     el.style.left = p.x + 'px'
     el.style.top = p.y + 'px'
-    const head = el.querySelector('.flow-nhead') as HTMLElement
-    head.onpointerdown = (e) => this.startDragNode(e, n)
     const editBtn = el.querySelector('.flow-editbtn') as HTMLElement | null
     if (editBtn) {
-      // Pointerdown-stop keeps the header-drag from swallowing the click.
+      // Pointerdown-stop keeps the node-drag from swallowing the click.
       editBtn.onpointerdown = (e) => e.stopPropagation()
       editBtn.onclick = (e) => {
         e.stopPropagation()
         this.openEditor(n.id)
       }
     }
+    // The whole card is the drag handle — grabbing anywhere but a port or a
+    // button moves the node (a click that doesn't move just selects it).
     el.onpointerdown = (e) => {
-      if ((e.target as HTMLElement).classList.contains('flow-port')) return
-      this.select(n.id)
+      const t = e.target as HTMLElement
+      if (t.classList.contains('flow-port') || t.closest('button')) return
+      this.startDragNode(e, n)
     }
     el.ondblclick = (e) => {
       if ((e.target as HTMLElement).classList.contains('flow-port')) return
@@ -464,6 +474,15 @@ export class FlowCanvas {
     const fields = (n.fields || []).map((f) => this.fieldHTML(f)).join('')
     const editable = (n.fields || []).some((f) => f.kind !== 'static')
     const draft = !!n.draft
+    const inb = n.inbound
+    const inbHTML =
+      !draft && inb
+        ? `<div class="flow-field"><label>Inbound chat</label><div class="flow-inbound">
+             <span class="flow-led ${inb.state === 'off' || inb.state === 'unlinked' ? 'off' : 'ok'}"></span>
+             <span class="flow-inbound-note">${esc(inb.note)}</span>
+             ${inb.canEnable ? '<button class="flow-btn" data-inbound>Enable</button>' : ''}
+           </div></div>`
+        : ''
     this.dialog.innerHTML = `
       <div class="flow-dialog-head">
         <span class="flow-nic">${svgIcon(n.type)}</span>
@@ -473,6 +492,7 @@ export class FlowCanvas {
       </div>
       <div class="flow-dialog-body">
         ${fields || '<p class="flow-nsub">Nothing to edit here — this node is wired from the canvas.</p>'}
+        ${inbHTML}
         ${draft ? '' : `<div class="flow-field"><label>Cables</label><div class="flow-wirelist">${cables}</div></div>`}
       </div>
       <div class="flow-dialog-foot">
@@ -495,6 +515,8 @@ export class FlowCanvas {
         this.closeEditor()
         this.cb.onDelete(n.id)
       }
+    const inbBtn = this.dialog.querySelector('[data-inbound]') as HTMLElement | null
+    if (inbBtn) inbBtn.onclick = () => this.cb.onEnableInbound(n.id)
     const discardBtn = this.dialog.querySelector('[data-discard]') as HTMLElement | null
     if (discardBtn) discardBtn.onclick = () => this.discardEditing()
     const createBtn = this.dialog.querySelector('[data-create]') as HTMLElement | null

--- a/providers/agents/portal/src/router.ts
+++ b/providers/agents/portal/src/router.ts
@@ -10,10 +10,10 @@
 //   #/connections #/toolsets #/schedules #/triggers #/models #/inbox
 
 export type MenuKey = 'agents' | 'connections' | 'toolsets' | 'schedules' | 'triggers' | 'models' | 'inbox'
-export type AgentTab = 'chat' | 'flow' | 'settings'
+export type AgentTab = 'chat' | 'flow' | 'wiring' | 'settings'
 
 export const MENUS: MenuKey[] = ['agents', 'connections', 'toolsets', 'schedules', 'triggers', 'models', 'inbox']
-const AGENT_TABS: AgentTab[] = ['chat', 'flow', 'settings']
+const AGENT_TABS: AgentTab[] = ['chat', 'flow', 'wiring', 'settings']
 
 export type Route = { kind: 'menu'; menu: MenuKey } | { kind: 'agent'; name: string; tab: AgentTab }
 

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -238,6 +238,12 @@ kedge-provider-agents .agents-linkbtn {
 }
 kedge-provider-agents .agents-linkbtn:hover { border-style: solid; background: var(--color-surface-hover, rgba(0,0,0,0.04)); }
 kedge-provider-agents .agents-inbound-on { color: var(--color-success, #10b981); font-weight: 700; }
+/* Wiring tab: stacked form panels, an inbound status line, and link checklists. */
+kedge-provider-agents .agents-wiring { display: flex; flex-direction: column; gap: 18px; }
+kedge-provider-agents .agents-inbound-line { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+kedge-provider-agents .agents-inbound-actions { margin-left: auto; display: flex; gap: 8px; }
+kedge-provider-agents .agents-wire-fs { border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 10px; padding: 11px 13px; display: flex; flex-direction: column; gap: 7px; }
+kedge-provider-agents .agents-wire-fs legend { font-weight: 600; padding: 0 6px; display: inline-flex; align-items: center; gap: 5px; }
 
 /* --- chat --- */
 /* Bound the chat to the viewport so the log scrolls internally instead of the
@@ -384,11 +390,11 @@ kedge-provider-agents .flow-wire-hit { fill: none; stroke: transparent; stroke-w
 /* node card */
 kedge-provider-agents .flow-node { position: absolute; width: 224px; background: var(--color-surface-raised, #fff);
   border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 13px; box-shadow: 0 1px 2px rgba(20,40,80,.06), 0 8px 22px rgba(20,40,80,.10);
-  user-select: none; --nc: var(--flow-agent); transition: box-shadow .15s, border-color .15s; }
+  user-select: none; --nc: var(--flow-agent); transition: box-shadow .15s, border-color .15s; cursor: grab; }
 kedge-provider-agents .flow-node.core { width: 238px; }
 kedge-provider-agents .flow-node.enter { animation: flow-pop .24s cubic-bezier(.2,.8,.3,1); }
 @keyframes flow-pop { from { transform: scale(.9); opacity: 0; } }
-kedge-provider-agents .flow-node.dragging { box-shadow: 0 4px 12px rgba(20,40,80,.18), 0 24px 60px rgba(20,40,80,.28); z-index: 4; }
+kedge-provider-agents .flow-node.dragging { box-shadow: 0 4px 12px rgba(20,40,80,.18), 0 24px 60px rgba(20,40,80,.28); z-index: 4; cursor: grabbing; }
 kedge-provider-agents .flow-node.sel { border-color: color-mix(in srgb, var(--nc) 60%, var(--color-border-default)); box-shadow: 0 2px 10px rgba(20,40,80,.12), 0 0 0 3px color-mix(in srgb, var(--nc) 28%, transparent); }
 kedge-provider-agents .flow-nhead { display: flex; align-items: center; gap: 9px; padding: 10px 11px; cursor: grab; }
 kedge-provider-agents .flow-nic { width: 28px; height: 28px; border-radius: 8px; flex: none; display: grid; place-items: center; background: var(--nc-soft); color: var(--nc); border: 1px solid var(--nc-line); }
@@ -489,6 +495,9 @@ kedge-provider-agents .flow-wireitem { display: flex; align-items: center; gap: 
 kedge-provider-agents .flow-wireitem.muted { color: var(--color-text-muted, #889); }
 kedge-provider-agents .flow-wireitem .sw { width: 9px; height: 9px; border-radius: 50%; flex: none; }
 kedge-provider-agents .flow-wireitem .dir { color: var(--color-text-muted, #889); font: 700 10px/1 "IBM Plex Mono", ui-monospace, monospace; }
+kedge-provider-agents .flow-inbound { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--color-text-secondary, #556); padding: 7px 9px; background: var(--color-surface, #f4f6fb); border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 8px; }
+kedge-provider-agents .flow-inbound .flow-inbound-note { flex: 1; }
+kedge-provider-agents .flow-inbound .flow-btn { padding: 5px 12px; font-size: 12px; }
 kedge-provider-agents .flow-btn { border: 1px solid var(--color-border-default, #d9e0ec); background: var(--color-surface, #f4f6fb); color: var(--color-text-primary, #123); font: inherit; font-weight: 600; font-size: 12.5px; padding: 8px 14px; border-radius: 9px; cursor: pointer; }
 kedge-provider-agents .flow-btn:hover { border-color: var(--color-border-strong, #bbb); }
 kedge-provider-agents .flow-btn.primary { background: var(--color-accent, #0fb9a3); border-color: transparent; color: #fff; }

--- a/providers/agents/portal/src/views/agent-detail.ts
+++ b/providers/agents/portal/src/views/agent-detail.ts
@@ -10,11 +10,13 @@ import { escapeHTML } from '../types'
 import { deleteAgent } from '../actions'
 import * as chat from './agent-chat'
 import * as settings from './agent-settings'
+import * as wiring from './agent-wiring'
 import * as flowView from './flow-view'
 
 const TABS: [AgentTab, string][] = [
   ['chat', `${ic('message')} Chat`],
   ['flow', `${ic('workflow')} Flow`],
+  ['wiring', `${ic('sliders')} Wiring`],
   ['settings', `${ic('settings')} Settings`],
 ]
 
@@ -25,7 +27,14 @@ export function render(vc: ViewCtx, name: string, tab: AgentTab): string {
     // error, since the list refreshes into place.
     return `<div class="agents-detail"><div class="agents-detail-head"><div class="agents-detail-title"><button class="agents-back" data-back>${ic('arrow-left')} Agents</button></div></div><div class="agents-empty"><p class="muted">Loading agent…</p></div></div>`
   }
-  const body = tab === 'chat' ? chat.render(a) : tab === 'settings' ? settings.render(vc, a) : `<div class="agents-flow-host" data-flow-host></div>`
+  const body =
+    tab === 'chat'
+      ? chat.render(a)
+      : tab === 'settings'
+        ? settings.render(vc, a)
+        : tab === 'wiring'
+          ? wiring.render(vc, a)
+          : `<div class="agents-flow-host" data-flow-host></div>`
   return `
     <div class="agents-detail ${tab === 'flow' ? 'is-flow' : ''}">
       <div class="agents-detail-head">
@@ -58,5 +67,6 @@ export function wire(vc: ViewCtx, root: HTMLElement, name: string, tab: AgentTab
   if (!a) return
   if (tab === 'chat') chat.wire(vc, root, a)
   else if (tab === 'settings') settings.wire(vc, root, a)
+  else if (tab === 'wiring') wiring.wire(vc, root, a)
   else flowView.mount(vc, root, name)
 }

--- a/providers/agents/portal/src/views/agent-wiring.ts
+++ b/providers/agents/portal/src/views/agent-wiring.ts
@@ -1,0 +1,170 @@
+// Agent Wiring tab: a form-based counterpart to the Flow canvas. Everything the
+// flow tab wires by dragging cables, this tab edits as plain forms scoped to one
+// agent — model, schedules, triggers, channels (in + out), and tools/toolsets.
+// The schedule/trigger sections reuse the menu views with an agentRef filter so
+// there's a single source of truth for those forms; channels and tools are
+// agent-link operations written here.
+
+import { ic } from '../portalkit/icons'
+import type { ViewCtx } from '../view'
+import type { Agent } from '../types'
+import { escapeHTML } from '../types'
+import { connCategory } from '../conn-defs'
+import { updateAgent, linkToolset, wireToolTo, testConnection, enableInbound } from '../actions'
+import * as schedules from './schedules'
+import * as triggers from './triggers'
+
+// Chat-capable channels: telegram/slack (webhook inbound) and the Discord bot
+// (channel is not a https:// webhook URL). Send-only otherwise.
+function channelInbound(c: { spec: { type: string; channel?: string }; status?: { webhookPath?: string } }, isNotify: boolean) {
+  const isDiscordWebhook = c.spec.type === 'discord' && (c.spec.channel || '').startsWith('https://')
+  const isDiscordBot = c.spec.type === 'discord' && !isDiscordWebhook
+  const canReceive = c.spec.type === 'telegram' || c.spec.type === 'slack' || isDiscordBot
+  if (!canReceive) return { on: false, canEnable: false, note: 'Send-only — this channel can notify you, but can’t receive chat.' }
+  if (!isNotify) return { on: false, canEnable: false, note: 'Set this as the notify channel to route messages to the agent.' }
+  if (isDiscordBot) return { on: true, canEnable: false, note: 'Inbound is automatic — the Discord bot delivers messages while linked.' }
+  if (c.status?.webhookPath) return { on: true, canEnable: false, note: 'Receiving — messages from this channel reach the agent.' }
+  return { on: false, canEnable: true, note: 'Not receiving yet — enable inbound to register the webhook.' }
+}
+
+export function render(vc: ViewCtx, a: Agent): string {
+  const name = a.metadata.name
+  const notify = a.spec?.defaultNotifyConnection || ''
+
+  // Model
+  const model = a.spec?.models?.chat || ''
+  const modelOptions =
+    `<option value="">— no model —</option>` +
+    vc.store.credentials.map((c) => `<option value="${escapeHTML(c.name)}" ${c.name === model ? 'selected' : ''}>${escapeHTML(c.name)}${c.model ? ` (${escapeHTML(c.model)})` : ''}</option>`).join('')
+  const modelSec = `<div class="agents-panel">
+      <h3>${ic('brain')} Model</h3>
+      <p class="muted">Which credential this agent reasons with. Personas and budget live in ${ic('settings')} Settings.</p>
+      <label>Model credential<select data-wire-model>${modelOptions}</select>
+        ${vc.store.credentials.length === 0 ? `<span class="muted" style="font-size:12px">No models yet — add one under ${ic('cpu')} Models.</span>` : ''}
+      </label>
+    </div>`
+
+  // Channels (in + out)
+  const channels = vc.store.connections.filter((c) => connCategory(c.spec.type) === 'channel')
+  const notifyOptions =
+    `<option value="">— none —</option>` +
+    channels.map((c) => `<option value="${escapeHTML(c.metadata.name)}" ${c.metadata.name === notify ? 'selected' : ''}>${escapeHTML(c.spec.displayName || c.metadata.name)} (${escapeHTML(c.spec.type)})</option>`).join('')
+  const notifyConn = notify ? channels.find((c) => c.metadata.name === notify) : undefined
+  const inb = notifyConn ? channelInbound(notifyConn, true) : undefined
+  const chanSec = `<div class="agents-panel">
+      <h3>${ic('megaphone')} Channels</h3>
+      <p class="muted">Where this agent messages you — and, for chat channels, where you message it. The one notify link works both ways. Manage channel credentials under ${ic('plug')} Connections.</p>
+      ${channels.length === 0 ? `<p class="agents-hint">No channels yet — add one under ${ic('plug')} Connections (Telegram, Slack, Discord, email).</p>` : ''}
+      <label>Notify channel<select data-wire-notify>${notifyOptions}</select></label>
+      ${
+        notifyConn && inb
+          ? `<div class="agents-inbound-line">
+               <span class="agents-badge ${inb.on ? 'agents-cat-channel' : ''}">${ic('swap')} inbound ${inb.on ? 'on' : 'off'}</span>
+               <span class="muted">${escapeHTML(inb.note)}</span>
+               <span class="agents-inbound-actions">
+                 ${inb.canEnable ? `<button type="button" class="secondary" data-wire-inbound="${escapeHTML(notify)}">Enable inbound</button>` : ''}
+                 <button type="button" class="secondary" data-wire-test="${escapeHTML(notify)}">${ic('send')} Test</button>
+               </span>
+             </div>`
+          : ''
+      }
+    </div>`
+
+  // Tools & toolsets
+  const agentToolsets = new Set([...(a.spec?.tools?.interactive?.toolsets || []), ...(a.spec?.tools?.background?.toolsets || [])])
+  const agentTools = new Set([...(a.spec?.tools?.interactive?.connections || []), ...(a.spec?.tools?.background?.connections || [])])
+  const toolConns = vc.store.connections.filter((c) => connCategory(c.spec.type) === 'tool')
+  const toolsetRows = vc.store.toolsets.length
+    ? vc.store.toolsets
+        .map(
+          (t) =>
+            `<label class="agents-check"><input type="checkbox" data-wire-toolset="${escapeHTML(t.metadata.name)}" ${agentToolsets.has(t.metadata.name) ? 'checked' : ''} /> ${escapeHTML(t.spec.displayName || t.metadata.name)}</label>`,
+        )
+        .join('')
+    : `<p class="agents-hint">No toolsets yet — create one under ${ic('puzzle')} Toolsets.</p>`
+  const toolRows = toolConns.length
+    ? toolConns
+        .map(
+          (c) =>
+            `<label class="agents-check"><input type="checkbox" data-wire-tool="${escapeHTML(c.metadata.name)}" ${agentTools.has(c.metadata.name) ? 'checked' : ''} /> ${escapeHTML(c.spec.displayName || c.metadata.name)} <span class="muted">${escapeHTML(c.spec.type)}</span></label>`,
+        )
+        .join('')
+    : `<p class="agents-hint">No tools yet — add one under ${ic('plug')} Connections.</p>`
+  const toolsSec = `<div class="agents-panel">
+      <h3>${ic('wrench')} Tools &amp; toolsets</h3>
+      <p class="muted">What this agent can call. Toolsets are shared bundles; direct tools grant a single connection.</p>
+      <fieldset class="agents-wire-fs"><legend>${ic('puzzle')} Toolsets</legend>${toolsetRows}</fieldset>
+      <fieldset class="agents-wire-fs"><legend>${ic('wrench')} Direct tools</legend>${toolRows}</fieldset>
+    </div>`
+
+  return `<div class="agents-wiring">
+      ${modelSec}
+      <div class="agents-wire-sec" data-sec="sched">${schedules.render(vc, name)}</div>
+      <div class="agents-wire-sec" data-sec="trig">${triggers.render(vc, name)}</div>
+      ${chanSec}
+      ${toolsSec}
+    </div>`
+}
+
+export function wire(vc: ViewCtx, root: HTMLElement, a: Agent): void {
+  const name = a.metadata.name
+
+  // Model
+  root.querySelector<HTMLSelectElement>('[data-wire-model]')?.addEventListener('change', (e) => {
+    void updateAgent(vc, name, { modelCredential: (e.target as HTMLSelectElement).value }, 'Model updated.')
+  })
+
+  // Schedules / Triggers reuse the menu views, scoped to this agent. Wire each
+  // within its own container so their forms/buttons don't cross-fire.
+  const schedRoot = root.querySelector<HTMLElement>('[data-sec="sched"]')
+  if (schedRoot) schedules.wire(vc, schedRoot, name)
+  const trigRoot = root.querySelector<HTMLElement>('[data-sec="trig"]')
+  if (trigRoot) triggers.wire(vc, trigRoot, name)
+
+  // Channels
+  root.querySelector<HTMLSelectElement>('[data-wire-notify]')?.addEventListener('change', (e) => {
+    void updateAgent(vc, name, { notifyConnection: (e.target as HTMLSelectElement).value }, 'Notify channel set.')
+  })
+  root.querySelector<HTMLElement>('[data-wire-inbound]')?.addEventListener('click', (e) => {
+    void enableInbound(vc, (e.currentTarget as HTMLElement).dataset.wireInbound!)
+  })
+  root.querySelector<HTMLElement>('[data-wire-test]')?.addEventListener('click', (e) => {
+    void testConnection(vc, (e.currentTarget as HTMLElement).dataset.wireTest!)
+  })
+
+  // Toolsets: link (checked) / unlink (unchecked) for this agent only.
+  root.querySelectorAll<HTMLInputElement>('[data-wire-toolset]').forEach((el) =>
+    el.addEventListener('change', () => {
+      const ts = el.dataset.wireToolset!
+      if (el.checked) {
+        void linkToolset(vc, name, ts).then(() => vc.notify('Toolset linked.'))
+      } else {
+        const cur = vc.store.agent(name)
+        const inter = (cur?.spec?.tools?.interactive?.toolsets || []).filter((t) => t !== ts)
+        const bg = (cur?.spec?.tools?.background?.toolsets || []).filter((t) => t !== ts)
+        void updateAgent(vc, name, { interactiveToolsets: inter, backgroundToolsets: bg }, 'Toolset unlinked.')
+      }
+    }),
+  )
+
+  // Direct tools: grant (checked) / revoke (unchecked). Families are re-derived
+  // from the resulting connection set so the grant stays consistent.
+  root.querySelectorAll<HTMLInputElement>('[data-wire-tool]').forEach((el) =>
+    el.addEventListener('change', () => {
+      const cn = el.dataset.wireTool!
+      if (el.checked) {
+        void wireToolTo(vc, name, 'agent', cn)
+      } else {
+        const cur = vc.store.agent(name)
+        const inter = (cur?.spec?.tools?.interactive?.connections || []).filter((x) => x !== cn)
+        const bg = (cur?.spec?.tools?.background?.connections || []).filter((x) => x !== cn)
+        void updateAgent(
+          vc,
+          name,
+          { interactiveConnections: inter, backgroundConnections: bg, interactiveFamilies: vc.store.familiesFor(inter), backgroundFamilies: vc.store.familiesFor(bg) },
+          'Tool removed.',
+        )
+      }
+    }),
+  )
+}

--- a/providers/agents/portal/src/views/flow-view.ts
+++ b/providers/agents/portal/src/views/flow-view.ts
@@ -25,6 +25,7 @@ import {
   runTrigger,
   linkToolset,
   wireToolTo,
+  enableInbound,
 } from '../actions'
 
 let flow: FlowCanvas | null = null
@@ -55,6 +56,7 @@ function callbacks(): FlowCallbacks {
     onDelete: (id) => void flowDelete(id),
     onOpenChat: () => cur && cur.vc.navigate({ kind: 'agent', name: cur.agent, tab: 'chat' }),
     onToast: (m) => flow?.toast(m),
+    onEnableInbound: (id) => void flowEnableInbound(id),
     draftFor: (t) => flowDraftFor(t),
     create: (t, values) => flowCreate(t, values),
     addExisting: (id) => flowAddExisting(id),
@@ -232,15 +234,35 @@ function flowModel(vc: ViewCtx, name: string): FlowModel {
     const id = 'conn:' + cn
     const used = usedConns.has(cn)
     const webish = c.spec.type === 'websearch'
+    // A channel talks two ways to the agent, keyed on the SAME notify link:
+    // NOTIFY (agent → channel, outbound) and LISTEN (channel → agent, inbound).
+    const isDiscordWebhook = c.spec.type === 'discord' && (c.spec.channel || '').startsWith('https://')
+    const isDiscordBot = c.spec.type === 'discord' && !isDiscordWebhook
+    const canReceive = c.spec.type === 'telegram' || c.spec.type === 'slack' || isDiscordBot
+    const isNotify = notify === cn
+    const inboundActive = isNotify && canReceive && (isDiscordBot || !!c.status?.webhookPath)
+    const inbound = isChannel
+      ? !canReceive
+        ? { state: 'off' as const, canEnable: false, note: 'Send-only channel — it can notify you, but can’t receive chat.' }
+        : !isNotify
+          ? { state: 'unlinked' as const, canEnable: false, note: 'Not linked yet — drag this channel onto the agent (or set it as Notify) to route messages here.' }
+          : isDiscordBot
+            ? { state: 'auto' as const, canEnable: false, note: 'Automatic — the Discord bot delivers messages to this agent while it’s linked.' }
+            : c.status?.webhookPath
+              ? { state: 'on' as const, canEnable: false, note: 'Receiving — messages from this channel reach the agent.' }
+              : { state: 'off' as const, canEnable: true, note: 'Not receiving yet — click Enable to register the inbound webhook.' }
+      : undefined
+    const outPort = isChannel ? 'listen' : 'events'
     nodes.push({
       id,
       type: isTool ? 'tool' : 'connection',
       title: c.spec.displayName || cn,
       ins: isChannel ? ['notify'] : [],
-      outs: ['events'],
+      outs: [outPort],
       sub: `<span class="mono">${escapeHTML(c.spec.type)}</span>${c.status?.oauthConnected ? ' · connected' : webish ? '' : used ? '' : ' · unwired'}`,
       status: c.status?.oauthConnected || c.status?.phase === 'Ready' || webish ? ['ok', webish ? 'ready' : 'connected'] : ['warn', c.status?.phase || 'setup'],
       canDelete: isTool,
+      inbound,
       fields: isTool
         ? [
             { key: 'displayName', label: 'Display name', kind: 'text', value: c.spec.displayName || cn },
@@ -254,9 +276,10 @@ function flowModel(vc: ViewCtx, name: string): FlowModel {
           ],
     })
     trigs.forEach((t) => {
-      if (t.spec.connectionRef === cn) wires.push({ from: [id, 'events'], to: ['trig:' + t.metadata.name, 'src'] })
+      if (t.spec.connectionRef === cn) wires.push({ from: [id, outPort], to: ['trig:' + t.metadata.name, 'src'] })
     })
-    if (notify === cn && isChannel) wires.push({ from: ['agent', 'result'], to: [id, 'notify'] })
+    if (isNotify && isChannel) wires.push({ from: ['agent', 'result'], to: [id, 'notify'] })
+    if (inboundActive) wires.push({ from: [id, 'listen'], to: ['agent', 'input'] })
     if (isTool && agentTools.has(cn)) wires.push({ from: [id, 'events'], to: ['agent', 'tools'] })
   }
 
@@ -631,6 +654,11 @@ async function flowLink(from: [string, string], to: [string, string]): Promise<v
   if (fromNode === 'agent' && toNode.startsWith('conn:') && toPort === 'notify') {
     return void updateAgent(vc, agent, { notifyConnection: toNode.slice(5) }, 'Notify channel set.')
   }
+  // connection.listen → agent.input : link a channel inbound. The notify link is
+  // symmetric — it also routes messages FROM the channel to the agent.
+  if (fromNode.startsWith('conn:') && toNode === 'agent' && toPort === 'input') {
+    return void updateAgent(vc, agent, { notifyConnection: fromNode.slice(5) }, 'Channel linked — it can message the agent both ways.')
+  }
   // toolset.use → agent.tools : link the shared toolset to this agent
   if (fromNode.startsWith('toolset:') && toNode === 'agent' && toPort === 'tools') {
     await linkToolset(vc, agent, fromNode.slice(8))
@@ -694,6 +722,13 @@ async function flowEdit(id: string, values: Record<string, string | string[]>): 
   } else if (id.startsWith('toolset:')) {
     if ('displayName' in values) await updateToolset(vc, id.slice(8), { displayName: str(values.displayName) })
   }
+}
+
+// Turn on inbound chat for a channel node: registers the webhook (telegram/slack)
+// so the channel the agent notifies can also talk back to it.
+async function flowEnableInbound(id: string): Promise<void> {
+  if (!cur || !id.startsWith('conn:')) return
+  await enableInbound(cur.vc, id.slice(5))
 }
 
 async function flowRun(id: string): Promise<void> {

--- a/providers/agents/portal/src/views/schedules.ts
+++ b/providers/agents/portal/src/views/schedules.ts
@@ -17,12 +17,17 @@ function agentOptions(vc: ViewCtx, selected: string): string {
   return vc.store.agents.map((a) => `<option value="${escapeHTML(a.metadata.name)}" ${a.metadata.name === selected ? 'selected' : ''}>${escapeHTML(a.spec?.displayName || a.metadata.name)}</option>`).join('')
 }
 
-function formHTML(vc: ViewCtx, editing: Schedule | undefined): string {
+function formHTML(vc: ViewCtx, editing: Schedule | undefined, agentRef?: string): string {
   const s = editing?.spec
   const type = s?.type || 'cron'
+  // When scoped to one agent (the Wiring tab), the agent is fixed — bind it in
+  // wire() and collect only the name.
+  const nameRow = agentRef
+    ? `<label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="daily-digest" /></label>`
+    : `<div class="agents-grid2"><label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="daily-digest" /></label><label>Agent<select name="agentRef" required>${agentOptions(vc, '')}</select></label></div>`
   return `<form class="agents-obj-form" ${editing ? `data-edit="${escapeHTML(editing.metadata.name)}"` : ''}>
       <h4>${editing ? `Edit schedule <code>${escapeHTML(editing.metadata.name)}</code>` : 'New schedule'}</h4>
-      ${editing ? '' : `<div class="agents-grid2"><label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="daily-digest" /></label><label>Agent<select name="agentRef" required>${agentOptions(vc, '')}</select></label></div>`}
+      ${editing ? '' : nameRow}
       <div class="agents-grid2">
         <label>Type<select name="type">${['cron', 'wakeup'].map((t) => `<option value="${t}" ${t === type ? 'selected' : ''}>${t === 'wakeup' ? 'one-shot (runAt)' : 'recurring (cron)'}</option>`).join('')}</select></label>
         <label>Timezone<input name="timeZone" value="${escapeHTML(s?.timeZone || '')}" placeholder="Europe/Vilnius" /></label>
@@ -35,20 +40,23 @@ function formHTML(vc: ViewCtx, editing: Schedule | undefined): string {
     </form>`
 }
 
-export function render(vc: ViewCtx): string {
-  const editing = editName ? vc.store.schedules.find((s) => s.metadata.name === editName) : undefined
+export function render(vc: ViewCtx, agentRef?: string): string {
+  const scoped = !!agentRef
+  const list = scoped ? vc.store.schedules.filter((s) => s.spec.agentRef === agentRef) : vc.store.schedules
+  const editing = editName ? list.find((s) => s.metadata.name === editName) : undefined
   const showForm = creating || !!editing
+  const cols = scoped ? 4 : 5
   const rows =
-    vc.store.schedules.length === 0
-      ? `<tr class="agents-empty-row"><td colspan="6"><span class="agents-empty">${ic('clock')} No schedules yet — add one below.</span></td></tr>`
-      : vc.store.schedules
+    list.length === 0
+      ? `<tr class="agents-empty-row"><td colspan="${cols}"><span class="agents-empty">${ic('clock')} No schedules yet — add one below.</span></td></tr>`
+      : list
           .map((s) => {
             const when = s.spec.type === 'wakeup' ? s.spec.runAt || '' : s.spec.schedule || ''
             const dis = s.status?.disabledReason
             const status = dis ? `<span class="agents-badge">${escapeHTML(dis)}</span>` : s.spec.suspend ? '<span class="agents-badge">paused</span>' : s.status?.nextRun ? `next ${escapeHTML(fmtTime(s.status.nextRun))}` : 'armed'
             return `<tr class="${editName === s.metadata.name ? 'is-editing' : ''}">
               <td><strong>${escapeHTML(s.metadata.name)}</strong></td>
-              <td><button class="agents-linkbtn" data-goagent="${escapeHTML(s.spec.agentRef)}">${escapeHTML(s.spec.agentRef)}</button></td>
+              ${scoped ? '' : `<td><button class="agents-linkbtn" data-goagent="${escapeHTML(s.spec.agentRef)}">${escapeHTML(s.spec.agentRef)}</button></td>`}
               <td class="mono">${escapeHTML(when)}${s.spec.timeZone ? ` <span class="muted">${escapeHTML(s.spec.timeZone)}</span>` : ''}</td>
               <td class="muted">${status}</td>
               <td class="agents-row-actions">
@@ -63,16 +71,16 @@ export function render(vc: ViewCtx): string {
   return `
     <div class="agents-panel">
       <div class="agents-panel-head"><h3>Schedules</h3>${showForm ? '' : `<button data-newobj ${vc.store.agents.length ? '' : 'disabled title="Create an agent first"'}>${ic('plus')} New schedule</button>`}</div>
-      <p class="muted">Recurring or one-shot tasks. Each runs as a specific agent. ${vc.store.agents.length ? '' : 'Create an agent first.'}</p>
+      <p class="muted">Recurring or one-shot tasks${scoped ? ' that run as this agent' : '. Each runs as a specific agent'}. ${vc.store.agents.length ? '' : 'Create an agent first.'}</p>
       <table class="agents-table">
-        <thead><tr><th>Name</th><th>Agent</th><th>When</th><th>Status</th><th class="agents-th-actions">Actions</th></tr></thead>
+        <thead><tr><th>Name</th>${scoped ? '' : '<th>Agent</th>'}<th>When</th><th>Status</th><th class="agents-th-actions">Actions</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
-      ${showForm ? formHTML(vc, editing) : ''}
+      ${showForm ? formHTML(vc, editing, agentRef) : ''}
     </div>`
 }
 
-export function wire(vc: ViewCtx, root: HTMLElement): void {
+export function wire(vc: ViewCtx, root: HTMLElement, agentRef?: string): void {
   root.querySelector<HTMLElement>('[data-newobj]')?.addEventListener('click', () => {
     creating = true
     editName = null
@@ -130,9 +138,9 @@ export function wire(vc: ViewCtx, root: HTMLElement): void {
       editName = null
     } else {
       const name = g('name')
-      const agentRef = g('agentRef')
-      if (!name || !agentRef) return
-      void createSchedule(vc, { name, agentRef, ...patch }).then((ok) => {
+      const ref = agentRef || g('agentRef')
+      if (!name || !ref) return
+      void createSchedule(vc, { name, agentRef: ref, ...patch }).then((ok) => {
         if (ok) creating = false
       })
     }

--- a/providers/agents/portal/src/views/triggers.ts
+++ b/providers/agents/portal/src/views/triggers.ts
@@ -19,12 +19,16 @@ function connOptions(vc: ViewCtx, selected: string): string {
   return [`<option value="">— none —</option>`, ...vc.store.connections.map((c) => `<option value="${escapeHTML(c.metadata.name)}" ${c.metadata.name === selected ? 'selected' : ''}>${escapeHTML(c.metadata.name)}</option>`)].join('')
 }
 
-function formHTML(vc: ViewCtx, editing: Trigger | undefined): string {
+function formHTML(vc: ViewCtx, editing: Trigger | undefined, agentRef?: string): string {
   const s = editing?.spec
   const source = s?.source || 'webhook'
+  // Scoped to one agent (Wiring tab): agent is fixed, bound in wire().
+  const nameRow = agentRef
+    ? `<label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="on-issue" /></label>`
+    : `<div class="agents-grid2"><label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="on-issue" /></label><label>Agent<select name="agentRef" required>${agentOptions(vc, '')}</select></label></div>`
   return `<form class="agents-obj-form" ${editing ? `data-edit="${escapeHTML(editing.metadata.name)}"` : ''}>
       <h4>${editing ? `Edit trigger <code>${escapeHTML(editing.metadata.name)}</code>` : 'New trigger'}</h4>
-      ${editing ? '' : `<div class="agents-grid2"><label>Name<input name="name" required pattern="[a-z0-9-]+" placeholder="on-issue" /></label><label>Agent<select name="agentRef" required>${agentOptions(vc, '')}</select></label></div>`}
+      ${editing ? '' : nameRow}
       <div class="agents-grid2">
         <label>Source<select name="source">${['webhook', 'github'].map((v) => `<option value="${v}" ${v === source ? 'selected' : ''}>${v}</option>`).join('')}</select></label>
         <label>Connection<select name="connectionRef">${connOptions(vc, s?.connectionRef || '')}</select></label>
@@ -35,18 +39,21 @@ function formHTML(vc: ViewCtx, editing: Trigger | undefined): string {
     </form>`
 }
 
-export function render(vc: ViewCtx): string {
-  const editing = editName ? vc.store.triggers.find((t) => t.metadata.name === editName) : undefined
+export function render(vc: ViewCtx, agentRef?: string): string {
+  const scoped = !!agentRef
+  const list = scoped ? vc.store.triggers.filter((t) => t.spec.agentRef === agentRef) : vc.store.triggers
+  const editing = editName ? list.find((t) => t.metadata.name === editName) : undefined
   const showForm = creating || !!editing
+  const cols = scoped ? 4 : 5
   const rows =
-    vc.store.triggers.length === 0
-      ? `<tr class="agents-empty-row"><td colspan="6"><span class="agents-empty">${ic('zap')} No triggers yet — add one below.</span></td></tr>`
-      : vc.store.triggers
+    list.length === 0
+      ? `<tr class="agents-empty-row"><td colspan="${cols}"><span class="agents-empty">${ic('zap')} No triggers yet — add one below.</span></td></tr>`
+      : list
           .map((t) => {
             const status = t.spec.suspend ? '<span class="agents-badge">paused</span>' : t.status?.lastFired ? `last ${escapeHTML(fmtTime(t.status.lastFired))}` : 'armed'
             return `<tr class="${editName === t.metadata.name ? 'is-editing' : ''}">
               <td><strong>${escapeHTML(t.metadata.name)}</strong></td>
-              <td><button class="agents-linkbtn" data-goagent="${escapeHTML(t.spec.agentRef)}">${escapeHTML(t.spec.agentRef)}</button></td>
+              ${scoped ? '' : `<td><button class="agents-linkbtn" data-goagent="${escapeHTML(t.spec.agentRef)}">${escapeHTML(t.spec.agentRef)}</button></td>`}
               <td class="mono">${escapeHTML(t.spec.source)}${t.spec.connectionRef ? ` <span class="muted">${escapeHTML(t.spec.connectionRef)}</span>` : ''}</td>
               <td class="muted">${status}</td>
               <td class="agents-row-actions">
@@ -61,16 +68,16 @@ export function render(vc: ViewCtx): string {
   return `
     <div class="agents-panel">
       <div class="agents-panel-head"><h3>Triggers</h3>${showForm ? '' : `<button data-newobj ${vc.store.agents.length ? '' : 'disabled title="Create an agent first"'}>${ic('plus')} New trigger</button>`}</div>
-      <p class="muted">External events that wake an agent. Each fires a specific agent. ${vc.store.agents.length ? '' : 'Create an agent first.'}</p>
+      <p class="muted">External events that wake an agent${scoped ? '' : '. Each fires a specific agent'}. ${vc.store.agents.length ? '' : 'Create an agent first.'}</p>
       <table class="agents-table">
-        <thead><tr><th>Name</th><th>Agent</th><th>Source</th><th>Status</th><th class="agents-th-actions">Actions</th></tr></thead>
+        <thead><tr><th>Name</th>${scoped ? '' : '<th>Agent</th>'}<th>Source</th><th>Status</th><th class="agents-th-actions">Actions</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
-      ${showForm ? formHTML(vc, editing) : ''}
+      ${showForm ? formHTML(vc, editing, agentRef) : ''}
     </div>`
 }
 
-export function wire(vc: ViewCtx, root: HTMLElement): void {
+export function wire(vc: ViewCtx, root: HTMLElement, agentRef?: string): void {
   root.querySelector<HTMLElement>('[data-newobj]')?.addEventListener('click', () => {
     creating = true
     editName = null
@@ -112,9 +119,9 @@ export function wire(vc: ViewCtx, root: HTMLElement): void {
       editName = null
     } else {
       const name = g('name')
-      const agentRef = g('agentRef')
-      if (!name || !agentRef) return
-      void createTrigger(vc, { name, agentRef, ...patch }).then((ok) => {
+      const ref = agentRef || g('agentRef')
+      if (!name || !ref) return
+      void createTrigger(vc, { name, agentRef: ref, ...patch }).then((ok) => {
         if (ok) creating = false
       })
     }


### PR DESCRIPTION
## Why

The refactored agents **flow editor** had three usability gaps reported in use:

1. **Not draggable** — nodes could only be grabbed by their thin header strip; the card body just selected.
2. **Unclear how to hook channels (Discord etc.)** — a single `defaultNotifyConnection` link silently drives *both* outbound (agent notifies you) and inbound (channel talks to the agent) routing, and inbound had no representation in flow at all.
3. **Can't edit in forms** — per-agent, the flow node-modals were the *only* editor for tools/schedules/triggers/channels; the real forms lived one level away in the workspace-global menus.

This is **Level 1** of the "make flow better" work: a richer editor over the *same* declarative model (no backend/execution-model changes). The canvas stays hand-rolled.

## What

**Draggability** — the whole node is now the drag handle (ports and buttons excluded), with a `grab`/`grabbing` cursor.

**Channels — inbound made visible & explained**
- Channel nodes expose two labeled ports: **NOTIFY** (agent → channel) and **LISTEN** (channel → agent). The inbound wire is drawn only when the channel is actually receiving.
- The node modal shows an **inbound status row** with per-type guidance, matching the backend contract (`channels_inbound.go`): Discord bot = automatic, Telegram/Slack = an **Enable** button that registers the webhook, send-only channels (Discord webhook / SMTP) flagged as such.
- Dragging a channel's **LISTEN** port onto the agent links it symmetrically (same as the outbound gesture).

**Form parity — new Wiring tab**
- Agent page tabs are now **Chat · Flow · Wiring · Settings**.
- `agent-wiring.ts` is a form-based counterpart to the canvas: model, schedules, triggers, channels (notify + inbound + test), and tools/toolsets checklists — all scoped to one agent.
- Schedules/triggers **reuse the existing menu forms** via a new optional `agentRef` filter, so there's a single source of truth rather than a parallel copy.
- Split of responsibility: **Settings** owns persona/model/budget/delegates; **Wiring** owns the feeds-and-outputs. (Model appears in both, harmless — both patch the same field.)

## Scope / non-goals
- No backend changes. This is a projection over the existing CRDs, not a Node-RED-style execution graph (that would be a separate, much larger backend effort — intentionally out of scope).

## Verification
- `npm run typecheck` and `vite build` both pass.
- ⚠️ **Not yet exercised in a real browser** — the portal is a custom element served by the running kedge hub, so the drag / inbound / Wiring interactions need the stack up to confirm visually. Happy to add a standalone mock-mount harness if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)