### PR TITLE
feat(infrastructure): MCP dev loop — dev_sync/dev_logs/dev_restart + development contract in describe_template

### DIFF
--- a/providers/infrastructure/install/templates/application.yaml
+++ b/providers/infrastructure/install/templates/application.yaml
@@ -78,9 +78,18 @@ spec:
           (set oidc.issuerURL + oidc.clientID; client secret via prerequisites).
         • platform — kedge SSO; NOT yet supported.
 
-      INPUTS you set when provisioning: frontendImage, backendImage (required);
-      name, frontendPort, backendPort, frontendReplicas, backendReplicas,
-      database.version, oidc.*. The platform stamps spec.expose.fqdn and
+      DEVELOPMENT MODE (provision with kedgeMode: development): both image
+      inputs are ignored (and may be omitted) — each tier runs a Node.js dev
+      server against its own workspace directory (frontend → web/, backend →
+      api/), with Postgres and DATABASE_URL exactly as in production. Push
+      source with the dev_sync tool (hot reload, no image builds; files are
+      routed by those directories), read dev-server logs with dev_logs, and
+      preview on the instance's status.url.
+
+      INPUTS you set when provisioning: frontendImage, backendImage (required
+      in production mode; omit in development mode); name, frontendPort,
+      backendPort, frontendReplicas, backendReplicas, database.version,
+      oidc.*. The platform stamps spec.expose.fqdn and
       spec.credentialsSecretName — do not set those.
     prerequisites:
       - "oidc.mode=byo only: a Secret named 'cloud-credentials' in the tenant's default namespace, key 'oidc_client_secret' = the OAuth2 client secret for your oidc.clientID."

--- a/providers/infrastructure/install/templates/simple-webapp.yaml
+++ b/providers/infrastructure/install/templates/simple-webapp.yaml
@@ -37,10 +37,11 @@ spec:
         • The platform provisions the Service, the public route, and the URL;
           you do NOT create Services, Ingresses, or routes.
 
-      DEVELOPMENT MODE (the platform-injected kedgeMode field): the image input
+      DEVELOPMENT MODE (provision with kedgeMode: development): the image input
       is ignored (and may be omitted) — the platform runs a Node.js dev
       container against the project workspace and serves it on the same public
-      URL a production instance would get. The whole project workspace is the
+      URL a production instance would get. Push source with the dev_sync tool
+      (hot reload, no image builds) and read dev-server logs with dev_logs. The whole project workspace is the
       app (workspacePath "."); a package.json with a dev script (vite et al)
       is auto-detected, otherwise vite is bootstrapped directly.
 

--- a/providers/infrastructure/install/templates/worker.yaml
+++ b/providers/infrastructure/install/templates/worker.yaml
@@ -34,11 +34,12 @@ spec:
         • Configuration comes from your image; there is no platform-injected
           env.
 
-      DEVELOPMENT MODE (the platform-injected kedgeMode field): the image
+      DEVELOPMENT MODE (provision with kedgeMode: development): the image
       input is ignored (and may be omitted) — the platform runs a Node.js dev
       container against the project workspace (workspacePath "."). The dev
-      process is `npm run dev` (falling back to `npm start`); logs and
-      restarts are available through the project's development runtime verbs.
+      process is `npm run dev` (falling back to `npm start`); push source with
+      the dev_sync tool (hot reload, no image builds), read logs with
+      dev_logs, and restart with dev_restart.
 
       INPUTS you set when provisioning: name (required); image (required in
       production, ignored in development), replicas.

--- a/providers/infrastructure/kro/types.go
+++ b/providers/infrastructure/kro/types.go
@@ -78,6 +78,13 @@ type Template struct {
 	// template via MCP (what it does, prerequisites, where outputs land).
 	// Read from the Template's spec.agent; nil when not provided.
 	Agent *TemplateAgent `json:"agent,omitempty"`
+	// Development is the template's development-mode contract, read from
+	// spec.development. Non-nil means instances can be provisioned with
+	// kedgeMode "development": image inputs are ignored, each component runs
+	// a platform dev server with hot reload, and source reaches it via the
+	// dev_sync tool routed by each component's workspacePath. nil means the
+	// template has no development mode.
+	Development *TemplateDevelopment `json:"development,omitempty"`
 	// View is optional presentation metadata that drives how the portal
 	// renders this template's instances (extra list columns + grouped
 	// detail fields). Read from the kedge.faros.sh/view annotation on the
@@ -143,6 +150,24 @@ type TemplateAgent struct {
 	Prerequisites []string `json:"prerequisites,omitempty"`
 	// Outputs describe where the instance's results land (URL, DB Secret, …).
 	Outputs []string `json:"outputs,omitempty"`
+}
+
+// TemplateDevelopment is the MCP-facing projection of a Template's
+// spec.development block: just enough for an agent to drive the dev loop —
+// which components exist and which workspace directory each one syncs from.
+// Runtime details (dev images, start commands, reload rules) stay
+// provider-internal.
+type TemplateDevelopment struct {
+	// Components maps each development component name to its contract.
+	Components map[string]TemplateDevelopmentComponent `json:"components"`
+}
+
+// TemplateDevelopmentComponent is one hot-swappable component's dev contract.
+type TemplateDevelopmentComponent struct {
+	// WorkspacePath is the source directory dev_sync routes to this
+	// component ("." = the whole workspace). Files outside every component's
+	// directory never reach the development sandbox.
+	WorkspacePath string `json:"workspacePath"`
 }
 
 // Instance is a portal-shaped view of a kro RGD instance CR in the

--- a/providers/infrastructure/main.go
+++ b/providers/infrastructure/main.go
@@ -136,21 +136,23 @@ func serveWithConfig(ctx context.Context, kcpConfig *rest.Config) {
 		port = "8081"
 	}
 
+	// Data-plane subresource proxy (logs/sync/restart/preview proxy/status).
+	// nil in REST-only/dev (no kcp or runtime cluster); the handler then reports
+	// 503 so the route exists but is clearly unavailable. Shared with the MCP
+	// server so the dev_* tools can drive the same verbs in-process.
+	var dataPlaneHandler http.Handler
+	if h := buildDataPlaneHandler(kcpConfig); h != nil {
+		dataPlaneHandler = h
+	}
+
 	mcpHandler := mcpserver.NewHandler(mcpserver.Deps{
-		Tenant: tenant.NewClientFactory(kcpConfig),
+		Tenant:    tenant.NewClientFactory(kcpConfig),
+		DataPlane: dataPlaneHandler,
 	})
 
 	fileServer, distFS, err := portalHandler()
 	if err != nil {
 		log.Fatalf("portal embed: %v", err)
-	}
-
-	// Data-plane subresource proxy (logs/sync/restart/preview proxy/status).
-	// nil in REST-only/dev (no kcp or runtime cluster); the handler then reports
-	// 503 so the route exists but is clearly unavailable.
-	var dataPlaneHandler http.Handler
-	if h := buildDataPlaneHandler(kcpConfig); h != nil {
-		dataPlaneHandler = h
 	}
 
 	srv := server.New(server.Deps{

--- a/providers/infrastructure/mcpserver/catalog.go
+++ b/providers/infrastructure/mcpserver/catalog.go
@@ -107,7 +107,25 @@ func templateFromUnstructured(u *unstructured.Unstructured) kro.Template {
 		InputsSchema: inputs,
 		SampleValues: sample,
 		Agent:        agent,
+		Development:  templateDevelopmentFromSpec(u),
 	}
+}
+
+// templateDevelopmentFromSpec projects spec.development into the MCP DTO:
+// component names + workspacePaths only (runtime details like dev images and
+// start commands stay provider-internal). Returns nil when the Template
+// declares no development block — the template then has no dev mode.
+func templateDevelopmentFromSpec(u *unstructured.Unstructured) *kro.TemplateDevelopment {
+	comps, found, _ := unstructured.NestedMap(u.Object, "spec", "development", "components")
+	if !found || len(comps) == 0 {
+		return nil
+	}
+	out := &kro.TemplateDevelopment{Components: make(map[string]kro.TemplateDevelopmentComponent, len(comps))}
+	for name := range comps {
+		wp, _, _ := unstructured.NestedString(u.Object, "spec", "development", "components", name, "workspacePath")
+		out.Components[name] = kro.TemplateDevelopmentComponent{WorkspacePath: wp}
+	}
+	return out
 }
 
 // templateAgentFromSpec reads spec.agent (AI-agent guidance) into the MCP DTO.

--- a/providers/infrastructure/mcpserver/server.go
+++ b/providers/infrastructure/mcpserver/server.go
@@ -33,9 +33,15 @@ import (
 
 // Deps is what the MCP transport needs. Templates + instances are CRD-based
 // against the tenant workspace (see catalog.go), so the per-tenant kcp client
-// factory is the only dependency — no RGD/kro-cluster client.
+// factory is the main dependency — no RGD/kro-cluster client.
 type Deps struct {
 	Tenant *tenant.ClientFactory
+	// DataPlane is the provider's own /dataplane/* subresource handler
+	// (serve_dataplane.go), shared so the dev_* tools can drive sync/log/
+	// restart verbs in-process — same caller auth, contract resolution, and
+	// runtime proxying as the hub HTTP route. nil (REST-only/dev, or no
+	// runtime cluster) disables the dev tools with a clear error.
+	DataPlane http.Handler
 }
 
 // NewHandler returns the streamable-HTTP MCP handler to mount at /mcp.
@@ -63,10 +69,17 @@ func newPerRequestServer(deps Deps, r *http.Request) *mcp.Server {
 	}, &mcp.ServerOptions{
 		Instructions: "This MCP endpoint brokers a curated catalog of kro " +
 			"(Kube Resource Orchestrator) templates into your kedge " +
-			"tenant workspace. Use kro_list_templates first to see " +
-			"what's available, then kro_describe_template to inspect a " +
-			"template's inputs schema, then kro_provision to " +
-			"materialize an instance. Cloud credentials are read from " +
+			"tenant workspace. Use list_templates first to see " +
+			"what's available, then describe_template to inspect a " +
+			"template's inputs schema, then provision to " +
+			"materialize an instance. Templates that report a " +
+			"`development` block support a live dev loop with no image " +
+			"builds: provision with values.kedgeMode=\"development\" " +
+			"(image inputs may be omitted), push source with dev_sync " +
+			"(hot reload), read dev server logs with dev_logs, and " +
+			"preview at the instance's status.url; ship for real by " +
+			"re-provisioning with kedgeMode \"production\" and built " +
+			"images. Cloud credentials are read from " +
 			"a `cloud-credentials` Secret in your workspace's default " +
 			"namespace; if it's missing, ask the user to create it (see " +
 			"the kedge-bound cloud-credentials docs). Tenant identity " +

--- a/providers/infrastructure/mcpserver/tools.go
+++ b/providers/infrastructure/mcpserver/tools.go
@@ -145,7 +145,7 @@ func registerTools(srv *mcp.Server, deps Deps, ident identity) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "describe_template",
 		Title:       "Inspect a template's inputs schema",
-		Description: "Return a template's metadata and JSON-schema for its inputs. Use this to learn what values kro_provision will require before calling it.",
+		Description: "Return a template's metadata, JSON-schema for its inputs, agent guidance (usage/prerequisites/outputs), and — when present — its development contract (development.components maps each component to the workspace directory dev_sync routes from). Use this to learn what values provision will require before calling it.",
 		Annotations: readOnly,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in describeTemplateInput) (*mcp.CallToolResult, kro.Template, error) {
 		dyn, err := tenantClient(deps, ident)
@@ -165,7 +165,7 @@ func registerTools(srv *mcp.Server, deps Deps, ident identity) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "provision",
 		Title:       "Provision a template instance in your workspace",
-		Description: "Create an instance of the named template as a CR in the caller's tenant workspace; the backend reconciles it. Identity is taken from the bearer token; the user does not need to supply a tenant path.",
+		Description: "Create an instance of the named template as a CR in the caller's tenant workspace; the backend reconciles it. For development-capable templates (describe_template reports a development block), set values.kedgeMode=\"development\" to get a live dev sandbox instead of a production deployment: image inputs may be omitted, and source is pushed with dev_sync (hot reload, no image builds). Identity is taken from the bearer token; the user does not need to supply a tenant path.",
 		Annotations: &mcp.ToolAnnotations{
 			IdempotentHint:  false,
 			DestructiveHint: &no,
@@ -269,4 +269,6 @@ func registerTools(srv *mcp.Server, deps Deps, ident identity) {
 		}
 		return nil, deleteOutput{Deleted: true}, nil
 	})
+
+	registerDevTools(srv, deps, ident)
 }

--- a/providers/infrastructure/mcpserver/tools_dev.go
+++ b/providers/infrastructure/mcpserver/tools_dev.go
@@ -1,0 +1,383 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package mcpserver
+
+// Development-loop tools: dev_sync / dev_logs / dev_restart drive the
+// template-declared data-plane verbs (sync, log, restart) on a development-mode
+// instance, so an MCP agent can edit source locally and hot-reload it in the
+// sandbox without building an image. The calls go through the provider's own
+// /dataplane/* handler IN-PROCESS (deps.DataPlane) — the same caller-token
+// authorization, template-contract resolution, and runtime proxying as the hub
+// HTTP route; these tools only add addressing (cluster ID from the request
+// identity) and workspacePath file routing on top.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/faroshq/provider-infrastructure/kro"
+)
+
+const (
+	// devLogDefaultBytes / devLogMaxBytes bound dev_logs responses so a noisy
+	// dev server cannot blow the caller's model context.
+	devLogDefaultBytes = 64 << 10
+	devLogMaxBytes     = 256 << 10
+
+	// devSyncMaxBytes bounds one dev_sync payload (all files, pre-routing).
+	// Matches the data-plane handler's own 16MB read bound.
+	devSyncMaxBytes = 16 << 20
+)
+
+type devSyncFile struct {
+	Path    string `json:"path" jsonschema:"Workspace-relative file path (e.g. web/src/App.jsx)"`
+	Content string `json:"content" jsonschema:"Full UTF-8 file content"`
+}
+
+type devSyncInput struct {
+	Instance string        `json:"instance" jsonschema:"Development-mode instance name (provisioned with values.kedgeMode=development)"`
+	Files    []devSyncFile `json:"files" jsonschema:"Files to sync, paths relative to the workspace root; each is routed to the component whose workspacePath prefixes it"`
+	Restart  string        `json:"restart,omitempty" jsonschema:"auto (default) restarts the dev process when needed per the template's reload rules; none only writes files"`
+}
+
+type devSyncComponentResult struct {
+	Files    int             `json:"files"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+type devSyncOutput struct {
+	Instance   string                            `json:"instance"`
+	Components map[string]devSyncComponentResult `json:"components"`
+}
+
+type devLogsInput struct {
+	Instance  string `json:"instance" jsonschema:"Development-mode instance name"`
+	Component string `json:"component" jsonschema:"Development component to read logs from (see the template's development.components)"`
+	MaxBytes  int    `json:"maxBytes,omitempty" jsonschema:"Response byte cap; default 65536, max 262144"`
+}
+
+type devLogsOutput struct {
+	Instance  string `json:"instance"`
+	Component string `json:"component"`
+	Log       string `json:"log"`
+	Truncated bool   `json:"truncated"`
+}
+
+type devRestartInput struct {
+	Instance  string `json:"instance" jsonschema:"Development-mode instance name"`
+	Component string `json:"component" jsonschema:"Development component whose dev process to restart"`
+}
+
+type devRestartOutput struct {
+	Instance  string          `json:"instance"`
+	Component string          `json:"component"`
+	Response  json.RawMessage `json:"response,omitempty"`
+}
+
+// devSandboxRequest is the control-plane sync payload the per-component dev
+// agent accepts (mirrors app-studio's projectSandboxSyncRequest).
+type devSandboxRequest struct {
+	Files   []devSyncFile `json:"files"`
+	Restart string        `json:"restart,omitempty"`
+}
+
+// devTarget is a resolved development instance: the instance CR plus its
+// template's plural (data-plane addressing) and development contract.
+type devTarget struct {
+	resource   string
+	instance   *kro.Instance
+	components map[string]string // component name → workspacePath
+}
+
+// registerDevTools wires the dev-loop tools. Registered unconditionally so
+// they are discoverable; each call fails with a clear reason when the data
+// plane is unavailable on this provider (REST-only dev, no runtime cluster).
+func registerDevTools(srv *mcp.Server, deps Deps, ident identity) {
+	yes := true
+	no := false
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "dev_sync",
+		Title:       "Sync source files into a development instance",
+		Description: "Push workspace files into a development-mode instance's sandbox with hot reload — no image build. Files are routed to components by the template's development.components workspacePath prefixes (see describe_template); files outside every component directory are rejected. Requires an instance provisioned with values.kedgeMode=\"development\".",
+		Annotations: &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: &no, OpenWorldHint: &yes},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in devSyncInput) (*mcp.CallToolResult, devSyncOutput, error) {
+		target, err := resolveDevTarget(ctx, deps, ident, in.Instance)
+		if err != nil {
+			return nil, devSyncOutput{}, err
+		}
+		if len(in.Files) == 0 {
+			return nil, devSyncOutput{}, fmt.Errorf("no files to sync — pass the changed files with workspace-relative paths")
+		}
+		total := 0
+		for _, f := range in.Files {
+			total += len(f.Content)
+		}
+		if total > devSyncMaxBytes {
+			return nil, devSyncOutput{}, fmt.Errorf("sync payload is %d bytes, above the %d limit — sync fewer files per call", total, devSyncMaxBytes)
+		}
+		restart := strings.TrimSpace(in.Restart)
+		if restart == "" {
+			restart = "auto"
+		}
+		if restart != "auto" && restart != "none" {
+			return nil, devSyncOutput{}, fmt.Errorf("restart must be \"auto\" or \"none\", got %q", in.Restart)
+		}
+
+		routed := routeDevSyncFiles(in.Files, target.components)
+		if countRoutedDevFiles(routed) == 0 {
+			return nil, devSyncOutput{}, fmt.Errorf(
+				"none of the %d files are under a development component directory (%s); source must live under those directories to reach the sandbox",
+				len(in.Files), devComponentSummary(target.components))
+		}
+
+		out := devSyncOutput{Instance: in.Instance, Components: map[string]devSyncComponentResult{}}
+		for _, component := range sortedDevComponents(target.components) {
+			payload, err := json.Marshal(devSandboxRequest{Files: routed[component], Restart: restart})
+			if err != nil {
+				return nil, devSyncOutput{}, fmt.Errorf("encode %s sync payload: %w", component, err)
+			}
+			body, status, err := callDataPlane(ctx, deps.DataPlane, ident, http.MethodPost, target.resource, in.Instance, component, "sync", payload)
+			if err != nil {
+				return nil, devSyncOutput{}, fmt.Errorf("component %s: %w", component, err)
+			}
+			if status < 200 || status >= 300 {
+				return nil, devSyncOutput{}, fmt.Errorf("component %s sync returned %d: %s", component, status, strings.TrimSpace(string(body)))
+			}
+			out.Components[component] = devSyncComponentResult{Files: len(routed[component]), Response: json.RawMessage(body)}
+		}
+		return nil, out, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "dev_logs",
+		Title:       "Read a development component's dev-server logs",
+		Description: "Return the dev-server log buffer for one component of a development-mode instance. Use it to diagnose why the sandbox app is failing after a dev_sync.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: &yes},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in devLogsInput) (*mcp.CallToolResult, devLogsOutput, error) {
+		target, err := resolveDevTarget(ctx, deps, ident, in.Instance)
+		if err != nil {
+			return nil, devLogsOutput{}, err
+		}
+		component, err := requireDevComponent(target, in.Component)
+		if err != nil {
+			return nil, devLogsOutput{}, err
+		}
+		maxBytes := in.MaxBytes
+		if maxBytes <= 0 {
+			maxBytes = devLogDefaultBytes
+		}
+		if maxBytes > devLogMaxBytes {
+			maxBytes = devLogMaxBytes
+		}
+		body, status, err := callDataPlane(ctx, deps.DataPlane, ident, http.MethodGet, target.resource, in.Instance, component, "log", nil)
+		if err != nil {
+			return nil, devLogsOutput{}, err
+		}
+		if status < 200 || status >= 300 {
+			return nil, devLogsOutput{}, fmt.Errorf("log returned %d: %s", status, strings.TrimSpace(string(body)))
+		}
+		out := devLogsOutput{Instance: in.Instance, Component: component}
+		// Keep the TAIL when over the cap — the newest lines hold the failure.
+		if len(body) > maxBytes {
+			out.Log = string(body[len(body)-maxBytes:])
+			out.Truncated = true
+		} else {
+			out.Log = string(body)
+		}
+		return nil, out, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "dev_restart",
+		Title:       "Restart a development component's dev process",
+		Description: "Restart the dev-server process of one component of a development-mode instance without syncing files. Rarely needed — dev_sync with restart \"auto\" already restarts per the template's reload rules.",
+		Annotations: &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: &no, OpenWorldHint: &yes},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in devRestartInput) (*mcp.CallToolResult, devRestartOutput, error) {
+		target, err := resolveDevTarget(ctx, deps, ident, in.Instance)
+		if err != nil {
+			return nil, devRestartOutput{}, err
+		}
+		component, err := requireDevComponent(target, in.Component)
+		if err != nil {
+			return nil, devRestartOutput{}, err
+		}
+		body, status, err := callDataPlane(ctx, deps.DataPlane, ident, http.MethodPost, target.resource, in.Instance, component, "restart", []byte(`{}`))
+		if err != nil {
+			return nil, devRestartOutput{}, err
+		}
+		if status < 200 || status >= 300 {
+			return nil, devRestartOutput{}, fmt.Errorf("restart returned %d: %s", status, strings.TrimSpace(string(body)))
+		}
+		return nil, devRestartOutput{Instance: in.Instance, Component: component, Response: json.RawMessage(body)}, nil
+	})
+}
+
+// resolveDevTarget authorizes the caller (tenant client), locates the instance
+// across template plurals, and returns its template's development contract.
+// Fails with actionable messages for every non-dev case: data plane off, no
+// such instance, template without a development block, instance not
+// provisioned in development mode.
+func resolveDevTarget(ctx context.Context, deps Deps, ident identity, instanceName string) (devTarget, error) {
+	if deps.DataPlane == nil {
+		return devTarget{}, fmt.Errorf("the development data plane is not available on this provider deployment")
+	}
+	if strings.TrimSpace(instanceName) == "" {
+		return devTarget{}, fmt.Errorf("instance is required")
+	}
+	dyn, err := tenantClient(deps, ident)
+	if err != nil {
+		return devTarget{}, err
+	}
+	templates, err := listTemplates(ctx, dyn)
+	if err != nil {
+		return devTarget{}, fmt.Errorf("list templates: %w", err)
+	}
+	inst, err := getInstance(ctx, dyn, templates, instanceName)
+	if err != nil {
+		if err == kro.ErrInstanceNotFound {
+			return devTarget{}, fmt.Errorf("instance %q not found — provision it first (values.kedgeMode=\"development\")", instanceName)
+		}
+		return devTarget{}, fmt.Errorf("get instance: %w", err)
+	}
+	var tmpl *kro.Template
+	for i := range templates {
+		if templates[i].Name == inst.Template {
+			tmpl = &templates[i]
+			break
+		}
+	}
+	if tmpl == nil {
+		return devTarget{}, fmt.Errorf("instance %q references template %q which is no longer in the catalog", instanceName, inst.Template)
+	}
+	if tmpl.Development == nil || len(tmpl.Development.Components) == 0 {
+		return devTarget{}, fmt.Errorf("template %q has no development mode — the dev tools only work on development-capable templates (see describe_template)", tmpl.Name)
+	}
+	if mode, _ := inst.Values["kedgeMode"].(string); mode != "development" {
+		return devTarget{}, fmt.Errorf("instance %q is not in development mode (kedgeMode=%q) — provision a dev instance with values.kedgeMode=\"development\"", instanceName, mode)
+	}
+	components := make(map[string]string, len(tmpl.Development.Components))
+	for name, c := range tmpl.Development.Components {
+		components[name] = c.WorkspacePath
+	}
+	return devTarget{resource: tmpl.InstanceGVR.Resource, instance: inst, components: components}, nil
+}
+
+// requireDevComponent validates a caller-supplied component name against the
+// template's development contract, listing the valid names on mismatch.
+func requireDevComponent(target devTarget, component string) (string, error) {
+	component = strings.TrimSpace(component)
+	if component == "" {
+		names := sortedDevComponents(target.components)
+		if len(names) == 1 {
+			return names[0], nil
+		}
+		return "", fmt.Errorf("component is required; this template's development components are: %s", strings.Join(names, ", "))
+	}
+	if _, ok := target.components[component]; !ok {
+		return "", fmt.Errorf("unknown component %q; this template's development components are: %s", component, strings.Join(sortedDevComponents(target.components), ", "))
+	}
+	return component, nil
+}
+
+// callDataPlane drives the provider's own data-plane handler in-process with
+// a synthesized request: same path shape and identity headers as the hub
+// route, so authorization (caller token → instance RBAC), contract method
+// allowlisting, and runtime proxying are all reused rather than duplicated.
+func callDataPlane(ctx context.Context, dp http.Handler, ident identity, method, resource, name, component, verb string, payload []byte) ([]byte, int, error) {
+	if strings.TrimSpace(ident.clusterID) == "" {
+		return nil, 0, fmt.Errorf("no workspace cluster on this request (X-Kedge-Cluster missing) — cannot address the development data plane")
+	}
+	p := "/dataplane/clusters/" + url.PathEscape(ident.clusterID) +
+		"/" + url.PathEscape(resource) + "/" + url.PathEscape(name)
+	if component != "" {
+		p += "/components/" + url.PathEscape(component)
+	}
+	p += "/" + url.PathEscape(verb)
+
+	var body io.Reader
+	if payload != nil {
+		body = strings.NewReader(string(payload))
+	}
+	req := httptest.NewRequest(method, p, body).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+ident.token)
+	req.Header.Set("X-Kedge-Tenant", ident.tenantPath)
+	req.Header.Set("X-Kedge-User", ident.user)
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	dp.ServeHTTP(rec, req)
+	return rec.Body.Bytes(), rec.Code, nil
+}
+
+// routeDevSyncFiles groups files by development component: a component whose
+// workspacePath is "." receives every file as-is; otherwise files under
+// "<workspacePath>/" are routed with the prefix stripped (the sandbox works
+// tree is the component directory). Files outside every component route
+// nowhere. Mirrors app-studio's routing so both edit paths behave identically.
+func routeDevSyncFiles(files []devSyncFile, components map[string]string) map[string][]devSyncFile {
+	out := make(map[string][]devSyncFile, len(components))
+	for component, workspacePath := range components {
+		wp := path.Clean(strings.TrimSpace(workspacePath))
+		if wp == "." {
+			out[component] = files
+			continue
+		}
+		prefix := wp + "/"
+		for _, f := range files {
+			if rest, ok := strings.CutPrefix(f.Path, prefix); ok {
+				out[component] = append(out[component], devSyncFile{Path: rest, Content: f.Content})
+			}
+		}
+	}
+	return out
+}
+
+func countRoutedDevFiles(routed map[string][]devSyncFile) int {
+	total := 0
+	for _, files := range routed {
+		total += len(files)
+	}
+	return total
+}
+
+func sortedDevComponents(components map[string]string) []string {
+	names := make([]string, 0, len(components))
+	for name := range components {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// devComponentSummary renders the component → workspacePath map for error
+// messages, sorted by component name (e.g. "backend → api/, frontend → web/").
+func devComponentSummary(components map[string]string) string {
+	parts := make([]string, 0, len(components))
+	for _, name := range sortedDevComponents(components) {
+		wp := path.Clean(strings.TrimSpace(components[name]))
+		if wp == "." {
+			parts = append(parts, name+" → the workspace root")
+			continue
+		}
+		parts = append(parts, name+" → "+wp+"/")
+	}
+	return strings.Join(parts, ", ")
+}

--- a/providers/infrastructure/mcpserver/tools_dev_test.go
+++ b/providers/infrastructure/mcpserver/tools_dev_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package mcpserver
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRouteDevSyncFilesRootComponentReceivesEverything(t *testing.T) {
+	files := []devSyncFile{
+		{Path: "src/index.js", Content: "a"},
+		{Path: "package.json", Content: "b"},
+	}
+	routed := routeDevSyncFiles(files, map[string]string{"app": "."})
+	if len(routed["app"]) != 2 {
+		t.Fatalf("app routed %d files, want 2", len(routed["app"]))
+	}
+	if routed["app"][0].Path != "src/index.js" {
+		t.Errorf("root component must keep paths as-is, got %q", routed["app"][0].Path)
+	}
+}
+
+func TestRouteDevSyncFilesStripsComponentPrefix(t *testing.T) {
+	components := map[string]string{"backend": "api", "frontend": "web"}
+	files := []devSyncFile{
+		{Path: "api/index.js", Content: "a"},
+		{Path: "web/src/App.jsx", Content: "b"},
+		{Path: "README.md", Content: "c"},
+		{Path: "apixel/trap.js", Content: "d"}, // prefix of a prefix — must NOT match "api/"
+	}
+	routed := routeDevSyncFiles(files, components)
+	if got := countRoutedDevFiles(routed); got != 2 {
+		t.Fatalf("routed %d files, want 2 (README + apixel outside every component)", got)
+	}
+	if len(routed["backend"]) != 1 || routed["backend"][0].Path != "index.js" {
+		t.Errorf("backend routed = %+v, want [index.js]", routed["backend"])
+	}
+	if len(routed["frontend"]) != 1 || routed["frontend"][0].Path != "src/App.jsx" {
+		t.Errorf("frontend routed = %+v, want [src/App.jsx]", routed["frontend"])
+	}
+}
+
+func TestRequireDevComponentDefaultsWhenSingle(t *testing.T) {
+	target := devTarget{components: map[string]string{"app": "."}}
+	got, err := requireDevComponent(target, "")
+	if err != nil || got != "app" {
+		t.Fatalf("single-component default = (%q, %v), want (app, nil)", got, err)
+	}
+
+	multi := devTarget{components: map[string]string{"frontend": "web", "backend": "api"}}
+	if _, err := requireDevComponent(multi, ""); err == nil || !strings.Contains(err.Error(), "backend, frontend") {
+		t.Errorf("multi-component empty pick must list components, got %v", err)
+	}
+	if _, err := requireDevComponent(multi, "db"); err == nil || !strings.Contains(err.Error(), "backend, frontend") {
+		t.Errorf("unknown component must list components, got %v", err)
+	}
+}
+
+// captureHandler records the request callDataPlane synthesizes.
+type captureHandler struct {
+	req  *http.Request
+	body string
+}
+
+func (c *captureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.req = r
+	b, _ := io.ReadAll(r.Body)
+	c.body = string(b)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+func TestCallDataPlaneSynthesizesHubShapedRequest(t *testing.T) {
+	h := &captureHandler{}
+	ident := identity{tenantPath: "root:orgs:acme", clusterID: "abc123xyz", user: "dev@acme.io", token: "tok"}
+
+	body, status, err := callDataPlane(context.Background(), h, ident, http.MethodPost, "simplewebapps", "my-site", "app", "sync", []byte(`{"files":[]}`))
+	if err != nil {
+		t.Fatalf("callDataPlane: %v", err)
+	}
+	if status != http.StatusOK || string(body) != `{"ok":true}` {
+		t.Fatalf("status/body = %d %q", status, string(body))
+	}
+	wantPath := "/dataplane/clusters/abc123xyz/simplewebapps/my-site/components/app/sync"
+	if h.req.URL.Path != wantPath {
+		t.Errorf("path = %q, want %q", h.req.URL.Path, wantPath)
+	}
+	if got := h.req.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Errorf("Authorization = %q, want caller bearer", got)
+	}
+	if got := h.req.Header.Get("X-Kedge-Tenant"); got != "root:orgs:acme" {
+		t.Errorf("X-Kedge-Tenant = %q", got)
+	}
+	if h.body != `{"files":[]}` {
+		t.Errorf("body = %q", h.body)
+	}
+}
+
+func TestCallDataPlaneRequiresClusterID(t *testing.T) {
+	h := &captureHandler{}
+	_, _, err := callDataPlane(context.Background(), h, identity{token: "tok"}, http.MethodGet, "simplewebapps", "x", "app", "log", nil)
+	if err == nil || !strings.Contains(err.Error(), "X-Kedge-Cluster") {
+		t.Fatalf("missing cluster ID must fail with an addressing error, got %v", err)
+	}
+	if h.req != nil {
+		t.Error("handler must not be invoked without a cluster ID")
+	}
+}
+
+func TestTemplateDevelopmentFromSpec(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "infrastructure.kedge.faros.sh/v1alpha1",
+		"kind":       "Template",
+		"metadata":   map[string]any{"name": "application"},
+		"spec": map[string]any{
+			"development": map[string]any{
+				"components": map[string]any{
+					"frontend": map[string]any{"workspacePath": "web", "imageInput": "frontendImage"},
+					"backend":  map[string]any{"workspacePath": "api", "imageInput": "backendImage"},
+				},
+			},
+		},
+	}}
+	dev := templateDevelopmentFromSpec(u)
+	if dev == nil {
+		t.Fatal("development block must be projected")
+	}
+	if dev.Components["frontend"].WorkspacePath != "web" || dev.Components["backend"].WorkspacePath != "api" {
+		t.Errorf("components = %+v", dev.Components)
+	}
+
+	plain := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{"displayName": "db"},
+	}}
+	if got := templateDevelopmentFromSpec(plain); got != nil {
+		t.Errorf("template without development block must project nil, got %+v", got)
+	}
+}


### PR DESCRIPTION
Closes the gap found while driving kedge from the Claude harness: MCP agents could provision templates but had no path to the template-native development sandboxes App Studio uses — every code change meant an image rebuild, and previews didn't reflect work in progress.

## What's new

**Discovery** — `describe_template` now projects the template's `spec.development` block (component → `workspacePath`) into the MCP DTO, so agents learn the source-directory contract and that a dev mode exists at all. Runtime details (dev images, start commands, reload rules) stay provider-internal.

**Dev-loop tools** — three new MCP tools drive the template-declared data-plane verbs on a development-mode instance:

- `dev_sync` — push workspace files into the sandbox with hot reload. Files are routed per component by `workspacePath` prefix (mirroring app-studio's routing exactly, incl. the "zero files routed" guardrail that fails with the expected layout instead of vacuously succeeding). `restart: auto|none`.
- `dev_logs` — per-component dev-server log buffer, tail-bounded (64KB default / 256KB max) so a noisy server can't blow the model context.
- `dev_restart` — force-restart a wedged dev process; auto-defaults the component when the template has exactly one.

The tools call the provider's own `/dataplane/*` handler **in-process** (shared via `mcpserver.Deps.DataPlane`) — same caller-token authorization (instance GET under the caller's RBAC is the gate), same contract method allowlisting, same runtime proxying as the hub HTTP route. No logic duplicated; the tools only add addressing (cluster ID from `X-Kedge-Cluster` identity) and file routing.

Every non-dev case fails with an actionable message: data plane off, instance missing, template without a development block, instance not provisioned with `kedgeMode: development`, unknown component (valid names listed).

**Provisioning + guidance** — `provision`/`describe_template` descriptions and the server instructions now document `values.kedgeMode: "development"` (image inputs omitted, dev sandbox on the instance's own `status.url`); template `agent.usage` texts no longer call `kedgeMode` "platform-injected" (which read as *don't set it* to an agent) and point at the dev tools. Also fixed the stale `kro_*` tool names in the instructions.

## Test plan

- [x] `go build ./...` + full `go test ./...` in the infrastructure provider
- [x] New unit tests: workspacePath routing (incl. prefix-of-prefix non-match), single-component defaulting, in-process data-plane request synthesis (path shape, caller bearer, tenant header), cluster-ID guard, `spec.development` projection

🤖 Generated with [Claude Code](https://claude.com/claude-code)