### PR TITLE
feat(agents): full agent configuration over MCP, not just settings

### DIFF
--- a/docs/agents-provider-architecture.md
+++ b/docs/agents-provider-architecture.md
@@ -90,9 +90,10 @@ and tools are edited inside the agent, next to a live chat playground.
 - **Tool loop** — agents call tools mid-conversation via a real tool-call loop
   in the engine (bind → call → observe → continue, bounded by
   `limits.maxToolTurns`, default 16). Families shipped:
-  - `core`: `memory_save/list`, `schedule_create` (cron/wakeup — agents
-    schedule *themselves*), `schedules_list`, `notify`, `ask` (posts a question
-    to the inbox + channel).
+  - `core`: `memory_save/list`, `schedule_create`/`schedule_update`/
+    `schedule_delete`/`schedules_list` (cron/wakeup — agents schedule and
+    re-schedule *themselves*; update/delete are scoped to the calling agent's
+    own schedules), `notify`, `ask` (posts a question to the inbox + channel).
   - `web`: `web_fetch` (SSRF-guarded at dial time — blocks private/loopback,
     defeats DNS rebinding) and `web_search`, backed by a `websearch`
     Connection speaking either a **self-hosted SearXNG instance** (no API key —
@@ -157,11 +158,31 @@ and tools are edited inside the agent, next to a live chat playground.
   calling user. Interactive runs only (background runs have no user token).
 - **Own MCP surface** — the provider serves `/mcp` (streamable HTTP,
   stateless, per-request identity), which the hub aggregate federates as
-  `agents__*` tools: `list_agents`/`get_agent`/`update_agent` (settings
-  read/edit sharing the REST `applyAgentUpdate` path) plus read-only
-  `list_model_credentials`/`list_connections`/`list_toolsets`/
-  `list_schedules`. This is how an agent — or any MCP client on the
-  aggregate — edits agent settings without the portal.
+  `agents__*` tools. It covers the **whole configuration surface** — whatever
+  the portal's settings screens can do, an MCP client can do:
+
+  | Resource | Tools |
+  | --- | --- |
+  | Agents | `list_agents`, `get_agent`, `create_agent`, `update_agent`, `delete_agent` |
+  | Schedules | `list_schedules`, `create_schedule`, `update_schedule`, `delete_schedule`, `run_schedule` |
+  | Triggers | `list_triggers`, `create_trigger`, `update_trigger`, `delete_trigger`, `run_trigger` |
+  | Toolsets | `list_toolsets`, `create_toolset`, `update_toolset`, `delete_toolset` |
+  | Connections | `list_connections`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` |
+  | Model credentials | `list_model_credentials`, `save_model_credential`, `delete_model_credential`, `test_model_credential` |
+  | Discovery | `list_tool_families` |
+
+  Every mutating tool delegates to the same `apply*` helper as the REST
+  handler (`applyAgentUpdate`, `applyScheduleCreate`/`Update`,
+  `applyTriggerCreate`/`Update`, `applyToolsetCreate`/`Update`,
+  `applyConnectionCreate`/`Update`, `applyCredentialUpsert`), so a change made
+  over MCP is indistinguishable from the same change made in the portal:
+  absent fields are untouched, list fields replace wholesale. Secrets are
+  write-only on every tool — tokens and API keys can be set or rotated, never
+  read back. Two things deliberately stay portal-only: the **OAuth Connect
+  flow** (it needs a browser) and **resolving approval requests** (an agent
+  must not be able to approve its own gated tool call). This is how an agent —
+  or any MCP client on the aggregate — configures the whole system without the
+  portal.
 
 ### Priority 0 — validate before building more
 

--- a/providers/agents/api/agents.go
+++ b/providers/agents/api/agents.go
@@ -200,10 +200,20 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
 	}
+	out, err := s.applyAgentCreate(r.Context(), c, &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// applyAgentCreate validates the request and creates the agent. Shared by the
+// REST handler and the MCP create_agent tool.
+func (s *Server) applyAgentCreate(ctx context.Context, c *agentsclient.Client, req *createAgentRequest) (*agentsv1alpha1.Agent, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "name is required")
-		return
+		return nil, errBadRequest("name is required")
 	}
 	if strings.TrimSpace(req.DisplayName) == "" {
 		req.DisplayName = req.Name
@@ -229,21 +239,14 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	if len(req.Channels) > 0 {
 		chans, err := normalizeChannels(req.Channels)
 		if err != nil {
-			writeStatus(w, http.StatusBadRequest, "BadRequest", err.Error())
-			return
+			return nil, errBadRequest(err.Error())
 		}
-		if err := s.validateChannelUniqueness(r.Context(), c, req.Name, chans); err != nil {
-			writeStatus(w, http.StatusConflict, "Conflict", err.Error())
-			return
+		if err := s.validateChannelUniqueness(ctx, c, req.Name, chans); err != nil {
+			return nil, errConflict(err.Error())
 		}
 		a.Spec.Channels = chans
 	}
-	out, err := c.Agents().Create(r.Context(), a, metav1.CreateOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusCreated, out)
+	return c.Agents().Create(ctx, a, metav1.CreateOptions{})
 }
 
 // knownToolFamilies are the grantable built-in families (core is always on).

--- a/providers/agents/api/connections.go
+++ b/providers/agents/api/connections.go
@@ -9,6 +9,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -18,6 +19,7 @@ import (
 
 	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
 	"github.com/faroshq/provider-agents/channels"
+	agentsclient "github.com/faroshq/provider-agents/client"
 	"github.com/faroshq/provider-agents/llm"
 )
 
@@ -66,11 +68,22 @@ func (s *Server) createConnection(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
 	}
+	out, err := s.applyConnectionCreate(r.Context(), c, &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// applyConnectionCreate writes the credential Secret and creates the
+// Connection. Shared by the REST handler and the MCP create_connection tool.
+// The pasted secret is write-only — it is never read back on any surface.
+func (s *Server) applyConnectionCreate(ctx context.Context, c *agentsclient.Client, req *createConnectionRequest) (*agentsv1alpha1.Connection, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	req.Type = strings.TrimSpace(req.Type)
 	if req.Name == "" || req.Type == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "name and type are required")
-		return
+		return nil, errBadRequest("name and type are required")
 	}
 	switch req.Type {
 	case agentsv1alpha1.ConnectionTypeGitHub, agentsv1alpha1.ConnectionTypeMCP,
@@ -79,8 +92,7 @@ func (s *Server) createConnection(w http.ResponseWriter, r *http.Request) {
 		agentsv1alpha1.ConnectionTypeTelegram, agentsv1alpha1.ConnectionTypeSlack,
 		agentsv1alpha1.ConnectionTypeSMTP, agentsv1alpha1.ConnectionTypeDiscord:
 	default:
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "unsupported connection type "+req.Type)
-		return
+		return nil, errBadRequest("unsupported connection type " + req.Type)
 	}
 
 	secretRef := connectionSecretName(req.Name)
@@ -106,8 +118,7 @@ func (s *Server) createConnection(w http.ResponseWriter, r *http.Request) {
 			// Allowed when the operator configured a platform OAuth app for this
 			// provider (mirrors the code provider's env-configured app).
 			if !platformApp {
-				writeStatus(w, http.StatusBadRequest, "BadRequest", "oauth connections need clientID and clientSecret, or a platform OAuth app configured for "+provider)
-				return
+				return nil, errBadRequest("oauth connections need clientID and clientSecret, or a platform OAuth app configured for " + provider)
 			}
 		} else {
 			secretData["client_id"] = strings.TrimSpace(req.ClientID)
@@ -121,9 +132,8 @@ func (s *Server) createConnection(w http.ResponseWriter, r *http.Request) {
 			Type:       corev1.SecretTypeOpaque,
 			StringData: secretData,
 		}
-		if _, err := c.ApplySecret(r.Context(), sec); err != nil {
-			writeResourceError(w, err)
-			return
+		if _, err := c.ApplySecret(ctx, sec); err != nil {
+			return nil, err
 		}
 	}
 
@@ -145,17 +155,11 @@ func (s *Server) createConnection(w http.ResponseWriter, r *http.Request) {
 			provider = "github"
 		}
 		if provider == "" {
-			writeStatus(w, http.StatusBadRequest, "BadRequest", "oauthProvider is required (github, google, or slack)")
-			return
+			return nil, errBadRequest("oauthProvider is required (github, google, or slack)")
 		}
 		conn.Spec.OAuth = &agentsv1alpha1.ConnectionOAuth{Provider: provider, Scopes: req.OAuthScopes}
 	}
-	out, err := c.Connections().Create(r.Context(), conn, metav1.CreateOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusCreated, out)
+	return c.Connections().Create(ctx, conn, metav1.CreateOptions{})
 }
 
 // updateConnectionRequest patches an existing connection. Pointer fields mean
@@ -174,16 +178,27 @@ func (s *Server) updateConnection(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	name := r.PathValue("name")
-	conn, err := c.Connections().Get(r.Context(), name, metav1.GetOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
 	var req updateConnectionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
+	}
+	out, err := applyConnectionUpdate(r.Context(), c, r.PathValue("name"), &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// applyConnectionUpdate patches the connection and, when a new secret is given,
+// rotates the credential in place. Shared by the REST handler and the MCP
+// update_connection tool.
+func applyConnectionUpdate(ctx context.Context, c *agentsclient.Client, name string, req *updateConnectionRequest) (*agentsv1alpha1.Connection, error) {
+	name = strings.TrimSpace(name)
+	conn, err := c.Connections().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
 	}
 	if req.DisplayName != nil {
 		conn.Spec.DisplayName = strings.TrimSpace(*req.DisplayName)
@@ -197,16 +212,15 @@ func (s *Server) updateConnection(w http.ResponseWriter, r *http.Request) {
 	if req.Config != nil {
 		conn.Spec.Config = *req.Config
 	}
-	out, err := c.Connections().Update(r.Context(), conn, metav1.UpdateOptions{})
+	out, err := c.Connections().Update(ctx, conn, metav1.UpdateOptions{})
 	if err != nil {
-		writeResourceError(w, err)
-		return
+		return nil, err
 	}
 	// Rotate the token when a new secret is provided, preserving any other keys
 	// already in the Secret (e.g. OAuth client_id/client_secret).
 	if req.Secret != nil && strings.TrimSpace(*req.Secret) != "" {
 		data := map[string]string{"token": strings.TrimSpace(*req.Secret)}
-		if existing, gerr := c.GetSecret(r.Context(), llm.SecretNamespace, connectionSecretName(name)); gerr == nil {
+		if existing, gerr := c.GetSecret(ctx, llm.SecretNamespace, connectionSecretName(name)); gerr == nil {
 			for k, v := range existing.Data {
 				if k != "token" {
 					data[k] = string(v)
@@ -219,12 +233,11 @@ func (s *Server) updateConnection(w http.ResponseWriter, r *http.Request) {
 			Type:       corev1.SecretTypeOpaque,
 			StringData: data,
 		}
-		if _, serr := c.ApplySecret(r.Context(), sec); serr != nil {
-			writeResourceError(w, serr)
-			return
+		if _, serr := c.ApplySecret(ctx, sec); serr != nil {
+			return nil, serr
 		}
 	}
-	writeJSON(w, http.StatusOK, out)
+	return out, nil
 }
 
 // testConnection sends a test message through a messaging connection
@@ -234,36 +247,44 @@ func (s *Server) testConnection(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	name := r.PathValue("name")
-	conn, err := c.Connections().Get(r.Context(), name, metav1.GetOptions{})
-	if err != nil {
-		writeResourceError(w, err)
+	if err := sendConnectionTest(r.Context(), c, r.PathValue("name")); err != nil {
+		writeUpdateError(w, err)
 		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+}
+
+// sendConnectionTest delivers a test message through a messaging connection so
+// the user can verify the credential works. Shared by the REST handler and the
+// MCP test_connection tool.
+func sendConnectionTest(ctx context.Context, c *agentsclient.Client, name string) error {
+	name = strings.TrimSpace(name)
+	conn, err := c.Connections().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
 	}
 	switch conn.Spec.Type {
 	case agentsv1alpha1.ConnectionTypeTelegram, agentsv1alpha1.ConnectionTypeSlack,
 		agentsv1alpha1.ConnectionTypeSMTP, agentsv1alpha1.ConnectionTypeDiscord:
 	default:
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "test send is only for messaging connections (telegram, slack, smtp, discord)")
-		return
+		return errBadRequest("test send is only for messaging connections (telegram, slack, smtp, discord)")
 	}
 	token := ""
-	if sec, serr := c.GetSecret(r.Context(), llm.SecretNamespace, connectionSecretName(name)); serr == nil {
+	if sec, serr := c.GetSecret(ctx, llm.SecretNamespace, connectionSecretName(name)); serr == nil {
 		if v, okk := sec.Data["token"]; okk {
 			token = string(v)
 		}
 	}
-	if err := channels.Send(r.Context(), channels.Message{
+	if err := channels.Send(ctx, channels.Message{
 		Type:   conn.Spec.Type,
 		Token:  token,
 		Target: conn.Spec.Channel,
 		Config: conn.Spec.Config,
 		Text:   "✅ Test message from your kedge agents — this connection works.",
 	}); err != nil {
-		writeStatus(w, http.StatusBadGateway, "SendFailed", err.Error())
-		return
+		return &requestError{http.StatusBadGateway, "SendFailed", err.Error()}
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+	return nil
 }
 
 func (s *Server) deleteConnection(w http.ResponseWriter, r *http.Request) {
@@ -271,12 +292,21 @@ func (s *Server) deleteConnection(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	name := r.PathValue("name")
-	if err := c.Connections().Delete(r.Context(), name, metav1.DeleteOptions{}); err != nil {
-		writeResourceError(w, err)
+	if err := deleteConnectionAndSecret(r.Context(), c, r.PathValue("name")); err != nil {
+		writeUpdateError(w, err)
 		return
 	}
-	// Best-effort delete of the credential Secret.
-	_ = c.DeleteSecret(r.Context(), llm.SecretNamespace, connectionSecretName(name))
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteConnectionAndSecret removes the Connection and, best-effort, its
+// credential Secret. Shared by the REST handler and the MCP delete_connection
+// tool so a credential is never orphaned by one surface.
+func deleteConnectionAndSecret(ctx context.Context, c *agentsclient.Client, name string) error {
+	name = strings.TrimSpace(name)
+	if err := c.Connections().Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	_ = c.DeleteSecret(ctx, llm.SecretNamespace, connectionSecretName(name))
+	return nil
 }

--- a/providers/agents/api/mcp.go
+++ b/providers/agents/api/mcp.go
@@ -45,16 +45,25 @@ func (s *Server) MCPHandler() http.Handler {
 				Version: "0.1.0",
 				Title:   "kedge agents provider",
 			}, &mcp.ServerOptions{
-				Instructions: "This MCP endpoint manages the AI agents hosted in your kedge " +
-					"tenant workspace: their settings (system prompt, model credential, " +
-					"autonomy, tool grants, channels, budgets, limits) plus the schedules, " +
-					"connections, toolsets, and model credentials they reference. Use " +
-					"list_agents / get_agent to inspect configuration and update_agent to " +
-					"change it — only the fields you pass change, list fields replace " +
-					"wholesale. Names for modelCredential, connections, and toolsets must " +
-					"come from the corresponding list_* tool. Tenant identity is taken from " +
-					"your bearer token — never ask the user for a tenant path. Creating " +
-					"agents and pasting credentials stay in the portal.",
+				Instructions: "This MCP endpoint is the full configuration surface for the AI " +
+					"agents hosted in your kedge tenant workspace — everything the portal's " +
+					"settings screens can do. Agents: list_agents / get_agent / create_agent / " +
+					"update_agent / delete_agent (settings, prompts, autonomy, tool grants, " +
+					"channels, budgets, limits). Schedules: list_schedules / create_schedule / " +
+					"update_schedule / delete_schedule / run_schedule. Triggers: list_triggers / " +
+					"create_trigger / update_trigger / delete_trigger / run_trigger. Toolsets, " +
+					"connections, and model credentials each have list + create/update + delete, " +
+					"plus test_connection and test_model_credential. list_tool_families explains " +
+					"the grantable families. Two rules govern every update tool: only the fields " +
+					"you pass change, and list fields replace the stored list wholesale — so read " +
+					"the resource first when appending. Prefer updating over delete-and-recreate; " +
+					"to stop something temporarily use suspend=true. Names referenced by one " +
+					"resource (modelCredential, connections, toolsets, agentRef) must come from " +
+					"the corresponding list_* tool. Secrets are write-only: tokens and API keys " +
+					"can be set or rotated, never read back. Tenant identity is taken from your " +
+					"bearer token — never ask the user for a tenant path. Two things stay in the " +
+					"portal: the OAuth Connect flow (it needs a browser) and resolving approval " +
+					"requests.",
 			})
 			s.registerMCPTools(srv, r)
 			return srv
@@ -206,22 +215,66 @@ type listToolsetsOutput struct {
 }
 
 type scheduleSummary struct {
-	Name     string `json:"name"`
-	AgentRef string `json:"agentRef"`
-	Type     string `json:"type"`
-	Schedule string `json:"schedule,omitempty"`
-	TimeZone string `json:"timeZone,omitempty"`
-	Task     string `json:"task,omitempty"`
-	Suspend  bool   `json:"suspend,omitempty"`
-	NextRun  string `json:"nextRun,omitempty"`
-	LastRun  string `json:"lastRun,omitempty"`
+	Name       string `json:"name"`
+	AgentRef   string `json:"agentRef"`
+	Type       string `json:"type"`
+	Schedule   string `json:"schedule,omitempty"`
+	TimeZone   string `json:"timeZone,omitempty"`
+	RunAt      string `json:"runAt,omitempty"`
+	Task       string `json:"task,omitempty"`
+	Checklist  string `json:"checklist,omitempty"`
+	ChannelRef string `json:"channelRef,omitempty"`
+	// Suspend has no omitempty: an update that resumes a schedule must show
+	// suspend=false rather than silently dropping the field.
+	Suspend bool   `json:"suspend"`
+	NextRun string `json:"nextRun,omitempty"`
+	LastRun string `json:"lastRun,omitempty"`
 }
 
 type listSchedulesOutput struct {
 	Schedules []scheduleSummary `json:"schedules"`
 }
 
+// createScheduleInput mirrors createScheduleRequest.
+type createScheduleInput struct {
+	Name       string `json:"name" jsonschema:"Lowercase schedule name, e.g. daily-news"`
+	AgentRef   string `json:"agentRef" jsonschema:"Name of the agent this schedule runs (see list_agents)"`
+	Type       string `json:"type" jsonschema:"cron (recurring), wakeup (one-shot), or heartbeat (recurring checklist)"`
+	Schedule   string `json:"schedule,omitempty" jsonschema:"5-field cron expression for cron/heartbeat types, e.g. 0 9 * * *"`
+	TimeZone   string `json:"timeZone,omitempty" jsonschema:"IANA time zone the cron is evaluated in, e.g. Europe/Vilnius; empty means UTC"`
+	RunAt      string `json:"runAt,omitempty" jsonschema:"RFC3339 fire time for wakeup type, e.g. 2026-08-02T09:00:00Z"`
+	Task       string `json:"task,omitempty" jsonschema:"The prompt the agent runs when the schedule fires (cron/wakeup)"`
+	Checklist  string `json:"checklist,omitempty" jsonschema:"Standing markdown checklist reviewed on each pulse (heartbeat type)"`
+	Suspend    bool   `json:"suspend,omitempty" jsonschema:"Create the schedule paused"`
+	ChannelRef string `json:"channelRef,omitempty" jsonschema:"Agent channel name this schedule's output is delivered to; empty means the primary channel"`
+}
+
+// updateScheduleInput mirrors updateScheduleRequest: only fields present in the
+// call are applied.
+type updateScheduleInput struct {
+	Name       string  `json:"name" jsonschema:"Name of the schedule to update (see list_schedules)"`
+	Schedule   *string `json:"schedule,omitempty" jsonschema:"New 5-field cron expression, e.g. 0 9 * * * for daily at 09:00"`
+	TimeZone   *string `json:"timeZone,omitempty" jsonschema:"New IANA time zone; empty string means UTC"`
+	RunAt      *string `json:"runAt,omitempty" jsonschema:"New RFC3339 fire time for wakeup schedules; empty string clears it"`
+	Task       *string `json:"task,omitempty" jsonschema:"New prompt to run when the schedule fires"`
+	Checklist  *string `json:"checklist,omitempty" jsonschema:"New standing checklist for heartbeat schedules"`
+	Suspend    *bool   `json:"suspend,omitempty" jsonschema:"true pauses the schedule without deleting it, false resumes it"`
+	ChannelRef *string `json:"channelRef,omitempty" jsonschema:"Agent channel name for this schedule's output; empty string means the primary channel"`
+}
+
+type deleteScheduleInput struct {
+	Name string `json:"name" jsonschema:"Name of the schedule to delete"`
+}
+
+type deleteScheduleOutput struct {
+	Deleted string `json:"deleted"`
+}
+
 func (s *Server) registerMCPTools(srv *mcp.Server, r *http.Request) {
+	// The rest of the configuration surface (triggers, toolsets, connections,
+	// credentials, agent lifecycle, discovery) lives in mcp_config.go.
+	s.registerConfigMCPTools(srv, r)
+
 	yes := true
 	no := false
 	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: &yes}
@@ -416,24 +469,95 @@ func (s *Server) registerMCPTools(srv *mcp.Server, r *http.Request) {
 		}
 		out := listSchedulesOutput{Schedules: make([]scheduleSummary, 0, len(list.Items))}
 		for i := range list.Items {
-			sch := &list.Items[i]
-			row := scheduleSummary{
-				Name:     sch.Name,
-				AgentRef: sch.Spec.AgentRef,
-				Type:     sch.Spec.Type,
-				Schedule: sch.Spec.Schedule,
-				TimeZone: sch.Spec.TimeZone,
-				Task:     sch.Spec.Task,
-				Suspend:  sch.Spec.Suspend,
-			}
-			if sch.Status.NextRun != nil {
-				row.NextRun = sch.Status.NextRun.UTC().Format("2006-01-02T15:04:05Z")
-			}
-			if sch.Status.LastRun != nil {
-				row.LastRun = sch.Status.LastRun.UTC().Format("2006-01-02T15:04:05Z")
-			}
-			out.Schedules = append(out.Schedules, row)
+			out.Schedules = append(out.Schedules, scheduleView(&list.Items[i]))
 		}
 		return nil, out, nil
 	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "create_schedule",
+		Title: "Create a schedule",
+		Description: "Create a schedule that runs an agent autonomously: a recurring cron task, a one-shot wakeup at a given time, or a recurring heartbeat checklist. " +
+			"Names must be unique — to retime or edit an existing schedule use update_schedule, not this tool.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createScheduleInput) (*mcp.CallToolResult, scheduleSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, scheduleSummary{}, err
+		}
+		req := createScheduleRequest{
+			Name: in.Name, AgentRef: in.AgentRef, Type: in.Type,
+			Schedule: in.Schedule, TimeZone: in.TimeZone, RunAt: in.RunAt,
+			Task: in.Task, Checklist: in.Checklist, Suspend: in.Suspend, ChannelRef: in.ChannelRef,
+		}
+		sch, err := applyScheduleCreate(ctx, c, &req)
+		if err != nil {
+			return nil, scheduleSummary{}, err
+		}
+		return nil, scheduleView(sch), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "update_schedule",
+		Title: "Update a schedule",
+		Description: "Retime or edit an existing schedule in place: change its cron expression or time zone, rewrite its task, move a wakeup, or pause/resume it with suspend. " +
+			"Only the fields you pass change. Use this instead of deleting and recreating.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in updateScheduleInput) (*mcp.CallToolResult, scheduleSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, scheduleSummary{}, err
+		}
+		req := updateScheduleRequest{
+			Schedule: in.Schedule, TimeZone: in.TimeZone, RunAt: in.RunAt,
+			Task: in.Task, Checklist: in.Checklist, Suspend: in.Suspend, ChannelRef: in.ChannelRef,
+		}
+		sch, err := applyScheduleUpdate(ctx, c, in.Name, &req)
+		if err != nil {
+			return nil, scheduleSummary{}, err
+		}
+		return nil, scheduleView(sch), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "delete_schedule",
+		Title:       "Delete a schedule",
+		Description: "Permanently delete a schedule. To stop it temporarily, prefer update_schedule with suspend=true.",
+		Annotations: &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: &yes, OpenWorldHint: &yes},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in deleteScheduleInput) (*mcp.CallToolResult, deleteScheduleOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, deleteScheduleOutput{}, err
+		}
+		name := strings.TrimSpace(in.Name)
+		if err := c.Schedules().Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return nil, deleteScheduleOutput{}, err
+		}
+		return nil, deleteScheduleOutput{Deleted: name}, nil
+	})
+}
+
+// scheduleView is the one row shape every schedule tool returns.
+func scheduleView(sch *agentsv1alpha1.Schedule) scheduleSummary {
+	row := scheduleSummary{
+		Name:       sch.Name,
+		AgentRef:   sch.Spec.AgentRef,
+		Type:       sch.Spec.Type,
+		Schedule:   sch.Spec.Schedule,
+		TimeZone:   sch.Spec.TimeZone,
+		Task:       sch.Spec.Task,
+		Checklist:  sch.Spec.Checklist,
+		ChannelRef: sch.Spec.ChannelRef,
+		Suspend:    sch.Spec.Suspend,
+	}
+	if sch.Spec.RunAt != nil {
+		row.RunAt = sch.Spec.RunAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if sch.Status.NextRun != nil {
+		row.NextRun = sch.Status.NextRun.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if sch.Status.LastRun != nil {
+		row.LastRun = sch.Status.LastRun.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	return row
 }

--- a/providers/agents/api/mcp_config.go
+++ b/providers/agents/api/mcp_config.go
@@ -1,0 +1,688 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package api
+
+// The rest of the MCP configuration surface: everything the portal's settings
+// screens can do, minus the parts that need a browser (OAuth Connect) or that
+// would let an agent widen its own permissions unattended (resolving approvals).
+//
+// Every tool delegates to the same apply* helper the REST handler uses, so a
+// change made here behaves exactly like the same change made in the portal.
+// Secrets are write-only throughout: tokens and API keys can be set or rotated,
+// never read back.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
+	agentsclient "github.com/faroshq/provider-agents/client"
+	"github.com/faroshq/provider-agents/llm"
+)
+
+// mcpIdentity reconstructs the caller identity for tools that touch
+// store-scoped data or mint cluster-scoped URLs. MCP federation forwards the
+// cluster ID in both X-Kedge-Tenant and X-Kedge-Cluster, so the org/workspace
+// UUIDs usually cannot be parsed from the header — they come from the
+// cluster→tenant mapping the portal records on every REST call (the same
+// mapping background execution uses).
+func (s *Server) mcpIdentity(ctx context.Context, r *http.Request) identity {
+	id := identity{
+		tenantPath: strings.TrimSpace(r.Header.Get("X-Kedge-Tenant")),
+		clusterID:  strings.TrimSpace(r.Header.Get("X-Kedge-Cluster")),
+		user:       strings.TrimSpace(r.Header.Get("X-Kedge-User")),
+		token:      bearerToken(r),
+	}
+	id.orgUUID, id.workspaceUUID = parseTenantPath(id.tenantPath)
+	if id.orgUUID == "" || id.workspaceUUID == "" {
+		if ref, ok, _ := s.store.GetTenantRef(ctx, id.clusterID); ok {
+			id.orgUUID, id.workspaceUUID = ref.OrgUUID, ref.WorkspaceUUID
+		}
+	}
+	return id
+}
+
+// --- agents ---
+
+type createAgentInput struct {
+	Name            string         `json:"name" jsonschema:"Lowercase agent name, e.g. research-bot"`
+	DisplayName     string         `json:"displayName,omitempty" jsonschema:"Human-readable name; defaults to name"`
+	Description     string         `json:"description,omitempty" jsonschema:"Short summary of what this agent is for"`
+	SystemPrompt    string         `json:"systemPrompt,omitempty" jsonschema:"The agent's persona and standing instructions"`
+	Autonomy        string         `json:"autonomy,omitempty" jsonschema:"Action posture: suggest (drafts only), ask (approval-gated), or auto"`
+	ModelCredential string         `json:"modelCredential,omitempty" jsonschema:"Named model credential for chat (see list_model_credentials)"`
+	ModelFallbacks  []string       `json:"modelFallbacks,omitempty" jsonschema:"Ordered credential names tried when the primary model fails"`
+	BudgetTokens    int64          `json:"budgetTokens,omitempty" jsonschema:"Token cap per rolling month; 0 means unlimited"`
+	BudgetUSD       string         `json:"budgetUSD,omitempty" jsonschema:"USD spend cap per rolling month as a decimal string; empty means unlimited"`
+	Channels        []channelInput `json:"channels,omitempty" jsonschema:"Messaging channel bindings (name + connectionRef + primary)"`
+}
+
+type nameInput struct {
+	Name string `json:"name" jsonschema:"Resource name"`
+}
+
+type deletedOutput struct {
+	Deleted string `json:"deleted"`
+}
+
+// --- triggers ---
+
+type triggerSummary struct {
+	Name          string            `json:"name"`
+	AgentRef      string            `json:"agentRef"`
+	Source        string            `json:"source"`
+	ConnectionRef string            `json:"connectionRef,omitempty"`
+	Filter        map[string]string `json:"filter,omitempty"`
+	Task          string            `json:"task,omitempty"`
+	ChannelRef    string            `json:"channelRef,omitempty"`
+	Suspend       bool              `json:"suspend"`
+	// WebhookPath is the inbound URL a webhook/github trigger listens on. It
+	// embeds the trigger's shared secret, so treat it as a credential.
+	WebhookPath string `json:"webhookPath,omitempty"`
+	LastFired   string `json:"lastFired,omitempty"`
+}
+
+type listTriggersOutput struct {
+	Triggers []triggerSummary `json:"triggers"`
+}
+
+type createTriggerInput struct {
+	Name          string            `json:"name" jsonschema:"Lowercase trigger name, e.g. deploy-failed"`
+	AgentRef      string            `json:"agentRef" jsonschema:"Name of the agent this trigger runs (see list_agents)"`
+	Source        string            `json:"source" jsonschema:"webhook (any HTTP POST) or github (GitHub webhook deliveries)"`
+	ConnectionRef string            `json:"connectionRef,omitempty" jsonschema:"Connection this trigger is wired to, for sources that need one"`
+	Filter        map[string]string `json:"filter,omitempty" jsonschema:"Key/value conditions the event payload must match, e.g. {\"action\":\"opened\"}"`
+	Task          string            `json:"task,omitempty" jsonschema:"The prompt the agent runs when the trigger fires; the event payload is appended"`
+	Suspend       bool              `json:"suspend,omitempty" jsonschema:"Create the trigger paused"`
+	ChannelRef    string            `json:"channelRef,omitempty" jsonschema:"Agent channel this trigger's output goes to; empty means the primary channel"`
+}
+
+type updateTriggerInput struct {
+	Name          string             `json:"name" jsonschema:"Name of the trigger to update (see list_triggers)"`
+	Task          *string            `json:"task,omitempty" jsonschema:"New prompt to run when the trigger fires"`
+	Source        *string            `json:"source,omitempty" jsonschema:"New source: webhook or github"`
+	ConnectionRef *string            `json:"connectionRef,omitempty" jsonschema:"Rewire the trigger to another connection; empty string unwires it"`
+	Filter        *map[string]string `json:"filter,omitempty" jsonschema:"Replacement filter map; replaces the whole map"`
+	Suspend       *bool              `json:"suspend,omitempty" jsonschema:"true pauses the trigger without deleting it, false resumes it"`
+	ChannelRef    *string            `json:"channelRef,omitempty" jsonschema:"Agent channel for this trigger's output; empty string means the primary channel"`
+}
+
+func triggerView(t *agentsv1alpha1.Trigger) triggerSummary {
+	row := triggerSummary{
+		Name:          t.Name,
+		AgentRef:      t.Spec.AgentRef,
+		Source:        t.Spec.Source,
+		ConnectionRef: t.Spec.ConnectionRef,
+		Filter:        t.Spec.Filter,
+		Task:          t.Spec.Task,
+		ChannelRef:    t.Spec.ChannelRef,
+		Suspend:       t.Spec.Suspend,
+		WebhookPath:   t.Status.WebhookPath,
+	}
+	if t.Status.LastFired != nil {
+		row.LastFired = t.Status.LastFired.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	return row
+}
+
+// --- toolsets / connections / credentials ---
+
+type createToolsetInput struct {
+	Name            string   `json:"name" jsonschema:"Lowercase toolset name, e.g. ops-tools"`
+	DisplayName     string   `json:"displayName,omitempty" jsonschema:"Human-readable name"`
+	Description     string   `json:"description,omitempty" jsonschema:"What this bundle is for"`
+	Families        []string `json:"families,omitempty" jsonschema:"Built-in tool families: core, web, github, mcp, files, edges"`
+	Connections     []string `json:"connections,omitempty" jsonschema:"Connection names whose tools this bundle grants"`
+	RequireApproval []string `json:"requireApproval,omitempty" jsonschema:"Tool-name patterns that must be approved before running; \"*\" gates everything"`
+}
+
+type updateToolsetInput struct {
+	Name            string    `json:"name" jsonschema:"Name of the toolset to update (see list_toolsets)"`
+	DisplayName     *string   `json:"displayName,omitempty" jsonschema:"New human-readable name"`
+	Description     *string   `json:"description,omitempty" jsonschema:"New description"`
+	Families        *[]string `json:"families,omitempty" jsonschema:"Replacement family list; replaces the whole list"`
+	Connections     *[]string `json:"connections,omitempty" jsonschema:"Replacement connection list; replaces the whole list"`
+	RequireApproval *[]string `json:"requireApproval,omitempty" jsonschema:"Replacement approval patterns; replaces the whole list"`
+}
+
+type createConnectionInput struct {
+	Name        string            `json:"name" jsonschema:"Lowercase connection name, e.g. team-telegram"`
+	Type        string            `json:"type" jsonschema:"github, mcp, websearch, edges, http, telegram, slack, smtp, or discord"`
+	DisplayName string            `json:"displayName,omitempty" jsonschema:"Human-readable name"`
+	BaseURL     string            `json:"baseURL,omitempty" jsonschema:"Endpoint URL for mcp/http/websearch connections"`
+	Channel     string            `json:"channel,omitempty" jsonschema:"Delivery target for messaging connections (chat id, channel, address)"`
+	Config      map[string]string `json:"config,omitempty" jsonschema:"Type-specific settings"`
+	Secret      string            `json:"secret,omitempty" jsonschema:"The credential (bot token, PAT, API key). Write-only: stored in a Secret and never returned"`
+}
+
+type updateConnectionInput struct {
+	Name        string             `json:"name" jsonschema:"Name of the connection to update (see list_connections)"`
+	DisplayName *string            `json:"displayName,omitempty" jsonschema:"New human-readable name"`
+	BaseURL     *string            `json:"baseURL,omitempty" jsonschema:"New endpoint URL"`
+	Channel     *string            `json:"channel,omitempty" jsonschema:"New delivery target"`
+	Config      *map[string]string `json:"config,omitempty" jsonschema:"Replacement config map; replaces the whole map"`
+	Secret      *string            `json:"secret,omitempty" jsonschema:"Rotate the credential. Write-only; omit to keep the current one"`
+}
+
+type saveCredentialInput struct {
+	Name     string `json:"name" jsonschema:"Credential name agents reference, e.g. anthropic-main"`
+	Model    string `json:"model" jsonschema:"Model id served by this endpoint, e.g. claude-sonnet-5"`
+	Provider string `json:"provider,omitempty" jsonschema:"Provider id; defaults to the OpenAI-compatible driver"`
+	BaseURL  string `json:"baseURL,omitempty" jsonschema:"API base URL; empty means the provider default"`
+	APIKey   string `json:"apiKey,omitempty" jsonschema:"The API key. Write-only: stored in a Secret and never returned. Omit to keep the existing key when updating"`
+}
+
+type testResultOutput struct {
+	OK        bool     `json:"ok"`
+	LatencyMS int64    `json:"latencyMS,omitempty"`
+	Error     string   `json:"error,omitempty"`
+	Models    []string `json:"models,omitempty"`
+}
+
+// --- discovery ---
+
+type toolFamilyInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type listToolFamiliesOutput struct {
+	Families []toolFamilyInfo `json:"families"`
+	// Providers are the kedge providers reachable through the hub's aggregate
+	// tool endpoint, which every interactive run gets for free.
+	Providers []string `json:"providers,omitempty"`
+	Note      string   `json:"note,omitempty"`
+}
+
+// toolFamilyDocs describes each grantable family in the terms a caller needs to
+// choose between them.
+var toolFamilyDocs = []toolFamilyInfo{
+	{"core", "Always on: memory, self-scheduling (schedule_create/update/delete), notify, ask, delegate."},
+	{"web", "web_fetch (SSRF-guarded) and web_search; needs a websearch Connection for search."},
+	{"github", "GitHub tools via a github Connection (issues, PRs, code)."},
+	{"mcp", "Tools from any mcp Connection the agent is granted."},
+	{"files", "Read/write files in the agent's workspace."},
+	{"edges", "Kubernetes clusters and SSH servers connected as edges. Interactive runs only."},
+}
+
+// --- run now ---
+
+type runNowOutput struct {
+	RunID string `json:"runID"`
+	// Status explains what to do next: runs are asynchronous.
+	Status string `json:"status"`
+}
+
+// registerConfigMCPTools adds the trigger, toolset, connection, credential,
+// agent-lifecycle, and discovery tools to the MCP server.
+func (s *Server) registerConfigMCPTools(srv *mcp.Server, r *http.Request) {
+	yes := true
+	no := false
+	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true, IdempotentHint: true, OpenWorldHint: &yes}
+	mutating := &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: &no, OpenWorldHint: &yes}
+	destructive := &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: &yes, OpenWorldHint: &yes}
+
+	// --- agents ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "create_agent",
+		Title: "Create an agent",
+		Description: "Create a new agent. Assign its model with modelCredential (from list_model_credentials) and bind messaging channels with channels. " +
+			"Tool grants, limits, and prompts can be set afterwards with update_agent.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createAgentInput) (*mcp.CallToolResult, agentSettings, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, agentSettings{}, err
+		}
+		req := createAgentRequest{
+			Name: in.Name, DisplayName: in.DisplayName, Description: in.Description,
+			SystemPrompt: in.SystemPrompt, Autonomy: in.Autonomy,
+			ModelCredential: in.ModelCredential, ModelFallbacks: in.ModelFallbacks,
+			BudgetTokens: in.BudgetTokens, BudgetUSD: in.BudgetUSD, Channels: in.Channels,
+		}
+		a, err := s.applyAgentCreate(ctx, c, &req)
+		if err != nil {
+			return nil, agentSettings{}, err
+		}
+		return nil, settingsView(a), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "delete_agent",
+		Title:       "Delete an agent",
+		Description: "Permanently delete an agent and its stored conversations, memories, and run history. Schedules and triggers pointing at it stop firing.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, deletedOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, deletedOutput{}, err
+		}
+		name := strings.TrimSpace(in.Name)
+		if err := c.Agents().Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return nil, deletedOutput{}, err
+		}
+		// Best-effort teardown of the agent's store data, exactly as the REST
+		// handler does. Skipped when the workspace scope is unknown, so we never
+		// delete another workspace's rows.
+		if id := s.mcpIdentity(ctx, r); id.workspaceUUID != "" {
+			_ = s.store.DeleteAgentData(ctx, id.scope(name), name)
+		}
+		return nil, deletedOutput{Deleted: name}, nil
+	})
+
+	// --- triggers ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list_triggers",
+		Title:       "List triggers",
+		Description: "List the event triggers that run agents on inbound webhooks or GitHub deliveries, with their filters and inbound URLs.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, listTriggersOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, listTriggersOutput{}, err
+		}
+		list, err := c.Triggers().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, listTriggersOutput{}, err
+		}
+		out := listTriggersOutput{Triggers: make([]triggerSummary, 0, len(list.Items))}
+		for i := range list.Items {
+			out.Triggers = append(out.Triggers, triggerView(&list.Items[i]))
+		}
+		return nil, out, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "create_trigger",
+		Title: "Create a trigger",
+		Description: "Create an event trigger that runs an agent when something arrives: source \"webhook\" for any HTTP POST, \"github\" for GitHub webhook deliveries. " +
+			"The response carries the inbound webhookPath to register with the sender — it embeds a secret, so share it carefully.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createTriggerInput) (*mcp.CallToolResult, triggerSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, triggerSummary{}, err
+		}
+		req := createTriggerRequest{
+			Name: in.Name, AgentRef: in.AgentRef, Source: in.Source,
+			ConnectionRef: in.ConnectionRef, Filter: in.Filter, Task: in.Task,
+			Suspend: in.Suspend, ChannelRef: in.ChannelRef,
+		}
+		t, err := s.applyTriggerCreate(ctx, c, s.mcpIdentity(ctx, r).clusterID, &req)
+		if err != nil {
+			return nil, triggerSummary{}, err
+		}
+		return nil, triggerView(t), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "update_trigger",
+		Title:       "Update a trigger",
+		Description: "Edit an existing trigger in place: rewrite its task, change its filter, rewire its connection, or pause/resume it with suspend. Only the fields you pass change.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in updateTriggerInput) (*mcp.CallToolResult, triggerSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, triggerSummary{}, err
+		}
+		req := updateTriggerRequest{
+			Task: in.Task, Source: in.Source, ConnectionRef: in.ConnectionRef,
+			Filter: in.Filter, Suspend: in.Suspend, ChannelRef: in.ChannelRef,
+		}
+		t, err := s.applyTriggerUpdate(ctx, c, s.mcpIdentity(ctx, r).clusterID, in.Name, &req)
+		if err != nil {
+			return nil, triggerSummary{}, err
+		}
+		return nil, triggerView(t), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "delete_trigger",
+		Title:       "Delete a trigger",
+		Description: "Permanently delete a trigger and invalidate its inbound URL. To stop it temporarily, prefer update_trigger with suspend=true.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, deletedOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, deletedOutput{}, err
+		}
+		name := strings.TrimSpace(in.Name)
+		if err := c.Triggers().Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return nil, deletedOutput{}, err
+		}
+		return nil, deletedOutput{Deleted: name}, nil
+	})
+
+	// --- toolsets ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "create_toolset",
+		Title: "Create a toolset",
+		Description: "Create a shared toolset: a reusable bundle of tool families, connections, and approval rules that agents link with update_agent's " +
+			"interactiveToolsets / backgroundToolsets. Family names come from list_tool_families.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createToolsetInput) (*mcp.CallToolResult, toolsetSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, toolsetSummary{}, err
+		}
+		req := toolsetRequest{
+			Name: in.Name, DisplayName: in.DisplayName, Description: in.Description,
+			Families: in.Families, Connections: in.Connections, RequireApproval: in.RequireApproval,
+		}
+		ts, err := applyToolsetCreate(ctx, c, &req)
+		if err != nil {
+			return nil, toolsetSummary{}, err
+		}
+		return nil, toolsetView(ts), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "update_toolset",
+		Title:       "Update a toolset",
+		Description: "Edit a shared toolset. Only the fields you pass change; list fields (families, connections, requireApproval) replace the stored list wholesale, so read it first when appending.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in updateToolsetInput) (*mcp.CallToolResult, toolsetSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, toolsetSummary{}, err
+		}
+		req := updateToolsetRequest{
+			DisplayName: in.DisplayName, Description: in.Description, Families: in.Families,
+			Connections: in.Connections, RequireApproval: in.RequireApproval,
+		}
+		ts, err := applyToolsetUpdate(ctx, c, in.Name, &req)
+		if err != nil {
+			return nil, toolsetSummary{}, err
+		}
+		return nil, toolsetView(ts), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "delete_toolset",
+		Title:       "Delete a toolset",
+		Description: "Delete a shared toolset. Agents linking it silently lose those grants, so check list_agents first.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, deletedOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, deletedOutput{}, err
+		}
+		name := strings.TrimSpace(in.Name)
+		if err := c.Toolsets().Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return nil, deletedOutput{}, err
+		}
+		return nil, deletedOutput{Deleted: name}, nil
+	})
+
+	// --- connections ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "create_connection",
+		Title: "Create a connection",
+		Description: "Create an external connection: a messaging channel (telegram, slack, smtp, discord), a tool source (github, mcp, http, websearch, edges). " +
+			"The credential goes in secret and is stored write-only. OAuth-based connections must be created in the portal — the Connect flow needs a browser.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createConnectionInput) (*mcp.CallToolResult, agentConnectionSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, agentConnectionSummary{}, err
+		}
+		req := createConnectionRequest{
+			Name: in.Name, Type: in.Type, DisplayName: in.DisplayName,
+			BaseURL: in.BaseURL, Channel: in.Channel, Config: in.Config, Secret: in.Secret,
+		}
+		conn, err := s.applyConnectionCreate(ctx, c, &req)
+		if err != nil {
+			return nil, agentConnectionSummary{}, err
+		}
+		return nil, connectionView(conn), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "update_connection",
+		Title:       "Update a connection",
+		Description: "Edit a connection: rename it, repoint its URL or delivery target, or rotate its credential by passing secret. Only the fields you pass change.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in updateConnectionInput) (*mcp.CallToolResult, agentConnectionSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, agentConnectionSummary{}, err
+		}
+		req := updateConnectionRequest{
+			DisplayName: in.DisplayName, BaseURL: in.BaseURL, Channel: in.Channel,
+			Config: in.Config, Secret: in.Secret,
+		}
+		conn, err := applyConnectionUpdate(ctx, c, in.Name, &req)
+		if err != nil {
+			return nil, agentConnectionSummary{}, err
+		}
+		return nil, connectionView(conn), nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "delete_connection",
+		Title:       "Delete a connection",
+		Description: "Delete a connection and its stored credential. Agents and triggers referencing it lose that capability, so check list_agents first.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, deletedOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, deletedOutput{}, err
+		}
+		name := strings.TrimSpace(in.Name)
+		if err := deleteConnectionAndSecret(ctx, c, name); err != nil {
+			return nil, deletedOutput{}, err
+		}
+		return nil, deletedOutput{Deleted: name}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "test_connection",
+		Title:       "Test a messaging connection",
+		Description: "Send a test message through a messaging connection (telegram, slack, smtp, discord) to verify the credential and target work. Delivers a real message.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, testResultOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, testResultOutput{}, err
+		}
+		if err := sendConnectionTest(ctx, c, in.Name); err != nil {
+			return nil, testResultOutput{}, err
+		}
+		return nil, testResultOutput{OK: true}, nil
+	})
+
+	// --- model credentials ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "save_model_credential",
+		Title: "Create or update a model credential",
+		Description: "Create or update a named model credential agents can be assigned. The apiKey is write-only — omit it when updating to keep the stored key. " +
+			"Assign the result to an agent with update_agent's modelCredential.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in saveCredentialInput) (*mcp.CallToolResult, credentialSummary, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, credentialSummary{}, err
+		}
+		req := modelCredential{Name: in.Name, Provider: in.Provider, BaseURL: in.BaseURL, Model: in.Model, APIKey: in.APIKey}
+		cred, err := applyCredentialUpsert(ctx, c, &req)
+		if err != nil {
+			return nil, credentialSummary{}, err
+		}
+		return nil, credentialSummary{Name: cred.Name, Provider: cred.Provider, Model: cred.Model, HasAPIKey: cred.HasAPIKey}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "delete_model_credential",
+		Title:       "Delete a model credential",
+		Description: "Delete a named model credential. Agents assigned it stop running until they are pointed at another one, so check list_agents first.",
+		Annotations: destructive,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, deletedOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, deletedOutput{}, err
+		}
+		name := strings.TrimSpace(in.Name)
+		if err := c.DeleteSecret(ctx, llm.SecretNamespace, llm.CredentialSecretName(name)); err != nil {
+			return nil, deletedOutput{}, err
+		}
+		return nil, deletedOutput{Deleted: name}, nil
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "test_model_credential",
+		Title:       "Test a model credential",
+		Description: "Health-check a model credential by listing the models its endpoint serves. Returns latency and, on success, the available model ids.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, testResultOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, testResultOutput{}, err
+		}
+		profile, err := llm.LoadCredential(ctx, c, strings.TrimSpace(in.Name))
+		if err != nil {
+			return nil, testResultOutput{OK: false, Error: "credential not configured: " + err.Error()}, nil
+		}
+		models, latency, perr := probeOpenAIModels(ctx, profile.BaseURL, profile.APIKey)
+		if perr != nil {
+			return nil, testResultOutput{OK: false, LatencyMS: latency.Milliseconds(), Error: perr.Error()}, nil
+		}
+		return nil, testResultOutput{OK: true, LatencyMS: latency.Milliseconds(), Models: models}, nil
+	})
+
+	// --- discovery ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "list_tool_families",
+		Title: "List tool families",
+		Description: "List the built-in tool families that can be granted to an agent or a toolset, with what each one provides. " +
+			"Use these names for update_agent's interactiveFamilies / backgroundFamilies and create_toolset's families.",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, listToolFamiliesOutput, error) {
+		out := listToolFamiliesOutput{
+			Families: toolFamilyDocs,
+			Note:     "core is always granted and cannot be removed.",
+		}
+		// Best-effort, cache-only: the aggregate endpoint knows which kedge
+		// providers an interactive run reaches without any grant. Probing it
+		// live would put a network round-trip inside a discovery call, so an
+		// empty list here means "not probed recently", not "nothing enabled".
+		if cached, hit := s.capabilities.get(s.mcpIdentity(ctx, r).clusterID); hit {
+			out.Providers = cached.Providers
+			out.Note += " The listed providers are reachable in interactive runs via the hub's aggregate endpoint, with no tool grant needed."
+		}
+		return nil, out, nil
+	})
+
+	// --- run now ---
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "run_schedule",
+		Title: "Run a schedule now",
+		Description: "Fire a schedule's task immediately without waiting for its next cron tick — the way to test a schedule after editing it. " +
+			"The run is asynchronous and its output goes to the schedule's channel, exactly like a real firing.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, runNowOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, runNowOutput{}, err
+		}
+		sched, err := c.Schedules().Get(ctx, strings.TrimSpace(in.Name), metav1.GetOptions{})
+		if err != nil {
+			return nil, runNowOutput{}, err
+		}
+		task := sched.Spec.Task
+		trigger := agentsv1alpha1.RunTriggerSchedule
+		if sched.Spec.Type == agentsv1alpha1.ScheduleTypeHeartbeat {
+			trigger = agentsv1alpha1.RunTriggerHeartbeat
+			task = "Review this standing checklist and report only if something is actionable:\n\n" + sched.Spec.Checklist
+		}
+		return s.mcpRunNow(ctx, r, c, sched.Spec.AgentRef, taskRun{
+			SessionID: "schedule:" + sched.Name, Task: task, Trigger: trigger,
+			SourceName: sched.Name, NotifyChannel: sched.Spec.ChannelRef,
+		})
+	})
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:  "run_trigger",
+		Title: "Run a trigger now",
+		Description: "Fire a trigger's task immediately, as if its event had arrived — the way to test a trigger after editing it. " +
+			"The run is asynchronous and its output goes to the trigger's channel.",
+		Annotations: mutating,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in nameInput) (*mcp.CallToolResult, runNowOutput, error) {
+		c, err := s.mcpClient(r)
+		if err != nil {
+			return nil, runNowOutput{}, err
+		}
+		trig, err := c.Triggers().Get(ctx, strings.TrimSpace(in.Name), metav1.GetOptions{})
+		if err != nil {
+			return nil, runNowOutput{}, err
+		}
+		return s.mcpRunNow(ctx, r, c, trig.Spec.AgentRef, taskRun{
+			SessionID: "trigger:" + trig.Name, Task: trig.Spec.Task,
+			Trigger: agentsv1alpha1.RunTriggerEvent, SourceName: trig.Name,
+			NotifyChannel: trig.Spec.ChannelRef,
+		})
+	})
+}
+
+// mcpRunNow starts a detached run for a schedule/trigger "run now" tool. It
+// mirrors the REST handlers: resolve the agent, refuse an empty task, and
+// return the run id for follow-up.
+func (s *Server) mcpRunNow(ctx context.Context, r *http.Request, c *agentsclient.Client, agentRef string, tr taskRun) (*mcp.CallToolResult, runNowOutput, error) {
+	agent, err := c.Agents().Get(ctx, agentRef, metav1.GetOptions{})
+	if err != nil {
+		return nil, runNowOutput{}, err
+	}
+	if strings.TrimSpace(tr.Task) == "" {
+		return nil, runNowOutput{}, errBadRequest("this schedule/trigger has no task to run")
+	}
+	id := s.mcpIdentity(ctx, r)
+	if id.workspaceUUID == "" {
+		// Without a workspace scope the run's transcript would land under a
+		// fallback scope the portal never reads — better to say so than to
+		// silently strand it.
+		return nil, runNowOutput{}, errBadRequest("this workspace is not mapped yet — open the agents UI once, then retry")
+	}
+	runID := s.startDetachedRun(r, c, id, agent, tr)
+	return nil, runNowOutput{
+		RunID:  runID,
+		Status: "started — the run is executing in the background; its output is delivered to the configured channel",
+	}, nil
+}
+
+// toolsetView / connectionView are the shared row shapes the toolset and
+// connection tools return.
+func toolsetView(ts *agentsv1alpha1.Toolset) toolsetSummary {
+	return toolsetSummary{
+		Name:            ts.Name,
+		DisplayName:     ts.Spec.DisplayName,
+		Families:        ts.Spec.Families,
+		Connections:     ts.Spec.Connections,
+		RequireApproval: ts.Spec.RequireApproval,
+	}
+}
+
+func connectionView(cn *agentsv1alpha1.Connection) agentConnectionSummary {
+	return agentConnectionSummary{
+		Name:           cn.Name,
+		Type:           cn.Spec.Type,
+		DisplayName:    cn.Spec.DisplayName,
+		Phase:          cn.Status.Phase,
+		OAuthConnected: cn.Status.OAuthConnected,
+	}
+}

--- a/providers/agents/api/mcp_test.go
+++ b/providers/agents/api/mcp_test.go
@@ -96,11 +96,68 @@ func TestMCPToolsList(t *testing.T) {
 		got[tool.Name] = true
 	}
 	for _, want := range []string{
-		"list_agents", "get_agent", "update_agent",
-		"list_model_credentials", "list_connections", "list_toolsets", "list_schedules",
+		// agents
+		"list_agents", "get_agent", "create_agent", "update_agent", "delete_agent",
+		// schedules
+		"list_schedules", "create_schedule", "update_schedule", "delete_schedule", "run_schedule",
+		// triggers
+		"list_triggers", "create_trigger", "update_trigger", "delete_trigger", "run_trigger",
+		// toolsets
+		"list_toolsets", "create_toolset", "update_toolset", "delete_toolset",
+		// connections
+		"list_connections", "create_connection", "update_connection", "delete_connection", "test_connection",
+		// model credentials
+		"list_model_credentials", "save_model_credential", "delete_model_credential", "test_model_credential",
+		// discovery
+		"list_tool_families",
 	} {
 		if !got[want] {
 			t.Errorf("tools/list missing %q (got %v)", want, out.Tools)
+		}
+	}
+}
+
+// TestMCPToolInputSchemas asserts every tool advertises an input schema whose
+// required fields are actually required — a tool whose schema regresses to an
+// empty object silently becomes uncallable for a model.
+func TestMCPToolInputSchemas(t *testing.T) {
+	result := mcpRPC(t, "/mcp", "tools/list", map[string]any{})
+	var out struct {
+		Tools []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			InputSchema struct {
+				Properties map[string]any `json:"properties"`
+				Required   []string       `json:"required"`
+			} `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(result, &out); err != nil {
+		t.Fatal(err)
+	}
+	wantRequired := map[string][]string{
+		"update_schedule": {"name"},
+		"create_schedule": {"name", "agentRef", "type"},
+		"create_trigger":  {"name", "agentRef", "source"},
+		"delete_trigger":  {"name"},
+		"create_agent":    {"name"},
+	}
+	for _, tool := range out.Tools {
+		if strings.TrimSpace(tool.Description) == "" {
+			t.Errorf("tool %q has no description", tool.Name)
+		}
+		want, ok := wantRequired[tool.Name]
+		if !ok {
+			continue
+		}
+		have := map[string]bool{}
+		for _, f := range tool.InputSchema.Required {
+			have[f] = true
+		}
+		for _, f := range want {
+			if !have[f] {
+				t.Errorf("tool %q should require %q (required: %v)", tool.Name, f, tool.InputSchema.Required)
+			}
 		}
 	}
 }

--- a/providers/agents/api/schedules.go
+++ b/providers/agents/api/schedules.go
@@ -9,6 +9,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
+	agentsclient "github.com/faroshq/provider-agents/client"
 )
 
 func (s *Server) listSchedules(w http.ResponseWriter, r *http.Request) {
@@ -57,27 +59,35 @@ func (s *Server) createSchedule(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
 	}
+	out, err := applyScheduleCreate(r.Context(), c, &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// applyScheduleCreate validates the request and creates the schedule. Shared by
+// the REST handler and the MCP create_schedule tool so both surfaces validate
+// identically.
+func applyScheduleCreate(ctx context.Context, c *agentsclient.Client, req *createScheduleRequest) (*agentsv1alpha1.Schedule, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	req.AgentRef = strings.TrimSpace(req.AgentRef)
 	req.Type = strings.TrimSpace(req.Type)
 	if req.Name == "" || req.AgentRef == "" || req.Type == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "name, agentRef, and type are required")
-		return
+		return nil, errBadRequest("name, agentRef, and type are required")
 	}
 	switch req.Type {
 	case agentsv1alpha1.ScheduleTypeCron, agentsv1alpha1.ScheduleTypeHeartbeat:
 		if strings.TrimSpace(req.Schedule) == "" {
-			writeStatus(w, http.StatusBadRequest, "BadRequest", "a cron schedule is required for cron/heartbeat types")
-			return
+			return nil, errBadRequest("a cron schedule is required for cron/heartbeat types")
 		}
 	case agentsv1alpha1.ScheduleTypeWakeup:
 		if strings.TrimSpace(req.RunAt) == "" {
-			writeStatus(w, http.StatusBadRequest, "BadRequest", "runAt is required for wakeup type")
-			return
+			return nil, errBadRequest("runAt is required for wakeup type")
 		}
 	default:
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "type must be cron, wakeup, or heartbeat")
-		return
+		return nil, errBadRequest("type must be cron, wakeup, or heartbeat")
 	}
 
 	sched := &agentsv1alpha1.Schedule{
@@ -96,18 +106,12 @@ func (s *Server) createSchedule(w http.ResponseWriter, r *http.Request) {
 	if req.RunAt != "" {
 		t, err := time.Parse(time.RFC3339, req.RunAt)
 		if err != nil {
-			writeStatus(w, http.StatusBadRequest, "BadRequest", "runAt must be RFC3339 (e.g. 2026-07-13T09:00:00Z): "+err.Error())
-			return
+			return nil, errBadRequest("runAt must be RFC3339 (e.g. 2026-07-13T09:00:00Z): " + err.Error())
 		}
 		mt := metav1.NewTime(t)
 		sched.Spec.RunAt = &mt
 	}
-	out, err := c.Schedules().Create(r.Context(), sched, metav1.CreateOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusCreated, out)
+	return c.Schedules().Create(ctx, sched, metav1.CreateOptions{})
 }
 
 // updateScheduleRequest patches an existing schedule. Pointer fields let the
@@ -127,16 +131,27 @@ func (s *Server) updateSchedule(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	name := r.PathValue("name")
-	sched, err := c.Schedules().Get(r.Context(), name, metav1.GetOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
 	var req updateScheduleRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
+	}
+	out, err := applyScheduleUpdate(r.Context(), c, r.PathValue("name"), &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// applyScheduleUpdate reads the schedule, applies the patch fields that are
+// present, and writes it back. Shared by the REST handler and the MCP
+// update_schedule tool so both surfaces have identical semantics: absent fields
+// are untouched, and an empty runAt clears the one-shot fire time.
+func applyScheduleUpdate(ctx context.Context, c *agentsclient.Client, name string, req *updateScheduleRequest) (*agentsv1alpha1.Schedule, error) {
+	sched, err := c.Schedules().Get(ctx, strings.TrimSpace(name), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
 	}
 	if req.Schedule != nil {
 		sched.Spec.Schedule = strings.TrimSpace(*req.Schedule)
@@ -160,8 +175,7 @@ func (s *Server) updateSchedule(w http.ResponseWriter, r *http.Request) {
 		if v := strings.TrimSpace(*req.RunAt); v != "" {
 			t, perr := time.Parse(time.RFC3339, v)
 			if perr != nil {
-				writeStatus(w, http.StatusBadRequest, "BadRequest", "runAt must be RFC3339: "+perr.Error())
-				return
+				return nil, errBadRequest("runAt must be RFC3339: " + perr.Error())
 			}
 			mt := metav1.NewTime(t)
 			sched.Spec.RunAt = &mt
@@ -169,12 +183,7 @@ func (s *Server) updateSchedule(w http.ResponseWriter, r *http.Request) {
 			sched.Spec.RunAt = nil
 		}
 	}
-	out, err := c.Schedules().Update(r.Context(), sched, metav1.UpdateOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, out)
+	return c.Schedules().Update(ctx, sched, metav1.UpdateOptions{})
 }
 
 func (s *Server) deleteSchedule(w http.ResponseWriter, r *http.Request) {

--- a/providers/agents/api/settings.go
+++ b/providers/agents/api/settings.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	agentsclient "github.com/faroshq/provider-agents/client"
 	"github.com/faroshq/provider-agents/llm"
 )
 
@@ -85,33 +86,43 @@ func (s *Server) createCredential(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
 	}
+	out, err := applyCredentialUpsert(r.Context(), c, &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// applyCredentialUpsert writes the named model-credential Secret
+// (create-or-update), preserving an existing key when none is supplied. Shared
+// by the REST handler and the MCP save_model_credential tool. The returned view
+// never carries the key.
+func applyCredentialUpsert(ctx context.Context, c *agentsclient.Client, req *modelCredential) (*modelCredential, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	req.Provider = strings.TrimSpace(req.Provider)
 	req.BaseURL = strings.TrimSpace(req.BaseURL)
 	req.Model = strings.TrimSpace(req.Model)
 	req.APIKey = strings.TrimSpace(req.APIKey)
 	if req.Name == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "name is required")
-		return
+		return nil, errBadRequest("name is required")
 	}
 	if req.Provider == "" {
 		req.Provider = llm.ProviderOpenAICompatible
 	}
 	if req.Model == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "model is required")
-		return
+		return nil, errBadRequest("model is required")
 	}
 	// Preserve an existing key when updating without a new one.
 	apiKey := req.APIKey
 	if apiKey == "" {
-		if existing, err := c.GetSecret(r.Context(), llm.SecretNamespace, llm.CredentialSecretName(req.Name)); err == nil {
+		if existing, err := c.GetSecret(ctx, llm.SecretNamespace, llm.CredentialSecretName(req.Name)); err == nil {
 			if v, okk := existing.Data["apiKey"]; okk {
 				apiKey = string(v)
 			}
 		}
 		if apiKey == "" {
-			writeStatus(w, http.StatusBadRequest, "BadRequest", "apiKey is required")
-			return
+			return nil, errBadRequest("apiKey is required")
 		}
 	}
 	sec := &corev1.Secret{
@@ -120,13 +131,12 @@ func (s *Server) createCredential(w http.ResponseWriter, r *http.Request) {
 		Type:       corev1.SecretTypeOpaque,
 		StringData: map[string]string{"provider": req.Provider, "baseURL": req.BaseURL, "model": req.Model, "apiKey": apiKey},
 	}
-	if _, err := c.ApplySecret(r.Context(), sec); err != nil {
-		writeResourceError(w, err)
-		return
+	if _, err := c.ApplySecret(ctx, sec); err != nil {
+		return nil, err
 	}
-	writeJSON(w, http.StatusCreated, modelCredential{
+	return &modelCredential{
 		Name: req.Name, Provider: req.Provider, BaseURL: req.BaseURL, Model: req.Model, HasAPIKey: true,
-	})
+	}, nil
 }
 
 // credentialTestResult is the outcome of a live credential health probe.

--- a/providers/agents/api/toolaccess.go
+++ b/providers/agents/api/toolaccess.go
@@ -36,6 +36,19 @@ func (a clientCR) CreateSchedule(ctx context.Context, s *agentsv1alpha1.Schedule
 	return err
 }
 
+func (a clientCR) GetSchedule(ctx context.Context, name string) (*agentsv1alpha1.Schedule, error) {
+	return a.c.Schedules().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (a clientCR) UpdateSchedule(ctx context.Context, s *agentsv1alpha1.Schedule) error {
+	_, err := a.c.Schedules().Update(ctx, s, metav1.UpdateOptions{})
+	return err
+}
+
+func (a clientCR) DeleteSchedule(ctx context.Context, name string) error {
+	return a.c.Schedules().Delete(ctx, name, metav1.DeleteOptions{})
+}
+
 func (a clientCR) ListSchedules(ctx context.Context) ([]agentsv1alpha1.Schedule, error) {
 	list, err := a.c.Schedules().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -82,6 +95,28 @@ func (a vwCR) CreateSchedule(ctx context.Context, s *agentsv1alpha1.Schedule) er
 	}
 	_, err = a.dyn.Resource(agentsclient.ScheduleGVR).Create(ctx, &unstructured.Unstructured{Object: obj}, metav1.CreateOptions{})
 	return err
+}
+
+func (a vwCR) GetSchedule(ctx context.Context, name string) (*agentsv1alpha1.Schedule, error) {
+	u, err := a.dyn.Resource(agentsclient.ScheduleGVR).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return fromU[agentsv1alpha1.Schedule](u)
+}
+
+func (a vwCR) UpdateSchedule(ctx context.Context, s *agentsv1alpha1.Schedule) error {
+	s.TypeMeta = metav1.TypeMeta{APIVersion: agentsv1alpha1.SchemeGroupVersion.String(), Kind: "Schedule"}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(s)
+	if err != nil {
+		return err
+	}
+	_, err = a.dyn.Resource(agentsclient.ScheduleGVR).Update(ctx, &unstructured.Unstructured{Object: obj}, metav1.UpdateOptions{})
+	return err
+}
+
+func (a vwCR) DeleteSchedule(ctx context.Context, name string) error {
+	return a.dyn.Resource(agentsclient.ScheduleGVR).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func (a vwCR) ListSchedules(ctx context.Context) ([]agentsv1alpha1.Schedule, error) {

--- a/providers/agents/api/toolset.go
+++ b/providers/agents/api/toolset.go
@@ -244,9 +244,12 @@ func (s *Server) expandToolsets(ctx context.Context, deps tools.Deps, grant agen
 // approvalExempt lists tools that never require approval: they only talk to
 // the user or the agent's own memory, so gating them (e.g. under
 // autonomy=suggest's "*") would make the agent unable to even ask.
+// The read-only schedules_list belongs here (it was misspelled "schedule_list"
+// and so was never actually exempt); the mutating schedule_create/update/delete
+// deliberately stay gated.
 var approvalExempt = map[string]bool{
 	"memory_save": true, "memory_list": true, "notify": true, "ask": true,
-	"wait": true, "schedule_list": true,
+	"wait": true, "schedules_list": true,
 }
 
 // wrapTool normalizes every tool onto one audited execution path (ExecRich —

--- a/providers/agents/api/toolset_test.go
+++ b/providers/agents/api/toolset_test.go
@@ -28,6 +28,11 @@ type fakeCR struct {
 
 func (f fakeCR) GetAgent(context.Context, string) (*agentsv1alpha1.Agent, error) { return nil, nil }
 func (f fakeCR) CreateSchedule(context.Context, *agentsv1alpha1.Schedule) error  { return nil }
+func (f fakeCR) UpdateSchedule(context.Context, *agentsv1alpha1.Schedule) error  { return nil }
+func (f fakeCR) DeleteSchedule(context.Context, string) error                    { return nil }
+func (f fakeCR) GetSchedule(context.Context, string) (*agentsv1alpha1.Schedule, error) {
+	return nil, nil
+}
 func (f fakeCR) ListSchedules(context.Context) ([]agentsv1alpha1.Schedule, error) {
 	return nil, nil
 }

--- a/providers/agents/api/toolsets_http.go
+++ b/providers/agents/api/toolsets_http.go
@@ -9,6 +9,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
+	agentsclient "github.com/faroshq/provider-agents/client"
 )
 
 // Toolsets are workspace-shared bundles of tool grants (families + connections
@@ -53,10 +55,20 @@ func (s *Server) createToolset(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
 	}
+	out, err := applyToolsetCreate(r.Context(), c, &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// applyToolsetCreate validates the request and creates the toolset. Shared by
+// the REST handler and the MCP create_toolset tool.
+func applyToolsetCreate(ctx context.Context, c *agentsclient.Client, req *toolsetRequest) (*agentsv1alpha1.Toolset, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "name is required")
-		return
+		return nil, errBadRequest("name is required")
 	}
 	ts := &agentsv1alpha1.Toolset{
 		ObjectMeta: metav1.ObjectMeta{Name: req.Name},
@@ -68,12 +80,7 @@ func (s *Server) createToolset(w http.ResponseWriter, r *http.Request) {
 			RequireApproval: req.RequireApproval,
 		},
 	}
-	out, err := c.Toolsets().Create(r.Context(), ts, metav1.CreateOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusCreated, out)
+	return c.Toolsets().Create(ctx, ts, metav1.CreateOptions{})
 }
 
 // updateToolsetRequest patches an existing toolset; pointer fields let the
@@ -91,16 +98,26 @@ func (s *Server) updateToolset(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	name := r.PathValue("name")
-	ts, err := c.Toolsets().Get(r.Context(), name, metav1.GetOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
 	var req updateToolsetRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
+	}
+	out, err := applyToolsetUpdate(r.Context(), c, r.PathValue("name"), &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// applyToolsetUpdate reads the toolset, applies the patch fields that are
+// present, and writes it back. Shared by the REST handler and the MCP
+// update_toolset tool; list fields replace wholesale.
+func applyToolsetUpdate(ctx context.Context, c *agentsclient.Client, name string, req *updateToolsetRequest) (*agentsv1alpha1.Toolset, error) {
+	ts, err := c.Toolsets().Get(ctx, strings.TrimSpace(name), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
 	}
 	if req.DisplayName != nil {
 		ts.Spec.DisplayName = strings.TrimSpace(*req.DisplayName)
@@ -117,12 +134,7 @@ func (s *Server) updateToolset(w http.ResponseWriter, r *http.Request) {
 	if req.RequireApproval != nil {
 		ts.Spec.RequireApproval = *req.RequireApproval
 	}
-	out, err := c.Toolsets().Update(r.Context(), ts, metav1.UpdateOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, out)
+	return c.Toolsets().Update(ctx, ts, metav1.UpdateOptions{})
 }
 
 func (s *Server) deleteToolset(w http.ResponseWriter, r *http.Request) {

--- a/providers/agents/api/triggers.go
+++ b/providers/agents/api/triggers.go
@@ -85,18 +85,28 @@ func (s *Server) createTrigger(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
 	}
+	out, err := s.applyTriggerCreate(r.Context(), c, id.clusterID, &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// applyTriggerCreate validates the request, creates the trigger, and mints its
+// inbound webhook URL. Shared by the REST handler and the MCP create_trigger
+// tool. clusterID may be empty (no webhook URL is minted then).
+func (s *Server) applyTriggerCreate(ctx context.Context, c *agentsclient.Client, clusterID string, req *createTriggerRequest) (*agentsv1alpha1.Trigger, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	req.AgentRef = strings.TrimSpace(req.AgentRef)
 	req.Source = strings.TrimSpace(req.Source)
 	if req.Name == "" || req.AgentRef == "" || req.Source == "" {
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "name, agentRef, and source are required")
-		return
+		return nil, errBadRequest("name, agentRef, and source are required")
 	}
 	switch req.Source {
 	case agentsv1alpha1.TriggerSourceWebhook, agentsv1alpha1.TriggerSourceGitHub:
 	default:
-		writeStatus(w, http.StatusBadRequest, "BadRequest", "unsupported source "+req.Source)
-		return
+		return nil, errBadRequest("unsupported source " + req.Source + " (use webhook or github)")
 	}
 	trig := &agentsv1alpha1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{Name: req.Name},
@@ -110,34 +120,27 @@ func (s *Server) createTrigger(w http.ResponseWriter, r *http.Request) {
 			ChannelRef:    strings.TrimSpace(req.ChannelRef),
 		},
 	}
-	out, err := c.Triggers().Create(r.Context(), trig, metav1.CreateOptions{})
+	out, err := c.Triggers().Create(ctx, trig, metav1.CreateOptions{})
 	if err != nil {
-		writeResourceError(w, err)
-		return
+		return nil, err
 	}
 	// Webhook-style sources get a token-guarded inbound URL (HMAC over
 	// cluster/name — no state to store). Best-effort status write; the token
 	// only works once the background executor is running.
-	if req.Source == agentsv1alpha1.TriggerSourceWebhook || req.Source == agentsv1alpha1.TriggerSourceGitHub {
-		if _, ok := s.requireIdentityCluster(w, id); ok {
-			if token := s.webhookToken(id.clusterID, req.Name); token != "" {
-				out.Status.WebhookPath = "/services/providers/agents/webhooks/triggers/" + id.clusterID + "/" + req.Name + "/" + token
-				if updated, uerr := c.Triggers().UpdateStatus(r.Context(), out, metav1.UpdateOptions{}); uerr == nil {
-					out = updated
-				}
+	if clusterID != "" {
+		if token := s.webhookToken(clusterID, req.Name); token != "" {
+			out.Status.WebhookPath = webhookPath(clusterID, req.Name, token)
+			if updated, uerr := c.Triggers().UpdateStatus(ctx, out, metav1.UpdateOptions{}); uerr == nil {
+				out = updated
 			}
 		}
 	}
-	writeJSON(w, http.StatusCreated, out)
+	return out, nil
 }
 
-// requireIdentityCluster is a small guard so webhook URLs are only minted when
-// the request carries a resolved cluster.
-func (s *Server) requireIdentityCluster(_ http.ResponseWriter, id identity) (string, bool) {
-	if id.clusterID == "" {
-		return "", false
-	}
-	return id.clusterID, true
+// webhookPath is the inbound URL a webhook-style trigger listens on.
+func webhookPath(clusterID, name, token string) string {
+	return "/services/providers/agents/webhooks/triggers/" + clusterID + "/" + name + "/" + token
 }
 
 // updateTriggerRequest patches an existing trigger. All fields are optional
@@ -157,16 +160,27 @@ func (s *Server) updateTrigger(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	name := r.PathValue("name")
-	trig, err := c.Triggers().Get(r.Context(), name, metav1.GetOptions{})
-	if err != nil {
-		writeResourceError(w, err)
-		return
-	}
 	var req updateTriggerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeStatus(w, http.StatusBadRequest, "BadRequest", "invalid JSON body: "+err.Error())
 		return
+	}
+	out, err := s.applyTriggerUpdate(r.Context(), c, id.clusterID, r.PathValue("name"), &req)
+	if err != nil {
+		writeUpdateError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// applyTriggerUpdate reads the trigger, applies the patch fields that are
+// present, writes it back, and keeps the inbound webhook URL in sync. Shared by
+// the REST handler and the MCP update_trigger tool.
+func (s *Server) applyTriggerUpdate(ctx context.Context, c *agentsclient.Client, clusterID, name string, req *updateTriggerRequest) (*agentsv1alpha1.Trigger, error) {
+	name = strings.TrimSpace(name)
+	trig, err := c.Triggers().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
 	}
 	if req.Task != nil {
 		trig.Spec.Task = *req.Task
@@ -189,35 +203,31 @@ func (s *Server) updateTrigger(w http.ResponseWriter, r *http.Request) {
 		case agentsv1alpha1.TriggerSourceWebhook, agentsv1alpha1.TriggerSourceGitHub:
 			trig.Spec.Source = src
 		default:
-			writeStatus(w, http.StatusBadRequest, "BadRequest", "unsupported source "+src)
-			return
+			return nil, errBadRequest("unsupported source " + src + " (use webhook or github)")
 		}
 	}
-	out, err := c.Triggers().Update(r.Context(), trig, metav1.UpdateOptions{})
+	out, err := c.Triggers().Update(ctx, trig, metav1.UpdateOptions{})
 	if err != nil {
-		writeResourceError(w, err)
-		return
+		return nil, err
 	}
 	// Keep the inbound webhook URL in sync: webhook-style sources need one; a
 	// source changed away from them should drop it.
 	wantsWebhook := out.Spec.Source == agentsv1alpha1.TriggerSourceWebhook || out.Spec.Source == agentsv1alpha1.TriggerSourceGitHub
 	switch {
-	case wantsWebhook && out.Status.WebhookPath == "":
-		if _, okc := s.requireIdentityCluster(w, id); okc {
-			if token := s.webhookToken(id.clusterID, name); token != "" {
-				out.Status.WebhookPath = "/services/providers/agents/webhooks/triggers/" + id.clusterID + "/" + name + "/" + token
-				if updated, uerr := c.Triggers().UpdateStatus(r.Context(), out, metav1.UpdateOptions{}); uerr == nil {
-					out = updated
-				}
+	case wantsWebhook && out.Status.WebhookPath == "" && clusterID != "":
+		if token := s.webhookToken(clusterID, name); token != "" {
+			out.Status.WebhookPath = webhookPath(clusterID, name, token)
+			if updated, uerr := c.Triggers().UpdateStatus(ctx, out, metav1.UpdateOptions{}); uerr == nil {
+				out = updated
 			}
 		}
 	case !wantsWebhook && out.Status.WebhookPath != "":
 		out.Status.WebhookPath = ""
-		if updated, uerr := c.Triggers().UpdateStatus(r.Context(), out, metav1.UpdateOptions{}); uerr == nil {
+		if updated, uerr := c.Triggers().UpdateStatus(ctx, out, metav1.UpdateOptions{}); uerr == nil {
 			out = updated
 		}
 	}
-	writeJSON(w, http.StatusOK, out)
+	return out, nil
 }
 
 func (s *Server) deleteTrigger(w http.ResponseWriter, r *http.Request) {

--- a/providers/agents/tools/core.go
+++ b/providers/agents/tools/core.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
@@ -51,6 +52,28 @@ func Core(d Deps) []engine.Tool {
 		})
 	}
 	return out
+}
+
+// ownSchedule resolves a schedule by name and refuses it unless it belongs to
+// the running agent. Schedules are cluster-scoped in the tenant workspace, so
+// without this an agent could retime or delete another agent's schedule — the
+// self-scheduling tools are explicitly about the agent managing *itself*.
+func (d Deps) ownSchedule(ctx context.Context, name string) (*agentsv1alpha1.Schedule, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	sched, err := d.CR.GetSchedule(ctx, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("no schedule named %q — use schedules_list to see your schedules", name)
+		}
+		return nil, err
+	}
+	if sched.Spec.AgentRef != d.Agent.Name {
+		return nil, fmt.Errorf("schedule %q belongs to agent %q, not you", name, sched.Spec.AgentRef)
+	}
+	return sched, nil
 }
 
 func coreTools(d Deps) []engine.Tool {
@@ -127,7 +150,7 @@ func coreTools(d Deps) []engine.Tool {
 		},
 		{
 			Name: "schedule_create",
-			Desc: "Create a schedule for yourself: a recurring cron task or a one-shot wakeup. Cron is 5-field (minute hour day month weekday).",
+			Desc: "Create a NEW schedule for yourself: a recurring cron task or a one-shot wakeup. Cron is 5-field (minute hour day month weekday). To retime, rewrite, or pause a schedule that already exists, use schedule_update instead — this tool fails on a name that is already taken.",
 			Params: map[string]engine.Param{
 				"name":     {Type: "string", Desc: "lowercase identifier, e.g. daily-digest", Required: true},
 				"type":     {Type: "string", Desc: "schedule type", Required: true, Enum: []string{"cron", "wakeup"}},
@@ -168,9 +191,96 @@ func coreTools(d Deps) []engine.Tool {
 					return "", fmt.Errorf("type must be cron or wakeup")
 				}
 				if err := d.CR.CreateSchedule(ctx, sched); err != nil {
+					if apierrors.IsAlreadyExists(err) || strings.Contains(strings.ToLower(err.Error()), "already exists") {
+						return "", fmt.Errorf("a schedule named %q already exists — use schedule_update to change it instead of creating a new one", name)
+					}
 					return "", err
 				}
 				return fmt.Sprintf("schedule %q created (%s)", name, typ), nil
+			},
+		},
+		{
+			Name: "schedule_update",
+			Desc: "Change one of your existing schedules in place: retime the cron, move a wakeup, rewrite the task, or pause/resume it. Only the fields you pass change. Use schedules_list first to get the exact name.",
+			Params: map[string]engine.Param{
+				"name":     {Type: "string", Desc: "the schedule's name, as shown by schedules_list", Required: true},
+				"schedule": {Type: "string", Desc: "new 5-field cron expression, e.g. 0 9 * * * for daily at 09:00"},
+				"timeZone": {Type: "string", Desc: "new IANA time zone the cron is evaluated in, e.g. Europe/Vilnius"},
+				"runAt":    {Type: "string", Desc: "new RFC3339 fire time (wakeup schedules)"},
+				"task":     {Type: "string", Desc: "new prompt to run when it fires"},
+				"suspend":  {Type: "boolean", Desc: "true pauses the schedule without deleting it, false resumes it"},
+			},
+			Exec: func(ctx context.Context, argsJSON string) (string, error) {
+				args, err := parseArgs(argsJSON)
+				if err != nil {
+					return "", err
+				}
+				sched, err := d.ownSchedule(ctx, argString(args, "name"))
+				if err != nil {
+					return "", err
+				}
+				changed := []string{}
+				if v, ok := args["schedule"]; ok {
+					sched.Spec.Schedule = strings.TrimSpace(fmt.Sprint(v))
+					changed = append(changed, "schedule="+sched.Spec.Schedule)
+				}
+				if v, ok := args["timeZone"]; ok {
+					sched.Spec.TimeZone = strings.TrimSpace(fmt.Sprint(v))
+					changed = append(changed, "timeZone="+sched.Spec.TimeZone)
+				}
+				if v, ok := args["runAt"]; ok {
+					raw := strings.TrimSpace(fmt.Sprint(v))
+					if raw == "" {
+						sched.Spec.RunAt = nil
+					} else {
+						t, perr := time.Parse(time.RFC3339, raw)
+						if perr != nil {
+							return "", fmt.Errorf("runAt must be RFC3339 (e.g. 2026-07-14T09:00:00Z): %v", perr)
+						}
+						mt := metav1.NewTime(t)
+						sched.Spec.RunAt = &mt
+					}
+					changed = append(changed, "runAt="+raw)
+				}
+				if _, ok := args["task"]; ok {
+					sched.Spec.Task = argString(args, "task")
+					changed = append(changed, "task")
+				}
+				if _, ok := args["suspend"]; ok {
+					sched.Spec.Suspend = argBool(args, "suspend")
+					changed = append(changed, fmt.Sprintf("suspend=%v", sched.Spec.Suspend))
+				}
+				if len(changed) == 0 {
+					return "", fmt.Errorf("nothing to update — pass at least one of schedule, timeZone, runAt, task, suspend")
+				}
+				if sched.Spec.Type == agentsv1alpha1.ScheduleTypeCron && strings.TrimSpace(sched.Spec.Schedule) == "" {
+					return "", fmt.Errorf("a cron schedule cannot have an empty cron expression")
+				}
+				if err := d.CR.UpdateSchedule(ctx, sched); err != nil {
+					return "", err
+				}
+				return fmt.Sprintf("schedule %q updated (%s)", sched.Name, strings.Join(changed, ", ")), nil
+			},
+		},
+		{
+			Name: "schedule_delete",
+			Desc: "Delete one of your schedules permanently. To stop it only temporarily, prefer schedule_update with suspend=true.",
+			Params: map[string]engine.Param{
+				"name": {Type: "string", Desc: "the schedule's name, as shown by schedules_list", Required: true},
+			},
+			Exec: func(ctx context.Context, argsJSON string) (string, error) {
+				args, err := parseArgs(argsJSON)
+				if err != nil {
+					return "", err
+				}
+				sched, err := d.ownSchedule(ctx, argString(args, "name"))
+				if err != nil {
+					return "", err
+				}
+				if err := d.CR.DeleteSchedule(ctx, sched.Name); err != nil {
+					return "", err
+				}
+				return fmt.Sprintf("schedule %q deleted", sched.Name), nil
 			},
 		},
 		{

--- a/providers/agents/tools/core_test.go
+++ b/providers/agents/tools/core_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
+)
+
+// scheduleCR is an in-memory CRAccess exercising the self-scheduling tools.
+type scheduleCR struct {
+	items   map[string]*agentsv1alpha1.Schedule
+	deleted []string
+	updated []*agentsv1alpha1.Schedule
+}
+
+func newScheduleCR(items ...*agentsv1alpha1.Schedule) *scheduleCR {
+	cr := &scheduleCR{items: map[string]*agentsv1alpha1.Schedule{}}
+	for _, s := range items {
+		cr.items[s.Name] = s
+	}
+	return cr
+}
+
+var scheduleResource = schema.GroupResource{Group: "agents.kedge.faros.sh", Resource: "schedules"}
+
+func (c *scheduleCR) GetAgent(context.Context, string) (*agentsv1alpha1.Agent, error) {
+	return nil, nil
+}
+
+func (c *scheduleCR) CreateSchedule(_ context.Context, s *agentsv1alpha1.Schedule) error {
+	if _, ok := c.items[s.Name]; ok {
+		return apierrors.NewAlreadyExists(scheduleResource, s.Name)
+	}
+	c.items[s.Name] = s
+	return nil
+}
+
+func (c *scheduleCR) GetSchedule(_ context.Context, name string) (*agentsv1alpha1.Schedule, error) {
+	s, ok := c.items[name]
+	if !ok {
+		return nil, apierrors.NewNotFound(scheduleResource, name)
+	}
+	return s.DeepCopy(), nil
+}
+
+func (c *scheduleCR) UpdateSchedule(_ context.Context, s *agentsv1alpha1.Schedule) error {
+	if _, ok := c.items[s.Name]; !ok {
+		return apierrors.NewNotFound(scheduleResource, s.Name)
+	}
+	c.items[s.Name] = s
+	c.updated = append(c.updated, s)
+	return nil
+}
+
+func (c *scheduleCR) DeleteSchedule(_ context.Context, name string) error {
+	if _, ok := c.items[name]; !ok {
+		return apierrors.NewNotFound(scheduleResource, name)
+	}
+	delete(c.items, name)
+	c.deleted = append(c.deleted, name)
+	return nil
+}
+
+func (c *scheduleCR) ListSchedules(context.Context) ([]agentsv1alpha1.Schedule, error) {
+	out := make([]agentsv1alpha1.Schedule, 0, len(c.items))
+	for _, s := range c.items {
+		out = append(out, *s)
+	}
+	return out, nil
+}
+
+func (c *scheduleCR) ListConnections(context.Context) ([]agentsv1alpha1.Connection, error) {
+	return nil, nil
+}
+
+func (c *scheduleCR) GetConnection(context.Context, string) (*agentsv1alpha1.Connection, error) {
+	return nil, nil
+}
+
+func (c *scheduleCR) GetToolset(context.Context, string) (*agentsv1alpha1.Toolset, error) {
+	return nil, nil
+}
+
+func cronSchedule(name, agentRef, expr string) *agentsv1alpha1.Schedule {
+	return &agentsv1alpha1.Schedule{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: agentsv1alpha1.ScheduleSpec{
+			AgentRef: agentRef, Type: agentsv1alpha1.ScheduleTypeCron,
+			Schedule: expr, Task: "post the news",
+		},
+	}
+}
+
+// coreTool finds one core tool by name, and fails the test if the family stopped
+// shipping it.
+func coreTool(t *testing.T, d Deps, name string) func(context.Context, string) (string, error) {
+	t.Helper()
+	for _, tool := range Core(d) {
+		if tool.Name == name {
+			return tool.Exec
+		}
+	}
+	t.Fatalf("core family has no %q tool", name)
+	return nil
+}
+
+func scheduleDeps(cr *scheduleCR) Deps {
+	return Deps{
+		Agent: &agentsv1alpha1.Agent{ObjectMeta: metav1.ObjectMeta{Name: "kedge"}},
+		CR:    cr,
+	}
+}
+
+// TestScheduleUpdateRetimesCron is the case that failed in production: an agent
+// asked to move its daily-news cron to 09:00 could only create and list, so it
+// gave up. Updating in place must retime the existing schedule.
+func TestScheduleUpdateRetimesCron(t *testing.T) {
+	cr := newScheduleCR(cronSchedule("daily-news", "kedge", "30 * * * *"))
+	exec := coreTool(t, scheduleDeps(cr), "schedule_update")
+
+	out, err := exec(t.Context(), `{"name":"daily-news","schedule":"0 9 * * *","timeZone":"Europe/Vilnius"}`)
+	if err != nil {
+		t.Fatalf("schedule_update: %v", err)
+	}
+	if !strings.Contains(out, "0 9 * * *") {
+		t.Errorf("result should report the new cron, got %q", out)
+	}
+	got := cr.items["daily-news"]
+	if got.Spec.Schedule != "0 9 * * *" || got.Spec.TimeZone != "Europe/Vilnius" {
+		t.Fatalf("schedule not retimed: %+v", got.Spec)
+	}
+	if got.Spec.Task != "post the news" {
+		t.Errorf("untouched fields must survive, task became %q", got.Spec.Task)
+	}
+}
+
+// TestScheduleUpdateSuspendResume asserts suspend round-trips both ways —
+// suspend=false must be applied, not read as "absent".
+func TestScheduleUpdateSuspendResume(t *testing.T) {
+	cr := newScheduleCR(cronSchedule("daily-news", "kedge", "0 9 * * *"))
+	exec := coreTool(t, scheduleDeps(cr), "schedule_update")
+
+	if _, err := exec(t.Context(), `{"name":"daily-news","suspend":true}`); err != nil {
+		t.Fatalf("suspend: %v", err)
+	}
+	if !cr.items["daily-news"].Spec.Suspend {
+		t.Fatal("schedule should be suspended")
+	}
+	if _, err := exec(t.Context(), `{"name":"daily-news","suspend":false}`); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if cr.items["daily-news"].Spec.Suspend {
+		t.Fatal("schedule should be resumed")
+	}
+}
+
+// TestScheduleUpdateRejectsEmptyPatch keeps a no-op call from reporting success.
+func TestScheduleUpdateRejectsEmptyPatch(t *testing.T) {
+	cr := newScheduleCR(cronSchedule("daily-news", "kedge", "0 9 * * *"))
+	exec := coreTool(t, scheduleDeps(cr), "schedule_update")
+
+	if _, err := exec(t.Context(), `{"name":"daily-news"}`); err == nil {
+		t.Fatal("expected an error when no field is patched")
+	}
+	if len(cr.updated) != 0 {
+		t.Fatalf("empty patch must not write, got %d updates", len(cr.updated))
+	}
+}
+
+// TestScheduleToolsRejectOtherAgents asserts the self-scheduling tools stay
+// self-scoped: schedules are cluster-scoped in the tenant workspace, so an agent
+// must not retime or delete a sibling agent's schedule.
+func TestScheduleToolsRejectOtherAgents(t *testing.T) {
+	cr := newScheduleCR(cronSchedule("their-news", "other-agent", "0 9 * * *"))
+	d := scheduleDeps(cr)
+
+	if _, err := coreTool(t, d, "schedule_update")(t.Context(), `{"name":"their-news","suspend":true}`); err == nil {
+		t.Fatal("expected schedule_update to refuse another agent's schedule")
+	}
+	if _, err := coreTool(t, d, "schedule_delete")(t.Context(), `{"name":"their-news"}`); err == nil {
+		t.Fatal("expected schedule_delete to refuse another agent's schedule")
+	}
+	if len(cr.deleted) != 0 || len(cr.updated) != 0 {
+		t.Fatal("another agent's schedule must be untouched")
+	}
+}
+
+func TestScheduleDelete(t *testing.T) {
+	cr := newScheduleCR(cronSchedule("daily-news", "kedge", "0 9 * * *"))
+	d := scheduleDeps(cr)
+
+	if _, err := coreTool(t, d, "schedule_delete")(t.Context(), `{"name":"daily-news"}`); err != nil {
+		t.Fatalf("schedule_delete: %v", err)
+	}
+	if _, ok := cr.items["daily-news"]; ok {
+		t.Fatal("schedule should be gone")
+	}
+	// Unknown names point back at schedules_list rather than leaking a raw 404.
+	_, err := coreTool(t, d, "schedule_update")(t.Context(), `{"name":"daily-news","suspend":true}`)
+	if err == nil || !strings.Contains(err.Error(), "schedules_list") {
+		t.Fatalf("expected a helpful not-found error, got %v", err)
+	}
+}
+
+// TestScheduleCreateDuplicateSuggestsUpdate: the model's next move after a name
+// collision should be schedule_update, so the error has to say so.
+func TestScheduleCreateDuplicateSuggestsUpdate(t *testing.T) {
+	cr := newScheduleCR(cronSchedule("daily-news", "kedge", "30 * * * *"))
+	exec := coreTool(t, scheduleDeps(cr), "schedule_create")
+
+	_, err := exec(t.Context(), `{"name":"daily-news","type":"cron","schedule":"0 9 * * *","task":"post the news"}`)
+	if err == nil {
+		t.Fatal("expected a duplicate-name error")
+	}
+	if !strings.Contains(err.Error(), "schedule_update") {
+		t.Errorf("error should point at schedule_update, got %q", err)
+	}
+}

--- a/providers/agents/tools/tools.go
+++ b/providers/agents/tools/tools.go
@@ -32,6 +32,9 @@ import (
 type CRAccess interface {
 	GetAgent(ctx context.Context, name string) (*agentsv1alpha1.Agent, error)
 	CreateSchedule(ctx context.Context, s *agentsv1alpha1.Schedule) error
+	GetSchedule(ctx context.Context, name string) (*agentsv1alpha1.Schedule, error)
+	UpdateSchedule(ctx context.Context, s *agentsv1alpha1.Schedule) error
+	DeleteSchedule(ctx context.Context, name string) error
 	ListSchedules(ctx context.Context) ([]agentsv1alpha1.Schedule, error)
 	ListConnections(ctx context.Context) ([]agentsv1alpha1.Connection, error)
 	GetConnection(ctx context.Context, name string) (*agentsv1alpha1.Connection, error)
@@ -161,6 +164,19 @@ func argInt(args map[string]any, key string) int {
 		return n
 	}
 	return 0
+}
+
+// argBool reads a boolean argument, tolerating the "true"/"false" strings some
+// models emit instead of a JSON boolean. Returns false when absent.
+func argBool(args map[string]any, key string) bool {
+	switch v := args[key].(type) {
+	case bool:
+		return v
+	case string:
+		b, _ := strconv.ParseBool(strings.TrimSpace(v))
+		return b
+	}
+	return false
 }
 
 func clip(s string, n int) string {

--- a/providers/agents/tools/websearch_e2e_test.go
+++ b/providers/agents/tools/websearch_e2e_test.go
@@ -26,6 +26,11 @@ type fakeCR struct{ conns []agentsv1alpha1.Connection }
 
 func (f fakeCR) GetAgent(context.Context, string) (*agentsv1alpha1.Agent, error) { return nil, nil }
 func (f fakeCR) CreateSchedule(context.Context, *agentsv1alpha1.Schedule) error  { return nil }
+func (f fakeCR) UpdateSchedule(context.Context, *agentsv1alpha1.Schedule) error  { return nil }
+func (f fakeCR) DeleteSchedule(context.Context, string) error                    { return nil }
+func (f fakeCR) GetSchedule(context.Context, string) (*agentsv1alpha1.Schedule, error) {
+	return nil, nil
+}
 func (f fakeCR) ListSchedules(context.Context) ([]agentsv1alpha1.Schedule, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Why

Asked in chat to move its `daily-news` cron to 09:00, an agent could not do it:

> D'oh! The daily-news schedule already exists, and this tool won't overwrite it directly. […] I don't have a delete/update tool in this setup, only create/list.

That was accurate. The core tool family shipped `schedule_create` + `schedules_list` and nothing else, and the provider's own `/mcp` surface had only `list_schedules` — with no write path at all for triggers, toolsets, connections or model credentials. Everything past "read your settings" required the portal.

## What changed

**Core family** (the agent managing *itself*):

- `schedule_update` — retime the cron, change time zone, move a wakeup, rewrite the task, suspend/resume. Only the fields you pass change.
- `schedule_delete`.
- Both go through `ownSchedule`, which refuses another agent's schedule. Schedules are cluster-scoped in the tenant workspace, so without that guard an agent could retime a sibling's cron.
- `schedule_create` now says *"already exists — use schedule_update"* on a name collision instead of dead-ending.

**Provider `/mcp` surface** (federated by the hub aggregate as `agents__*`) — now the whole configuration surface, 27 tools:

| Resource | Tools |
| --- | --- |
| Agents | list, get, **create**, update, **delete** |
| Schedules | list, create, update, delete, **run now** |
| Triggers | **list, create, update, delete, run now** |
| Toolsets | list, **create, update, delete** |
| Connections | list, **create, update, delete, test** |
| Model credentials | list, **save, delete, test** |
| Discovery | **list_tool_families** |

## How

Every mutating tool delegates to the same `apply*` helper as the REST handler, so a change over MCP is indistinguishable from the portal's save — absent fields untouched, list fields replaced wholesale. This meant extracting `applyScheduleCreate`/`Update`, `applyTriggerCreate`/`Update`, `applyToolsetCreate`/`Update`, `applyConnectionCreate`/`Update`, `applyCredentialUpsert` and `applyAgentCreate` alongside the existing `applyAgentUpdate`; the REST handlers now call that same code, so the two surfaces cannot drift. Validation errors moved onto the typed `requestError` so both surfaces report the same class rather than relying on `writeResourceError`'s phrase sniffing.

`CRAccess` gains `GetSchedule`/`UpdateSchedule`/`DeleteSchedule`, implemented for both execution paths (per-request tenant client and APIExport virtual workspace), so the new tools work in background runs too.

## Boundaries kept

- **Secrets are write-only** on every tool — tokens and API keys can be set or rotated, never read back.
- **OAuth Connect stays portal-only** — it needs a browser redirect.
- **Resolving approval requests stays portal-only** — an agent must not be able to approve its own approval-gated tool call, which would defeat `autonomy: ask`.

## Drive-by fix

`approvalExempt` listed `schedule_list`, but the tool is named `schedules_list` — the typo meant listing your own schedules was approval-gated under `autonomy=suggest`. The mutating schedule tools stay gated deliberately.

## Testing

`go build`, `go vet` and the full suite pass. New coverage:

- The exact production case: retime `daily-news` from `30 * * * *` to `0 9 * * *`, untouched fields surviving.
- suspend/resume round-trip (`suspend=false` must apply, not read as absent).
- Empty-patch rejection — a no-op call must not report success.
- Cross-agent refusal for update and delete.
- Duplicate-name error points at `schedule_update`.
- `tools/list` asserts all 27 tool names, plus a schema check that required fields stay required (a schema regressing to `{}` makes a tool silently uncallable for a model).

## Note for reviewers

Interactive runs dial the hub aggregate with the prefix `edges` ([api/toolset.go](https://github.com/faroshq/kedge/blob/main/providers/agents/api/toolset.go#L181)), so an agent in chat sees these as `edges__agents__update_schedule` — which reads like an edges tool and may steer the model away from it. Not changed here: tool names are what users' `requireApproval` patterns match against, so renaming the prefix could silently un-gate approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)