### PR TITLE
fix(app-studio/portal): import tenant helpers in api.ts

### DIFF
--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -20,6 +20,7 @@ import type {
   ProviderItem,
 } from './types'
 import type { ProjectCreateReadiness } from './createReadiness'
+import { readTenant, serviceBase, tenantHeaders } from './portalkit/tenant'
 
 interface TenantSelection {
   orgUUID: string | null


### PR DESCRIPTION
## Problem

After the recent portal UI changes, prod App Studio threw **`readTenant is not defined`** on the first tenant-scoped request.

`api.ts` calls `readTenant()`, `serviceBase()`, and `tenantHeaders()` — all defined in `portalkit/tenant.ts` — but the import statement was missing.

## Why it reached prod

The portal `build` script is `vite build` only; it does **not** run `vue-tsc`. esbuild transpiles without type-checking, so the undefined identifier passed straight through into the bundle (as a bare global reference) instead of failing the build. `vue-tsc --noEmit` catches it.

## Fix

Add the missing import:

```ts
import { readTenant, serviceBase, tenantHeaders } from './portalkit/tenant'
```

- `vue-tsc --noEmit` passes clean
- Rebuilt `dist/` locally: the bare `readTenant()` global is gone and the tenant helper (`kedge:portal:tenant`) is bundled correctly (`dist/` is gitignored, built at deploy)

## Follow-up (not in this PR)

Wire typecheck into the build (`"build": "vue-tsc --noEmit && vite build && ..."`) so this class of bug fails CI instead of prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)