### PR TITLE
feat(agents): per-agent ServiceAccount so background runs can use instance-backed tools

### DIFF
--- a/docs/agent-web-access.md
+++ b/docs/agent-web-access.md
@@ -142,17 +142,40 @@ upstream set (the prefix is the Connection name).
 An `mcp` Connection with a `baseURL` and no `instance` is unchanged: that is how
 you reach an MCP server outside the platform.
 
-### Background and scheduled runs cannot use this yet
+### Background and scheduled runs: the agent's own identity
 
-The data plane authorizes as the calling user, and a scheduled, heartbeat or
-inbound-channel run has no user token — so an instance-backed tool (search or
-browser) fails there with an explicit message rather than a confusing 401.
-Interactive chat works. Closing this needs the provider to call the data plane
-under its own identity with the requesting user's scope attached; see the
-provider-identity phase in
-[platform-internal-networking.md](platform-internal-networking.md).
+The data plane authorizes per caller, and a scheduled, heartbeat, wakeup or
+inbound-channel run has no human to act as. Each agent therefore gets a
+**ServiceAccount of its own** in the tenant workspace, and background runs call
+the data plane as that identity. Nothing to configure: the provider creates it
+on first use.
 
-A Brave-backed `websearch` Connection has no such limit — its credential is in
+What gets created, once per agent, in the `default` namespace:
+
+| Object | Name | Purpose |
+|---|---|---|
+| ServiceAccount | `kedge-agent-<agent>` | the identity |
+| Secret | `kedge-agent-<agent>-token` | its token, populated by kcp's token controller |
+| ClusterRole + binding | `kedge-agent-<agent>` | `get`/`list` on `infrastructure.kedge.faros.sh` |
+
+Things worth knowing before you rely on it:
+
+- **The grant is workspace-wide, not connection-scoped.** The agent's identity
+  can read *any* infrastructure instance in its workspace, not only the ones its
+  Connections name. That keeps the Role stable as connections change, at the
+  cost of a wider blast radius if the token is read out of the workspace.
+- **It is a standing credential.** kcp has no TokenRequest API, so this is a
+  long-lived ("legacy") ServiceAccount token that does not expire. Revoking it
+  means deleting the ServiceAccount; the provider caches tokens for 30 minutes,
+  so a revocation takes effect within that window.
+- **Read-only.** The Role grants `get` and `list` and nothing else, over one API
+  group. An agent identity cannot read Secrets or mutate anything.
+- **Failure is not fatal to the run.** If the identity cannot be provisioned,
+  the run proceeds without instance-backed tools rather than being lost, and the
+  provider logs `identity unavailable`. The tool then reports that it has no
+  identity, instead of composing a call that 401s two hops away.
+
+A Brave-backed `websearch` Connection needs none of this — its credential is in
 the Connection Secret, which every run can read.
 
 ### Local development (Tilt)

--- a/docs/platform-internal-networking.md
+++ b/docs/platform-internal-networking.md
@@ -524,10 +524,16 @@ URL. The kro backend rejects a template whose marker contradicts its graph — a
 `internal` template carrying an HTTPRoute, or an `optional` one whose route has
 no `includeWhen` — so the marker cannot drift away from what is deployed.
 
-The known gap is stated where it bites: the data plane authorizes as the caller,
-so **background and scheduled runs cannot use an instance-backed tool** until
-provider identity lands. The tools return an explicit message saying so rather
-than a bare 401 two hops away.
+The caller-authorizes property initially left background and scheduled runs
+unable to use an instance-backed tool at all. That is now closed, not by giving
+the provider an identity of its own, but by giving **each agent** a ServiceAccount
+in the tenant workspace and having background runs act as it — the same shape
+the hub already uses for per-MCPServer identities. Interactive runs still act as
+the human. See the background-runs section of
+[agent-web-access.md](agent-web-access.md) for what is created and the two
+properties worth knowing: the grant is workspace-wide rather than
+connection-scoped, and the token is long-lived because kcp has no TokenRequest
+API.
 
 ## Open questions
 

--- a/providers/agents/api/agentidentity.go
+++ b/providers/agents/api/agentidentity.go
@@ -1,0 +1,230 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package api
+
+// Per-agent identity for background runs.
+//
+// An interactive run acts as the human driving it: their bearer token reaches
+// the platform data plane, which authorizes by re-reading the target instance
+// as them. A scheduled, heartbeat, wakeup or inbound-channel run has no human,
+// so it had no token and instance-backed tools (self-hosted search, a browser
+// instance) simply refused to run.
+//
+// This gives each agent a ServiceAccount of its own in the tenant workspace,
+// with a long-lived token, and background runs call the data plane as that
+// identity. The shape mirrors the hub's per-MCPServer identity
+// (pkg/hub/controllers/mcpserver, ensureMCPIdentity) — the same pattern kcp
+// already supports. Long-lived because kcp has no TokenRequest API: its token
+// controller populates a Secret, which is what "legacy" means here.
+//
+// SCOPE, STATED PLAINLY: the agent's ServiceAccount can read every
+// infrastructure instance in its workspace, not only the ones its Connections
+// name. That is a deliberate choice for a stable Role that does not churn as
+// connections change. The consequence is that this token, if read out of the
+// workspace, reaches any instance there — including a browser instance holding
+// live logins the agent was never wired to. It is a standing credential: it
+// does not expire, and revoking it means deleting the ServiceAccount.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+)
+
+var (
+	serviceAccountGVR     = schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}
+	clusterRoleGVR        = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}
+	clusterRoleBindingGVR = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}
+	secretsGVR            = schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
+)
+
+// identityNamespace is where the agent ServiceAccount and its token Secret
+// live — the same namespace the provider already keeps credential Secrets in,
+// so the permission claim covers both without widening anything.
+const identityNamespace = "default"
+
+// instanceGroup is the infrastructure provider's instance API group. The
+// agent's Role grants read across it; instance kinds are created at runtime
+// from Templates, so they cannot be enumerated ahead of time and the grant is
+// written against the group rather than a fixed resource list.
+const instanceGroup = "infrastructure.kedge.faros.sh"
+
+// agentIdentityName is the ServiceAccount / ClusterRole / binding name for one
+// agent. Prefixed so it is obviously platform-managed in a workspace a human
+// also uses.
+func agentIdentityName(agent string) string { return "kedge-agent-" + agent }
+
+// agentTokenSecretName is the Secret kcp's token controller populates.
+func agentTokenSecretName(agent string) string { return "kedge-agent-" + agent + "-token" }
+
+// identityCache memoises minted tokens per (cluster, agent). Provisioning is
+// idempotent but involves several API calls and a poll, and the background
+// scheduler may start many runs a minute — re-minting each time would be a
+// needless round-trip storm against the tenant workspace.
+//
+// Entries expire. These tokens do not — revocation means deleting the
+// ServiceAccount — so without a TTL a revoked identity would keep being used
+// from memory until the provider restarted. The TTL bounds how long a run can
+// act on an identity the tenant has already withdrawn.
+type identityCache struct {
+	mu     sync.Mutex
+	tokens map[string]cachedIdentity
+	ttl    time.Duration
+	now    func() time.Time // overridable in tests
+}
+
+type cachedIdentity struct {
+	token   string
+	expires time.Time
+}
+
+// identityTTL is a compromise: long enough that a per-minute scheduler is not
+// re-provisioning constantly, short enough that a withdrawn identity stops
+// working within the hour.
+const identityTTL = 30 * time.Minute
+
+func newIdentityCache() *identityCache {
+	return &identityCache{tokens: map[string]cachedIdentity{}, ttl: identityTTL, now: time.Now}
+}
+
+func (c *identityCache) get(cluster, agent string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.tokens[cluster+"/"+agent]
+	if !ok || c.now().After(e.expires) {
+		return "", false
+	}
+	return e.token, true
+}
+
+func (c *identityCache) put(cluster, agent, token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokens[cluster+"/"+agent] = cachedIdentity{token: token, expires: c.now().Add(c.ttl)}
+}
+
+// ensureAgentIdentity provisions (idempotently) the agent's ServiceAccount, its
+// read-instances ClusterRole and binding, and its token Secret, then waits for
+// kcp's token controller to fill the token in. Every object is created-if-absent
+// and never updated, which is what the create-only permission claim allows.
+func ensureAgentIdentity(ctx context.Context, dyn dynamic.Interface, agent string) (string, error) {
+	name := agentIdentityName(agent)
+
+	sa := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ServiceAccount",
+		"metadata":   map[string]any{"name": name, "namespace": identityNamespace},
+	}}
+	if err := createIfAbsent(ctx, dyn.Resource(serviceAccountGVR).Namespace(identityNamespace), sa); err != nil {
+		return "", fmt.Errorf("agent ServiceAccount: %w", err)
+	}
+
+	// Read-only, and only over the instance group. Instances are cluster-scoped
+	// (the per-template CRDs are), so this has to be a ClusterRole.
+	role := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata":   map[string]any{"name": name},
+		"rules": []any{map[string]any{
+			"apiGroups": []any{instanceGroup},
+			"resources": []any{"*"},
+			"verbs":     []any{"get", "list"},
+		}},
+	}}
+	if err := createIfAbsent(ctx, dyn.Resource(clusterRoleGVR), role); err != nil {
+		return "", fmt.Errorf("agent ClusterRole: %w", err)
+	}
+
+	binding := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": name},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     name,
+		},
+		"subjects": []any{map[string]any{
+			"kind":      "ServiceAccount",
+			"name":      name,
+			"namespace": identityNamespace,
+		}},
+	}}
+	if err := createIfAbsent(ctx, dyn.Resource(clusterRoleBindingGVR), binding); err != nil {
+		return "", fmt.Errorf("agent ClusterRoleBinding: %w", err)
+	}
+
+	return ensureAgentToken(ctx, dyn, agent)
+}
+
+// ensureAgentToken creates the legacy service-account-token Secret and waits
+// for the token controller to populate it. Mirrors pkg/hub/providers
+// ensureLegacySAToken; kcp has no TokenRequest subresource, so this is how a
+// usable token is obtained.
+func ensureAgentToken(ctx context.Context, dyn dynamic.Interface, agent string) (string, error) {
+	secretName := agentTokenSecretName(agent)
+	secrets := dyn.Resource(secretsGVR).Namespace(identityNamespace)
+
+	sec := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name":        secretName,
+			"namespace":   identityNamespace,
+			"annotations": map[string]any{corev1.ServiceAccountNameKey: agentIdentityName(agent)},
+		},
+		"type": string(corev1.SecretTypeServiceAccountToken),
+	}}
+	if err := createIfAbsent(ctx, secrets, sec); err != nil {
+		return "", fmt.Errorf("agent token Secret: %w", err)
+	}
+
+	var token string
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		got, err := secrets.Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		// Secret data is base64 in unstructured form; NestedString gives the
+		// encoded value, so decode through the typed object instead.
+		typed, err := fromU[corev1.Secret](got)
+		if err != nil {
+			return false, nil
+		}
+		if t := typed.Data[corev1.ServiceAccountTokenKey]; len(t) > 0 {
+			token = string(t)
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("waiting for kcp's token controller to populate Secret %s/%s: %w", identityNamespace, secretName, err)
+	}
+	return token, nil
+}
+
+// createIfAbsent creates an object, treating AlreadyExists as success. Nothing
+// here is ever updated: the provider holds create-only rights on the RBAC
+// objects precisely so it cannot later widen a grant it once made.
+func createIfAbsent(ctx context.Context, ri dynamic.ResourceInterface, obj *unstructured.Unstructured) error {
+	_, err := ri.Create(ctx, obj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}

--- a/providers/agents/api/agentidentity_test.go
+++ b/providers/agents/api/agentidentity_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func identityScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+// newIdentityFake returns a dynamic fake plus a hook that simulates kcp's token
+// controller: it fills the token in on the Nth Get of the Secret, so the poll
+// in ensureAgentToken is exercised rather than short-circuited.
+func newIdentityFake(t *testing.T, fillAfterGets int) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	dyn := dynamicfake.NewSimpleDynamicClient(identityScheme())
+	gets := 0
+	dyn.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ga, ok := action.(k8stesting.GetAction)
+		if !ok || ga.GetName() != agentTokenSecretName("scout") {
+			return false, nil, nil
+		}
+		gets++
+		if gets < fillAfterGets {
+			return true, &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1", "kind": "Secret",
+				"metadata": map[string]any{"name": ga.GetName(), "namespace": identityNamespace},
+			}}, nil
+		}
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "Secret",
+			"metadata": map[string]any{"name": ga.GetName(), "namespace": identityNamespace},
+			"data": map[string]any{
+				corev1.ServiceAccountTokenKey: base64.StdEncoding.EncodeToString([]byte("sa-token-value")),
+			},
+		}}, nil
+	})
+	return dyn
+}
+
+func TestEnsureAgentIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("provisions the identity and returns the populated token", func(t *testing.T) {
+		dyn := newIdentityFake(t, 3) // token appears on the third Get
+		tok, err := ensureAgentIdentity(ctx, dyn, "scout")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok != "sa-token-value" {
+			t.Fatalf("token = %q, want the decoded Secret value", tok)
+		}
+
+		sa, err := dyn.Resource(serviceAccountGVR).Namespace(identityNamespace).
+			Get(ctx, agentIdentityName("scout"), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("ServiceAccount: %v", err)
+		}
+		if sa.GetName() != "kedge-agent-scout" {
+			t.Fatalf("SA name = %q", sa.GetName())
+		}
+
+		// The RBAC is the security surface, so its exact shape is pinned. Read
+		// only, and confined to the infrastructure instance group: an agent
+		// identity must never be able to read Secrets or mutate anything.
+		role, err := dyn.Resource(clusterRoleGVR).Get(ctx, agentIdentityName("scout"), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("ClusterRole: %v", err)
+		}
+		rules, _, _ := unstructured.NestedSlice(role.Object, "rules")
+		if len(rules) != 1 {
+			t.Fatalf("want exactly one rule, got %v", rules)
+		}
+		rule := rules[0].(map[string]any)
+		groups, _, _ := unstructured.NestedStringSlice(rule, "apiGroups")
+		verbs, _, _ := unstructured.NestedStringSlice(rule, "verbs")
+		if len(groups) != 1 || groups[0] != instanceGroup {
+			t.Fatalf("apiGroups = %v, want only %q", groups, instanceGroup)
+		}
+		for _, v := range verbs {
+			if v != "get" && v != "list" {
+				t.Fatalf("verb %q grants more than read", v)
+			}
+		}
+
+		binding, err := dyn.Resource(clusterRoleBindingGVR).Get(ctx, agentIdentityName("scout"), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("ClusterRoleBinding: %v", err)
+		}
+		roleName, _, _ := unstructured.NestedString(binding.Object, "roleRef", "name")
+		if roleName != agentIdentityName("scout") {
+			t.Fatalf("binding points at %q", roleName)
+		}
+		subjects, _, _ := unstructured.NestedSlice(binding.Object, "subjects")
+		subj := subjects[0].(map[string]any)
+		if subj["name"] != agentIdentityName("scout") || subj["namespace"] != identityNamespace {
+			t.Fatalf("subject = %v", subj)
+		}
+	})
+
+	t.Run("the token Secret is a service-account-token naming the SA", func(t *testing.T) {
+		// Without the right type and annotation, kcp's token controller never
+		// populates it and the poll would time out with nothing to show for it.
+		dyn := newIdentityFake(t, 1)
+		if _, err := ensureAgentIdentity(ctx, dyn, "scout"); err != nil {
+			t.Fatal(err)
+		}
+		created := findCreated(t, dyn, "secrets")
+		if got, _, _ := unstructured.NestedString(created.Object, "type"); got != string(corev1.SecretTypeServiceAccountToken) {
+			t.Fatalf("Secret type = %q", got)
+		}
+		ann := created.GetAnnotations()
+		if ann[corev1.ServiceAccountNameKey] != agentIdentityName("scout") {
+			t.Fatalf("annotations = %v", ann)
+		}
+	})
+
+	t.Run("is idempotent — a second call creates nothing new", func(t *testing.T) {
+		// Every background run calls this. AlreadyExists must be success, not
+		// an error that disables instance tools for the rest of the process.
+		dyn := newIdentityFake(t, 1)
+		if _, err := ensureAgentIdentity(ctx, dyn, "scout"); err != nil {
+			t.Fatal(err)
+		}
+		before := countCreates(dyn)
+		dyn.ClearActions()
+		tok, err := ensureAgentIdentity(ctx, dyn, "scout")
+		if err != nil {
+			t.Fatalf("second call: %v", err)
+		}
+		if tok != "sa-token-value" {
+			t.Fatalf("token = %q", tok)
+		}
+		if before == 0 {
+			t.Fatal("first call created nothing")
+		}
+	})
+
+	t.Run("a token that never arrives is an error, not an empty token", func(t *testing.T) {
+		// An empty token would compose a data-plane URL that 401s two hops
+		// away; the caller needs to know provisioning failed.
+		dyn := newIdentityFake(t, 1_000_000)
+		ctx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+		defer cancel()
+		if _, err := ensureAgentIdentity(ctx, dyn, "scout"); err == nil {
+			t.Fatal("want an error when the token controller never populates the Secret")
+		}
+	})
+}
+
+// The identity cache is what keeps a busy scheduler from re-provisioning on
+// every run, and what lets a revoked identity recover.
+func TestIdentityCache(t *testing.T) {
+	c := newIdentityCache()
+	if _, ok := c.get("c1", "scout"); ok {
+		t.Fatal("empty cache returned a token")
+	}
+	c.put("c1", "scout", "t1")
+	if tok, ok := c.get("c1", "scout"); !ok || tok != "t1" {
+		t.Fatalf("get = %q,%v", tok, ok)
+	}
+	// Same agent name in a different workspace is a different identity; sharing
+	// one token across clusters would send workspace A's credential to B.
+	if _, ok := c.get("c2", "scout"); ok {
+		t.Fatal("token leaked across clusters")
+	}
+	// These tokens never expire on their own, so a withdrawn identity would be
+	// used from memory until restart if the cache did not age entries out.
+	now := time.Now()
+	c.now = func() time.Time { return now }
+	c.put("c1", "scout", "t1")
+	now = now.Add(identityTTL + time.Second)
+	if _, ok := c.get("c1", "scout"); ok {
+		t.Fatal("expired entry still served")
+	}
+}
+
+func findCreated(t *testing.T, dyn *dynamicfake.FakeDynamicClient, resource string) *unstructured.Unstructured {
+	t.Helper()
+	for _, a := range dyn.Actions() {
+		ca, ok := a.(k8stesting.CreateAction)
+		if !ok || a.GetResource().Resource != resource {
+			continue
+		}
+		if u, ok := ca.GetObject().(*unstructured.Unstructured); ok {
+			return u
+		}
+	}
+	t.Fatalf("no create recorded for %s", resource)
+	return nil
+}
+
+func countCreates(dyn *dynamicfake.FakeDynamicClient) int {
+	n := 0
+	for _, a := range dyn.Actions() {
+		if a.GetVerb() == "create" {
+			n++
+		}
+	}
+	return n
+}

--- a/providers/agents/api/background.go
+++ b/providers/agents/api/background.go
@@ -72,6 +72,10 @@ type background struct {
 	interval time.Duration
 	key      []byte // webhook HMAC key ("" → webhooks disabled)
 
+	// identities memoises each agent's minted ServiceAccount token, so a busy
+	// scheduler does not re-provision on every run. See agentidentity.go.
+	identities *identityCache
+
 	discord *discordManager // Discord gateway bots (inbound chat)
 }
 
@@ -92,7 +96,7 @@ func (s *Server) StartBackground(ctx context.Context) {
 	if s.cfg.SchedulerInterval > 0 {
 		interval = s.cfg.SchedulerInterval
 	}
-	bg := &background{server: s, base: base, interval: interval, key: s.webhookKeyBytes()}
+	bg := &background{server: s, base: base, interval: interval, key: s.webhookKeyBytes(), identities: newIdentityCache()}
 	bg.exec = executor.NewInProcess(bg.handle, 4, 10*time.Minute)
 	bg.discord = newDiscordManager(bg)
 	_ = bg.exec.Start(ctx)
@@ -162,6 +166,26 @@ func (b *background) ensureVW(ctx context.Context) error {
 	b.wildcard = wildcard
 	log.Printf("background: using APIExport virtual workspace %s", b.vwURL)
 	return nil
+}
+
+// agentToken returns the agent's ServiceAccount token, provisioning the
+// identity on first use. Returns "" on failure — the caller degrades to a run
+// without instance-backed tools, which reports a clear message per tool, rather
+// than failing the whole run.
+func (b *background) agentToken(ctx context.Context, dyn dynamic.Interface, cluster, agent string) string {
+	if b.identities == nil {
+		return ""
+	}
+	if tok, ok := b.identities.get(cluster, agent); ok {
+		return tok
+	}
+	tok, err := ensureAgentIdentity(ctx, dyn, agent)
+	if err != nil {
+		log.Printf("background: agent %q identity unavailable, instance-backed tools disabled for this run: %v", agent, err)
+		return ""
+	}
+	b.identities.put(cluster, agent, tok)
+	return tok
 }
 
 // apiExportNameForSlice is the slice name (same as the export by convention).
@@ -425,6 +449,12 @@ func (b *background) handle(ctx context.Context, job executor.Job) error {
 		Creds: vwSecrets{dyn}, CR: vwCR{dyn}, Scope: scope, Agent: agent,
 		SessionID: job.SessionID, Task: job.Task, Trigger: job.Trigger, SourceName: job.SourceName,
 		NotifyChannel: job.NotifyChannel,
+		// There is no user to act as here, so the run acts as the AGENT's own
+		// ServiceAccount. Failing to mint one is not fatal: the run proceeds
+		// without instance-backed tools, exactly as it did before, rather than
+		// losing a scheduled run over a search backend it may never touch.
+		ClusterID: job.ClusterID,
+		HubToken:  b.agentToken(ctx, dyn, job.ClusterID, agent.Name),
 	})
 
 	b.recordOutcome(ctx, job, res.RunID, runErr)

--- a/providers/agents/deploy/chart/templates/catalogentry.yaml
+++ b/providers/agents/deploy/chart/templates/catalogentry.yaml
@@ -32,6 +32,23 @@ spec:
       - resource: secrets
         verbs: ["get", "list", "watch", "create", "update", "delete"]
         tenantScoped: true
+      # Per-agent identity for background runs. A scheduled run has no user to
+      # act as, so the provider mints the agent a ServiceAccount in the tenant
+      # workspace and calls the platform data plane as that identity. See
+      # api/agentidentity.go. Create-only on the RBAC objects: the provider
+      # grants the agent read access to instances and can never widen it to
+      # anything else, because it cannot write arbitrary roles.
+      - resource: serviceaccounts
+        verbs: ["get", "create"]
+        tenantScoped: true
+      - resource: clusterroles
+        group: rbac.authorization.k8s.io
+        verbs: ["get", "create"]
+        tenantScoped: true
+      - resource: clusterrolebindings
+        group: rbac.authorization.k8s.io
+        verbs: ["get", "create"]
+        tenantScoped: true
 {{- end -}}
 
 {{- if .Values.catalogEntry.enabled -}}

--- a/providers/agents/manifest.yaml
+++ b/providers/agents/manifest.yaml
@@ -56,3 +56,20 @@ spec:
       - resource: secrets
         verbs: ["get", "list", "watch", "create", "update", "delete"]
         tenantScoped: true
+      # Per-agent identity for background runs. A scheduled run has no user to
+      # act as, so the provider mints the agent a ServiceAccount in the tenant
+      # workspace and calls the platform data plane as that identity. See
+      # api/agentidentity.go. Create-only on the RBAC objects: the provider
+      # grants the agent read access to instances and can never widen it to
+      # anything else, because it cannot write arbitrary roles.
+      - resource: serviceaccounts
+        verbs: ["get", "create"]
+        tenantScoped: true
+      - resource: clusterroles
+        group: rbac.authorization.k8s.io
+        verbs: ["get", "create"]
+        tenantScoped: true
+      - resource: clusterrolebindings
+        group: rbac.authorization.k8s.io
+        verbs: ["get", "create"]
+        tenantScoped: true

--- a/providers/agents/tools/mcp_test.go
+++ b/providers/agents/tools/mcp_test.go
@@ -35,10 +35,13 @@ func TestConnectMCPInstanceAddressing(t *testing.T) {
 		}
 	})
 
-	t.Run("a background run is told why, not left with a 401", func(t *testing.T) {
+	t.Run("a run with no identity is told why, not left with a 401", func(t *testing.T) {
+		// Interactive runs carry the user's token, background runs the agent's
+		// ServiceAccount token. Neither means provisioning failed, and the
+		// message has to point at that rather than at the instance.
 		_, err := DataPlane{HubBase: dp.HubBase, ClusterID: dp.ClusterID}.ProxyURL("mcp", "browser", browserResource, "browser")
-		if err == nil || !strings.Contains(err.Error(), "background") {
-			t.Fatalf("want the background-run limitation named, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "no identity") {
+			t.Fatalf("want the missing identity named, got %v", err)
 		}
 	})
 

--- a/providers/agents/tools/tools.go
+++ b/providers/agents/tools/tools.go
@@ -64,9 +64,11 @@ type Deps struct {
 // hostname. See docs/platform-internal-networking.md.
 //
 // Token is the CALLER's bearer token: the data plane authorizes by re-reading
-// the instance as the caller, so a run with no user token (any background run,
-// today) cannot use it. That is a deliberate property of the contract, not an
-// oversight here — see the provider-identity phase in the design note.
+// the instance as the caller. An interactive run supplies the human's token; a
+// background run supplies the AGENT's own ServiceAccount token, minted into the
+// tenant workspace (see api/agentidentity.go). Empty means neither was
+// available — the identity could not be provisioned — and instance-backed tools
+// report that rather than composing a call that 401s two hops away.
 type DataPlane struct {
 	HubBase   string
 	ClusterID string
@@ -93,10 +95,7 @@ func (d DataPlane) ProxyURL(kind, connName, resource, instance string) (string, 
 		return "", fmt.Errorf("%s connection %q names instance %q, but this provider has no hub/workspace context to reach it", kind, connName, instance)
 	}
 	if d.Token == "" {
-		// Background runs carry no user token, and the data plane has no other
-		// identity to authorize yet. See the provider-identity phase in
-		// docs/platform-internal-networking.md.
-		return "", fmt.Errorf("%s connection %q reaches instance %q over the platform data plane, which authorizes as the calling user — unavailable to scheduled/background runs until provider identity lands", kind, connName, instance)
+		return "", fmt.Errorf("%s connection %q reaches instance %q over the platform data plane, which authorizes per caller, but this run has no identity — an interactive run uses yours, a background run uses the agent's own ServiceAccount, and provisioning that failed (check the provider log for \"identity unavailable\")", kind, connName, instance)
 	}
 	return strings.TrimRight(d.HubBase, "/") +
 		fmt.Sprintf("/services/providers/infrastructure/dataplane/clusters/%s/%s/%s/proxy",

--- a/providers/agents/tools/web_test.go
+++ b/providers/agents/tools/web_test.go
@@ -226,14 +226,14 @@ func TestDataPlaneSearchRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("a background run gets a precise error, not a bare 401 two hops away", func(t *testing.T) {
+	t.Run("a run with no identity gets a precise error, not a bare 401 two hops away", func(t *testing.T) {
 		noToken := DataPlane{HubBase: dp.HubBase, ClusterID: dp.ClusterID}
 		_, err := searchRequest(ctx, instanceConn(map[string]string{"instance": "search"}), noToken, "", "x")
 		if err == nil {
-			t.Fatal("want an error explaining background runs cannot use the data plane")
+			t.Fatal("want an error explaining the run has no identity to authorize as")
 		}
-		if !strings.Contains(err.Error(), "background") {
-			t.Fatalf("error should name the limitation: %v", err)
+		if !strings.Contains(err.Error(), "no identity") {
+			t.Fatalf("error should name the missing identity: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Why

The platform data plane authorizes **per caller**: it re-reads the target instance as whoever made the call. A scheduled, heartbeat, wakeup or inbound-channel run has no human to act as, so it had no token — and instance-backed tools (self-hosted search, a browser instance) refused to run. They worked in interactive chat and nowhere else.

## What

Each agent now gets a **ServiceAccount of its own** in the tenant workspace, and background runs call the data plane as that identity. Interactive runs still act as the human.

This is the same shape the hub already uses for per-MCPServer identities (`pkg/hub/controllers/mcpserver`, `ensureMCPIdentity`) — SA + long-lived token Secret + ClusterRoleBinding, created on first use and idempotent thereafter. Created once per agent in the `default` namespace:

| Object | Name | Purpose |
|---|---|---|
| ServiceAccount | `kedge-agent-<agent>` | the identity |
| Secret | `kedge-agent-<agent>-token` | its token, populated by kcp's token controller |
| ClusterRole + binding | `kedge-agent-<agent>` | `get`/`list` on `infrastructure.kedge.faros.sh` |

## Review these two decisions specifically

**The grant is workspace-wide, not connection-scoped.** The agent's identity can read *any* infrastructure instance in its workspace, not only the ones its Connections name. This keeps the Role stable as connections change; the cost is that the token reaches every instance there — including a browser instance holding live logins the agent was never wired to. The narrower alternative (RBAC derived from the agent's connections, by `resourceName`) was considered and deliberately not taken.

**It is a standing credential that does not expire.** kcp has no TokenRequest API — its token controller populates a Secret, which is what "legacy" means here — so short-lived per-run tokens were not available. Revocation means deleting the ServiceAccount, so cached tokens carry a 30-minute TTL; without one, a withdrawn identity would keep working from memory until the provider restarted.

## Permission claims widen

The provider now claims `serviceaccounts`, `clusterroles` and `clusterrolebindings` — **`get` + `create` only**. Create-only is the point: the provider can make the initial grant and can never later widen it, because it cannot write an existing role.

## Failure behaviour

Not fatal to the run. If the identity cannot be provisioned the run proceeds without instance-backed tools rather than being lost, the provider logs `identity unavailable`, and the tool reports a missing identity instead of composing a call that 401s two hops away.

## Tests

- RBAC shape pinned exactly — one rule, one API group, read verbs only — so a later edit cannot quietly widen it
- Token Secret type + `kubernetes.io/service-account.name` annotation (without both, kcp's token controller never populates it)
- Idempotency across repeated runs (every background run calls this; `AlreadyExists` must be success)
- The poll erroring rather than returning an empty token
- Cache TTL and cross-cluster isolation (one agent name in two workspaces is two identities)

## Not verified live

Two things need a real kcp and are unverified here: that kcp's token controller populates the Secret **through the APIExport permission claim**, and that the front-proxy accepts an SA token at the data plane. The second has prior form in this repo — hub-proxy TokenReview has 404'd for workspace-scoped configs where static tokens worked. That is where I would look first if background search still fails after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)