### PR TITLE
fix(agents): fan background work out across every kcp shard's APIExport VW

### DIFF
--- a/providers/agents/api/background.go
+++ b/providers/agents/api/background.go
@@ -13,13 +13,22 @@ package api
 //
 // The provider's own service-account kubeconfig (from init) targets its kcp
 // workspace. From there we read the agents APIExportEndpointSlice to discover
-// the APIExport virtual-workspace URL, which serves every bound tenant
+// the APIExport virtual-workspace URLs, which serve every bound tenant
 // workspace (wildcard /clusters/* for lists, /clusters/<id> for writes) plus
 // the claimed core resources (Secrets — the model credentials). A small
 // polling loop derives due schedules from CR state, claims each fire with an
 // optimistic status update (conflict = another replica won), and submits a
 // serializable Job to the executor (in-process pool today; swappable for a
 // durable engine — see the executor package).
+//
+// The slice advertises ONE ENDPOINT PER KCP SHARD, and each endpoint only
+// serves the tenant workspaces bound on that shard. Binding to a single URL
+// therefore makes every tenant on the other shards invisible: no schedules, no
+// heartbeats, no trigger webhooks, no Discord gateway, no OAuth refresh — all
+// silently, since a wildcard list against the wrong shard returns an empty list
+// rather than an error. So we hold one wildcard client per shard, merge across
+// them on every list, and remember which shard serves each tenant cluster for
+// the single-cluster (write) path.
 
 import (
 	"context"
@@ -27,12 +36,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -60,14 +71,27 @@ var sliceGVR = schema.GroupVersionResource{Group: "apis.kcp.io", Version: "v1alp
 // back-to-back failures reach it.
 const maxConsecutiveFailures = 5
 
+// vwShard is one APIExport virtual-workspace endpoint — one kcp shard — and
+// the wildcard client bound to it.
+type vwShard struct {
+	url      string
+	wildcard dynamic.Interface
+}
+
 // background owns the VW plumbing + scheduler policy.
 type background struct {
 	server *Server
 	base   *rest.Config
 	exec   executor.Executor
 
-	vwURL    string
-	wildcard dynamic.Interface
+	// mu guards shards + clusterShard: the poll loop rebuilds them while HTTP
+	// handlers (webhooks, OAuth callbacks) and Discord gateway callbacks read
+	// them.
+	mu     sync.RWMutex
+	shards []*vwShard
+	// clusterShard maps a tenant logical cluster to the URL of the shard that
+	// serves it, learned from wildcard lists and endpoint probes.
+	clusterShard map[string]string
 
 	interval time.Duration
 	key      []byte // webhook HMAC key ("" → webhooks disabled)
@@ -133,8 +157,9 @@ func (s *Server) webhookToken(clusterID, name string) string {
 
 // ---- virtual-workspace plumbing --------------------------------------------
 
-// ensureVW discovers (and re-discovers) the APIExport VW URL from the
-// endpoint slice in the provider workspace.
+// ensureVW discovers (and re-discovers) the APIExport VW endpoints from the
+// endpoint slice in the provider workspace — one per kcp shard. Existing shard
+// clients are preserved across calls; only new URLs build a client.
 func (b *background) ensureVW(ctx context.Context) error {
 	dyn, err := dynamic.NewForConfig(b.base)
 	if err != nil {
@@ -144,28 +169,171 @@ func (b *background) ensureVW(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("reading APIExportEndpointSlice %q: %w", apiExportNameForSlice, err)
 	}
-	endpoints, _, _ := unstructured.NestedSlice(u.Object, "status", "endpoints")
-	if len(endpoints) == 0 {
-		return fmt.Errorf("endpoint slice %q has no endpoints yet", apiExportNameForSlice)
-	}
-	first, _ := endpoints[0].(map[string]any)
-	url, _ := first["url"].(string)
-	if url == "" {
-		return fmt.Errorf("endpoint slice %q endpoint has no url", apiExportNameForSlice)
-	}
-	if url == b.vwURL && b.wildcard != nil {
-		return nil
-	}
-	wc := rest.CopyConfig(b.base)
-	wc.Host = strings.TrimRight(url, "/") + "/clusters/*"
-	wildcard, err := dynamic.NewForConfig(wc)
+	urls, err := sliceEndpointURLs(u)
 	if err != nil {
 		return err
 	}
-	b.vwURL = strings.TrimRight(url, "/")
-	b.wildcard = wildcard
-	log.Printf("background: using APIExport virtual workspace %s", b.vwURL)
+	seen := make(map[string]bool, len(urls))
+	for _, url := range urls {
+		seen[url] = true
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	existing := make(map[string]*vwShard, len(b.shards))
+	for _, s := range b.shards {
+		existing[s.url] = s
+	}
+	shards := make([]*vwShard, 0, len(urls))
+	var added []string
+	for _, url := range urls {
+		if s, ok := existing[url]; ok {
+			shards = append(shards, s)
+			continue
+		}
+		wc := rest.CopyConfig(b.base)
+		wc.Host = url + "/clusters/*"
+		wildcard, err := dynamic.NewForConfig(wc)
+		if err != nil {
+			return err
+		}
+		shards = append(shards, &vwShard{url: url, wildcard: wildcard})
+		added = append(added, url)
+	}
+	if len(added) > 0 || len(shards) != len(b.shards) {
+		log.Printf("background: using %d APIExport virtual workspace endpoint(s): %s", len(shards), strings.Join(urls, ", "))
+	}
+	b.shards = shards
+	// Forget cluster→shard bindings whose shard is gone, so they re-resolve
+	// against the current endpoint set instead of pinning a dead URL.
+	for cluster, url := range b.clusterShard {
+		if !seen[url] {
+			delete(b.clusterShard, cluster)
+		}
+	}
 	return nil
+}
+
+// sliceEndpointURLs reads EVERY endpoint URL off an APIExportEndpointSlice,
+// trimmed and de-duplicated in slice order. kcp publishes one endpoint per
+// shard, so taking only the first silently drops every tenant workspace bound
+// on the other shards.
+func sliceEndpointURLs(u *unstructured.Unstructured) ([]string, error) {
+	endpoints, _, _ := unstructured.NestedSlice(u.Object, "status", "endpoints")
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("endpoint slice %q has no endpoints yet", apiExportNameForSlice)
+	}
+	urls := make([]string, 0, len(endpoints))
+	seen := map[string]bool{}
+	for _, e := range endpoints {
+		m, _ := e.(map[string]any)
+		raw, _ := m["url"].(string)
+		url := strings.TrimRight(strings.TrimSpace(raw), "/")
+		if url == "" || seen[url] {
+			continue
+		}
+		seen[url] = true
+		urls = append(urls, url)
+	}
+	if len(urls) == 0 {
+		return nil, fmt.Errorf("endpoint slice %q has no endpoint with a url", apiExportNameForSlice)
+	}
+	return urls, nil
+}
+
+// ready reports whether at least one VW endpoint has been discovered.
+func (b *background) ready() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.shards) > 0
+}
+
+// snapshotShards returns the current shard set for lock-free iteration.
+func (b *background) snapshotShards() []*vwShard {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return append([]*vwShard(nil), b.shards...)
+}
+
+// rememberCluster records which shard serves a tenant cluster.
+func (b *background) rememberCluster(clusterID, shardURL string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.clusterShard == nil {
+		b.clusterShard = map[string]string{}
+	}
+	b.clusterShard[clusterID] = shardURL
+}
+
+// listAll lists a resource across EVERY shard's wildcard endpoint and merges
+// the results, recording each item's owning shard on the way. Listing a single
+// endpoint would silently return only the tenants bound on that one shard.
+//
+// A shard that errors is logged and skipped so its outage cannot stall the
+// tenants on the healthy shards; the call fails only when every shard failed.
+func (b *background) listAll(ctx context.Context, gvr schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	shards := b.snapshotShards()
+	if len(shards) == 0 {
+		return nil, fmt.Errorf("no APIExport virtual workspace endpoint discovered yet")
+	}
+	var out []unstructured.Unstructured
+	var failures []string
+	for _, s := range shards {
+		l, err := s.wildcard.Resource(gvr).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", s.url, err))
+			continue
+		}
+		for i := range l.Items {
+			if c := l.Items[i].GetAnnotations()["kcp.io/cluster"]; c != "" {
+				b.rememberCluster(c, s.url)
+			}
+			out = append(out, l.Items[i])
+		}
+	}
+	if len(failures) == len(shards) {
+		return nil, errors.New(strings.Join(failures, "; "))
+	}
+	for _, f := range failures {
+		log.Printf("background: listing %s: %s", gvr.Resource, f)
+	}
+	return out, nil
+}
+
+// shardFor resolves which shard's VW serves a tenant cluster. It answers from
+// cache once any list has seen the cluster; otherwise it probes each endpoint,
+// because the inbound paths (trigger webhooks, channel webhooks, OAuth
+// callbacks) can name a cluster before a list has surfaced it.
+func (b *background) shardFor(ctx context.Context, clusterID string) (string, error) {
+	b.mu.RLock()
+	url, cached := b.clusterShard[clusterID]
+	b.mu.RUnlock()
+	if cached {
+		return url, nil
+	}
+	shards := b.snapshotShards()
+	switch len(shards) {
+	case 0:
+		return "", fmt.Errorf("no APIExport virtual workspace endpoint discovered yet")
+	case 1:
+		return shards[0].url, nil
+	}
+	for _, s := range shards {
+		c := rest.CopyConfig(b.base)
+		c.Host = s.url + "/clusters/" + clusterID
+		dyn, err := dynamic.NewForConfig(c)
+		if err != nil {
+			continue
+		}
+		// A shard that does not host this logical cluster rejects the read;
+		// the one that does answers (an empty list is still an answer).
+		if _, err := dyn.Resource(agentsclient.AgentGVR).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+			continue
+		}
+		b.rememberCluster(clusterID, s.url)
+		return s.url, nil
+	}
+	return "", fmt.Errorf("tenant workspace %q is not served by any of the %d APIExport virtual workspace endpoints", clusterID, len(shards))
 }
 
 // agentToken returns the agent's ServiceAccount token, provisioning the
@@ -191,10 +359,15 @@ func (b *background) agentToken(ctx context.Context, dyn dynamic.Interface, clus
 // apiExportNameForSlice is the slice name (same as the export by convention).
 const apiExportNameForSlice = "agents.kedge.faros.sh"
 
-// scoped returns a dynamic client bound to one tenant logical cluster.
-func (b *background) scoped(clusterID string) (dynamic.Interface, error) {
+// scoped returns a dynamic client bound to one tenant logical cluster, on
+// whichever shard's VW actually serves it.
+func (b *background) scoped(ctx context.Context, clusterID string) (dynamic.Interface, error) {
+	url, err := b.shardFor(ctx, clusterID)
+	if err != nil {
+		return nil, err
+	}
 	c := rest.CopyConfig(b.base)
-	c.Host = b.vwURL + "/clusters/" + clusterID
+	c.Host = url + "/clusters/" + clusterID
 	return dynamic.NewForConfig(c)
 }
 
@@ -225,11 +398,11 @@ func (b *background) loop(ctx context.Context) {
 	defer t.Stop()
 	// Discover the VW immediately so OAuth callbacks and inbound webhooks work
 	// right after startup instead of failing for a full interval (they depend
-	// on b.vwURL, which is otherwise only set on the first tick).
+	// on the shard set, which is otherwise only built on the first tick).
 	if err := b.ensureVW(ctx); err != nil {
 		log.Printf("background: virtual workspace not ready at startup: %v", err)
 	}
-	if b.vwURL != "" && b.discord != nil {
+	if b.ready() && b.discord != nil {
 		b.discord.reconcile(ctx)
 	}
 	for {
@@ -254,14 +427,14 @@ func (b *background) loop(ctx context.Context) {
 }
 
 func (b *background) tick(ctx context.Context) {
-	list, err := b.wildcard.Resource(agentsclient.ScheduleGVR).List(ctx, metav1.ListOptions{})
+	items, err := b.listAll(ctx, agentsclient.ScheduleGVR)
 	if err != nil {
 		log.Printf("background: listing schedules: %v", err)
 		return
 	}
 	now := time.Now().UTC()
-	for i := range list.Items {
-		item := &list.Items[i]
+	for i := range items {
+		item := &items[i]
 		if err := b.process(ctx, item, now); err != nil {
 			log.Printf("background: schedule %s/%s: %v", item.GetAnnotations()["kcp.io/cluster"], item.GetName(), err)
 		}
@@ -406,7 +579,7 @@ func scheduleDue(sched *agentsv1alpha1.Schedule, now time.Time) (fire bool, next
 // updateStatus merges fields into .status and PUTs the status subresource in
 // the object's cluster, using the object's resourceVersion (optimistic claim).
 func (b *background) updateStatus(ctx context.Context, clusterID string, u *unstructured.Unstructured, fields map[string]any) error {
-	dyn, err := b.scoped(clusterID)
+	dyn, err := b.scoped(ctx, clusterID)
 	if err != nil {
 		return err
 	}
@@ -430,7 +603,7 @@ func (b *background) updateStatus(ctx context.Context, clusterID string, u *unst
 // handle executes one background job: load the agent via the VW, run the task
 // through the shared executeTask path, update source status, notify.
 func (b *background) handle(ctx context.Context, job executor.Job) error {
-	dyn, err := b.scoped(job.ClusterID)
+	dyn, err := b.scoped(ctx, job.ClusterID)
 	if err != nil {
 		return err
 	}
@@ -515,7 +688,7 @@ func (b *background) scopeFor(ctx context.Context, clusterID, agentName string) 
 // recordOutcome updates the firing schedule's status counters (lastRunID,
 // consecutiveFailures, disable-after-N). Triggers record lastFired instead.
 func (b *background) recordOutcome(ctx context.Context, job executor.Job, runID string, runErr error) {
-	dyn, err := b.scoped(job.ClusterID)
+	dyn, err := b.scoped(ctx, job.ClusterID)
 	if err != nil {
 		return
 	}
@@ -673,7 +846,7 @@ func webhookEventType(r *http.Request, body []byte) string {
 func (s *Server) webhookTrigger(w http.ResponseWriter, r *http.Request) {
 	cluster, name, token := r.PathValue("cluster"), r.PathValue("name"), r.PathValue("token")
 	expected := s.webhookToken(cluster, name)
-	if expected == "" || s.bg == nil || s.bg.wildcard == nil {
+	if expected == "" || s.bg == nil || !s.bg.ready() {
 		writeStatus(w, http.StatusServiceUnavailable, "Unavailable", "background executor is not running on this provider")
 		return
 	}
@@ -681,7 +854,7 @@ func (s *Server) webhookTrigger(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusForbidden, "Forbidden", "invalid webhook token")
 		return
 	}
-	dyn, err := s.bg.scoped(cluster)
+	dyn, err := s.bg.scoped(r.Context(), cluster)
 	if err != nil {
 		writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())
 		return

--- a/providers/agents/api/background_shards_test.go
+++ b/providers/agents/api/background_shards_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package api
+
+// Multi-shard virtual-workspace coverage. An APIExportEndpointSlice carries one
+// endpoint per kcp shard, and each endpoint serves only the tenant workspaces
+// bound on that shard. Binding to a single endpoint made every tenant on the
+// other shards invisible with no error anywhere — a wildcard list against the
+// wrong shard returns an empty list, not a failure.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	agentsclient "github.com/faroshq/provider-agents/client"
+)
+
+func sliceWithEndpoints(urls ...string) *unstructured.Unstructured {
+	eps := make([]any, 0, len(urls))
+	for _, u := range urls {
+		eps = append(eps, map[string]any{"url": u})
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apis.kcp.io/v1alpha1",
+		"kind":       "APIExportEndpointSlice",
+		"metadata":   map[string]any{"name": apiExportNameForSlice},
+		"status":     map[string]any{"endpoints": eps},
+	}}
+}
+
+// TestSliceEndpointURLsKeepsEveryShard is the regression: a two-shard slice
+// must yield BOTH URLs. Returning only the first is what stranded every tenant
+// on the second shard.
+func TestSliceEndpointURLsKeepsEveryShard(t *testing.T) {
+	root := "https://root-kcp:6443/services/apiexport/2tr07/agents.kedge.faros.sh"
+	alpha := "https://alpha-shard-kcp:6443/services/apiexport/2tr07/agents.kedge.faros.sh"
+
+	got, err := sliceEndpointURLs(sliceWithEndpoints(root, alpha))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != root || got[1] != alpha {
+		t.Fatalf("want both endpoints in order, got %v", got)
+	}
+}
+
+func TestSliceEndpointURLsNormalizes(t *testing.T) {
+	// Trailing slashes trimmed, blanks dropped, duplicates collapsed — so a
+	// cosmetic difference cannot produce two clients for one shard.
+	got, err := sliceEndpointURLs(sliceWithEndpoints("https://a/vw/", "", "https://a/vw", "  https://b/vw  "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "https://a/vw" || got[1] != "https://b/vw" {
+		t.Fatalf("want [https://a/vw https://b/vw], got %v", got)
+	}
+}
+
+func TestSliceEndpointURLsErrors(t *testing.T) {
+	if _, err := sliceEndpointURLs(sliceWithEndpoints()); err == nil {
+		t.Error("want an error for a slice with no endpoints")
+	}
+	if _, err := sliceEndpointURLs(sliceWithEndpoints("", "  ")); err == nil {
+		t.Error("want an error when no endpoint carries a url")
+	}
+}
+
+// connectionsScheme registers the list kind the dynamic fake needs to serve
+// wildcard List calls for connections.
+func connectionsScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: agentsclient.ConnectionGVR.Group, Version: agentsclient.ConnectionGVR.Version, Kind: "ConnectionList"},
+		&unstructured.UnstructuredList{},
+	)
+	return s
+}
+
+func connectionObj(cluster, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": agentsclient.ConnectionGVR.GroupVersion().String(),
+		"kind":       "Connection",
+		"metadata": map[string]any{
+			"name":        name,
+			"annotations": map[string]any{"kcp.io/cluster": cluster},
+		},
+		"spec": map[string]any{"type": "discord"},
+	}}
+}
+
+func shardWith(t *testing.T, url string, objs ...runtime.Object) *vwShard {
+	t.Helper()
+	return &vwShard{
+		url: url,
+		wildcard: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			connectionsScheme(),
+			map[schema.GroupVersionResource]string{agentsclient.ConnectionGVR: "ConnectionList"},
+			objs...,
+		),
+	}
+}
+
+// TestListAllMergesAcrossShards covers the real production shape: the tenant
+// with the Discord connection lives on the SECOND endpoint. Listing only the
+// first returns nothing and the bot never connects.
+func TestListAllMergesAcrossShards(t *testing.T) {
+	b := &background{
+		shards: []*vwShard{
+			shardWith(t, "https://root/vw", connectionObj("rootcluster", "other-conn")),
+			shardWith(t, "https://alpha/vw", connectionObj("tenantcluster", "discordia-kedge")),
+		},
+	}
+
+	items, err := b.listAll(t.Context(), agentsclient.ConnectionGVR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for i := range items {
+		names[items[i].GetName()] = true
+	}
+	if !names["discordia-kedge"] || !names["other-conn"] {
+		t.Fatalf("want connections from both shards, got %v", names)
+	}
+
+	// The merge must also record where each tenant lives, so the write path
+	// (scoped) addresses the shard that actually serves it.
+	if got := b.clusterShard["tenantcluster"]; got != "https://alpha/vw" {
+		t.Errorf("tenantcluster should map to the alpha endpoint, got %q", got)
+	}
+	if got := b.clusterShard["rootcluster"]; got != "https://root/vw" {
+		t.Errorf("rootcluster should map to the root endpoint, got %q", got)
+	}
+}
+
+// brokenShard is a shard whose VW endpoint errors on every list (unreachable
+// shard, expired credential).
+func brokenShard(t *testing.T, url string) *vwShard {
+	t.Helper()
+	s := shardWith(t, url)
+	s.wildcard.(*dynamicfake.FakeDynamicClient).PrependReactor("list", "connections",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("shard unreachable")
+		})
+	return s
+}
+
+// TestListAllToleratesOneBadShard: one unhealthy shard must not stall the
+// tenants on the healthy ones.
+func TestListAllToleratesOneBadShard(t *testing.T) {
+	b := &background{
+		shards: []*vwShard{
+			brokenShard(t, "https://broken/vw"),
+			shardWith(t, "https://alpha/vw", connectionObj("tenantcluster", "discordia-kedge")),
+		},
+	}
+
+	items, err := b.listAll(t.Context(), agentsclient.ConnectionGVR)
+	if err != nil {
+		t.Fatalf("a single failing shard must not fail the whole list: %v", err)
+	}
+	if len(items) != 1 || items[0].GetName() != "discordia-kedge" {
+		t.Fatalf("want the healthy shard's connection, got %v", items)
+	}
+}
+
+// TestListAllFailsWhenEveryShardFails distinguishes a total outage from an
+// empty-but-healthy result, which would otherwise look the same.
+func TestListAllFailsWhenEveryShardFails(t *testing.T) {
+	b := &background{shards: []*vwShard{brokenShard(t, "https://a/vw"), brokenShard(t, "https://b/vw")}}
+	if _, err := b.listAll(t.Context(), agentsclient.ConnectionGVR); err == nil {
+		t.Fatal("want an error when every shard fails")
+	}
+}
+
+func TestListAllWithoutShards(t *testing.T) {
+	b := &background{}
+	if _, err := b.listAll(t.Context(), agentsclient.ConnectionGVR); err == nil {
+		t.Fatal("want an error before any endpoint is discovered")
+	}
+	if b.ready() {
+		t.Error("ready() must be false before any endpoint is discovered")
+	}
+}
+
+// TestShardForUsesCache: once a list has placed a cluster, scoped() must
+// address that shard rather than probing or defaulting to the first.
+func TestShardForUsesCache(t *testing.T) {
+	b := &background{
+		shards:       []*vwShard{{url: "https://root/vw"}, {url: "https://alpha/vw"}},
+		clusterShard: map[string]string{"tenantcluster": "https://alpha/vw"},
+	}
+	got, err := b.shardFor(t.Context(), "tenantcluster")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://alpha/vw" {
+		t.Fatalf("want the cached alpha endpoint, got %q", got)
+	}
+}
+
+// TestShardForSingleShard: with one endpoint there is nothing to resolve, so an
+// unseen cluster must not pay for a probe.
+func TestShardForSingleShard(t *testing.T) {
+	b := &background{shards: []*vwShard{{url: "https://only/vw"}}}
+	got, err := b.shardFor(t.Context(), "never-listed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://only/vw" {
+		t.Fatalf("want the only endpoint, got %q", got)
+	}
+}
+
+func TestShardForNoShards(t *testing.T) {
+	b := &background{}
+	if _, err := b.shardFor(t.Context(), "c"); err == nil || !strings.Contains(err.Error(), "no APIExport") {
+		t.Fatalf("want a clear not-discovered-yet error, got %v", err)
+	}
+}
+
+// TestRememberClusterIsConcurrencySafe: the poll loop rewrites the map while
+// webhook and gateway callbacks read it.
+func TestRememberClusterIsConcurrencySafe(t *testing.T) {
+	b := &background{shards: []*vwShard{{url: "https://a/vw"}}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 200 {
+			b.rememberCluster("c"+string(rune('a'+i%26)), "https://a/vw")
+		}
+	}()
+	for range 200 {
+		_, _ = b.shardFor(t.Context(), "cq")
+		b.ready()
+	}
+	<-done
+}

--- a/providers/agents/api/channels_inbound.go
+++ b/providers/agents/api/channels_inbound.go
@@ -49,7 +49,7 @@ func channelWebhookName(conn string) string { return "channel/" + conn }
 func (s *Server) webhookChannel(w http.ResponseWriter, r *http.Request) {
 	cluster, name, token := r.PathValue("cluster"), r.PathValue("name"), r.PathValue("token")
 	expected := s.webhookToken(cluster, channelWebhookName(name))
-	if expected == "" || s.bg == nil || s.bg.wildcard == nil {
+	if expected == "" || s.bg == nil || !s.bg.ready() {
 		writeStatus(w, http.StatusServiceUnavailable, "Unavailable", "background executor is not running on this provider")
 		return
 	}
@@ -57,7 +57,7 @@ func (s *Server) webhookChannel(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusForbidden, "Forbidden", "invalid webhook token")
 		return
 	}
-	dyn, err := s.bg.scoped(cluster)
+	dyn, err := s.bg.scoped(r.Context(), cluster)
 	if err != nil {
 		writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())
 		return

--- a/providers/agents/api/discord_gateway.go
+++ b/providers/agents/api/discord_gateway.go
@@ -64,26 +64,34 @@ func tokenFingerprint(tok string) string {
 // tick, so bots connect within one poll interval of being created and
 // disconnect when their connection (or token) is removed.
 func (m *discordManager) reconcile(ctx context.Context) {
-	list, err := m.bg.wildcard.Resource(agentsclient.ConnectionGVR).List(ctx, metav1.ListOptions{})
+	// Across every shard: a connection on a shard we did not list is a bot that
+	// never comes online, with no error anywhere to say so.
+	items, err := m.bg.listAll(ctx, agentsclient.ConnectionGVR)
 	if err != nil {
+		log.Printf("discord: listing connections: %v", err)
 		return
 	}
 	desired := map[string]string{} // key -> bot token
-	for i := range list.Items {
-		conn, err := fromU[agentsv1alpha1.Connection](&list.Items[i])
+	for i := range items {
+		conn, err := fromU[agentsv1alpha1.Connection](&items[i])
 		if err != nil || conn.Spec.Type != agentsv1alpha1.ConnectionTypeDiscord {
 			continue
 		}
-		cluster := list.Items[i].GetAnnotations()["kcp.io/cluster"]
+		cluster := items[i].GetAnnotations()["kcp.io/cluster"]
 		if cluster == "" {
 			continue
 		}
-		dyn, err := m.bg.scoped(cluster)
+		dyn, err := m.bg.scoped(ctx, cluster)
 		if err != nil {
+			log.Printf("discord: connection %s/%s: addressing its workspace: %v", cluster, conn.Name, err)
 			continue
 		}
+		// Report rather than swallow: without this a connection whose Secret is
+		// missing or unreadable through the permission claim looks identical to
+		// a healthy webhook-only one — the bot simply never appears.
 		sec, err := (vwSecrets{dyn}).GetSecret(ctx, llm.SecretNamespace, connectionSecretName(conn.Name))
 		if err != nil {
+			log.Printf("discord: connection %s/%s: reading its credential Secret: %v", cluster, conn.Name, err)
 			continue
 		}
 		token := strings.TrimSpace(string(sec.Data["token"]))
@@ -160,7 +168,7 @@ func (m *discordManager) makeHandler(cluster, connName string) func(*discordgo.S
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		dyn, err := m.bg.scoped(cluster)
+		dyn, err := m.bg.scoped(ctx, cluster)
 		if err != nil {
 			return
 		}

--- a/providers/agents/api/oauth.go
+++ b/providers/agents/api/oauth.go
@@ -221,7 +221,7 @@ func (s *Server) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 // stores tokens in the connection Secret via the virtual workspace (this
 // route is anonymous — the signed state is the auth).
 func (s *Server) oauthCallback(w http.ResponseWriter, r *http.Request) {
-	if s.bg == nil || s.bg.vwURL == "" {
+	if s.bg == nil || !s.bg.ready() {
 		http.Error(w, "background executor is not running on this provider", http.StatusServiceUnavailable)
 		return
 	}
@@ -235,7 +235,7 @@ func (s *Server) oauthCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing code", http.StatusBadRequest)
 		return
 	}
-	dyn, err := s.bg.scoped(st.Cluster)
+	dyn, err := s.bg.scoped(r.Context(), st.Cluster)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -415,18 +415,18 @@ func updateSecretKeys(ctx context.Context, dyn dynamic.Interface, name string, u
 // background tick). Only connections with a refresh_token and an expiry within
 // the horizon are touched.
 func (b *background) refreshOAuthTokens(ctx context.Context) {
-	list, err := b.wildcard.Resource(agentsclient.ConnectionGVR).List(ctx, metav1.ListOptions{})
+	items, err := b.listAll(ctx, agentsclient.ConnectionGVR)
 	if err != nil {
 		return
 	}
-	for i := range list.Items {
-		item := &list.Items[i]
+	for i := range items {
+		item := &items[i]
 		conn, err := fromU[agentsv1alpha1.Connection](item)
 		if err != nil || conn.Spec.Auth != "oauth" || conn.Spec.OAuth == nil {
 			continue
 		}
 		cluster := item.GetAnnotations()["kcp.io/cluster"]
-		dyn, err := b.scoped(cluster)
+		dyn, err := b.scoped(ctx, cluster)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## The bug

An `APIExportEndpointSlice` publishes **one endpoint per kcp shard**, and each endpoint serves only the tenant workspaces bound on *that* shard. The background executor read `endpoints[0]` and bound a single wildcard client to it — so every tenant on any other shard was invisible, and invisible *silently*, because a wildcard list against the wrong shard returns an empty list rather than an error.

For those tenants nothing autonomous ran at all: no schedules, no heartbeats, no trigger or channel webhooks, no OAuth token refresh, and no Discord gateway. Which endpoint wins is just slice order, so this also isn't stable across restarts.

Found while debugging "Discord can send but not receive" on the dev hub. Verified against the live two-shard cluster with the provider's own credentials:

| VW endpoint | connections visible |
|---|---|
| root shard (the one the provider dialed) | **0** |
| alpha shard (where the tenant lives) | **4**, including the Discord connection |

Outbound kept working the whole time because `notify` and the portal's test-send run on the per-request tenant client with the *user's* token, which addresses the workspace by cluster ID regardless of shard. That split is exactly what made it look like a Discord-specific problem rather than a dead background executor.

## The fix

Hold one wildcard client per endpoint instead of one overall:

- **`ensureVW`** builds a shard set from *all* endpoint URLs (trimmed, de-duplicated), reusing existing clients across polls and dropping `cluster→shard` cache entries for endpoints that disappear.
- **`listAll`** merges a resource across every shard and records which shard owns each tenant cluster. A failing shard is logged and skipped so its outage can't stall healthy shards; the call fails only when *every* shard fails — which keeps a total outage distinguishable from a legitimately empty result.
- **`scoped`** resolves the owning shard through `shardFor`: cache first, else probe each endpoint. The probe is needed because trigger webhooks, channel webhooks, and OAuth callbacks can name a cluster before any list has surfaced it. Verified against the live hub that the probe discriminates: the wrong shard answers **403**, the owner **200**.

Also stops swallowing two errors in the Discord reconcile — a connection whose workspace can't be addressed, or whose credential Secret can't be read through the permission claim, now logs instead of looking identical to a healthy webhook-only connection. That silence is why the original failure produced no log line at all.

## Testing

New `background_shards_test.go` covers the regression directly: a two-shard slice must yield both URLs; `listAll` merges across shards and maps each tenant to its owning endpoint (modelled on the real layout, with the Discord connection on the *second* shard); one bad shard degrades but doesn't fail; all-bad does fail; `shardFor` prefers cache, short-circuits single-shard, and errors clearly before discovery. Concurrency test covers the poll loop rewriting the map while handlers read it.

Full module `go build` / `go vet` / `go test ./... -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)