### PR TITLE
agents background tool opt-in + app-studio component directory contract

### DIFF
--- a/providers/agents/api/run.go
+++ b/providers/agents/api/run.go
@@ -141,6 +141,11 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 		maxIters = min(v, 32)
 	}
 
+	// Assemble the turn before persisting the task message — LoadRecentMessages
+	// has no notion of "current run", so appending first would replay the task
+	// into history and the model would see it twice.
+	msgs := s.assembleTurnCtx(ctx, scope, agent, sessionID, run.Task, run.Trigger, mcpInstructions)
+
 	_ = s.store.AppendMessage(ctx, scope, store.Message{
 		ID: uuid.NewString(), AgentName: agent.Name, SessionID: sessionID, RunID: runID,
 		Role: "user", Content: run.Task, CreatedAt: now,
@@ -150,8 +155,6 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 		ParentRunID: run.ParentRunID,
 		Phase:       store.RunPhaseRunning, Input: run.Task, CreatedAt: now, UpdatedAt: now, StartedAt: &now,
 	})
-
-	msgs := s.assembleTurnCtx(ctx, scope, agent, sessionID, run.Task, mcpInstructions)
 	res, err := s.engine.StreamTurnWithTools(ctx, model, msgs, toolset, maxIters, run.OnDelta, run.OnTool)
 	end := time.Now().UTC()
 	if err != nil {
@@ -195,7 +198,7 @@ func (s *Server) executeTask(ctx context.Context, run taskRun) (runResult, error
 // assembleTurnCtx builds the message list (system prompt + recent history +
 // task) using a context rather than an *http.Request, so background callers
 // (scheduler) can reuse it.
-func (s *Server) assembleTurnCtx(ctx context.Context, scope store.Scope, agent *agentsv1alpha1.Agent, sessionID, task, mcpInstructions string) []engine.Message {
+func (s *Server) assembleTurnCtx(ctx context.Context, scope store.Scope, agent *agentsv1alpha1.Agent, sessionID, task, trigger, mcpInstructions string) []engine.Message {
 	var msgs []engine.Message
 	if sp := agent.Spec.SystemPrompt; sp != "" {
 		msgs = append(msgs, engine.Message{Role: engine.RoleSystem, Content: sp})
@@ -214,6 +217,14 @@ func (s *Server) assembleTurnCtx(ctx context.Context, scope store.Scope, agent *
 			role = engine.RoleAssistant
 		}
 		msgs = append(msgs, engine.Message{Role: role, Content: m.Content})
+	}
+	// Background sessions (schedule/heartbeat/wakeup) accumulate the agent's
+	// own prior replies turn after turn — kept deliberately, so e.g. a news
+	// schedule can see what it already posted and not repeat itself. That pile
+	// can outweigh the one persona line at the top, so re-assert it after
+	// history to keep the agent in character.
+	if sp := agent.Spec.SystemPrompt; sp != "" && !isInteractive(trigger) && len(history) > 0 {
+		msgs = append(msgs, engine.Message{Role: engine.RoleSystem, Content: "Reminder — your persona and standing instructions still apply to this reply:\n\n" + sp})
 	}
 	msgs = append(msgs, engine.Message{Role: engine.RoleUser, Content: task})
 	return msgs

--- a/providers/agents/portal/src/actions.ts
+++ b/providers/agents/portal/src/actions.ts
@@ -321,3 +321,25 @@ export async function wireToolTo(vc: ViewCtx, agentName: string, target: string,
   await vc.api.send('PUT', `/api/agents/${encodeURIComponent(agentName)}`, { interactiveConnections: [...cur, cn], interactiveFamilies: vc.store.familiesFor([...cur, cn]) })
   await vc.store.loadAgents()
 }
+
+// setToolsetBackground toggles whether a linked toolset also applies to
+// background runs (schedules, triggers, heartbeats). The interactive link is
+// untouched — background is an explicit opt-in on top of it.
+export async function setToolsetBackground(vc: ViewCtx, agentName: string, toolset: string, on: boolean): Promise<void> {
+  const a = vc.store.agent(agentName)
+  const cur = a?.spec?.tools?.background?.toolsets || []
+  if (on === cur.includes(toolset)) return
+  const next = on ? [...cur, toolset] : cur.filter((t) => t !== toolset)
+  await updateAgent(vc, agentName, { backgroundToolsets: next }, on ? 'Toolset enabled for background runs.' : 'Toolset is now interactive-only.')
+}
+
+// setToolBackground toggles a directly-granted tool for background runs,
+// re-deriving background families from the resulting connection set so the
+// tool actually resolves there (same derivation as the interactive grant).
+export async function setToolBackground(vc: ViewCtx, agentName: string, cn: string, on: boolean): Promise<void> {
+  const a = vc.store.agent(agentName)
+  const cur = a?.spec?.tools?.background?.connections || []
+  if (on === cur.includes(cn)) return
+  const next = on ? [...cur, cn] : cur.filter((x) => x !== cn)
+  await updateAgent(vc, agentName, { backgroundConnections: next, backgroundFamilies: vc.store.familiesFor(next) }, on ? 'Tool enabled for background runs.' : 'Tool is now interactive-only.')
+}

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -243,6 +243,10 @@ kedge-provider-agents .agents-wiring { display: flex; flex-direction: column; ga
 kedge-provider-agents .agents-inbound-line { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 kedge-provider-agents .agents-inbound-actions { margin-left: auto; display: flex; gap: 8px; }
 kedge-provider-agents .agents-wire-fs { border: 1px solid var(--color-border-default, #d9e0ec); border-radius: 10px; padding: 11px 13px; display: flex; flex-direction: column; gap: 7px; }
+kedge-provider-agents .agents-tool-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+kedge-provider-agents .agents-bg-toggle { font-size: 12px; color: var(--color-text-secondary, currentColor); white-space: nowrap; }
+kedge-provider-agents .agents-bg-toggle svg { width: 12px; height: 12px; }
+kedge-provider-agents .agents-bg-toggle:has(input:disabled) { opacity: 0.45; }
 kedge-provider-agents .agents-wire-fs legend { font-weight: 600; padding: 0 6px; display: inline-flex; align-items: center; gap: 5px; }
 /* Multi-channel editor: one row per bound channel (role name, connection,
  * primary radio, remove), then a save/add action bar and inbound status list. */

--- a/providers/agents/portal/src/views/agent-wiring.ts
+++ b/providers/agents/portal/src/views/agent-wiring.ts
@@ -10,7 +10,7 @@ import type { ViewCtx } from '../view'
 import type { Agent, Connection } from '../types'
 import { escapeHTML, effectiveChannels } from '../types'
 import { connCategory } from '../conn-defs'
-import { updateAgent, linkToolset, wireToolTo, testConnection, enableInbound } from '../actions'
+import { updateAgent, linkToolset, wireToolTo, setToolBackground, setToolsetBackground, testConnection, enableInbound } from '../actions'
 import * as schedules from './schedules'
 import * as triggers from './triggers'
 
@@ -95,29 +95,41 @@ export function render(vc: ViewCtx, a: Agent): string {
       ${inboundRows ? `<div class="agents-chan-inbound">${inboundRows}</div>` : ''}
     </div>`
 
-  // Tools & toolsets
+  // Tools & toolsets. The main checkbox grants the tool (interactive); the
+  // background toggle additionally opts it into schedules/triggers/heartbeats,
+  // which get a deliberately smaller default surface (design rule 5).
   const agentToolsets = new Set([...(a.spec?.tools?.interactive?.toolsets || []), ...(a.spec?.tools?.background?.toolsets || [])])
   const agentTools = new Set([...(a.spec?.tools?.interactive?.connections || []), ...(a.spec?.tools?.background?.connections || [])])
+  const bgToolsets = new Set(a.spec?.tools?.background?.toolsets || [])
+  const bgTools = new Set(a.spec?.tools?.background?.connections || [])
+  const bgToggle = (attr: string, key: string, linked: boolean, on: boolean) =>
+    `<label class="agents-check agents-bg-toggle" title="Background runs (schedules, triggers, heartbeats) have no human watching, so tools stay interactive-only unless opted in here."><input type="checkbox" ${attr}="${escapeHTML(key)}" ${on ? 'checked' : ''} ${linked ? '' : 'disabled'} /> ${ic('clock')} background</label>`
   const toolConns = vc.store.connections.filter((c) => connCategory(c.spec.type) === 'tool')
   const toolsetRows = vc.store.toolsets.length
     ? vc.store.toolsets
-        .map(
-          (t) =>
-            `<label class="agents-check"><input type="checkbox" data-wire-toolset="${escapeHTML(t.metadata.name)}" ${agentToolsets.has(t.metadata.name) ? 'checked' : ''} /> ${escapeHTML(t.spec.displayName || t.metadata.name)}</label>`,
-        )
+        .map((t) => {
+          const n = t.metadata.name
+          return `<div class="agents-tool-row">
+              <label class="agents-check"><input type="checkbox" data-wire-toolset="${escapeHTML(n)}" ${agentToolsets.has(n) ? 'checked' : ''} /> ${escapeHTML(t.spec.displayName || n)}</label>
+              ${bgToggle('data-wire-toolset-bg', n, agentToolsets.has(n), bgToolsets.has(n))}
+            </div>`
+        })
         .join('')
     : `<p class="agents-hint">No toolsets yet — create one under ${ic('puzzle')} Toolsets.</p>`
   const toolRows = toolConns.length
     ? toolConns
-        .map(
-          (c) =>
-            `<label class="agents-check"><input type="checkbox" data-wire-tool="${escapeHTML(c.metadata.name)}" ${agentTools.has(c.metadata.name) ? 'checked' : ''} /> ${escapeHTML(c.spec.displayName || c.metadata.name)} <span class="muted">${escapeHTML(c.spec.type)}</span></label>`,
-        )
+        .map((c) => {
+          const n = c.metadata.name
+          return `<div class="agents-tool-row">
+              <label class="agents-check"><input type="checkbox" data-wire-tool="${escapeHTML(n)}" ${agentTools.has(n) ? 'checked' : ''} /> ${escapeHTML(c.spec.displayName || n)} <span class="muted">${escapeHTML(c.spec.type)}</span></label>
+              ${bgToggle('data-wire-tool-bg', n, agentTools.has(n), bgTools.has(n))}
+            </div>`
+        })
         .join('')
     : `<p class="agents-hint">No tools yet — add one under ${ic('plug')} Connections.</p>`
   const toolsSec = `<div class="agents-panel">
       <h3>${ic('wrench')} Tools &amp; toolsets</h3>
-      <p class="muted">What this agent can call. Toolsets are shared bundles; direct tools grant a single connection.</p>
+      <p class="muted">What this agent can call. Toolsets are shared bundles; direct tools grant a single connection. Chat always gets a granted tool; tick <strong>background</strong> to also allow it on schedules, triggers, and heartbeats.</p>
       <fieldset class="agents-wire-fs"><legend>${ic('puzzle')} Toolsets</legend>${toolsetRows}</fieldset>
       <fieldset class="agents-wire-fs"><legend>${ic('wrench')} Direct tools</legend>${toolRows}</fieldset>
     </div>`
@@ -220,5 +232,14 @@ export function wire(vc: ViewCtx, root: HTMLElement, a: Agent): void {
         )
       }
     }),
+  )
+
+  // Background opt-in per toolset / tool. Only enabled while the item is linked;
+  // unlinking above clears the background grant too.
+  root.querySelectorAll<HTMLInputElement>('[data-wire-toolset-bg]').forEach((el) =>
+    el.addEventListener('change', () => void setToolsetBackground(vc, name, el.dataset.wireToolsetBg!, el.checked)),
+  )
+  root.querySelectorAll<HTMLInputElement>('[data-wire-tool-bg]').forEach((el) =>
+    el.addEventListener('change', () => void setToolBackground(vc, name, el.dataset.wireToolBg!, el.checked)),
   )
 }

--- a/providers/app-studio/api/assistant_eino_session.go
+++ b/providers/app-studio/api/assistant_eino_session.go
@@ -37,7 +37,12 @@ type projectEinoAssistantSessionSnapshot struct {
 	LastKnownBranch   string                            `json:"lastKnownBranch"`
 	LastFileSnapshot  []string                          `json:"lastFileSnapshot"`
 	RecommendedChecks []string                          `json:"recommendedChecks,omitempty"`
-	Memory            projectEinoAssistantSessionMemory `json:"memory"`
+	// DevelopmentComponents maps each of the bound template's development
+	// component names to the workspace directory file sync routes from ("."
+	// is the workspace root). Application source outside every listed
+	// directory never reaches the development sandbox.
+	DevelopmentComponents map[string]string                 `json:"developmentComponents,omitempty"`
+	Memory                projectEinoAssistantSessionMemory `json:"memory"`
 	LastBuildRun      *projectEinoAssistantSessionBuild `json:"lastBuildRun,omitempty"`
 	ContextIssue      string                            `json:"contextIssue,omitempty"`
 }
@@ -103,8 +108,29 @@ func projectEinoAssistantSnapshot(ctx context.Context, req projectAssistantRunRe
 	files, issue := projectEinoAssistantWorkspaceSnapshot(ctx, req)
 	snapshot.LastFileSnapshot = files
 	snapshot.RecommendedChecks = projectAssistantRecommendedRuntimeChecks(files)
+	snapshot.DevelopmentComponents = projectAssistantTemplateComponents(ctx, req)
 	snapshot.ContextIssue = issue
 	return snapshot
+}
+
+// projectAssistantTemplateComponents reads the bound template's development
+// component → workspacePath map for the turn snapshot. Best-effort: a project
+// without a template, a missing client, or a failed catalog read yields nil —
+// the snapshot then simply carries no directory contract instead of failing
+// the turn.
+func projectAssistantTemplateComponents(ctx context.Context, req projectAssistantRunRequest) map[string]string {
+	if req.Client == nil || req.Project == nil || req.Project.Spec.Template == nil {
+		return nil
+	}
+	name := strings.TrimSpace(req.Project.Spec.Template.Name)
+	if name == "" {
+		return nil
+	}
+	info, err := fetchProjectTemplate(ctx, req.Client, name)
+	if err != nil {
+		return nil
+	}
+	return info.Components
 }
 
 func projectEinoAssistantLatestBuild(commits []ProjectRepositoryCommitView) *projectEinoAssistantSessionBuild {

--- a/providers/app-studio/api/assistant_tool_registry.go
+++ b/providers/app-studio/api/assistant_tool_registry.go
@@ -259,7 +259,7 @@ func projectAssistantLocalToolRegistry(server *Server) projectAssistantToolRegis
 				return projectAssistantToolJSONResult(map[string]any{
 					"template":   info.Name,
 					"components": info.Components,
-					"note":       "development environment is re-provisioning in development mode; the workspace will be synced into it automatically",
+					"note":       "development environment is re-provisioning in development mode; the workspace will be synced into it automatically. Write each component's source under its directory from `components` (component name → workspace directory) — files outside every component directory are never synced to the development sandbox and cannot run",
 				}, nil)
 			},
 		},

--- a/providers/app-studio/api/development_sync.go
+++ b/providers/app-studio/api/development_sync.go
@@ -81,6 +81,21 @@ func (t projectDevelopmentSyncTargetInfo) sortedComponents() []string {
 	return names
 }
 
+// componentWorkspacePathSummary renders the component → workspacePath map for
+// error messages, sorted by component name (e.g. "backend → api/, frontend → web/").
+func (t projectDevelopmentSyncTargetInfo) componentWorkspacePathSummary() string {
+	parts := make([]string, 0, len(t.Components))
+	for _, name := range t.sortedComponents() {
+		wp := path.Clean(strings.TrimSpace(t.Components[name]))
+		if wp == "." {
+			parts = append(parts, name+" → the workspace root")
+			continue
+		}
+		parts = append(parts, name+" → "+wp+"/")
+	}
+	return strings.Join(parts, ", ")
+}
+
 type projectSandboxSyncFile struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
@@ -211,6 +226,15 @@ func (s *Server) syncProjectDevelopmentTarget(ctx context.Context, c *asclient.C
 	// by workspacePath prefix (docs/app-studio-template-sandboxes.md §4.2).
 	// Files outside every component (README, docs) sync nowhere.
 	routed := routeProjectSyncFiles(files, target.Components)
+	// A populated workspace whose files all fall outside every component
+	// directory would "succeed" while shipping nothing to the sandbox — the
+	// app never starts and nothing explains why. Fail with the expected
+	// layout instead.
+	if len(files) > 0 && countRoutedProjectSyncFiles(routed) == 0 {
+		return nil, fmt.Errorf(
+			"none of the %d workspace files are under a development component directory (%s); application source must live under those directories to reach the development sandbox",
+			len(files), target.componentWorkspacePathSummary())
+	}
 	results := map[string]json.RawMessage{}
 	for _, component := range target.sortedComponents() {
 		payload, err := json.Marshal(projectSandboxSyncRequest{Files: routed[component], Restart: "auto"})
@@ -269,6 +293,15 @@ func routeProjectSyncFiles(files []projectSandboxSyncFile, components map[string
 		}
 	}
 	return out
+}
+
+// countRoutedProjectSyncFiles totals the files routed across all components.
+func countRoutedProjectSyncFiles(routed map[string][]projectSandboxSyncFile) int {
+	total := 0
+	for _, files := range routed {
+		total += len(files)
+	}
+	return total
 }
 
 // authorizeProjectDevelopmentPreviewTarget resolves the preview for a
@@ -351,6 +384,8 @@ func (s *Server) syncDevelopmentAfterMutationWithClient(c *asclient.Client, id i
 		return
 	}
 	if _, err := s.syncProjectDevelopmentTarget(ctx, c, id, p, target); err != nil {
-		klog.V(2).Infof("development sync after %s failed for project %s: %v", projectToolBaseName(name), p.Name, err)
+		// A failed post-mutation sync means the user's edit never reached the
+		// development sandbox — warn, don't bury it at debug verbosity.
+		klog.Warningf("development sync after %s failed for project %s: %v", projectToolBaseName(name), p.Name, err)
 	}
 }

--- a/providers/app-studio/api/development_sync_test.go
+++ b/providers/app-studio/api/development_sync_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+)
+
+func TestRouteProjectSyncFilesDropsFilesOutsideEveryComponent(t *testing.T) {
+	components := map[string]string{"backend": "api", "frontend": "web"}
+	files := []projectSandboxSyncFile{
+		{Path: "backend/index.js", Content: "x"},
+		{Path: "frontend/src/App.jsx", Content: "y"},
+		{Path: "README.md", Content: "z"},
+	}
+
+	routed := routeProjectSyncFiles(files, components)
+
+	if got := countRoutedProjectSyncFiles(routed); got != 0 {
+		t.Fatalf("countRoutedProjectSyncFiles = %d, want 0 — files under directories matching no component workspacePath must route nowhere", got)
+	}
+}
+
+func TestRouteProjectSyncFilesCountsRoutedFiles(t *testing.T) {
+	components := map[string]string{"backend": "api", "frontend": "web"}
+	files := []projectSandboxSyncFile{
+		{Path: "api/index.js", Content: "x"},
+		{Path: "web/src/App.jsx", Content: "y"},
+		{Path: "README.md", Content: "z"},
+	}
+
+	routed := routeProjectSyncFiles(files, components)
+
+	if got := countRoutedProjectSyncFiles(routed); got != 2 {
+		t.Fatalf("countRoutedProjectSyncFiles = %d, want 2", got)
+	}
+	if len(routed["backend"]) != 1 || routed["backend"][0].Path != "index.js" {
+		t.Errorf("backend routed = %+v, want [index.js]", routed["backend"])
+	}
+	if len(routed["frontend"]) != 1 || routed["frontend"][0].Path != "src/App.jsx" {
+		t.Errorf("frontend routed = %+v, want [src/App.jsx]", routed["frontend"])
+	}
+}
+
+func TestComponentWorkspacePathSummary(t *testing.T) {
+	target := projectDevelopmentSyncTargetInfo{
+		Components: map[string]string{"frontend": "web", "backend": "api"},
+	}
+	if got, want := target.componentWorkspacePathSummary(), "backend → api/, frontend → web/"; got != want {
+		t.Errorf("componentWorkspacePathSummary = %q, want %q", got, want)
+	}
+
+	root := projectDevelopmentSyncTargetInfo{Components: map[string]string{"app": "."}}
+	if got, want := root.componentWorkspacePathSummary(), "app → the workspace root"; got != want {
+		t.Errorf("componentWorkspacePathSummary = %q, want %q", got, want)
+	}
+}
+
+func TestProjectAssistantTemplateComponentsIsNilSafe(t *testing.T) {
+	ctx := context.Background()
+
+	if got := projectAssistantTemplateComponents(ctx, projectAssistantRunRequest{}); got != nil {
+		t.Errorf("nil project/client: got %v, want nil", got)
+	}
+	if got := projectAssistantTemplateComponents(ctx, projectAssistantRunRequest{
+		Project: &aiv1alpha1.Project{},
+	}); got != nil {
+		t.Errorf("project without template: got %v, want nil", got)
+	}
+	if got := projectAssistantTemplateComponents(ctx, projectAssistantRunRequest{
+		Project: &aiv1alpha1.Project{
+			Spec: aiv1alpha1.ProjectSpec{Template: &aiv1alpha1.ProjectTemplateSpec{Name: "  "}},
+		},
+	}); got != nil {
+		t.Errorf("blank template name: got %v, want nil", got)
+	}
+}
+
+func TestSystemPromptCarriesComponentDirectoryContract(t *testing.T) {
+	p := &aiv1alpha1.Project{}
+	p.Name = "demo"
+	p.Spec.Template = &aiv1alpha1.ProjectTemplateSpec{Name: "application"}
+
+	prompt := projectSystemPrompt(p, nil)
+
+	for _, required := range []string{
+		"developmentComponents",
+		"NEVER synced to the development sandbox",
+	} {
+		if !strings.Contains(prompt, required) {
+			t.Errorf("system prompt for a template-backed project missing %q", required)
+		}
+	}
+}

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -2058,6 +2058,7 @@ func projectSystemPromptForInitialPlan(p *aiv1alpha1.Project, repository *Projec
 	b.WriteString("- Name: " + p.Name + "\n")
 	if p.Spec.Template != nil && strings.TrimSpace(p.Spec.Template.Name) != "" {
 		b.WriteString("- Development template: " + strings.TrimSpace(p.Spec.Template.Name) + " (the development environment runs this infrastructure template in development mode; source directories map to its declared components, so keep new code under the component directories). " +
+			"The turn snapshot's developmentComponents field maps each component to the exact workspace directory file sync routes from — ALL application source MUST live under one of those directories (never invent your own top-level source directories); files outside every component directory are NEVER synced to the development sandbox and cannot run, so only non-runtime files like README or docs belong outside. " +
 			"This template is the app's ENVIRONMENT CONTRACT: before reasoning about what infrastructure, backing services, or environment variables the app has, call infrastructure__describe_template on THIS template and treat its agent.usage / agent.outputs as authoritative. " +
 			"Backing services the template declares (for example a managed database) exist for the development instance too, with the same injected environment (for example DATABASE_URL) — do not conclude a declared service is missing just because the app code does not use it yet, and do not provision a separate instance of a service the bound template already provides.\n")
 	} else {


### PR DESCRIPTION
Two independent change sets bundled per request.

## agents: background tool opt-in + persona reminder

- **Portal**: each granted toolset / direct tool on the wiring page gets a "background" toggle that additionally opts it into schedules, triggers, and heartbeats. Interactive (chat) remains the default surface; the toggle is only enabled while the item is linked, and unlinking clears the background grant.
- **Runner**: assemble the turn context *before* persisting the task message — appending first replayed the task into history so the model saw it twice. On non-interactive runs (schedule/heartbeat/wakeup) with accumulated history, re-assert the agent's system prompt after history so long background sessions stay in character.

## app-studio: enforce the development component directory contract

Files outside every template component directory silently synced nowhere — an assistant that invented its own source layout got a "successful" sync and a sandbox that never ran anything.

- Turn snapshot carries `developmentComponents` (component → workspace directory) and the project system prompt states the contract explicitly.
- Syncing a populated workspace that routes **zero** files now fails with the expected layout in the error instead of succeeding vacuously.
- Post-mutation sync failures log at `Warning` instead of `V(2)`.
- The select-template tool result spells out where source must live.
- New unit tests for routing/counting and the layout summary.

## Test plan

- [x] `go build ./...` + `go test ./api/` in both providers
- [x] `tsc --noEmit` clean in the agents portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)