### PR TITLE
feat(infrastructure): update_instance MCP tool + env inputs on workload templates

### DIFF
--- a/providers/infrastructure/backend/kro/backend_test.go
+++ b/providers/infrastructure/backend/kro/backend_test.go
@@ -75,6 +75,32 @@ func TestOpenAPIToSimpleSchemaNested(t *testing.T) {
 	}
 }
 
+func TestOpenAPIToSimpleSchemaMap(t *testing.T) {
+	raw := []byte(`{
+		"type": "object",
+		"properties": {
+			"env":    {"type": "object", "additionalProperties": {"type": "string"}, "default": {}, "description": "env vars"},
+			"limits": {"type": "object", "additionalProperties": {"type": "integer"}},
+			"full":   {"type": "object", "additionalProperties": {"type": "string"}, "default": {"A": "b"}}
+		}
+	}`)
+	got, err := openAPIToSimpleSchema(raw)
+	if err != nil {
+		t.Fatalf("openAPIToSimpleSchema: %v", err)
+	}
+	if got["env"] != `map[string]string | default={} description="env vars"` {
+		t.Errorf("env: got %v", got["env"])
+	}
+	if got["limits"] != `map[string]integer` {
+		t.Errorf("limits: got %v", got["limits"])
+	}
+	// Non-empty map defaults are inexpressible in kro's marker syntax (no
+	// quote escaping) — the default must be dropped, never emitted corrupt.
+	if got["full"] != `map[string]string` {
+		t.Errorf("full: non-empty map default must be dropped, got %v", got["full"])
+	}
+}
+
 func TestBuildRGD(t *testing.T) {
 	tmpl := &infrav1alpha1.Template{}
 	tmpl.Name = "redis-cache"

--- a/providers/infrastructure/backend/kro/simpleschema.go
+++ b/providers/infrastructure/backend/kro/simpleschema.go
@@ -31,6 +31,10 @@ type openAPISchema struct {
 	Maximum     *float64                 `json:"maximum"`
 	Pattern     string                   `json:"pattern"`
 	Items       *openAPISchema           `json:"items"`
+	// AdditionalProperties turns an object without fixed properties into a
+	// kro map type: {type: object, additionalProperties: {type: string}} →
+	// "map[string]string". Used for free-form inputs like env.
+	AdditionalProperties *openAPISchema `json:"additionalProperties"`
 }
 
 // openAPIToSimpleSchema converts a Template's spec.schema (OpenAPI JSON
@@ -98,7 +102,18 @@ func leafToSimpleSchema(p openAPISchema, required bool) string {
 		markers = append(markers, "enum="+quote(strings.Join(vals, ",")))
 	}
 	if p.Default != nil {
-		markers = append(markers, "default="+formatScalar(p.Default))
+		if m, isMap := p.Default.(map[string]any); isMap {
+			// Map defaults: only the empty map is expressible — kro's marker
+			// tokenizer treats a bare double quote as a delimiter with no
+			// escaping, so non-empty JSON object defaults cannot survive it.
+			// Template authors default maps to {} and set real values per
+			// instance.
+			if len(m) == 0 {
+				markers = append(markers, "default={}")
+			}
+		} else {
+			markers = append(markers, "default="+formatScalar(p.Default))
+		}
 	}
 	if p.Minimum != nil {
 		markers = append(markers, fmt.Sprintf("minimum=%v", *p.Minimum))
@@ -137,6 +152,13 @@ func openAPIToKROType(p openAPISchema) string {
 		}
 		return "[]" + elem
 	case "object":
+		if p.AdditionalProperties != nil {
+			elem := "string"
+			if p.AdditionalProperties.Type != "" {
+				elem = openAPIToKROType(*p.AdditionalProperties)
+			}
+			return "map[string]" + elem
+		}
 		return "object"
 	case "string":
 		return "string"

--- a/providers/infrastructure/install/templates/application.yaml
+++ b/providers/infrastructure/install/templates/application.yaml
@@ -2,6 +2,10 @@ apiVersion: infrastructure.kedge.faros.sh/v1alpha1
 kind: Template
 metadata:
   name: application
+  annotations:
+    # database.version: a Postgres major upgrade is not an in-place operation;
+    # update_instance rejects it (recreate — and migrate — instead).
+    kedge.faros.sh/immutable-inputs: "database.version"
 spec:
   displayName: "Web application"
   description: "A 3-tier app — frontend + backend + Postgres — exposed on a URL guarded by OIDC (oauth2-proxy). Authenticated users only; the backend and database are never exposed."
@@ -88,9 +92,11 @@ spec:
 
       INPUTS you set when provisioning: frontendImage, backendImage (required
       in production mode; omit in development mode); name, frontendPort,
-      backendPort, frontendReplicas, backendReplicas, database.version,
-      oidc.*. The platform stamps spec.expose.fqdn and
-      spec.credentialsSecretName — do not set those.
+      backendPort, frontendReplicas, backendReplicas, frontendEnv, backendEnv
+      (per-tier env-var maps; not for secrets), database.version, oidc.*. The
+      platform stamps spec.expose.fqdn and spec.credentialsSecretName — do not
+      set those. All except name, kedgeMode, and database.version can be
+      changed later with update_instance.
     prerequisites:
       - "oidc.mode=byo only: a Secret named 'cloud-credentials' in the tenant's default namespace, key 'oidc_client_secret' = the OAuth2 client secret for your oidc.clientID."
     outputs:
@@ -181,6 +187,12 @@ spec:
         default: 1
         minimum: 1
         maximum: 10
+      frontendEnv:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+        description: "Environment variables for the frontend container, injected via a ConfigMap + envFrom (updatable in place). Platform-set vars (PORT) win on name conflicts. Values are stored world-readable — not for secrets."
 
       # ── Backend tier (internal; reachable only via cluster DNS) ──
       backendImage:
@@ -194,6 +206,12 @@ spec:
         default: 1
         minimum: 1
         maximum: 10
+      backendEnv:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+        description: "Environment variables for the backend container, injected via a ConfigMap + envFrom (updatable in place). Platform-set vars (PORT, DATABASE_URL) win on name conflicts. Values are stored world-readable — not for secrets."
 
       # ── Database tier (Postgres; always provisioned in v1) ──
       # default: {} so an omitted database object is instantiated and its nested
@@ -543,6 +561,18 @@ spec:
                 targetPort: 5432
 
       # ───────────────────── Backend tier ─────────────────────
+      # Tenant env vars ride ConfigMaps consumed via envFrom so the map inputs
+      # need no CEL list synthesis; explicit container env (PORT, DATABASE_URL)
+      # wins over envFrom on name conflicts, so platform vars can't be
+      # clobbered.
+      - id: backendEnvMap
+        template:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: ${schema.spec.name}-backend-env
+            namespace: default
+          data: ${schema.spec.backendEnv}
       - id: backendDeployment
         template:
           apiVersion: apps/v1
@@ -577,6 +607,9 @@ spec:
                           secretKeyRef:
                             name: ${dbCredentials.metadata.name}
                             key: uri
+                    envFrom:
+                      - configMapRef:
+                          name: ${backendEnvMap.metadata.name}
                     ports:
                       - containerPort: ${schema.spec.backendPort}
       - id: backendService
@@ -595,6 +628,14 @@ spec:
                 targetPort: ${schema.spec.backendPort}
 
       # ───────────────────── Frontend tier ─────────────────────
+      - id: frontendEnvMap
+        template:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: ${schema.spec.name}-frontend-env
+            namespace: default
+          data: ${schema.spec.frontendEnv}
       - id: frontendDeployment
         template:
           apiVersion: apps/v1
@@ -624,6 +665,9 @@ spec:
                     env:
                       - name: PORT
                         value: ${string(schema.spec.frontendPort)}
+                    envFrom:
+                      - configMapRef:
+                          name: ${frontendEnvMap.metadata.name}
                     ports:
                       - containerPort: ${schema.spec.frontendPort}
       - id: frontendService

--- a/providers/infrastructure/install/templates/cron-job.yaml
+++ b/providers/infrastructure/install/templates/cron-job.yaml
@@ -39,7 +39,9 @@ spec:
       elsewhere, then provision it here. No network exposure; durable state
       belongs in a database template instance.
 
-      INPUTS you set when provisioning: name, image (both required); schedule.
+      INPUTS you set when provisioning: name, image (both required);
+      schedule, env (env-var map; not for secrets). All except name can be
+      changed later with update_instance.
     outputs:
       - "status.schedule — the active cron schedule."
   # ── Portal presentation ───────────────────────────────────────────────
@@ -75,6 +77,12 @@ spec:
         type: string
         default: "0 * * * *"
         description: "Standard 5-field cron expression, evaluated in UTC. Default: hourly."
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+        description: "Environment variables for the container, injected via a ConfigMap + envFrom (updatable in place). Values are stored world-readable — not for secrets."
     required:
       - name
       - image
@@ -84,6 +92,16 @@ spec:
   # cluster — same convention as every seed template.
   backendConfig:
     resources:
+      # Tenant env vars ride a ConfigMap consumed via envFrom so the map input
+      # needs no CEL list synthesis.
+      - id: jobEnv
+        template:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: ${schema.spec.name}-env
+            namespace: default
+          data: ${schema.spec.env}
       - id: cronJob
         template:
           apiVersion: batch/v1
@@ -110,6 +128,9 @@ spec:
                     containers:
                       - name: job
                         image: ${schema.spec.image}
+                        envFrom:
+                          - configMapRef:
+                              name: ${jobEnv.metadata.name}
     # Echoed from the materialized CronJob (this kro fork forbids ${schema.*}
     # in status — status may reference resources only).
     status:

--- a/providers/infrastructure/install/templates/database.yaml
+++ b/providers/infrastructure/install/templates/database.yaml
@@ -2,6 +2,10 @@ apiVersion: infrastructure.kedge.faros.sh/v1alpha1
 kind: Template
 metadata:
   name: database
+  annotations:
+    # A Postgres major upgrade is not an in-place operation; update_instance
+    # rejects it (recreate — and migrate — instead).
+    kedge.faros.sh/immutable-inputs: "version"
 spec:
   displayName: "PostgreSQL database"
   description: "A standalone PostgreSQL database for workloads. StatefulSet + Service + credentials Secret; credentials stay in-cluster and are exposed only as a Secret reference."

--- a/providers/infrastructure/install/templates/simple-webapp.yaml
+++ b/providers/infrastructure/install/templates/simple-webapp.yaml
@@ -46,8 +46,10 @@ spec:
       is auto-detected, otherwise vite is bootstrapped directly.
 
       INPUTS you set when provisioning: name (required); image (required in
-      production, ignored in development), port, replicas, expose.hostnamePrefix.
-      The platform stamps spec.expose.fqdn — do not set it.
+      production, ignored in development), port, replicas, env (env-var map;
+      not for secrets), expose.hostnamePrefix. The platform stamps
+      spec.expose.fqdn — do not set it. All except name and kedgeMode can be
+      changed later with update_instance.
     outputs:
       - "status.url — the public HTTPS URL the app is served on (status.host = bare hostname)."
       - "status.ready — ready replica count for the app Deployment."
@@ -98,6 +100,12 @@ spec:
         default: 1
         minimum: 1
         maximum: 10
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+        description: "Environment variables for the container, injected via a ConfigMap + envFrom (updatable in place). Platform-set vars (PORT) win on name conflicts. Values are stored world-readable — not for secrets."
       # default: {} so nested defaults apply and the controller can stamp fqdn
       # onto an instance that omitted the expose object.
       expose:
@@ -186,6 +194,17 @@ spec:
   # for the platform's configured Gateway API parent before the RGD is authored.
   backendConfig:
     resources:
+      # Tenant env vars ride a ConfigMap consumed via envFrom so the map input
+      # needs no CEL list synthesis; explicit container env (PORT) wins over
+      # envFrom on name conflicts, so platform vars can't be clobbered.
+      - id: appEnv
+        template:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: ${schema.spec.name}-env
+            namespace: default
+          data: ${schema.spec.env}
       # The graph id follows the dev-overlay convention: component "app" →
       # workload id "appDeployment".
       - id: appDeployment
@@ -217,6 +236,9 @@ spec:
                     env:
                       - name: PORT
                         value: ${string(schema.spec.port)}
+                    envFrom:
+                      - configMapRef:
+                          name: ${appEnv.metadata.name}
                     ports:
                       - containerPort: ${schema.spec.port}
       - id: appService

--- a/providers/infrastructure/install/templates/worker.yaml
+++ b/providers/infrastructure/install/templates/worker.yaml
@@ -42,7 +42,9 @@ spec:
       dev_logs, and restart with dev_restart.
 
       INPUTS you set when provisioning: name (required); image (required in
-      production, ignored in development), replicas.
+      production, ignored in development), replicas, env (env-var map; not for
+      secrets). All except name and kedgeMode can be changed later with
+      update_instance.
     outputs:
       - "status.ready — ready replica count for the worker Deployment."
   # ── Portal presentation ───────────────────────────────────────────────
@@ -71,6 +73,12 @@ spec:
         default: 1
         minimum: 1
         maximum: 5
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+        description: "Environment variables for the container, injected via a ConfigMap + envFrom (updatable in place). Values are stored world-readable — not for secrets."
     required:
       - name
     # The image is only required when the instance actually runs it: production
@@ -138,6 +146,16 @@ spec:
   # the dev-overlay convention: component "worker" → id "workerDeployment".
   backendConfig:
     resources:
+      # Tenant env vars ride a ConfigMap consumed via envFrom so the map input
+      # needs no CEL list synthesis.
+      - id: workerEnv
+        template:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: ${schema.spec.name}-env
+            namespace: default
+          data: ${schema.spec.env}
       - id: workerDeployment
         template:
           apiVersion: apps/v1
@@ -158,5 +176,8 @@ spec:
                 containers:
                   - name: worker
                     image: ${schema.spec.image}
+                    envFrom:
+                      - configMapRef:
+                          name: ${workerEnv.metadata.name}
     status:
       ready: ${workerDeployment.status.readyReplicas}

--- a/providers/infrastructure/kro/types.go
+++ b/providers/infrastructure/kro/types.go
@@ -85,6 +85,13 @@ type Template struct {
 	// dev_sync tool routed by each component's workspacePath. nil means the
 	// template has no development mode.
 	Development *TemplateDevelopment `json:"development,omitempty"`
+	// ImmutableInputs are value dot-paths this template declares as not
+	// updatable on a live instance (e.g. "database.version" — a Postgres
+	// major upgrade is not an in-place operation), read from the
+	// kedge.faros.sh/immutable-inputs annotation (comma-separated). The
+	// platform's own always-immutable set (name, kedgeMode, platform-stamped
+	// fields) applies on top and is not listed here.
+	ImmutableInputs []string `json:"immutableInputs,omitempty"`
 	// View is optional presentation metadata that drives how the portal
 	// renders this template's instances (extra list columns + grouped
 	// detail fields). Read from the kedge.faros.sh/view annotation on the

--- a/providers/infrastructure/mcpserver/catalog.go
+++ b/providers/infrastructure/mcpserver/catalog.go
@@ -18,6 +18,7 @@ package mcpserver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -104,11 +105,31 @@ func templateFromUnstructured(u *unstructured.Unstructured) kro.Template {
 		Backend:      "kro",
 		InstanceKind: kind,
 		InstanceGVR:  schema.GroupVersionResource{Group: group, Version: crdVersion, Resource: resource},
-		InputsSchema: inputs,
-		SampleValues: sample,
-		Agent:        agent,
-		Development:  templateDevelopmentFromSpec(u),
+		InputsSchema:    inputs,
+		SampleValues:    sample,
+		Agent:           agent,
+		Development:     templateDevelopmentFromSpec(u),
+		ImmutableInputs: immutableInputsFromAnnotation(u),
 	}
+}
+
+// immutableInputsAnnotation lets a Template declare value dot-paths that
+// update_instance must reject (comma-separated). Rides on an annotation
+// rather than a spec field so the Template CRD schema stays untouched.
+const immutableInputsAnnotation = "kedge.faros.sh/immutable-inputs"
+
+func immutableInputsFromAnnotation(u *unstructured.Unstructured) []string {
+	raw := strings.TrimSpace(u.GetAnnotations()[immutableInputsAnnotation])
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // templateDevelopmentFromSpec projects spec.development into the MCP DTO:

--- a/providers/infrastructure/mcpserver/server.go
+++ b/providers/infrastructure/mcpserver/server.go
@@ -78,8 +78,11 @@ func newPerRequestServer(deps Deps, r *http.Request) *mcp.Server {
 			"(image inputs may be omitted), push source with dev_sync " +
 			"(hot reload), read dev server logs with dev_logs, and " +
 			"preview at the instance's status.url; ship for real by " +
-			"re-provisioning with kedgeMode \"production\" and built " +
-			"images. Cloud credentials are read from " +
+			"provisioning a production instance with built images. " +
+			"To change a live instance (roll a new image tag, scale, " +
+			"env, ports, schedule), use update_instance — a merge " +
+			"patch reconciled in place, managed state kept — instead " +
+			"of delete+provision. Cloud credentials are read from " +
 			"a `cloud-credentials` Secret in your workspace's default " +
 			"namespace; if it's missing, ask the user to create it (see " +
 			"the kedge-bound cloud-credentials docs). Tenant identity " +

--- a/providers/infrastructure/mcpserver/tools.go
+++ b/providers/infrastructure/mcpserver/tools.go
@@ -100,6 +100,18 @@ type instanceNameInput struct {
 	Name string `json:"name" jsonschema:"Instance name"`
 }
 
+type updateInstanceInput struct {
+	Name   string         `json:"name" jsonschema:"Instance name"`
+	Values map[string]any `json:"values" jsonschema:"JSON merge patch for the instance's values: send only the fields to change (objects merge, null unsets, scalars/arrays replace). Immutable fields (name, kedgeMode, platform-stamped, template-declared) are rejected."`
+}
+
+type updateInstanceOutput struct {
+	Name     string   `json:"name"`
+	Template string   `json:"template"`
+	Phase    string   `json:"phase"`
+	Changed  []string `json:"changed"`
+}
+
 type deleteOutput struct {
 	Deleted bool `json:"deleted"`
 }
@@ -189,7 +201,7 @@ func registerTools(srv *mcp.Server, deps Deps, ident identity) {
 		inst, err := createInstance(ctx, dyn, t, in.Name, in.Values)
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				return nil, provisionOutput{}, fmt.Errorf("instance %q already exists", in.Name)
+				return nil, provisionOutput{}, fmt.Errorf("instance %q already exists — use update_instance to change it in place, or pick another name", in.Name)
 			}
 			return nil, provisionOutput{}, fmt.Errorf("create instance: %w", err)
 		}
@@ -247,6 +259,37 @@ func registerTools(srv *mcp.Server, deps Deps, ident identity) {
 			return nil, kro.Instance{}, fmt.Errorf("get instance: %w", err)
 		}
 		return nil, *inst, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "update_instance",
+		Title:       "Update a live instance's values in place",
+		Description: "Merge-patch an instance's values (RFC 7386: send only what changes, null unsets) and let the backend reconcile the delta — an image bump becomes a rolling update with managed state (e.g. the database) untouched. Use this instead of delete+provision to roll a new image tag, scale replicas, change ports/env/schedule, or adjust oidc settings. Rejected for immutable fields: name, kedgeMode (dev↔production is a recreate), platform-stamped fields, and anything the template declares immutable (e.g. database.version).",
+		Annotations: &mcp.ToolAnnotations{
+			IdempotentHint:  true,
+			DestructiveHint: &no,
+			OpenWorldHint:   &yes,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in updateInstanceInput) (*mcp.CallToolResult, updateInstanceOutput, error) {
+		if len(in.Values) == 0 {
+			return nil, updateInstanceOutput{}, fmt.Errorf("values is required — send the fields to change as a merge patch")
+		}
+		dyn, err := tenantClient(deps, ident)
+		if err != nil {
+			return nil, updateInstanceOutput{}, err
+		}
+		ts, err := listTemplates(ctx, dyn)
+		if err != nil {
+			return nil, updateInstanceOutput{}, fmt.Errorf("list templates: %w", err)
+		}
+		inst, changed, err := updateInstance(ctx, dyn, ts, in.Name, in.Values)
+		if err != nil {
+			if errors.Is(err, kro.ErrInstanceNotFound) {
+				return nil, updateInstanceOutput{}, fmt.Errorf("instance %q not found", in.Name)
+			}
+			return nil, updateInstanceOutput{}, err
+		}
+		return nil, updateInstanceOutput{Name: inst.Name, Template: inst.Template, Phase: inst.Phase, Changed: changed}, nil
 	})
 
 	mcp.AddTool(srv, &mcp.Tool{

--- a/providers/infrastructure/mcpserver/update.go
+++ b/providers/infrastructure/mcpserver/update.go
@@ -1,0 +1,192 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package mcpserver
+
+// In-place instance updates. update_instance merge-patches an instance's
+// values (RFC 7386 semantics: send only what changes, null unsets) and writes
+// the CR back — kro reconciles the delta into the children, so an image bump
+// is a rolling Deployment update with the database child untouched. This is
+// the same lifecycle the portal's applyYaml path drives; without it MCP
+// agents had to delete+re-provision, wiping managed state.
+//
+// Guardrails: identity and platform-owned fields are always immutable
+// (name, kedgeMode, expose, credentialsSecretName); templates declare their
+// own immutable inputs via the kedge.faros.sh/immutable-inputs annotation
+// (e.g. database.version — a Postgres major upgrade is not an in-place
+// operation). A rejected update names the offending path and why.
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/faroshq/provider-infrastructure/kro"
+)
+
+// alwaysImmutableInputs are denied on every template. name is child-resource
+// (and host) identity; kedgeMode is a lifecycle transition (dev↔production
+// swaps the resource graph — recreate instead); expose/credentialsSecretName
+// are platform-stamped.
+var alwaysImmutableInputs = []string{"name", "kedgeMode", "expose", "credentialsSecretName"}
+
+// updateInstance locates the named instance, merge-patches its spec, rejects
+// immutable-path changes, and writes the CR back. Returns the refreshed
+// instance and the dot-paths that actually changed (empty patch or no-op
+// patch → no write, empty changed list).
+func updateInstance(ctx context.Context, dyn dynamic.Interface, templates []kro.Template, name string, patch map[string]any) (*kro.Instance, []string, error) {
+	for i := range templates {
+		t := &templates[i]
+		if t.InstanceGVR.Resource == "" {
+			continue
+		}
+		u, err := dyn.Resource(t.InstanceGVR).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			continue
+		}
+		spec, _, _ := unstructured.NestedMap(u.Object, "spec")
+		if spec == nil {
+			spec = map[string]any{}
+		}
+		merged := mergePatchValues(spec, patch)
+		changed := changedValuePaths(spec, merged)
+		if len(changed) == 0 {
+			inst := instanceFromUnstructured(u, t.Name)
+			return inst, nil, nil
+		}
+		if err := rejectImmutableChanges(changed, t); err != nil {
+			return nil, nil, err
+		}
+		u.Object["spec"] = merged
+		updated, err := dyn.Resource(t.InstanceGVR).Update(ctx, u, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, nil, fmt.Errorf("update %s/%s: %w", t.InstanceGVR.Resource, name, err)
+		}
+		return instanceFromUnstructured(updated, t.Name), changed, nil
+	}
+	return nil, nil, kro.ErrInstanceNotFound
+}
+
+// rejectImmutableChanges fails when any changed path is covered by the
+// always-immutable set or the template's declared immutable inputs.
+func rejectImmutableChanges(changed []string, t *kro.Template) error {
+	immutable := append(append([]string{}, alwaysImmutableInputs...), t.ImmutableInputs...)
+	for _, path := range changed {
+		for _, imm := range immutable {
+			if path == imm || strings.HasPrefix(path, imm+".") {
+				return fmt.Errorf(
+					"value %q cannot be changed on a live instance (immutable: %s); recreate the instance to change it",
+					path, immutableReason(imm))
+			}
+		}
+	}
+	return nil
+}
+
+// immutableReason maps the built-in immutable inputs to a why; template-
+// declared ones get a generic "declared immutable by the template".
+func immutableReason(input string) string {
+	switch input {
+	case "name":
+		return "it is the instance's identity — child resources and the public hostname derive from it"
+	case "kedgeMode":
+		return "development↔production is a lifecycle transition that swaps the resource graph, not a config edit"
+	case "expose", "credentialsSecretName":
+		return "it is platform-stamped"
+	default:
+		return "declared immutable by the template"
+	}
+}
+
+// mergePatchValues applies RFC 7386 JSON-merge-patch semantics: objects merge
+// recursively, null deletes a key, everything else (scalars, arrays) replaces.
+// The inputs are not mutated; patched branches are fresh maps.
+func mergePatchValues(target, patch map[string]any) map[string]any {
+	out := make(map[string]any, len(target)+len(patch))
+	maps.Copy(out, target)
+	for k, v := range patch {
+		if v == nil {
+			delete(out, k)
+			continue
+		}
+		if pm, ok := v.(map[string]any); ok {
+			tm, _ := out[k].(map[string]any)
+			if tm == nil {
+				tm = map[string]any{}
+			}
+			out[k] = mergePatchValues(tm, pm)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// changedValuePaths returns the sorted dot-paths whose values differ between
+// old and new: additions, removals, and changes. Nested maps recurse; any
+// other type is a leaf compared by deep equality.
+func changedValuePaths(old, new map[string]any) []string {
+	var out []string
+	collectChangedPaths(old, new, "", &out)
+	sort.Strings(out)
+	return out
+}
+
+func collectChangedPaths(old, new map[string]any, prefix string, out *[]string) {
+	keys := map[string]struct{}{}
+	for k := range old {
+		keys[k] = struct{}{}
+	}
+	for k := range new {
+		keys[k] = struct{}{}
+	}
+	for k := range keys {
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+		ov, oOK := old[k]
+		nv, nOK := new[k]
+		om, oIsMap := ov.(map[string]any)
+		nm, nIsMap := nv.(map[string]any)
+		// Recurse whenever either side is a map — an added or removed subtree
+		// must report its LEAF paths, or a wholesale-added object (e.g.
+		// database: {version: ...} where none existed) would bypass an
+		// immutability rule on a nested path.
+		if oIsMap || nIsMap {
+			if om == nil {
+				om = map[string]any{}
+			}
+			if nm == nil {
+				nm = map[string]any{}
+			}
+			collectChangedPaths(om, nm, path, out)
+			// A map replaced by a scalar (or vice versa) also changes the
+			// path itself.
+			if oOK && nOK && oIsMap != nIsMap {
+				*out = append(*out, path)
+			}
+			continue
+		}
+		if oOK && nOK {
+			if !reflect.DeepEqual(ov, nv) {
+				*out = append(*out, path)
+			}
+			continue
+		}
+		// Added or removed scalar.
+		*out = append(*out, path)
+	}
+}

--- a/providers/infrastructure/mcpserver/update_test.go
+++ b/providers/infrastructure/mcpserver/update_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package mcpserver
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/faroshq/provider-infrastructure/kro"
+)
+
+func TestMergePatchValues(t *testing.T) {
+	target := map[string]any{
+		"name":          "shop",
+		"frontendImage": "ghcr.io/acme/web:sha-old",
+		"oidc":          map[string]any{"mode": "none", "clientID": ""},
+		"replicas":      float64(2),
+	}
+	patch := map[string]any{
+		"frontendImage": "ghcr.io/acme/web:sha-new",
+		"oidc":          map[string]any{"mode": "byo", "issuerURL": "https://idp"},
+		"replicas":      nil, // null unsets
+	}
+	got := mergePatchValues(target, patch)
+
+	if got["frontendImage"] != "ghcr.io/acme/web:sha-new" {
+		t.Errorf("scalar replace failed: %v", got["frontendImage"])
+	}
+	oidc := got["oidc"].(map[string]any)
+	if oidc["mode"] != "byo" || oidc["issuerURL"] != "https://idp" || oidc["clientID"] != "" {
+		t.Errorf("object merge failed: %v", oidc)
+	}
+	if _, ok := got["replicas"]; ok {
+		t.Error("null must unset the key")
+	}
+	// Inputs must not be mutated.
+	if target["frontendImage"] != "ghcr.io/acme/web:sha-old" {
+		t.Error("target was mutated")
+	}
+	if target["oidc"].(map[string]any)["mode"] != "none" {
+		t.Error("nested target map was mutated")
+	}
+}
+
+func TestChangedValuePaths(t *testing.T) {
+	old := map[string]any{
+		"image": "a:1",
+		"oidc":  map[string]any{"mode": "none", "clientID": "x"},
+		"port":  float64(8080),
+	}
+	new := map[string]any{
+		"image": "a:2",
+		"oidc":  map[string]any{"mode": "byo", "clientID": "x"},
+		"env":   map[string]any{"LOG_LEVEL": "debug"},
+	}
+	got := changedValuePaths(old, new)
+	want := []string{"env.LOG_LEVEL", "image", "oidc.mode", "port"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("changed = %v, want %v", got, want)
+	}
+}
+
+func TestRejectImmutableChanges(t *testing.T) {
+	tmpl := &kro.Template{Name: "application", ImmutableInputs: []string{"database.version"}}
+
+	if err := rejectImmutableChanges([]string{"frontendImage", "oidc.mode"}, tmpl); err != nil {
+		t.Errorf("mutable paths must pass, got %v", err)
+	}
+	for _, path := range []string{"kedgeMode", "name", "expose.fqdn", "credentialsSecretName", "database.version"} {
+		err := rejectImmutableChanges([]string{path}, tmpl)
+		if err == nil || !strings.Contains(err.Error(), path) {
+			t.Errorf("path %q must be rejected naming the path, got %v", path, err)
+		}
+	}
+	// Prefix must not over-match: "database.versionX" is not "database.version".
+	if err := rejectImmutableChanges([]string{"database.versionExtra"}, tmpl); err != nil {
+		t.Errorf("sibling path must pass, got %v", err)
+	}
+}
+
+func TestChangedValuePathsAddedSubtreeReportsLeaves(t *testing.T) {
+	// A wholesale-added subtree must surface leaf paths so immutability rules
+	// on nested paths (database.version) can't be bypassed by adding the
+	// parent object in one patch.
+	old := map[string]any{"image": "a:1"}
+	new := map[string]any{"image": "a:1", "database": map[string]any{"version": "15"}}
+	got := changedValuePaths(old, new)
+	if !reflect.DeepEqual(got, []string{"database.version"}) {
+		t.Errorf("changed = %v, want [database.version]", got)
+	}
+}
+
+func TestImmutableInputsFromAnnotation(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":        "application",
+			"annotations": map[string]any{immutableInputsAnnotation: " database.version , foo "},
+		},
+	}}
+	got := immutableInputsFromAnnotation(u)
+	if !reflect.DeepEqual(got, []string{"database.version", "foo"}) {
+		t.Errorf("parsed = %v", got)
+	}
+	if immutableInputsFromAnnotation(&unstructured.Unstructured{Object: map[string]any{}}) != nil {
+		t.Error("no annotation must yield nil")
+	}
+}


### PR DESCRIPTION
Follow-up to #480. Rolling a new image over MCP meant delete+re-provision — wiping the managed Postgres — because the surface had no update path, even though the platform reconciles instance spec changes in place (the portal's `applyYaml` path does exactly this). And no template accepted env vars at all.

## update_instance

- **RFC 7386 merge patch** on `values`: send only what changes, `null` unsets, objects merge, scalars/arrays replace. Written back to the instance CR; kro rolls the delta — same instance, same URL, managed state (the database) untouched.
- **Mutable**: images, ports, replicas, `env` maps, `schedule`, `oidc.*`, redis `size`/`version`.
- **Always immutable**: `name` (child-resource + hostname identity), `kedgeMode` (dev↔production swaps the resource graph — lifecycle, not config), platform-stamped `expose`/`credentialsSecretName`. Each rejection names the path and the reason.
- **Template-declared immutables** via the `kedge.faros.sh/immutable-inputs` annotation — `database.version` on `application`, `version` on `database` (a Postgres major upgrade is not an in-place operation). Annotation instead of a spec field so the Template CRD schema stays untouched (`make crds` stays off the table). Exposed on `describe_template` as `immutableInputs`.
- The change-path diff **recurses into wholesale-added subtrees**, so `values: {database: {version: "15"}}` on an instance that never set `database` still trips the `database.version` rule — no bypass by adding the parent object.
- `provision`'s already-exists error and the server instructions now steer agents to `update_instance` instead of delete+provision.

## env inputs

- `simple-webapp` / `worker` / `cron-job` gain `env`; `application` gains `frontendEnv` + `backendEnv` (per tier — a shared map would leak backend config to the frontend).
- Rendered as a **ConfigMap consumed via `envFrom`** — no CEL list synthesis from maps (a known kro edge), and Kubernetes precedence means explicit platform env (`PORT`, `DATABASE_URL`) beats `envFrom`, so tenant values can't clobber platform wiring. The dev overlay deep-copies production containers, so env applies in dev sandboxes too.
- Schema docs state plainly: world-readable, **not for secrets** (a Secret-backed `secretEnv` is a natural follow-up).
- The OpenAPI→SimpleSchema converter learns `additionalProperties` → `map[string]<elem>`. Map defaults support only `{}`: kro's marker tokenizer cannot escape double quotes, so non-empty JSON-object defaults are dropped rather than emitted corrupt (regression-tested).

## Test plan

- [x] `go build ./...`, `go vet ./...`, full `go test ./...` green
- [x] New unit tests: merge-patch semantics (merge/replace/unset, input immutability), change-path diffing incl. the added-subtree leaf reporting, immutable rejection (exact + prefix, no sibling over-match), annotation parsing, converter map types + the `{}`-only default rule
- [x] Seed-template tests exercise all four modified templates through RGD conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)