### PR TITLE
Fix App Studio progress and preview probes

### DIFF
--- a/providers/app-studio/api/assistant_eino_lifecycle.go
+++ b/providers/app-studio/api/assistant_eino_lifecycle.go
@@ -37,7 +37,6 @@ type projectEinoAssistantLifecycle struct {
 	runState         *projectEinoAssistantRunState
 	server           *Server
 	req              projectAssistantRunRequest
-	initialBuild     bool
 	repositoryRef    string
 	workspace        *workspace.FileStore
 	workspaceScope   workspace.Scope
@@ -59,7 +58,6 @@ func projectEinoAssistantLifecycleMiddleware(
 		BaseChatModelAgentMiddleware: &adk.BaseChatModelAgentMiddleware{},
 		runState:                     runState,
 		req:                          req,
-		initialBuild:                 projectAssistantInitialBuildActive(req, runState),
 		repositoryRef:                projectEinoAssistantProjectRepositoryRef(req),
 		workspace:                    req.Workspace,
 		workspaceScope:               req.WorkspaceScope,
@@ -434,15 +432,6 @@ func (m *projectEinoAssistantLifecycle) WrapInvokableToolCall(
 						m.runState.RecordVerifiedWorkspaceDigest(digest)
 					}
 				}
-				if m.initialBuild && m.runState.SourceMutationVerified() {
-					m.completeExecutionPlan()
-				}
-			}
-		case name == projectToolInspectDevelopmentPreview && succeeded:
-			if m.initialBuild && m.runState != nil {
-				if revision, _ := m.runState.SourceMutationRevisions(); revision > 0 {
-					m.completeExecutionPlan()
-				}
 			}
 		}
 		if m.runState != nil && !projectEinoAssistantFilesystemReadTool(name) &&
@@ -452,13 +441,6 @@ func (m *projectEinoAssistantLifecycle) WrapInvokableToolCall(
 		}
 		return result, nil
 	}, nil
-}
-
-func (m *projectEinoAssistantLifecycle) completeExecutionPlan() {
-	if m == nil || m.runState == nil {
-		return
-	}
-	projectEinoAssistantPublishCompletedExecutionPlan(m.runState, m.req.StreamCallbacks)
 }
 
 func (m *projectEinoAssistantLifecycle) WrapEnhancedInvokableToolCall(

--- a/providers/app-studio/api/assistant_eino_plan_progress.go
+++ b/providers/app-studio/api/assistant_eino_plan_progress.go
@@ -94,17 +94,6 @@ func projectEinoAssistantPublishPlanProgress(
 	}
 }
 
-func projectEinoAssistantPublishCompletedExecutionPlan(
-	runState *projectEinoAssistantRunState,
-	callbacks projectAssistantStreamCallbacks,
-) {
-	if runState == nil {
-		return
-	}
-	runState.CompleteExecutionPlan()
-	projectEinoAssistantPublishPlanProgress(runState, callbacks, runState.PlanProgress())
-}
-
 func projectEinoAssistantPlanProgressStatus(plan projectAssistantPlanSnapshot) string {
 	completed := 0
 	for _, step := range plan.Steps {

--- a/providers/app-studio/api/assistant_eino_plan_progress_test.go
+++ b/providers/app-studio/api/assistant_eino_plan_progress_test.go
@@ -18,11 +18,13 @@ package api
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/cloudwego/eino/adk"
 	einotool "github.com/cloudwego/eino/components/tool"
+	"github.com/faroshq/provider-app-studio/workspace"
 )
 
 func TestProjectEinoAssistantWriteTodosPublishesCodexStylePlanUpdate(t *testing.T) {
@@ -56,6 +58,149 @@ func TestProjectEinoAssistantWriteTodosPublishesCodexStylePlanUpdate(t *testing.
 	}
 	if got := projectEinoAssistantPlanProgressStatus(published[0]); got != "Building · 1 of 3 steps" {
 		t.Fatalf("derived status = %q", got)
+	}
+}
+
+func TestProjectEinoAssistantWriteTodosPublishesDerivedStatusWithoutPlanCallback(t *testing.T) {
+	runState := newProjectEinoAssistantRunState()
+	var status string
+	lifecycle := projectEinoAssistantLifecycleMiddleware(projectAssistantRunRequest{
+		StreamCallbacks: projectAssistantStreamCallbacks{
+			OnStatus: func(next string) { status = next },
+		},
+	}, runState).(*projectEinoAssistantLifecycle)
+	wrapped, err := lifecycle.WrapInvokableToolCall(
+		context.Background(),
+		func(_ context.Context, _ string, _ ...einotool.Option) (string, error) {
+			return `Updated todo list`, nil
+		},
+		&adk.ToolContext{Name: projectEinoAssistantWriteTodosTool},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arguments := `{"todos":[{"content":"Inspect current app","activeForm":"Inspecting current app","status":"completed"},{"content":"Implement the fix","activeForm":"Implementing the fix","status":"in_progress"},{"content":"Verify behavior","activeForm":"Verifying behavior","status":"pending"}]}`
+	if _, err := wrapped(context.Background(), arguments); err != nil {
+		t.Fatal(err)
+	}
+	if status != "Building · 1 of 3 steps" {
+		t.Fatalf("derived status = %q, want model-authored checklist status", status)
+	}
+}
+
+func TestProjectEinoAssistantWriteTodosPublishesCompletedPlanSnapshot(t *testing.T) {
+	plan := projectAssistantApprovedPlan{Steps: []string{"Implement the change", "Verify the result"}}
+	runState := newProjectEinoAssistantRunState()
+	runState.SetExecutionPlan(plan)
+	var published []projectAssistantPlanSnapshot
+	lifecycle := projectEinoAssistantLifecycleMiddleware(projectAssistantRunRequest{
+		StreamCallbacks: projectAssistantStreamCallbacks{
+			OnPlan: func(next projectAssistantPlanSnapshot) { published = append(published, next) },
+		},
+	}, runState).(*projectEinoAssistantLifecycle)
+	wrapper, err := lifecycle.WrapInvokableToolCall(
+		context.Background(),
+		func(_ context.Context, _ string, _ ...einotool.Option) (string, error) {
+			return `Updated todo list`, nil
+		},
+		&adk.ToolContext{Name: projectEinoAssistantWriteTodosTool},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapper(context.Background(), `{"todos":[{"content":"Implement the change","activeForm":"Implementing the change","status":"completed"},{"content":"Verify the result","activeForm":"Verifying the result","status":"completed"}]}`); err != nil {
+		t.Fatal(err)
+	}
+	if len(published) != 1 || !runState.ExecutionPlanComplete() {
+		t.Fatalf("write_todos terminal snapshot = %#v, execution plan complete = %t", published, runState.ExecutionPlanComplete())
+	}
+	if got := projectEinoAssistantPlanProgressStatus(runState.PlanProgress()); got != "Building · 2 of 2 steps" {
+		t.Fatalf("terminal status = %q", got)
+	}
+}
+
+func TestProjectEinoAssistantWriteTodosPublishesTerminalStatusWithoutPlanCallback(t *testing.T) {
+	runState := newProjectEinoAssistantRunState()
+	var status string
+	lifecycle := projectEinoAssistantLifecycleMiddleware(projectAssistantRunRequest{
+		StreamCallbacks: projectAssistantStreamCallbacks{
+			OnStatus: func(next string) { status = next },
+		},
+	}, runState).(*projectEinoAssistantLifecycle)
+	wrapper, err := lifecycle.WrapInvokableToolCall(
+		context.Background(),
+		func(_ context.Context, _ string, _ ...einotool.Option) (string, error) {
+			return `Updated todo list`, nil
+		},
+		&adk.ToolContext{Name: projectEinoAssistantWriteTodosTool},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapper(context.Background(), `{"todos":[{"content":"Implement the change","activeForm":"Implementing the change","status":"completed"},{"content":"Verify the result","activeForm":"Verifying the result","status":"completed"}]}`); err != nil {
+		t.Fatal(err)
+	}
+	if status != "Building · 2 of 2 steps" {
+		t.Fatalf("terminal status = %q, want model-authored checklist status", status)
+	}
+}
+
+func TestProjectEinoAssistantRuntimeVerificationDoesNotAdvancePlanProgress(t *testing.T) {
+	plan := projectAssistantApprovedPlan{Steps: []string{"Implement the change", "Verify the result"}}
+	runState := newProjectEinoAssistantRunState()
+	runState.SetExecutionPlan(plan)
+	runState.SetPlanProgress(projectAssistantInitialPlanProgress(plan))
+	runState.RecordSourceMutation()
+	before := runState.PlanProgress()
+	approved := plan
+	lifecycle := projectEinoAssistantLifecycleMiddleware(projectAssistantRunRequest{
+		InitialApprovedPlan: &approved,
+		Workspace:           workspace.NewFileStore(t.TempDir()),
+	}, runState).(*projectEinoAssistantLifecycle)
+	wrapper, err := lifecycle.WrapInvokableToolCall(
+		context.Background(),
+		func(_ context.Context, _ string, _ ...einotool.Option) (string, error) {
+			return `{"status":"ready","checkedMutationRevision":1}`, nil
+		},
+		&adk.ToolContext{Name: projectToolVerifyDevelopmentRuntime},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapper(context.Background(), `{}`); err != nil {
+		t.Fatal(err)
+	}
+	if got := runState.PlanProgress(); !reflect.DeepEqual(got, before) {
+		t.Fatalf("runtime verification advanced plan: got %#v, before %#v", got, before)
+	}
+}
+
+func TestProjectEinoAssistantPreviewInspectionDoesNotAdvancePlanProgress(t *testing.T) {
+	plan := projectAssistantApprovedPlan{Steps: []string{"Implement the change", "Verify the result"}}
+	runState := newProjectEinoAssistantRunState()
+	runState.SetExecutionPlan(plan)
+	runState.SetPlanProgress(projectAssistantInitialPlanProgress(plan))
+	runState.RecordSourceMutation()
+	before := runState.PlanProgress()
+	approved := plan
+	lifecycle := projectEinoAssistantLifecycleMiddleware(projectAssistantRunRequest{
+		InitialApprovedPlan: &approved,
+	}, runState).(*projectEinoAssistantLifecycle)
+	wrapper, err := lifecycle.WrapInvokableToolCall(
+		context.Background(),
+		func(_ context.Context, _ string, _ ...einotool.Option) (string, error) {
+			return `{}`, nil
+		},
+		&adk.ToolContext{Name: projectToolInspectDevelopmentPreview},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapper(context.Background(), `{}`); err != nil {
+		t.Fatal(err)
+	}
+	if got := runState.PlanProgress(); !reflect.DeepEqual(got, before) {
+		t.Fatalf("preview inspection advanced plan: got %#v, before %#v", got, before)
 	}
 }
 
@@ -98,22 +243,5 @@ func TestProjectEinoAssistantPlanProgressBoundsModelLabels(t *testing.T) {
 	}
 	if got := plan.Steps[0]; len(got.Content) > projectEinoAssistantTodoProgressMaxLabelBytes || len(got.ActiveForm) > projectEinoAssistantTodoProgressMaxLabelBytes {
 		t.Fatalf("bounded step = %#v", got)
-	}
-}
-
-func TestProjectEinoAssistantCompletedExecutionPlanPublishesTerminalSnapshot(t *testing.T) {
-	runState := newProjectEinoAssistantRunState()
-	runState.SetExecutionPlan(projectAssistantApprovedPlan{Steps: []string{"Implement", "Verify"}})
-	runState.SetPlanProgress(projectAssistantInitialPlanProgress(projectAssistantApprovedPlan{Steps: []string{"Implement", "Verify"}}))
-	var status string
-	projectEinoAssistantPublishCompletedExecutionPlan(runState, projectAssistantStreamCallbacks{
-		OnStatus: func(next string) { status = next },
-	})
-	plan := runState.PlanProgress()
-	if len(plan.Steps) != 2 || plan.Steps[0].Status != "completed" || plan.Steps[1].Status != "completed" {
-		t.Fatalf("terminal plan = %#v", plan)
-	}
-	if status != "Building · 2 of 2 steps" {
-		t.Fatalf("terminal status = %q", status)
 	}
 }

--- a/providers/app-studio/api/assistant_eino_state.go
+++ b/providers/app-studio/api/assistant_eino_state.go
@@ -600,27 +600,6 @@ func (s *projectEinoAssistantRunState) ExecutionPlanComplete() bool {
 	return true
 }
 
-func (s *projectEinoAssistantRunState) CompleteExecutionPlan() {
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.executionPlan == nil || len(s.executionPlan.Steps) == 0 {
-		return
-	}
-	completed := projectAssistantPlanSnapshot{
-		Steps: make([]projectAssistantPlanStep, 0, len(s.executionPlan.Steps)),
-	}
-	for _, content := range s.executionPlan.Steps {
-		completed.Steps = append(completed.Steps, projectAssistantPlanStep{
-			Content: projectEinoAssistantTodoProgressLabel(content),
-			Status:  "completed",
-		})
-	}
-	s.planProgress = completed
-}
-
 func (s *projectEinoAssistantRunState) ClearApprovedPlan() {
 	if s == nil {
 		return

--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -659,7 +659,6 @@ func (t projectEinoAssistantTool) recoverV2CommitSettlement(
 			cancelSettlement()
 		}
 		t.runState.RecordSourceCommit(workspaceDigest)
-		projectEinoAssistantPublishCompletedExecutionPlan(t.runState, t.req.StreamCallbacks)
 		if settlementBlocker != "" {
 			// The repository effect and durable ledger outcome remain successful,
 			// so never expose a tool error that could provoke a second commit ID.

--- a/providers/app-studio/api/assistant_eino_v2_test.go
+++ b/providers/app-studio/api/assistant_eino_v2_test.go
@@ -643,7 +643,10 @@ func TestInitialProjectPlanProgressBoundsLabelsForDurablePresentation(t *testing
 	runState := newProjectEinoAssistantRunState()
 	runState.SetExecutionPlan(plan)
 	runState.SetPlanProgress(progress)
-	runState.CompleteExecutionPlan()
+	runState.SetPlanProgress(projectAssistantPlanSnapshot{Steps: []projectAssistantPlanStep{
+		{Content: projectEinoAssistantTodoProgressLabel(plan.Steps[0]), Status: "completed"},
+		{Content: projectEinoAssistantTodoProgressLabel(plan.Steps[1]), Status: "completed"},
+	}})
 	if !runState.ExecutionPlanComplete() || !runState.CompletionEvidence().PlanComplete {
 		t.Fatalf("bounded presentation labels broke execution-plan completion: %#v", runState.PlanProgress())
 	}
@@ -737,6 +740,51 @@ func TestEinoV2CommitSettlementClearsCompleteDirtyBundleAtToolBoundary(t *testin
 	}
 	if got := runState.CheckpointState().CommittedWorkspaceDigest; got != digest {
 		t.Fatalf("committed workspace digest = %q, want %q", got, digest)
+	}
+}
+
+func TestEinoV2SuccessfulCommitSettlementDoesNotAdvancePlanProgress(t *testing.T) {
+	ctx := context.Background()
+	workspaces := workspace.NewFileStore(t.TempDir())
+	scope := workspace.Scope{OrgUUID: "org-a", WorkspaceUUID: "ws-1", ProjectName: "demo", ProjectUID: "project-uid"}
+	writeTestWorkspaceFiles(t, ctx, workspaces, scope, []workspace.File{{Path: "src/App.tsx", Content: "app\n"}})
+	if _, err := workspaces.AddUncommittedPaths(ctx, scope, []string{"src/App.tsx"}); err != nil {
+		t.Fatal(err)
+	}
+	plan := projectAssistantApprovedPlan{Steps: []string{"Implement the change", "Verify the result"}}
+	runState := newProjectEinoAssistantRunState()
+	runState.SetExecutionPlan(plan)
+	runState.SetPlanProgress(projectAssistantInitialPlanProgress(plan))
+	runState.RecordSourceMutation()
+	before := runState.PlanProgress()
+	planPublishes := 0
+	statusPublishes := 0
+	tool := projectEinoAssistantTool{
+		req: projectAssistantRunRequest{
+			Workspace:      workspaces,
+			WorkspaceScope: scope,
+			StreamCallbacks: projectAssistantStreamCallbacks{
+				OnPlan:   func(projectAssistantPlanSnapshot) { planPublishes++ },
+				OnStatus: func(string) { statusPublishes++ },
+			},
+		},
+		runState: runState,
+	}
+	digest, err := projectEinoAssistantWorkspaceDigest(ctx, workspaces, scope, []string{"src/App.tsx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tool.recordV2CommitSettlement(ctx, projectAssistantToolSpec{Name: projectToolCommitProjectFiles, Risk: projectAssistantToolRiskCommit}, map[string]any{
+		"paths":           []any{"src/App.tsx"},
+		"workspaceDigest": digest,
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := runState.PlanProgress(); got.Steps[0].Status != before.Steps[0].Status || got.Steps[1].Status != before.Steps[1].Status {
+		t.Fatalf("successful commit advanced plan: got %#v, before %#v", got, before)
+	}
+	if planPublishes != 0 || statusPublishes != 0 {
+		t.Fatalf("successful commit published plan/status (%d/%d), want no checklist projection", planPublishes, statusPublishes)
 	}
 }
 

--- a/providers/infrastructure/backend/kro/devoverlay.go
+++ b/providers/infrastructure/backend/kro/devoverlay.go
@@ -366,8 +366,8 @@ func synthesizeDevDeployment(name string, comp infrav1alpha1.TemplateDevelopment
 	app["securityContext"] = devContainerSecurityContext(appReadOnlyRoot)
 	app["env"] = appendDevRuntimeEnv(app, comp, workingDir, appPort)
 	ensureContainerPort(app, "runtime", devRuntimePort)
-	app["livenessProbe"] = devTCPProbe(devRuntimePort, 1)
-	app["readinessProbe"] = devTCPProbe(devRuntimePort, 1)
+	app["livenessProbe"] = devExecProbe(devRuntimeAddress, 1)
+	app["readinessProbe"] = devExecProbe(devRuntimeAddress, 1)
 
 	// A production volume mount at workingDir is reused for all three
 	// containers. Otherwise the overlay creates the per-component workspace
@@ -444,8 +444,8 @@ func synthesizeDevDeployment(name string, comp infrav1alpha1.TemplateDevelopment
 			map[string]any{"name": "kedge-dev-exec-tmp", "mountPath": "/tmp"},
 			map[string]any{"name": "kedge-dev-no-serviceaccount", "mountPath": devServiceAccountDir, "readOnly": true},
 		},
-		"livenessProbe":   devTCPProbe(devExecRunnerPort, 1),
-		"readinessProbe":  devTCPProbe(devExecRunnerPort, 1),
+		"livenessProbe":   devExecProbe(devExecutorAddress, 1),
+		"readinessProbe":  devExecProbe(devExecutorAddress, 1),
 		"securityContext": devContainerSecurityContext(true),
 	}
 	extraVolumes = append(extraVolumes, map[string]any{"name": "kedge-dev-exec-tmp", "emptyDir": map[string]any{}})
@@ -576,10 +576,13 @@ func devHTTPProbe(port int64, initialDelay int64) map[string]any {
 	}
 }
 
-func devTCPProbe(port int64, initialDelay int64) map[string]any {
+// devExecProbe runs the injected static agent inside the target container.
+// Runtime-supervisor and executor listeners bind only to pod loopback, so a
+// kubelet tcpSocket probe against the pod IP would never reach them.
+func devExecProbe(address string, initialDelay int64) map[string]any {
 	return map[string]any{
-		"tcpSocket": map[string]any{
-			"port": port,
+		"exec": map[string]any{
+			"command": []any{devAgentBinDir + "/kedge-dev-agent", "--healthcheck", address},
 		},
 		"initialDelaySeconds": initialDelay,
 		"periodSeconds":       int64(5),

--- a/providers/infrastructure/backend/kro/devoverlay_test.go
+++ b/providers/infrastructure/backend/kro/devoverlay_test.go
@@ -264,25 +264,56 @@ func assertSecureDevContainer(t *testing.T, container map[string]any, wantReadOn
 
 func assertDevProbes(t *testing.T, container map[string]any) {
 	t.Helper()
+	containerName, _ := container["name"].(string)
 	for _, name := range []string{"livenessProbe", "readinessProbe"} {
 		probe, ok := container[name].(map[string]any)
 		if !ok {
 			t.Errorf("%s has no %s", container["name"], name)
 			continue
 		}
-		if httpGet, ok := probe["httpGet"].(map[string]any); ok {
-			if httpGet["path"] != "/healthz" || numberValue(httpGet["port"]) == 0 {
-				t.Errorf("%s %s = %v", container["name"], name, probe)
+		switch containerName {
+		case "kedge-platform-coordinator":
+			httpGet, ok := probe["httpGet"].(map[string]any)
+			if !ok || httpGet["path"] != "/healthz" || numberValue(httpGet["port"]) != devAgentPort {
+				t.Errorf("%s %s = %v, want coordinator HTTP /healthz:%d probe", containerName, name, probe, devAgentPort)
 			}
-			continue
-		}
-		if tcpSocket, ok := probe["tcpSocket"].(map[string]any); ok {
-			if numberValue(tcpSocket["port"]) == 0 {
-				t.Errorf("%s %s = %v", container["name"], name, probe)
+			if _, ok := probe["exec"]; ok {
+				t.Errorf("%s %s unexpectedly has an exec probe: %v", containerName, name, probe)
 			}
-			continue
+		case "backend", "frontend":
+			assertDevExecProbeCommand(t, containerName, name, probe, devRuntimeAddress)
+		case "kedge-exec-runner":
+			assertDevExecProbeCommand(t, containerName, name, probe, devExecutorAddress)
+		default:
+			t.Errorf("unexpected container %q while checking %s", containerName, name)
 		}
-		t.Errorf("%s %s = %v", container["name"], name, probe)
+	}
+}
+
+func assertDevExecProbeCommand(t *testing.T, containerName, probeName string, probe map[string]any, address string) {
+	t.Helper()
+	execProbe, ok := probe["exec"].(map[string]any)
+	if !ok {
+		t.Errorf("%s %s = %v, want exec probe", containerName, probeName, probe)
+		return
+	}
+	command, _ := execProbe["command"].([]any)
+	want := []string{devAgentBinDir + "/kedge-dev-agent", "--healthcheck", address}
+	if len(command) != len(want) {
+		t.Errorf("%s %s command = %v, want %v", containerName, probeName, command, want)
+		return
+	}
+	for i, expected := range want {
+		if got, _ := command[i].(string); got != expected {
+			t.Errorf("%s %s command = %v, want %v", containerName, probeName, command, want)
+			break
+		}
+	}
+	if _, ok := probe["tcpSocket"]; ok {
+		t.Errorf("%s %s unexpectedly has a pod-IP tcpSocket probe: %v", containerName, probeName, probe)
+	}
+	if _, ok := probe["httpGet"]; ok {
+		t.Errorf("%s %s unexpectedly has an HTTP probe: %v", containerName, probeName, probe)
 	}
 }
 

--- a/providers/infrastructure/dev-agent/main.go
+++ b/providers/infrastructure/dev-agent/main.go
@@ -34,6 +34,10 @@ You may obtain a copy of the License at
 // into <dir> and exits — the init-container injection mode, which is what
 // lets the dev image stay a plain toolchain image with nothing kedge-specific
 // baked in.
+// Invoked as `kedge-dev-agent --healthcheck <address>` it performs a
+// container-local TCP health check and exits. This mode is used by the
+// runtime-supervisor and executor Kubernetes exec probes; it intentionally
+// does not load the coordinator configuration or expose a shell.
 package main
 
 import (
@@ -111,6 +115,17 @@ func main() {
 		}
 		return
 	}
+	if len(os.Args) >= 2 && os.Args[1] == "--healthcheck" {
+		if len(os.Args) != 3 {
+			log.Printf("healthcheck: one address is required")
+			os.Exit(1)
+		}
+		if err := runHealthcheck(os.Args[2]); err != nil {
+			log.Printf("healthcheck %s: %v", os.Args[2], err)
+			os.Exit(1)
+		}
+		return
+	}
 	cfg, err := configFromEnv()
 	if err != nil {
 		log.Fatalf("config: %v", err)
@@ -138,6 +153,24 @@ func main() {
 	if err := runCoordinator(ctx, cfg); err != nil {
 		log.Fatalf("coordinator: %v", err)
 	}
+}
+
+const healthcheckTimeout = time.Second
+
+// runHealthcheck verifies that an internal control listener is accepting TCP
+// connections from the current container. Callers provide a fixed loopback
+// address from the generated development deployment; no HTTP client, shell,
+// or pod-network address is involved.
+func runHealthcheck(address string) error {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return errors.New("address is required")
+	}
+	conn, err := net.DialTimeout("tcp", address, healthcheckTimeout)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
 }
 
 func runRuntimeSupervisor(ctx context.Context, cfg *agentConfig) error {

--- a/providers/infrastructure/dev-agent/main_test.go
+++ b/providers/infrastructure/dev-agent/main_test.go
@@ -49,6 +49,26 @@ func TestReloadRulesFromEnv(t *testing.T) {
 	}
 }
 
+func TestRunHealthcheckUsesContainerLocalTCPAddress(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	if err := runHealthcheck(address); err != nil {
+		t.Fatalf("runHealthcheck(%q): %v", address, err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := runHealthcheck(address); err == nil {
+		t.Fatalf("runHealthcheck(%q) succeeded after listener closed", address)
+	}
+	if err := runHealthcheck(""); err == nil {
+		t.Fatal("runHealthcheck accepted an empty address")
+	}
+}
+
 func TestMatchReloadRules(t *testing.T) {
 	rules := []reloadRule{
 		{Paths: []string{"package.json", "package-lock.json"}, Command: "npm install"},


### PR DESCRIPTION
## Summary

- keep App Studio checklist progress model-authored through `write_todos`
- remove server-side whole-plan completion after runtime verification, preview inspection, and commit settlement
- replace pod-IP TCP probes for loopback-only runtime/executor services with container-local exec healthchecks
- add focused regression coverage for plan projection and probe wiring

## Root cause

Initial builds treated operational runtime readiness as proof that every execution-plan step was complete. Separately, the runtime supervisor and stateless executor listened on `127.0.0.1:7072` and `127.0.0.1:7073`, while Kubernetes `tcpSocket` probes targeted the pod IP. Those probes failed after their threshold and restarted both containers approximately every 60 seconds.

## Impact

Checklist status now reflects explicit model-authored progress instead of inferred completion. Development preview workloads retain their loopback-only security boundary while remaining healthy under Kubernetes probes.

## Validation

- `go test -count=1 ./api` in `providers/app-studio`
- `go test -count=1 ./...` in `providers/infrastructure/dev-agent`
- `go test -count=1 ./backend/kro` in `providers/infrastructure`
- `gofmt` and `git diff --check`
- live `toast-notification-app-dev` remained 3/3 with zero restarts for approximately 14 minutes
- live preview returned HTTP 200 with the expected title and controls
