### PR TITLE
fix(infra): default empty source namespace in RuntimeNamespace

### DIFF
--- a/providers/infrastructure/kro/namespace.go
+++ b/providers/infrastructure/kro/namespace.go
@@ -89,7 +89,19 @@ func TenantNamespace(tenantPath string) string { return tenantNamespaceName(tena
 // Secrets and the default-SA imagePullSecrets — must target this namespace,
 // not the kedge-tenants-<hash> control-plane namespace (TenantNamespace),
 // or they land in an empty namespace no pod can see.
+//
+// An empty sourceNamespace defaults to "default": instances created without an
+// explicit namespace (e.g. App Studio's promoted Application/SimpleWebApp) carry
+// namespace "" on the instance object, yet their children materialize into
+// "<sourceCluster>-default" (children default to the "default" namespace). Bare
+// concatenation would produce "<sourceCluster>-", which is both an invalid
+// RFC 1123 label (trailing "-") and the wrong target — the bridged Secret would
+// miss the namespace the pods actually run in. Defaulting here keeps the bridge
+// aligned with kro's child placement.
 func RuntimeNamespace(sourceCluster, sourceNamespace string) string {
+	if sourceNamespace == "" {
+		sourceNamespace = "default"
+	}
 	return sourceCluster + "-" + sourceNamespace
 }
 

--- a/providers/infrastructure/kro/namespace_test.go
+++ b/providers/infrastructure/kro/namespace_test.go
@@ -96,3 +96,29 @@ func TestEnsureTenantNamespaceLimitRangeDisabled(t *testing.T) {
 		t.Fatal("LimitRange was created despite KEDGE_TENANT_LIMITRANGE=disabled")
 	}
 }
+
+// TestRuntimeNamespace pins the source→runtime namespace mapping. An empty
+// source namespace must default to "default" — instances created without an
+// explicit namespace (App Studio's promoted Application/SimpleWebApp) carry ""
+// on the instance object, yet kro materializes their children into
+// "<cluster>-default". Bare concatenation yielded "<cluster>-", an invalid
+// RFC 1123 label that both crashed the bridge reconcile and missed the pods'
+// namespace, leaving instances stuck on "no such key: fqdn (data pending)".
+func TestRuntimeNamespace(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cluster string
+		ns      string
+		want    string
+	}{
+		{name: "empty namespace defaults to default", cluster: "jcb49sm6dkg85xwg", ns: "", want: "jcb49sm6dkg85xwg-default"},
+		{name: "explicit namespace preserved", cluster: "jcb49sm6dkg85xwg", ns: "team-a", want: "jcb49sm6dkg85xwg-team-a"},
+		{name: "explicit default preserved", cluster: "abc", ns: "default", want: "abc-default"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RuntimeNamespace(tc.cluster, tc.ns); got != tc.want {
+				t.Fatalf("RuntimeNamespace(%q, %q) = %q, want %q", tc.cluster, tc.ns, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Promoting an App Studio project to prod left the runtime instance stuck:

```
ResourcesReady  False  waiting for unresolved resource: httproutes ...
  node "httpRoute": failed to evaluate expression: eval "schema.spec.expose.fqdn":
  no such key: fqdn (data pending)
```

`spec.expose.fqdn` is stamped asynchronously onto the instance by the infra `application` controller. It was never landing for **promoted** instances.

## Root cause (confirmed in prod logs)

```
controller="infra-simplewebapp" err="bridging registry pull secret:
create namespace jcb49sm6dkg85xwg-: Namespace \"jcb49sm6dkg85xwg-\" is invalid
... must end with an alphanumeric character"
```

- App Studio creates the promoted `Application`/`SimpleWebApp` with **no namespace**, so the instance object carries namespace `""`.
- kro still materializes the children into `<cluster>-default` (verified: the prod pods run there).
- The controller computed the secret-bridge target as `RuntimeNamespace(tenant, "")` → bare concat → `<cluster>-`, which is an **invalid RFC 1123 label** *and* the wrong namespace.
- In `Reconcile`, the pull-secret bridge runs **before** the fqdn stamp and returns on error → `spec.expose.fqdn` never stamped → kro sits on `data pending` forever.

Dev instances have no private image → no registry secret → the bridge is skipped → fqdn stamps fine. That's why only **promoted prod** instances hung.

## Fix

Default an empty source namespace to `default` in `RuntimeNamespace`, matching where kro actually places the workloads. The bridge then targets the existing `<cluster>-default`, succeeds, and the reconcile proceeds to stamp the fqdn.

**Self-healing:** on redeploy, the controller re-reconciles the stuck `*-prod` instances and they go Ready with no manual intervention.

Added `TestRuntimeNamespace`; `go build` + `go test ./kro/` pass.

## Follow-ups (not in this PR)

- Have App Studio create the instance with an explicit `default` namespace so the instance object is consistent with its children.
- Stamp `fqdn` **before** the pull-secret bridge so a bridge hiccup can't block exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)