### PR TITLE
Improve App Studio assistant recovery and conversation resilience

### DIFF
--- a/providers/app-studio/api/assistant_checkpoint.go
+++ b/providers/app-studio/api/assistant_checkpoint.go
@@ -83,6 +83,7 @@ type projectAssistantCheckpointState struct {
 	ObservedReadFilePaths            []string                                            `json:"observedReadFilePaths,omitempty"`
 	ReadFileVersions                 map[string]string                                   `json:"readFileVersions,omitempty"`
 	SuccessfulMutationPaths          []string                                            `json:"successfulMutationPaths,omitempty"`
+	MutationRecoveryAttempts         map[string]projectAssistantMutationRecoveryAttempt  `json:"mutationRecoveryAttempts,omitempty"`
 	MutationRecoveryRefs             []string                                            `json:"mutationRecoveryRefs,omitempty"`
 	MutationRecoveryIdentities       map[string]projectAssistantMutationRecoveryIdentity `json:"mutationRecoveryIdentities,omitempty"`
 	SessionSnapshot                  *projectEinoAssistantSessionSnapshot                `json:"sessionSnapshot,omitempty"`

--- a/providers/app-studio/api/assistant_eino_lifecycle.go
+++ b/providers/app-studio/api/assistant_eino_lifecycle.go
@@ -95,6 +95,16 @@ func (m *projectEinoAssistantLifecycle) BeforeModelRewriteState(
 	if state == nil {
 		return ctx, state, nil
 	}
+	// A failed mutation gets one deterministic reread/repair attempt. Once the
+	// same canonical target fails again at the same source revision, terminate
+	// at this model boundary instead of sampling the model into an unbounded
+	// recovery loop. Read-only/Q&A turns and permission waits remain outside
+	// this implementation-only guard.
+	if projectEinoAssistantProgressApplies(m.req, m.runState) && !m.runState.PermissionBarrierActive() {
+		if err := m.runState.MutationRecoveryBlockedError(); err != nil {
+			return ctx, state, err
+		}
+	}
 	if err := m.refreshLiveRequestContext(ctx); err != nil {
 		return ctx, state, err
 	}

--- a/providers/app-studio/api/assistant_eino_lifecycle_helpers.go
+++ b/providers/app-studio/api/assistant_eino_lifecycle_helpers.go
@@ -35,6 +35,12 @@ const (
 
 	projectEinoAssistantRepeatedActionWarnAt = 2
 	projectEinoAssistantRepeatedActionLimit  = 100
+
+	// A failed mutation gets one complete-reread repair attempt. If that
+	// repair also fails at the same source revision and canonical target, stop
+	// before asking the model for another sample.
+	projectEinoAssistantMutationRecoveryFailureLimit       = 2
+	projectEinoAssistantMaxTrackedMutationRecoveryAttempts = 128
 )
 
 type projectEinoAssistantNoProgressError struct {
@@ -43,11 +49,20 @@ type projectEinoAssistantNoProgressError struct {
 	Limit            int
 	SourceRevision   uint64
 	VerifiedRevision uint64
+	Target           string
+	RecoveryBlocked  bool
 }
 
 func (e *projectEinoAssistantNoProgressError) Error() string {
 	if e == nil {
 		return errProjectAssistantNoProgress.Error()
+	}
+	if e.RecoveryBlocked {
+		target := strings.TrimSpace(e.Target)
+		if target == "" {
+			target = "the same mutation target"
+		}
+		return fmt.Sprintf("%s: recovery_blocked after %d failed %s mutations for %s at source revision %d", errProjectAssistantNoProgress, e.Calls, projectToolBaseName(e.ToolName), target, e.SourceRevision)
 	}
 	if toolName := projectToolBaseName(e.ToolName); toolName != "" {
 		return fmt.Sprintf("%s: repeated %s %d times", errProjectAssistantNoProgress, toolName, e.Limit)
@@ -57,6 +72,38 @@ func (e *projectEinoAssistantNoProgressError) Error() string {
 
 func (e *projectEinoAssistantNoProgressError) Unwrap() error {
 	return errProjectAssistantNoProgress
+}
+
+// projectEinoAssistantRecoveryBlockedError is emitted by the lifecycle
+// boundary after the second failed mutation for one target/revision. It wraps
+// the existing no-progress sentinel so audit and terminal classification stay
+// compatible while callers can distinguish the recovery-specific reason.
+type projectEinoAssistantRecoveryBlockedError struct {
+	projectEinoAssistantNoProgressError
+}
+
+func newProjectEinoAssistantRecoveryBlockedError(
+	attempt projectAssistantMutationRecoveryAttempt,
+	verifiedRevision uint64,
+) error {
+	return &projectEinoAssistantRecoveryBlockedError{
+		projectEinoAssistantNoProgressError: projectEinoAssistantNoProgressError{
+			ToolName:         attempt.Operation,
+			Calls:            attempt.Failures,
+			Limit:            projectEinoAssistantMutationRecoveryFailureLimit,
+			SourceRevision:   attempt.SourceRevision,
+			VerifiedRevision: verifiedRevision,
+			Target:           attempt.Target,
+			RecoveryBlocked:  true,
+		},
+	}
+}
+
+func (e *projectEinoAssistantRecoveryBlockedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return &e.projectEinoAssistantNoProgressError
 }
 
 func projectEinoAssistantProgressApplies(req projectAssistantRunRequest, runState *projectEinoAssistantRunState) bool {

--- a/providers/app-studio/api/assistant_eino_reduction.go
+++ b/providers/app-studio/api/assistant_eino_reduction.go
@@ -135,6 +135,14 @@ func projectEinoAssistantWorkspaceMutationTool(name string) bool {
 }
 
 func projectEinoAssistantSuccessfulWorkspaceMutationResult(name, content string) bool {
+	// Mutation-shaped JSON can carry a failed semantic disposition while still
+	// exposing a path (and no explicit changed=false). Consult the typed
+	// settlement adapter before treating the shape as source progress; the
+	// transport-error partial-mutation branch deliberately uses its separate
+	// HasChanges predicate so genuine post-write failures remain recoverable.
+	if projectAssistantToolResultDisposition(name, content, nil) != projectAssistantToolDispositionSucceeded {
+		return false
+	}
 	var result struct {
 		Operation string `json:"operation"`
 		Changed   *bool  `json:"changed"`

--- a/providers/app-studio/api/assistant_eino_state.go
+++ b/providers/app-studio/api/assistant_eino_state.go
@@ -99,6 +99,7 @@ type projectEinoAssistantRunState struct {
 	observedReadFilePaths            map[string]struct{}
 	readFileVersions                 map[string]string
 	successfulMutationPaths          map[string]struct{}
+	mutationRecoveryAttempts         map[string]projectAssistantMutationRecoveryAttempt
 	mutationRecoveryRefs             map[string]struct{}
 	mutationRecoveryIdentities       map[string]projectAssistantMutationRecoveryIdentity
 	readFileCoverage                 map[string][]projectEinoAssistantLineRange
@@ -132,6 +133,18 @@ type projectAssistantMutationRecoveryIdentity struct {
 	Target    string `json:"target"`
 }
 
+// projectAssistantMutationRecoveryAttempt is durable, server-owned retry
+// state for one canonical mutation target. It does not grant mutation
+// authority; it only bounds repeated failures at the same source revision.
+type projectAssistantMutationRecoveryAttempt struct {
+	Operation      string `json:"operation"`
+	Target         string `json:"target"`
+	SourceRevision uint64 `json:"sourceRevision"`
+	Failures       int    `json:"failures"`
+	Reread         bool   `json:"reread"`
+	Blocked        bool   `json:"blocked"`
+}
+
 type projectEinoAssistantLineRange struct {
 	start int
 	end   int
@@ -162,6 +175,7 @@ func newProjectEinoAssistantRunState() *projectEinoAssistantRunState {
 		readFileVersions:           map[string]string{},
 		readFileCoverage:           map[string][]projectEinoAssistantLineRange{},
 		successfulMutationPaths:    map[string]struct{}{},
+		mutationRecoveryAttempts:   map[string]projectAssistantMutationRecoveryAttempt{},
 		mutationRecoveryRefs:       map[string]struct{}{},
 		mutationRecoveryIdentities: map[string]projectAssistantMutationRecoveryIdentity{},
 		transientToolResults:       map[string]string{},
@@ -603,6 +617,7 @@ func (s *projectEinoAssistantRunState) RestoreCheckpointState(state projectAssis
 	s.observedReadFilePaths = projectEinoAssistantReadPathSet(state.ObservedReadFilePaths)
 	s.readFileVersions = projectEinoAssistantReadVersionMap(state.ReadFileVersions)
 	s.successfulMutationPaths = projectEinoAssistantReadPathSet(state.SuccessfulMutationPaths)
+	s.mutationRecoveryAttempts = projectEinoAssistantRestoreMutationRecoveryAttempts(state.MutationRecoveryAttempts)
 	s.mutationRecoveryRefs = projectEinoAssistantRecoveryReferenceSet(state.MutationRecoveryRefs)
 	s.mutationRecoveryIdentities = projectEinoAssistantRecoveryIdentitySnapshot(state.MutationRecoveryIdentities)
 	for ref := range s.mutationRecoveryIdentities {
@@ -761,6 +776,10 @@ func (s *projectEinoAssistantRunState) RecordSourceMutation() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sourceMutationRevision++
+	// A successful source mutation establishes progress for every prior
+	// recovery target. Keep no stale same-revision failure budget after the
+	// revision advances.
+	s.mutationRecoveryAttempts = map[string]projectAssistantMutationRecoveryAttempt{}
 	if s.developmentSyncRevision != s.sourceMutationRevision {
 		s.developmentSyncRevision = s.sourceMutationRevision
 		s.developmentSyncStatus = "unknown"
@@ -1226,6 +1245,10 @@ func (s *projectEinoAssistantRunState) InvalidateObservedReadFile(path string) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.invalidateObservedReadFileLocked(path)
+}
+
+func (s *projectEinoAssistantRunState) invalidateObservedReadFileLocked(path string) {
 	s.completedReadCalls = map[string]uint64{}
 	delete(s.readFileCoverage, path)
 	delete(s.observedReadFilePaths, path)
@@ -1270,6 +1293,13 @@ func (s *projectEinoAssistantRunState) RecordObservedReadFileVersion(path, versi
 		}
 	}
 	s.readFileVersions[path] = strings.TrimSpace(version)
+	if attempt, ok := s.mutationRecoveryAttempts[path]; ok &&
+		attempt.SourceRevision == s.sourceMutationRevision && attempt.Failures > 0 && !attempt.Blocked {
+		// A complete read is the only evidence that authorizes a retry after a
+		// mutation failure. Partial reads never record a version here.
+		attempt.Reread = true
+		s.mutationRecoveryAttempts[path] = attempt
+	}
 	if s.observedReadFilePaths == nil {
 		s.observedReadFilePaths = map[string]struct{}{}
 	}
@@ -1317,6 +1347,10 @@ func (s *projectEinoAssistantRunState) RecordSuccessfulMutationPath(path string)
 		s.successfulMutationPaths = map[string]struct{}{}
 	}
 	s.successfulMutationPaths[path] = struct{}{}
+	// The path has made real mutation progress. Remove only the matching
+	// target's recovery budget; RecordSourceMutation clears all targets when
+	// the durable source revision advances.
+	delete(s.mutationRecoveryAttempts, path)
 }
 
 func (s *projectEinoAssistantRunState) SuccessfulMutationPaths() []string {
@@ -1326,6 +1360,114 @@ func (s *projectEinoAssistantRunState) SuccessfulMutationPaths() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return projectEinoAssistantObservedReadPaths(s.successfulMutationPaths)
+}
+
+// RecordMutationFailure records one failed workspace mutation at the current
+// source revision. A later complete read marks the target as eligible for one
+// deterministic repair attempt. The second failed attempt for the same
+// canonical target and revision is marked blocked; lifecycle checks turn that
+// marker into a typed terminal error before another model sample.
+func (s *projectEinoAssistantRunState) RecordMutationFailure(name string, args map[string]any) (projectAssistantMutationRecoveryAttempt, bool) {
+	if s == nil {
+		return projectAssistantMutationRecoveryAttempt{}, false
+	}
+	identity, ok := projectAssistantMutationRecoveryIdentityFromTool(name, args)
+	if !ok {
+		return projectAssistantMutationRecoveryAttempt{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mutationRecoveryAttempts == nil {
+		s.mutationRecoveryAttempts = map[string]projectAssistantMutationRecoveryAttempt{}
+	}
+	attempt := s.mutationRecoveryAttempts[identity.Target]
+	if attempt.Target == "" || attempt.SourceRevision != s.sourceMutationRevision ||
+		!projectAssistantMutationRecoveryIdentityCompatible(
+			projectAssistantMutationRecoveryIdentity{Operation: attempt.Operation, Target: attempt.Target},
+			identity,
+		) {
+		attempt = projectAssistantMutationRecoveryAttempt{
+			Operation:      identity.Operation,
+			Target:         identity.Target,
+			SourceRevision: s.sourceMutationRevision,
+		}
+	}
+	attempt.Operation = identity.Operation
+	attempt.Target = identity.Target
+	attempt.SourceRevision = s.sourceMutationRevision
+	attempt.Failures = min(max(attempt.Failures, 0)+1, projectEinoAssistantMutationRecoveryFailureLimit)
+	attempt.Reread = false
+	attempt.Blocked = attempt.Failures >= projectEinoAssistantMutationRecoveryFailureLimit
+	if _, exists := s.mutationRecoveryAttempts[identity.Target]; !exists &&
+		len(s.mutationRecoveryAttempts) >= projectEinoAssistantMaxTrackedMutationRecoveryAttempts {
+		// Keep blocked entries at the current revision forever. They are the
+		// terminal guard that prevents another model sample, so evicting one
+		// merely to admit a new target would reopen the recovery loop. Prefer
+		// stale entries, then unblocked entries, using a stable target tie-break.
+		if !s.evictMutationRecoveryAttemptLocked() {
+			// The existing current-revision blocked entries already provide the
+			// terminal guard. Do not grow the map or discard that evidence when
+			// this new target cannot be tracked within the bound.
+			s.invalidateObservedReadFileLocked(identity.Target)
+			return projectAssistantMutationRecoveryAttempt{}, false
+		}
+	}
+	s.mutationRecoveryAttempts[identity.Target] = attempt
+	// Never let a failed mutation reuse the expectedVersion from the prior
+	// attempt. The next write must carry evidence from a fresh complete read.
+	s.invalidateObservedReadFileLocked(identity.Target)
+	return attempt, attempt.Blocked
+}
+
+// evictMutationRecoveryAttemptLocked makes room for one new target while
+// preserving every blocked attempt at the current source revision. It must be
+// called with s.mu held and returns false when no safe entry can be evicted.
+func (s *projectEinoAssistantRunState) evictMutationRecoveryAttemptLocked() bool {
+	if len(s.mutationRecoveryAttempts) < projectEinoAssistantMaxTrackedMutationRecoveryAttempts {
+		return true
+	}
+	currentRevision := s.sourceMutationRevision
+	candidate := ""
+	candidateStale := false
+	for target, attempt := range s.mutationRecoveryAttempts {
+		stale := attempt.SourceRevision != currentRevision
+		if !stale && attempt.Blocked && attempt.Failures >= projectEinoAssistantMutationRecoveryFailureLimit {
+			continue
+		}
+		if candidate == "" ||
+			(stale && !candidateStale) ||
+			(stale == candidateStale && target < candidate) {
+			candidate = target
+			candidateStale = stale
+		}
+	}
+	if candidate == "" {
+		return false
+	}
+	delete(s.mutationRecoveryAttempts, candidate)
+	return true
+}
+
+func (s *projectEinoAssistantRunState) MutationRecoveryBlockedError() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var selected projectAssistantMutationRecoveryAttempt
+	for _, attempt := range s.mutationRecoveryAttempts {
+		if !attempt.Blocked || attempt.Failures < projectEinoAssistantMutationRecoveryFailureLimit ||
+			attempt.SourceRevision != s.sourceMutationRevision {
+			continue
+		}
+		if selected.Target == "" || attempt.Target < selected.Target {
+			selected = attempt
+		}
+	}
+	if selected.Target == "" {
+		return nil
+	}
+	return newProjectEinoAssistantRecoveryBlockedError(selected, s.verifiedMutationRevision)
 }
 
 // RecordMutationRecoveryReference records a server-generated public action ID
@@ -1742,6 +1884,7 @@ func (s *projectEinoAssistantRunState) CheckpointState() projectAssistantCheckpo
 		ObservedReadFilePaths:            projectEinoAssistantObservedReadPaths(s.observedReadFilePaths),
 		ReadFileVersions:                 projectEinoAssistantCloneReadVersions(s.readFileVersions),
 		SuccessfulMutationPaths:          projectEinoAssistantObservedReadPaths(s.successfulMutationPaths),
+		MutationRecoveryAttempts:         projectEinoAssistantMutationRecoveryAttemptsSnapshot(s.mutationRecoveryAttempts),
 		MutationRecoveryRefs:             projectEinoAssistantRecoveryReferences(s.mutationRecoveryRefs),
 		MutationRecoveryIdentities:       projectEinoAssistantRecoveryIdentitySnapshot(s.mutationRecoveryIdentities),
 		SessionSnapshot:                  cloneProjectEinoAssistantSessionSnapshot(s.sessionSnapshot),
@@ -1790,6 +1933,71 @@ func projectEinoAssistantCloneReadVersions(versions map[string]string) map[strin
 	out := make(map[string]string, len(versions))
 	for path, version := range versions {
 		out[path] = version
+	}
+	return out
+}
+
+func projectEinoAssistantRestoreMutationRecoveryAttempts(
+	attempts map[string]projectAssistantMutationRecoveryAttempt,
+) map[string]projectAssistantMutationRecoveryAttempt {
+	if len(attempts) == 0 {
+		return map[string]projectAssistantMutationRecoveryAttempt{}
+	}
+	keys := make([]string, 0, len(attempts))
+	for key := range attempts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make(map[string]projectAssistantMutationRecoveryAttempt, min(len(keys), projectEinoAssistantMaxTrackedMutationRecoveryAttempts))
+	for _, rawKey := range keys {
+		if len(out) >= projectEinoAssistantMaxTrackedMutationRecoveryAttempts {
+			break
+		}
+		attempt := attempts[rawKey]
+		attempt.Operation = projectAssistantMutationRecoveryOperationFamily(attempt.Operation)
+		attempt.Target = strings.TrimSpace(attempt.Target)
+		if attempt.Target == "" {
+			attempt.Target = strings.TrimSpace(rawKey)
+		}
+		clean, err := workspace.CleanProjectPath(attempt.Target)
+		if err != nil || clean == "" || len([]byte(clean)) > 240 || attempt.Operation == "" {
+			continue
+		}
+		attempt.Target = clean
+		attempt.Failures = min(max(attempt.Failures, 0), projectEinoAssistantMutationRecoveryFailureLimit)
+		if attempt.Failures == 0 {
+			continue
+		}
+		attempt.Blocked = attempt.Blocked || attempt.Failures >= projectEinoAssistantMutationRecoveryFailureLimit
+		out[clean] = attempt
+	}
+	return out
+}
+
+func projectEinoAssistantMutationRecoveryAttemptsSnapshot(
+	attempts map[string]projectAssistantMutationRecoveryAttempt,
+) map[string]projectAssistantMutationRecoveryAttempt {
+	if len(attempts) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(attempts))
+	for key := range attempts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make(map[string]projectAssistantMutationRecoveryAttempt, min(len(keys), projectEinoAssistantMaxTrackedMutationRecoveryAttempts))
+	for _, key := range keys {
+		if len(out) >= projectEinoAssistantMaxTrackedMutationRecoveryAttempts {
+			break
+		}
+		attempt := attempts[key]
+		if attempt.Target == "" || attempt.Failures <= 0 {
+			continue
+		}
+		out[key] = attempt
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/providers/app-studio/api/assistant_eino_tool.go
+++ b/providers/app-studio/api/assistant_eino_tool.go
@@ -611,6 +611,12 @@ func (t projectEinoAssistantTool) invokeAllowedToolWithPlan(
 		return "", err
 	}
 	successful := t.durableToolCallSucceeded(ctx, callID, spec.Name, modelResult)
+	if !successful && projectAssistantWorkspaceMutationTool(spec.Name) && t.runState != nil {
+		// Some provider mutations return a typed failed result without a
+		// transport error. Count that semantic failure at the same boundary as
+		// invoke errors.
+		t.runState.RecordMutationFailure(spec.Name, args)
+	}
 	if settlementErr := t.recordV2CommitSettlement(ctx, spec, args, successful); settlementErr != nil {
 		return "", settlementErr
 	}
@@ -1416,6 +1422,10 @@ func (t projectEinoAssistantTool) finishFailedMutationToolCall(callID, name stri
 	inputRecovery := projectAssistantValidatedMutationRecoveryOf(t.runState, args, name)
 	publicRecovery := ""
 	if t.runState != nil {
+		// Record the server-owned retry budget before publishing the failure. The
+		// lifecycle boundary observes this state after the tool result and stops
+		// before another model sample once the repair budget is exhausted.
+		t.runState.RecordMutationFailure(name, args)
 		publicRecovery = t.runState.RecordMutationRecoveryReferenceForMutation(callID, name, args)
 	} else {
 		publicRecovery = projectAssistantActionPublicID(callID)

--- a/providers/app-studio/api/assistant_mutation_recovery_bound_test.go
+++ b/providers/app-studio/api/assistant_mutation_recovery_bound_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+)
+
+func projectAssistantMutationRecoveryTestArgs(path string) map[string]any {
+	return map[string]any{
+		"path":            path,
+		"expectedVersion": "sha256:current",
+	}
+}
+
+func projectAssistantMutationRecoveryTestStateAtRevision(revision int) *projectEinoAssistantRunState {
+	state := newProjectEinoAssistantRunState()
+	state.SetTurnPolicy(projectAssistantTurnPolicyForProfile(projectAssistantTurnProfileImplementation))
+	for i := 0; i < revision; i++ {
+		state.RecordSourceMutation()
+	}
+	return state
+}
+
+func TestProjectAssistantMutationRecoveryBoundsSameTargetAfterReread(t *testing.T) {
+	state := projectAssistantMutationRecoveryTestStateAtRevision(4)
+	args := projectAssistantMutationRecoveryTestArgs("src/index.tsx")
+
+	first, blocked := state.RecordMutationFailure(projectToolEditFile, args)
+	if blocked || first.Failures != 1 || first.SourceRevision != 4 || first.Reread {
+		t.Fatalf("first mutation failure = %#v, blocked=%v", first, blocked)
+	}
+	state.RecordObservedReadFileVersion("src/index.tsx", "sha256:reread")
+	checkpoint := state.CheckpointState()
+	if got := checkpoint.MutationRecoveryAttempts["src/index.tsx"]; !got.Reread {
+		t.Fatalf("checkpoint reread evidence = %#v, want true", got)
+	}
+
+	second, blocked := state.RecordMutationFailure(projectToolEditFile, args)
+	if !blocked || !second.Blocked || second.Failures != projectEinoAssistantMutationRecoveryFailureLimit {
+		t.Fatalf("second mutation failure = %#v, blocked=%v", second, blocked)
+	}
+	err := state.MutationRecoveryBlockedError()
+	var recoveryBlocked *projectEinoAssistantRecoveryBlockedError
+	if !errors.As(err, &recoveryBlocked) || !errors.Is(err, errProjectAssistantNoProgress) {
+		t.Fatalf("blocked error = %v, want typed no-progress/recovery-blocked error", err)
+	}
+	if !strings.Contains(err.Error(), "recovery_blocked") || !strings.Contains(err.Error(), "src/index.tsx") {
+		t.Fatalf("blocked error = %q, want target evidence", err)
+	}
+}
+
+func TestProjectAssistantMutationRecoveryBoundSurvivesCheckpointAndProgress(t *testing.T) {
+	state := projectAssistantMutationRecoveryTestStateAtRevision(4)
+	args := projectAssistantMutationRecoveryTestArgs("src/index.tsx")
+	state.RecordMutationFailure(projectToolEditFile, args)
+
+	restarted := newProjectEinoAssistantRunState()
+	restarted.RestoreCheckpointState(state.CheckpointState())
+	restarted.RecordObservedReadFileVersion("src/index.tsx", "sha256:reread")
+	if _, blocked := restarted.RecordMutationFailure(projectToolEditFile, args); !blocked {
+		t.Fatal("restored second failure was not blocked")
+	}
+
+	// A source revision or successful mutation is progress and must clear the
+	// old target's budget before a later failure can start a fresh repair pair.
+	restarted.RecordSourceMutation()
+	if err := restarted.MutationRecoveryBlockedError(); err != nil {
+		t.Fatalf("source revision retained old recovery block: %v", err)
+	}
+	if attempt, blocked := restarted.RecordMutationFailure(projectToolEditFile, args); blocked || attempt.Failures != 1 || attempt.SourceRevision != 5 {
+		t.Fatalf("new revision failure = %#v, blocked=%v", attempt, blocked)
+	}
+	restarted.RecordSuccessfulMutationPath("src/index.tsx")
+	if err := restarted.MutationRecoveryBlockedError(); err != nil {
+		t.Fatalf("successful target mutation retained recovery block: %v", err)
+	}
+
+	continues := projectAssistantMutationRecoveryTestStateAtRevision(4)
+	continues.RecordMutationFailure(projectToolEditFile, args)
+	continues.RecordObservedReadFileVersion("src/index.tsx", "sha256:reread")
+	continues.RecordSuccessfulMutationPath("src/index.tsx")
+	if attempt := continues.CheckpointState().MutationRecoveryAttempts["src/index.tsx"]; attempt.Failures != 0 {
+		t.Fatalf("successful reread/repair retained recovery attempt = %#v", attempt)
+	}
+}
+
+func TestProjectAssistantMutationRecoveryBoundRetainsBlockedTargetAtCap(t *testing.T) {
+	state := projectAssistantMutationRecoveryTestStateAtRevision(4)
+	blockedArgs := projectAssistantMutationRecoveryTestArgs("src/blocked.tsx")
+	state.RecordMutationFailure(projectToolEditFile, blockedArgs)
+	if _, blocked := state.RecordMutationFailure(projectToolEditFile, blockedArgs); !blocked {
+		t.Fatal("blocked target did not reach its recovery bound")
+	}
+
+	for i := 0; i < projectEinoAssistantMaxTrackedMutationRecoveryAttempts+16; i++ {
+		path := fmt.Sprintf("src/overflow-%03d.tsx", i)
+		state.RecordMutationFailure(projectToolEditFile, projectAssistantMutationRecoveryTestArgs(path))
+	}
+
+	checkpoint := state.CheckpointState()
+	if len(checkpoint.MutationRecoveryAttempts) > projectEinoAssistantMaxTrackedMutationRecoveryAttempts {
+		t.Fatalf("checkpoint retained %d recovery attempts, want at most %d", len(checkpoint.MutationRecoveryAttempts), projectEinoAssistantMaxTrackedMutationRecoveryAttempts)
+	}
+	blocked, ok := checkpoint.MutationRecoveryAttempts["src/blocked.tsx"]
+	if !ok || !blocked.Blocked || blocked.SourceRevision != 4 {
+		t.Fatalf("blocked target after cap pressure = %#v, present=%v", blocked, ok)
+	}
+
+	restarted := newProjectEinoAssistantRunState()
+	restarted.RestoreCheckpointState(checkpoint)
+	err := restarted.MutationRecoveryBlockedError()
+	if err == nil || !strings.Contains(err.Error(), "src/blocked.tsx") {
+		t.Fatalf("restored blocked target error = %v, want blocked target evidence", err)
+	}
+}
+
+func TestProjectAssistantBlockedMutationSettlementDoesNotAdvanceRevision(t *testing.T) {
+	h := newProjectAssistantV2ToolHarness(t, "mutation-blocked-settlement")
+	state := projectAssistantMutationRecoveryTestStateAtRevision(4)
+	state.RecordObservedReadFileVersion("src/App.tsx", "sha256:current")
+	backend := projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{Name: projectToolEditFile, Risk: projectAssistantToolRiskWrite},
+		call: func(context.Context, projectAssistantToolCallRequest) (string, error) {
+			return `{"operation":"edit_file","status":"blocked","path":"src/App.tsx"}`, nil
+		},
+	}
+	tool := projectEinoAssistantTool{server: h.server, tool: backend, req: h.req, runState: state}
+	result, err := tool.invokeAllowedTool(context.Background(), "call-blocked-edit", backend.Spec(), projectAssistantMutationRecoveryTestArgs("src/App.tsx"))
+	if err != nil {
+		t.Fatalf("blocked mutation invocation returned error: %v", err)
+	}
+	if projectEinoAssistantSuccessfulWorkspaceMutationResult(projectToolEditFile, result) {
+		t.Fatalf("blocked mutation result was classified as successful: %s", result)
+	}
+	if revision, _ := state.SourceMutationRevisions(); revision != 4 {
+		t.Fatalf("blocked semantic result advanced source revision to %d, want 4", revision)
+	}
+	attempt := state.CheckpointState().MutationRecoveryAttempts["src/App.tsx"]
+	if attempt.Failures != 1 || attempt.SourceRevision != 4 || attempt.Blocked {
+		t.Fatalf("blocked semantic result recovery state = %#v, want one failed attempt at revision 4", attempt)
+	}
+}
+
+func TestProjectAssistantPartialMutationTransportErrorAdvancesRevision(t *testing.T) {
+	h := newProjectAssistantV2ToolHarness(t, "mutation-partial-settlement")
+	state := newProjectEinoAssistantRunState()
+	state.RecordObservedReadFileVersion("src/App.tsx", "sha256:current")
+	backend := projectAssistantToolFunc{
+		spec: projectAssistantToolSpec{Name: projectToolEditFile, Risk: projectAssistantToolRiskWrite},
+		call: func(context.Context, projectAssistantToolCallRequest) (string, error) {
+			return `{"operation":"edit_file","changed":true,"path":"src/App.tsx"}`, errors.New("transport closed after write")
+		},
+	}
+	tool := projectEinoAssistantTool{server: h.server, tool: backend, req: h.req, runState: state}
+	result, err := tool.invokeAllowedTool(context.Background(), "call-partial-edit", backend.Spec(), projectAssistantMutationRecoveryTestArgs("src/App.tsx"))
+	if err != nil {
+		t.Fatalf("partial mutation invocation returned error: %v", err)
+	}
+	if !strings.Contains(result, `"status":"partial_failure"`) {
+		t.Fatalf("partial mutation result = %s, want partial_failure disposition", result)
+	}
+	if revision, _ := state.SourceMutationRevisions(); revision != 1 {
+		t.Fatalf("partial transport error source revision = %d, want one observed mutation", revision)
+	}
+	if attempt := state.CheckpointState().MutationRecoveryAttempts["src/App.tsx"]; attempt.Failures != 0 {
+		t.Fatalf("partial mutation was counted as a retry failure = %#v", attempt)
+	}
+}
+
+func TestProjectAssistantMutationRecoveryBoundScopesTargetsAndTurnModes(t *testing.T) {
+	state := projectAssistantMutationRecoveryTestStateAtRevision(1)
+	firstArgs := projectAssistantMutationRecoveryTestArgs("src/first.tsx")
+	secondArgs := projectAssistantMutationRecoveryTestArgs("src/second.tsx")
+	state.RecordMutationFailure(projectToolEditFile, firstArgs)
+	state.RecordMutationFailure(projectToolEditFile, secondArgs)
+	if _, blocked := state.RecordMutationFailure(projectToolEditFile, firstArgs); !blocked {
+		t.Fatal("same target did not reach its own recovery bound")
+	}
+	second := state.CheckpointState().MutationRecoveryAttempts["src/second.tsx"]
+	if second.Failures != 1 || second.Blocked {
+		t.Fatalf("different target recovery state = %#v, want independent first failure", second)
+	}
+
+	readOnly := newProjectEinoAssistantRunState()
+	readOnly.SetTurnPolicy(projectAssistantTurnPolicyForProfile(projectAssistantTurnProfileDebugging))
+	readOnly.RecordMutationFailure(projectToolEditFile, firstArgs)
+	readOnly.RecordMutationFailure(projectToolEditFile, firstArgs)
+	readOnlyLifecycle := &projectEinoAssistantLifecycle{runState: readOnly, req: projectAssistantRunRequest{TurnPolicy: projectAssistantTurnPolicyForProfile(projectAssistantTurnProfileDebugging)}}
+	if _, _, err := readOnlyLifecycle.BeforeModelRewriteState(context.Background(), &adk.ChatModelAgentState{Messages: []*schema.Message{}}, nil); err != nil {
+		t.Fatalf("read-only lifecycle returned recovery bound: %v", err)
+	}
+
+	permission := projectAssistantMutationRecoveryTestStateAtRevision(1)
+	permission.RecordMutationFailure(projectToolEditFile, firstArgs)
+	permission.RecordMutationFailure(projectToolEditFile, firstArgs)
+	permissionLifecycle := &projectEinoAssistantLifecycle{runState: permission, req: projectAssistantRunRequest{TurnPolicy: projectAssistantTurnPolicyForProfile(projectAssistantTurnProfileImplementation)}}
+	permission.TryStartPermissionBarrier()
+	if _, _, err := permissionLifecycle.BeforeModelRewriteState(context.Background(), &adk.ChatModelAgentState{Messages: []*schema.Message{}}, nil); err != nil {
+		t.Fatalf("permission barrier returned recovery bound: %v", err)
+	}
+}
+
+func TestProjectAssistantMutationFailureSettlementRecordsRecoveryBudget(t *testing.T) {
+	state := projectAssistantMutationRecoveryTestStateAtRevision(4)
+	tool := projectEinoAssistantTool{
+		runState: state,
+		req: projectAssistantRunRequest{
+			StreamCallbacks: projectAssistantStreamCallbacks{},
+		},
+	}
+	args := projectAssistantMutationRecoveryTestArgs("src/index.tsx")
+	tool.finishFailedMutationToolCall("call-failed", projectToolEditFile, args, errors.New("stale source"))
+	attempt := state.CheckpointState().MutationRecoveryAttempts["src/index.tsx"]
+	if attempt.Failures != 1 || attempt.SourceRevision != 4 || attempt.Blocked {
+		t.Fatalf("failure settlement recovery state = %#v", attempt)
+	}
+}

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -63,6 +63,7 @@ import {
 } from './assistantProgress'
 import { buildAssistantTrace, type AssistantTraceBlock } from './assistantTrace'
 import {
+  appendAssistantCommentaryToMessage,
   assistantThreadItemIdentity,
   assistantThreadItemToRun,
   assistantThreadItemsToMessages,
@@ -96,6 +97,8 @@ import {
   normalizeSnapshotMessage,
   orderConversationMessages,
   replaceOptimisticUserMessage,
+  reconcileAssistantRunInterrupt,
+  reconcileAssistantRunTerminal,
   type AssistantRun,
 } from './conversationResilience'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
@@ -433,7 +436,7 @@ const messagesRef = ref<HTMLDivElement | null>(null)
 const expandedMessageTimestampID = ref<string | null>(null)
 const expandedAssistantProgressIDs = ref<Set<string>>(new Set())
 const assistantDurationNowMs = ref(Date.now())
-const assistantWorkedDurationClock = new AssistantWorkedDurationClock()
+const assistantWorkedDurationClock = new AssistantWorkedDurationClock({ namespace: 'app-studio' })
 const assistantPlanAnnouncement = ref('')
 const promptRef = ref<HTMLTextAreaElement | null>(null)
 const workspaceRef = ref<HTMLDivElement | null>(null)
@@ -507,7 +510,7 @@ function projectAssistantThreadItems(
 
 function latestAssistantThreadRun(items: ProjectAssistantThreadItem[], turnID = ''): AssistantRun | undefined {
   const item = items
-    .filter((candidate) => candidate.type === 'agentMessage' && candidate.turnID && (!turnID || candidate.turnID === turnID))
+    .filter((candidate) => candidate.type === 'agentMessage' && candidate.phase !== 'commentary' && candidate.turnID && (!turnID || candidate.turnID === turnID))
     .reduce<ProjectAssistantThreadItem | undefined>((current, candidate) => {
       if (!current) return candidate
       const candidateRevision = typeof candidate.revision === 'number' && Number.isFinite(candidate.revision) ? candidate.revision : candidate.sequence
@@ -2085,7 +2088,14 @@ async function refreshSelectedProjectConversation(projectName: string) {
   if (!threads.some((thread) => thread.id === activeAssistantThreadID.value)) activeAssistantThreadID.value = threads[0]?.id ?? ''
   const threadItems = activeAssistantThreadID.value ? await api.listAssistantThreadItems(props.ctx, projectName, activeAssistantThreadID.value) : []
   activeAssistantThreadSequence = maxAssistantThreadSequence(threadItems)
-  messages.value = projectAssistantThreadItems(threadItems, projectName)
+  // A refresh can race the live stream. Merge the durable list into the live
+  // projection while this project/run is still active so a newer delta or
+  // commentary item is never rolled back to the request's earlier snapshot.
+  messages.value = projectAssistantThreadItems(
+    threadItems,
+    projectName,
+    messageStreaming.value && activeAssistantProject === projectName,
+  )
   projects.value = projectList
   await recoverAssistantConversation(projectName)
 }
@@ -2160,6 +2170,7 @@ function applyAssistantSnapshot(snapshot: ProjectAssistantSnapshot, projectName 
   const previousRun = assistantRunRevisions[normalized.run.id]
   const accepted = acceptScopedConversationSnapshot(selectedProject, activeAssistantProject, activeAssistantRun ?? previousRun, projectName, normalized.run, source, expectedRunID)
   if (!accepted.accepted) return accepted
+  observeAssistantWorkedDuration(normalized.message, normalized.run, projectName)
   const current = mergeConversationSnapshot(
     { messages: messages.value, runs: assistantRunRevisions },
     normalized,
@@ -2194,13 +2205,42 @@ function applyAssistantSnapshot(snapshot: ProjectAssistantSnapshot, projectName 
 
 async function recoverAssistantConversation(projectName: string): Promise<{ accepted: boolean; current: AssistantRun | undefined } | undefined> {
   if (selected.value?.name !== projectName || !activeAssistantThreadID.value) return undefined
+  const threadID = activeAssistantThreadID.value
   const expectedRunID = activeAssistantProject === projectName ? activeAssistantRun?.id ?? '' : ''
-  const turn = await api.getActiveAssistantTurn(props.ctx, projectName, activeAssistantThreadID.value)
-  if (!turn || selected.value?.name !== projectName) return undefined
-  const items = await api.listAssistantThreadItems(props.ctx, projectName, activeAssistantThreadID.value)
+  const turn = await api.getActiveAssistantTurn(props.ctx, projectName, threadID)
+  if (selected.value?.name !== projectName || activeAssistantThreadID.value !== threadID) return undefined
+  const items = await api.listAssistantThreadItems(props.ctx, projectName, threadID)
+  if (selected.value?.name !== projectName || activeAssistantThreadID.value !== threadID) return undefined
   activeAssistantThreadSequence = maxAssistantThreadSequence(items)
-  messages.value = projectAssistantThreadItems(items, projectName, true)
-  const assistantItem = [...items].reverse().find((item) => item.turnID === turn.id && item.type === 'agentMessage')
+  messages.value = projectAssistantThreadItems(items, projectName, Boolean(turn))
+  // A 204 means the stream may have missed its terminal event. The durable
+  // thread items are authoritative in that case: materialize their terminal
+  // owner, then clear every scoped live control so no stale spinner or input
+  // panel survives reload/reconnect.
+  if (!turn) {
+    const materializedRuns = assistantThreadItemsToRuns(items) as Record<string, AssistantRun>
+    for (const run of Object.values(materializedRuns)) {
+      if (!assistantRunTerminal(run.status)) continue
+      const terminalMessage = messages.value.find((candidate) => candidate.role === 'assistant' && (
+        candidate.id === run.activeMessageID || candidate.metadata?.assistantMessageID === run.activeMessageID
+      ))
+      if (terminalMessage) observeAssistantWorkedDuration(terminalMessage, run, projectName)
+    }
+    const priorRunID = activeAssistantRun?.id ?? ''
+    const materialized = priorRunID
+      ? materializedRuns[priorRunID]
+      : Object.values(materializedRuns).sort((left, right) => right.revision - left.revision)[0]
+    assistantRunController.disconnect()
+    activeAssistantSubscription?.abort()
+    activeAssistantSubscription = null
+    if (priorRunID) delete pendingAssistantStopRequestIDs[priorRunID]
+    activeAssistantRun = null
+    activeAssistantProject = ''
+    messageStreaming.value = false
+    conversationStatus.value = ''
+    return { accepted: false, current: materialized }
+  }
+  const assistantItem = [...items].reverse().find((item) => item.turnID === turn.id && item.type === 'agentMessage' && item.phase !== 'commentary')
   const userItem = [...items].reverse().find((item) => item.turnID === turn.id && item.type === 'userMessage')
   const message = assistantItem
     ? messages.value.find((candidate) => candidate.role === 'assistant' && (
@@ -2931,10 +2971,15 @@ function projectMessagesForConversation(source: ProjectMessageView[]): ProjectMe
 function assistantMessageIDForThreadItem(item: ProjectAssistantThreadItem, turnID = ''): string {
   const explicit = item.assistantMessageID?.trim()
   if (explicit) return explicit
+  if (item.phase === 'commentary') {
+    const derived = /^commentary-(.+)-(\d+)$/u.exec(item.id.trim())?.[1]?.trim()
+    if (derived) return derived
+  }
   if (item.type === 'agentMessage') return item.id
   const scopedTurnID = item.turnID || turnID
   const scoped = messages.value.filter((message) => {
     if (message.role !== 'assistant') return false
+    if (message.metadata?.assistantPhase === 'commentary') return false
     return !scopedTurnID || message.metadata?.assistantTurnID === scopedTurnID
   })
   return scoped[scoped.length - 1]?.id
@@ -2942,10 +2987,11 @@ function assistantMessageIDForThreadItem(item: ProjectAssistantThreadItem, turnI
 }
 
 function assistantMessageIndexForThreadItem(item: ProjectAssistantThreadItem, turnID = ''): number {
+  if (item.phase === 'commentary') return -1
   const messageID = assistantMessageIDForThreadItem(item, turnID)
   if (!messageID) return -1
   return messages.value.findIndex((message) =>
-    message.role === 'assistant' && (message.id === messageID || message.metadata?.assistantMessageID === messageID),
+    message.role === 'assistant' && message.metadata?.assistantPhase !== 'commentary' && (message.id === messageID || message.metadata?.assistantMessageID === messageID),
   )
 }
 
@@ -2989,37 +3035,58 @@ function applyAssistantThreadEvent(event: ProjectAssistantThreadEvent, projectNa
     }
   } else if (rawItem?.id && (rawItem.type === 'userMessage' || rawItem.type === 'agentMessage')) {
     const role = rawItem.type === 'userMessage' ? 'user' : 'assistant'
-    const messageID = role === 'assistant' && rawItem.phase !== 'commentary'
-      ? assistantMessageIDForThreadItem(rawItem, event.turnID || runID)
-      : rawItem.id
-    const existing = messages.value.find((message) => message.id === messageID || message.id === rawItem.id)
-    const itemRun = role === 'assistant' ? assistantThreadItemToRun(rawItem) : undefined
-    const itemContent = rawItem.content ?? ''
-    const existingContent = existing?.content ?? ''
-    const metadata: Record<string, unknown> = {
-      ...(existing?.metadata ?? {}),
-      ...(role === 'assistant' ? {
-        assistantStatus: itemRun?.status ?? (rawItem.phase === 'commentary' && rawItem.status === 'completed' ? 'completed' : 'running'),
-        assistantMessageID: rawItem.assistantMessageID || messageID,
-        ...(rawItem.turnID ? { assistantTurnID: rawItem.turnID } : {}),
-        ...(itemRun ? { assistantMode: itemRun.mode, assistantRevision: itemRun.revision } : {}),
-        ...(rawItem.error ? { assistantError: rawItem.error } : {}),
-        ...(rawItem.phase ? { assistantPhase: rawItem.phase } : {}),
-      } : {}),
-      ...(role === 'assistant' && rawItem.data?.assistantProgress ? { assistantProgress: rawItem.data.assistantProgress } : {}),
+    if (role === 'assistant' && rawItem.phase === 'commentary') {
+      const assistantMessageID = assistantMessageIDForThreadItem(rawItem, event.turnID || runID)
+      if (assistantMessageID) {
+        let ownerIndex = messages.value.findIndex((message) =>
+          message.role === 'assistant' &&
+          message.metadata?.assistantPhase !== 'commentary' &&
+          (message.id === assistantMessageID || message.metadata?.assistantMessageID === assistantMessageID),
+        )
+        // A reconnect can deliver the commentary item before the owner start
+        // event. Create the owner placeholder, then append commentary to its
+        // canonical progress trace instead of rendering a second message.
+        if (ownerIndex < 0) ownerIndex = ensureAssistantMessage(projectName, assistantMessageID, event.turnID || runID)
+        const owner = messages.value[ownerIndex]
+        // The payload sequence is zero for commentary lifecycle items, while
+        // the event sequence is only an SSE cursor. `append...` derives the
+        // stable domain progress sequence from the canonical commentary ID.
+        const projectedOwner = toProjectMessageView(appendAssistantCommentaryToMessage(owner, rawItem))
+        messages.value = messages.value.map((message, index) => index === ownerIndex ? projectedOwner : message)
+      }
+    } else {
+      const messageID = role === 'assistant' && rawItem.phase !== 'commentary'
+        ? assistantMessageIDForThreadItem(rawItem, event.turnID || runID)
+        : rawItem.id
+      const existing = messages.value.find((message) => message.id === messageID || message.id === rawItem.id)
+      const itemRun = role === 'assistant' ? assistantThreadItemToRun(rawItem) : undefined
+      const itemContent = rawItem.content ?? ''
+      const existingContent = existing?.content ?? ''
+      const metadata: Record<string, unknown> = {
+        ...(existing?.metadata ?? {}),
+        ...(role === 'assistant' ? {
+          assistantStatus: itemRun?.status ?? (rawItem.phase === 'commentary' && rawItem.status === 'completed' ? 'completed' : 'running'),
+          assistantMessageID: rawItem.assistantMessageID || messageID,
+          ...(rawItem.turnID ? { assistantTurnID: rawItem.turnID } : {}),
+          ...(itemRun ? { assistantMode: itemRun.mode, assistantRevision: itemRun.revision } : {}),
+          ...(rawItem.error ? { assistantError: rawItem.error } : {}),
+          ...(rawItem.phase ? { assistantPhase: rawItem.phase } : {}),
+        } : {}),
+        ...(role === 'assistant' && rawItem.data?.assistantProgress ? { assistantProgress: rawItem.data.assistantProgress } : {}),
+      }
+      const projected = toProjectMessageView({
+        id: messageID,
+        projectID: projectName,
+        role,
+        content: existingContent.length >= itemContent.length && existingContent.startsWith(itemContent) ? existingContent : itemContent,
+        metadata,
+        createdAt: event.createdAt,
+      })
+      messages.value = existing
+        ? messages.value.map((message) => message.id === existing.id ? projected : message)
+        : [...messages.value, projected]
+      if (role === 'assistant') updateActiveRunFromAssistantItem(rawItem, runID)
     }
-    const projected = toProjectMessageView({
-      id: messageID,
-      projectID: projectName,
-      role,
-      content: existingContent.length >= itemContent.length && existingContent.startsWith(itemContent) ? existingContent : itemContent,
-      metadata,
-      createdAt: event.createdAt,
-    })
-    messages.value = existing
-      ? messages.value.map((message) => message.id === existing.id ? projected : message)
-      : [...messages.value, projected]
-    if (role === 'assistant') updateActiveRunFromAssistantItem(rawItem, runID)
   } else if (rawItem?.id && event.turnID) {
     const assistantIndex = assistantMessageIndexForThreadItem(rawItem, event.turnID)
     if (assistantIndex >= 0) {
@@ -3046,43 +3113,67 @@ function applyAssistantThreadEvent(event: ProjectAssistantThreadEvent, projectNa
     const assistantMessageID = interrupt.action?.assistantMessageId
       || activeAssistantRun?.activeMessageID
     const index = assistantMessageID
-      ? messages.value.findIndex((message) => message.role === 'assistant' && (message.id === assistantMessageID || message.metadata?.assistantMessageID === assistantMessageID))
+      ? messages.value.findIndex((message) => message.role === 'assistant' && message.metadata?.assistantPhase !== 'commentary' && (message.id === assistantMessageID || message.metadata?.assistantMessageID === assistantMessageID))
       : lastAssistantMessageIndex(messages.value)
     if (index >= 0) {
       const next = [...messages.value]
       const message = next[index]
       next[index] = toProjectMessageView({ ...message, metadata: { ...(message.metadata ?? {}), assistantInterrupt: interrupt } })
       messages.value = next
-      if (activeAssistantRun?.id === runID) {
-        activeAssistantRun = {
-          ...activeAssistantRun,
-          status: event.type === 'approval.requested' ? 'pending_permission' : 'pending_input',
-          revision: activeAssistantRun.revision + 1,
-        }
-      }
+    }
+    if (activeAssistantRun?.id === runID) {
+      const currentRun = activeAssistantRun
+      const nextRun = reconcileAssistantRunInterrupt(
+        currentRun,
+        event.type,
+        interrupt.action?.requestId || event.requestID || '',
+      )
+      activeAssistantRun = nextRun
+      assistantRunRevisions[runID] = nextRun
+      assistantRunController.setRevision(nextRun.revision)
     }
   }
   if (event.type === 'approval.resolved' || event.type === 'input.resolved') {
+    const requestID = event.requestID || (typeof payload.requestID === 'string' ? payload.requestID : '')
     messages.value = messages.value.map((message) => message.role === 'assistant'
-      ? toProjectMessageView({ ...message, metadata: Object.fromEntries(Object.entries(message.metadata ?? {}).filter(([key]) => key !== 'assistantInterrupt')) })
+      ? toProjectMessageView({
+          ...message,
+          metadata: Object.fromEntries(Object.entries(message.metadata ?? {}).filter(([key, value]) => {
+            if (key !== 'assistantInterrupt') return true
+            if (!requestID) return false
+            const interrupt = value as ProjectAssistantUIInterruptRequest
+            return interrupt?.action?.requestId !== requestID
+          })),
+        })
       : message)
+    if (activeAssistantRun?.id === runID && !assistantRunTerminal(activeAssistantRun.status)) {
+      const currentRun = activeAssistantRun
+      const nextRun = reconcileAssistantRunInterrupt(currentRun, event.type, requestID)
+      activeAssistantRun = nextRun
+      assistantRunRevisions[runID] = nextRun
+      assistantRunController.setRevision(nextRun.revision)
+      messageStreaming.value = true
+      conversationStatus.value = 'Working'
+    }
   }
   if ((event.type === 'turn.completed' || event.type === 'turn.failed' || event.type === 'turn.interrupted') && activeAssistantRun?.id === runID) {
-    const status = event.type === 'turn.completed' ? 'completed' : event.type === 'turn.interrupted' ? 'interrupted' : 'failed'
-    const message = messages.value.find((candidate) => candidate.id === activeAssistantRun?.activeMessageID)
+    const status: 'completed' | 'failed' | 'interrupted' = event.type === 'turn.completed' ? 'completed' : event.type === 'turn.interrupted' ? 'interrupted' : 'failed'
+    const message = messages.value.find((candidate) => candidate.role === 'assistant' &&
+      candidate.metadata?.assistantPhase !== 'commentary' &&
+      (candidate.id === activeAssistantRun?.activeMessageID || candidate.metadata?.assistantMessageID === activeAssistantRun?.activeMessageID))
     if (message) {
       const rawError = message.metadata?.assistantError
       const error = activeAssistantRun.error || (rawError && typeof rawError === 'object' && typeof (rawError as { message?: unknown }).message === 'string'
         ? { message: (rawError as { message: string }).message, errorInfo: typeof (rawError as { errorInfo?: unknown }).errorInfo === 'string' ? (rawError as { errorInfo: string }).errorInfo : undefined }
         : undefined)
-      applyAssistantSnapshot({ run: { ...activeAssistantRun, status, revision: activeAssistantRun.revision + 1, error }, message }, projectName, 'stream')
+      applyAssistantSnapshot({ run: { ...reconcileAssistantRunTerminal(activeAssistantRun, status), error }, message }, projectName, 'stream')
     }
   }
 }
 
 function lastAssistantMessageIndex(source: ProjectMessageView[]): number {
   for (let index = source.length - 1; index >= 0; index--) {
-    if (source[index].role === 'assistant') return index
+    if (source[index].role === 'assistant' && source[index].metadata?.assistantPhase !== 'commentary') return index
   }
   return -1
 }
@@ -3152,15 +3243,25 @@ function assistantProgressRegionID(messageID: string): string {
   return `assistant-progress-${messageID}`
 }
 
-function assistantWorkedLabel(message: ProjectMessageView): string {
-  const status = assistantRunStatusForMessage(message)
-  const durationMs = assistantWorkedDurationClock.observe({
+function assistantDurationScope(projectName = selected.value?.name ?? ''): string {
+  return [props.ctx?.tenant, props.ctx?.subPath, projectName].filter(Boolean).join(':') || 'app-studio'
+}
+
+function observeAssistantWorkedDuration(message: ProjectMessage, run: { status?: AssistantRun['status'] }, projectName = selected.value?.name ?? ''): number {
+  const status = normalizeAssistantRunStatus(run.status)
+  return assistantWorkedDurationClock.observe({
     messageID: message.id,
-    snapshotDurationMs: message.progress?.workedDurationMs ?? 0,
+    scope: assistantDurationScope(projectName),
+    snapshotDurationMs: parseAssistantProgress(message.metadata?.assistantProgress)?.workedDurationMs ?? 0,
     nowMs: assistantDurationNowMs.value,
     ticking: status === 'running' || status === 'stopping',
     terminal: assistantRunTerminal(status),
   })
+}
+
+function assistantWorkedLabel(message: ProjectMessageView): string {
+  const status = assistantRunStatusForMessage(message)
+  const durationMs = observeAssistantWorkedDuration(message, { status })
   return formatAssistantWorkedDuration(durationMs)
 }
 

--- a/providers/app-studio/portal/src/assistantProgress.test.mjs
+++ b/providers/app-studio/portal/src/assistantProgress.test.mjs
@@ -90,3 +90,48 @@ test('advances active worked duration, freezes pauses, and trusts terminal snaps
   assert.equal(clock.observe({ ...observation, nowMs: 9_000, snapshotDurationMs: 44_000 }), 45_000)
   assert.equal(clock.observe({ ...observation, nowMs: 10_000, snapshotDurationMs: 44_700, terminal: true }), 44_700)
 })
+
+class MemoryStorage {
+  values = new Map()
+
+  getItem(key) { return this.values.get(key) ?? null }
+  setItem(key, value) { this.values.set(key, value) }
+  removeItem(key) { this.values.delete(key) }
+}
+
+test('persists an active duration across a same-tab hard refresh before the first snapshot', () => {
+  const storage = new MemoryStorage()
+  const observation = {
+    messageID: 'assistant-commentary-only',
+    scope: 'tenant-a:project-a',
+    snapshotDurationMs: 0,
+    ticking: true,
+    terminal: false,
+  }
+  const firstClock = new AssistantWorkedDurationClock({ storage, namespace: 'app-studio' })
+  assert.equal(firstClock.observe({ ...observation, nowMs: 1_000 }), 0)
+  assert.equal(firstClock.observe({ ...observation, nowMs: 6_000 }), 5_000)
+
+  // A hard refresh constructs a new clock, but session-scoped state keeps the
+  // running segment continuous while the server snapshot is still zero.
+  const reloadedClock = new AssistantWorkedDurationClock({ storage, namespace: 'app-studio' })
+  assert.equal(reloadedClock.observe({ ...observation, nowMs: 7_000 }), 6_000)
+})
+
+test('does not accrue through a pending pause, resumes from the frozen value, and cleans terminal state', () => {
+  const storage = new MemoryStorage()
+  const base = { messageID: 'assistant-paused', scope: 'tenant-a:project-a', terminal: false }
+  const clock = new AssistantWorkedDurationClock({ storage, namespace: 'app-studio' })
+  assert.equal(clock.observe({ ...base, snapshotDurationMs: 0, nowMs: 1_000, ticking: true }), 0)
+  assert.equal(clock.observe({ ...base, snapshotDurationMs: 0, nowMs: 4_000, ticking: true }), 3_000)
+  assert.equal(clock.observe({ ...base, snapshotDurationMs: 0, nowMs: 5_000, ticking: false }), 4_000)
+
+  const reloaded = new AssistantWorkedDurationClock({ storage, namespace: 'app-studio' })
+  assert.equal(reloaded.observe({ ...base, snapshotDurationMs: 0, nowMs: 20_000, ticking: false }), 4_000)
+  assert.equal(reloaded.observe({ ...base, snapshotDurationMs: 0, nowMs: 21_000, ticking: true }), 4_000)
+  assert.equal(reloaded.observe({ ...base, snapshotDurationMs: 0, nowMs: 25_000, ticking: true }), 8_000)
+
+  assert.equal(reloaded.observe({ ...base, snapshotDurationMs: 4_200, nowMs: 26_000, ticking: false, terminal: true }), 4_200)
+  const afterTerminal = new AssistantWorkedDurationClock({ storage, namespace: 'app-studio' })
+  assert.equal(afterTerminal.observe({ ...base, snapshotDurationMs: 0, nowMs: 27_000, ticking: true }), 0)
+})

--- a/providers/app-studio/portal/src/assistantProgress.ts
+++ b/providers/app-studio/portal/src/assistantProgress.ts
@@ -13,8 +13,31 @@ interface AssistantWorkedDurationClockState {
   ticking: boolean
 }
 
+interface AssistantWorkedDurationPersistedState extends AssistantWorkedDurationClockState {
+  savedAtMs: number
+}
+
+interface AssistantWorkedDurationStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+export interface AssistantWorkedDurationClockOptions {
+  /** Session-scoped storage; injectable for deterministic tests. */
+  storage?: AssistantWorkedDurationStorage | null
+  /** Storage namespace (tenant/project scope is supplied per observation). */
+  namespace?: string
+  /** Maximum persisted entries retained in one namespace bucket. */
+  maxEntries?: number
+  /** Maximum age for a persisted active segment. */
+  maxAgeMs?: number
+}
+
 export interface AssistantWorkedDurationObservation {
   messageID: string
+  /** Stable tenant/project scope; prevents state leaking between conversations. */
+  scope?: string
   snapshotDurationMs: number
   nowMs: number
   ticking: boolean
@@ -29,47 +52,219 @@ export interface AssistantWorkedDurationObservation {
  */
 export class AssistantWorkedDurationClock {
   private readonly states = new Map<string, AssistantWorkedDurationClockState>()
+  private readonly storage?: AssistantWorkedDurationStorage
+  private readonly namespace: string
+  private readonly maxEntries: number
+  private readonly maxAgeMs: number
+
+  constructor(options: AssistantWorkedDurationClockOptions = {}) {
+    this.storage = options.storage === undefined ? defaultAssistantWorkedDurationStorage() : options.storage ?? undefined
+    this.namespace = normalizeDurationScope(options.namespace || 'default')
+    this.maxEntries = Number.isSafeInteger(options.maxEntries) && (options.maxEntries as number) > 0
+      ? Math.min(options.maxEntries as number, 128)
+      : 64
+    this.maxAgeMs = Number.isFinite(options.maxAgeMs) && (options.maxAgeMs as number) > 0
+      ? Math.min(options.maxAgeMs as number, MAX_DURATION_MS)
+      : MAX_DURATION_MS
+  }
 
   observe(observation: AssistantWorkedDurationObservation): number {
     const snapshotDurationMs = Math.max(0, observation.snapshotDurationMs)
     const nowMs = Number.isFinite(observation.nowMs) ? observation.nowMs : Date.now()
+    const stateKey = this.stateKey(observation)
     if (observation.terminal) {
-      this.states.delete(observation.messageID)
+      this.states.delete(stateKey)
+      this.removePersistedState(observation, stateKey)
       return snapshotDurationMs
     }
 
-    let state = this.states.get(observation.messageID)
+    let state = this.states.get(stateKey)
     if (!state) {
-      state = {
-        snapshotDurationMs,
-        displayedDurationMs: snapshotDurationMs,
-        segmentBaseMs: snapshotDurationMs,
-        observedAtMs: nowMs,
-        ticking: observation.ticking,
-      }
-      this.states.set(observation.messageID, state)
+      state = this.restoreState(observation, stateKey, snapshotDurationMs, nowMs)
+      this.states.set(stateKey, state)
+      this.persistState(observation, stateKey, state, nowMs)
       return state.displayedDurationMs
     }
 
-    if (state.ticking) {
+    const wasTicking = state.ticking
+    if (wasTicking) {
       state.displayedDurationMs = state.segmentBaseMs + Math.max(0, nowMs - state.observedAtMs)
     }
-    if (state.snapshotDurationMs !== snapshotDurationMs) {
+
+    // Non-terminal server snapshots are monotonic hints. Preserve a local
+    // estimate that is ahead of a stale/replayed snapshot so reloads and
+    // reconnects cannot make the disclosure jump backwards.
+    if (snapshotDurationMs > state.snapshotDurationMs) {
       state.snapshotDurationMs = snapshotDurationMs
-      state.displayedDurationMs = snapshotDurationMs
-      state.segmentBaseMs = snapshotDurationMs
+      state.displayedDurationMs = Math.max(state.displayedDurationMs, snapshotDurationMs)
+      state.segmentBaseMs = state.displayedDurationMs
       state.observedAtMs = nowMs
-    } else if (observation.ticking !== state.ticking) {
+    }
+    if (observation.ticking !== wasTicking) {
       state.segmentBaseMs = state.displayedDurationMs
       state.observedAtMs = nowMs
     }
     state.ticking = observation.ticking
+    this.persistState(observation, stateKey, state, nowMs)
     return state.displayedDurationMs
   }
 
   clear(): void {
     this.states.clear()
   }
+
+  private stateKey(observation: AssistantWorkedDurationObservation): string {
+    return `${normalizeDurationScope(observation.scope || 'default')}:${normalizeDurationScope(observation.messageID)}`
+  }
+
+  private storageKey(scope: string): string {
+    return `kedge:app-studio:assistant-worked-duration:v1:${encodeDurationScope(this.namespace)}:${encodeDurationScope(scope || 'default')}`
+  }
+
+  private restoreState(
+    observation: AssistantWorkedDurationObservation,
+    stateKey: string,
+    snapshotDurationMs: number,
+    nowMs: number,
+  ): AssistantWorkedDurationClockState {
+    const persisted = this.readPersistedState(observation, stateKey, nowMs)
+    if (!persisted) {
+      return {
+        snapshotDurationMs,
+        displayedDurationMs: snapshotDurationMs,
+        segmentBaseMs: snapshotDurationMs,
+        observedAtMs: nowMs,
+        ticking: observation.ticking,
+      }
+    }
+
+    let displayedDurationMs = Math.max(snapshotDurationMs, persisted.displayedDurationMs)
+    let segmentBaseMs = persisted.segmentBaseMs
+    let observedAtMs = persisted.observedAtMs
+    const persistedSnapshot = Math.max(0, persisted.snapshotDurationMs)
+    const serverAdvanced = snapshotDurationMs > persistedSnapshot
+
+    // A pending approval/input is a deliberate pause. If the page reloads
+    // while paused, do not credit time since the last running observation.
+    if (persisted.ticking && observation.ticking) {
+      if (serverAdvanced) {
+        displayedDurationMs = Math.max(displayedDurationMs, snapshotDurationMs)
+        segmentBaseMs = displayedDurationMs
+        observedAtMs = nowMs
+      } else {
+        displayedDurationMs = Math.max(
+          displayedDurationMs,
+          persisted.segmentBaseMs + Math.max(0, nowMs - persisted.observedAtMs),
+        )
+      }
+    } else if (serverAdvanced || persisted.ticking !== observation.ticking) {
+      segmentBaseMs = displayedDurationMs
+      observedAtMs = nowMs
+    }
+
+    return {
+      snapshotDurationMs: Math.max(persistedSnapshot, snapshotDurationMs),
+      displayedDurationMs,
+      segmentBaseMs,
+      observedAtMs,
+      ticking: observation.ticking,
+    }
+  }
+
+  private readPersistedState(
+    observation: AssistantWorkedDurationObservation,
+    stateKey: string,
+    nowMs: number,
+  ): AssistantWorkedDurationPersistedState | undefined {
+    if (!this.storage) return undefined
+    try {
+      const raw = this.storage.getItem(this.storageKey(observation.scope || 'default'))
+      if (!raw) return undefined
+      const bucket = JSON.parse(raw) as { version?: unknown; entries?: Record<string, unknown> }
+      if (bucket.version !== 1 || !bucket.entries || typeof bucket.entries !== 'object') return undefined
+      const candidate = bucket.entries[stateKey]
+      if (!candidate || typeof candidate !== 'object') return undefined
+      const value = candidate as Record<string, unknown>
+      const numeric = (key: string) => {
+        const candidate = value[key]
+        return typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : undefined
+      }
+      const savedAtMs = numeric('savedAtMs')
+      const snapshotDurationMs = numeric('snapshotDurationMs')
+      const displayedDurationMs = numeric('displayedDurationMs')
+      const segmentBaseMs = numeric('segmentBaseMs')
+      const observedAtMs = numeric('observedAtMs')
+      if (savedAtMs === undefined || snapshotDurationMs === undefined || displayedDurationMs === undefined ||
+        segmentBaseMs === undefined || observedAtMs === undefined || typeof value.ticking !== 'boolean') return undefined
+      if (savedAtMs < nowMs - this.maxAgeMs || snapshotDurationMs < 0 || displayedDurationMs < 0 ||
+        segmentBaseMs < 0 || displayedDurationMs > MAX_DURATION_MS || segmentBaseMs > MAX_DURATION_MS) return undefined
+      return { savedAtMs, snapshotDurationMs, displayedDurationMs, segmentBaseMs, observedAtMs, ticking: value.ticking }
+    } catch {
+      return undefined
+    }
+  }
+
+  private persistState(
+    observation: AssistantWorkedDurationObservation,
+    stateKey: string,
+    state: AssistantWorkedDurationClockState,
+    nowMs: number,
+  ): void {
+    if (!this.storage) return
+    try {
+      const key = this.storageKey(observation.scope || 'default')
+      const raw = this.storage.getItem(key)
+      const decoded = raw ? JSON.parse(raw) as { version?: unknown; entries?: Record<string, AssistantWorkedDurationPersistedState> } : undefined
+      const entries: Record<string, AssistantWorkedDurationPersistedState> = decoded?.version === 1 && decoded.entries && typeof decoded.entries === 'object'
+        ? { ...decoded.entries }
+        : {}
+      entries[stateKey] = { ...state, savedAtMs: nowMs }
+      const cutoff = nowMs - this.maxAgeMs
+      const retained = Object.entries(entries)
+        .filter(([, value]) => value && typeof value.savedAtMs === 'number' && value.savedAtMs >= cutoff)
+        .sort(([, left], [, right]) => right.savedAtMs - left.savedAtMs)
+        .slice(0, this.maxEntries)
+      this.storage.setItem(key, JSON.stringify({ version: 1, entries: Object.fromEntries(retained) }))
+    } catch {
+      // Storage can be disabled, full, or unavailable in privacy mode. The
+      // in-memory clock remains authoritative for the current page.
+    }
+  }
+
+  private removePersistedState(observation: AssistantWorkedDurationObservation, stateKey: string): void {
+    if (!this.storage) return
+    try {
+      const key = this.storageKey(observation.scope || 'default')
+      const raw = this.storage.getItem(key)
+      if (!raw) return
+      const decoded = JSON.parse(raw) as { version?: unknown; entries?: Record<string, unknown> }
+      if (decoded.version !== 1 || !decoded.entries || typeof decoded.entries !== 'object') return
+      const entries = { ...decoded.entries }
+      delete entries[stateKey]
+      if (Object.keys(entries).length === 0) this.storage.removeItem(key)
+      else this.storage.setItem(key, JSON.stringify({ version: 1, entries }))
+    } catch {
+      // Ignore storage cleanup failures; terminal rendering still uses the
+      // server snapshot and the stale entry is bounded by the age limit.
+    }
+  }
+}
+
+function defaultAssistantWorkedDurationStorage(): AssistantWorkedDurationStorage | undefined {
+  try {
+    if (typeof window === 'undefined') return undefined
+    return window.sessionStorage
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeDurationScope(value: string): string {
+  return value.trim().slice(0, 256) || 'default'
+}
+
+function encodeDurationScope(value: string): string {
+  return encodeURIComponent(normalizeDurationScope(value)).slice(0, 256)
 }
 
 const MAX_MESSAGES = 32

--- a/providers/app-studio/portal/src/assistantThreadProjection.test.mjs
+++ b/providers/app-studio/portal/src/assistantThreadProjection.test.mjs
@@ -90,7 +90,7 @@ test('keeps terminal trace ordering and response surfaces after commentary colla
   const { buildAssistantTrace } = await vite.ssrLoadModule('/src/assistantTrace.ts')
   const items = [
     {
-      id: 'commentary-assistant-2-1', turnID: 'run-2', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      id: 'commentary-assistant-2-2', turnID: 'run-2', type: 'agentMessage', phase: 'commentary', status: 'completed',
       assistantMessageID: 'assistant-2', content: 'I am mapping the project.', sequence: 2,
       createdAt: '2026-08-02T17:42:09Z',
     },
@@ -100,7 +100,7 @@ test('keeps terminal trace ordering and response surfaces after commentary colla
       createdAt: '2026-08-02T17:42:10Z',
     },
     {
-      id: 'commentary-assistant-2-2', turnID: 'run-2', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      id: 'commentary-assistant-2-4', turnID: 'run-2', type: 'agentMessage', phase: 'commentary', status: 'completed',
       assistantMessageID: 'assistant-2', content: 'I found the edit seam.', sequence: 4,
       createdAt: '2026-08-02T17:42:11Z',
     },
@@ -190,6 +190,104 @@ test('uses the same interleaved trace for an active typed-commentary owner', asy
     { kind: 'progress', key: 'progress-1', message: 'I found the edit seam.' },
     { kind: 'actions', key: 'actions-1', items: [owner.metadata.assistantActionFeed[1]] },
   ])
+})
+
+test('materializes owner-start commentary and tool events into one canonical live trace', async () => {
+  const { assistantThreadItemsToMessages, hideCommentaryRepresentedInTrace } = await vite.ssrLoadModule('/src/assistantThreadProjection.ts')
+  const { buildAssistantTrace } = await vite.ssrLoadModule('/src/assistantTrace.ts')
+  const messages = assistantThreadItemsToMessages([
+    {
+      id: 'assistant-live', turnID: 'run-live', type: 'agentMessage', status: 'in_progress',
+      assistantMessageID: 'assistant-live', content: '', sequence: 1,
+      createdAt: '2026-08-02T17:42:09Z',
+    },
+    {
+      id: 'commentary-live-2', turnID: 'run-live', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      assistantMessageID: 'assistant-live', content: 'I am checking the project.', sequence: 2,
+      createdAt: '2026-08-02T17:42:10Z',
+    },
+    {
+      id: 'tool-live-3', turnID: 'run-live', type: 'dynamicToolCall', status: 'completed',
+      assistantMessageID: 'assistant-live',
+      data: { id: 'call-live-3', kind: 'inspect', status: 'succeeded', title: 'Read project', severity: 'normal', sequence: 3 },
+      sequence: 3, createdAt: '2026-08-02T17:42:11Z',
+    },
+  ], 'demo')
+
+  const visible = hideCommentaryRepresentedInTrace(messages)
+  assert.deepEqual(visible.map(({ id }) => id), ['assistant-live'])
+  const owner = visible[0]
+  assert.deepEqual(owner.metadata.assistantProgress.messages, ['I am checking the project.'])
+  assert.deepEqual(buildAssistantTrace(owner.metadata.assistantProgress, owner.metadata.assistantActionFeed), [
+    { kind: 'progress', key: 'progress-0', message: 'I am checking the project.' },
+    { kind: 'actions', key: 'actions-0', items: [owner.metadata.assistantActionFeed[0]] },
+  ])
+})
+
+test('preserves repeated commentary prose at distinct sequence positions', async () => {
+  const { assistantThreadItemsToMessages, hideCommentaryRepresentedInTrace } = await vite.ssrLoadModule('/src/assistantThreadProjection.ts')
+  const messages = assistantThreadItemsToMessages([
+    {
+      id: 'assistant-repeat', turnID: 'run-repeat', type: 'agentMessage', status: 'in_progress',
+      assistantMessageID: 'assistant-repeat', content: '', sequence: 1,
+      createdAt: '2026-08-02T17:42:09Z',
+    },
+    {
+      id: 'commentary-repeat-2', turnID: 'run-repeat', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      assistantMessageID: 'assistant-repeat', content: 'Checking again.', sequence: 2,
+      createdAt: '2026-08-02T17:42:10Z',
+    },
+    {
+      id: 'commentary-repeat-4', turnID: 'run-repeat', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      assistantMessageID: 'assistant-repeat', content: 'Checking again.', sequence: 4,
+      createdAt: '2026-08-02T17:42:12Z',
+    },
+  ], 'demo')
+
+  const owner = messages.find(({ id }) => id === 'assistant-repeat')
+  assert.deepEqual(owner.metadata.assistantProgress.messages, ['Checking again.', 'Checking again.'])
+  assert.deepEqual(owner.metadata.assistantProgress.messageSequences, [2, 4])
+  assert.deepEqual(hideCommentaryRepresentedInTrace(messages).map(({ id }) => id), ['assistant-repeat'])
+})
+
+test('deduplicates commentary lifecycle cursors by the real item ID suffix', async () => {
+  const { assistantThreadItemsToMessages, hideCommentaryRepresentedInTrace } = await vite.ssrLoadModule('/src/assistantThreadProjection.ts')
+  const messages = assistantThreadItemsToMessages([
+    {
+      id: 'assistant-lifecycle', turnID: 'run-lifecycle', type: 'agentMessage', status: 'in_progress',
+      assistantMessageID: 'assistant-lifecycle', content: '', sequence: 1,
+      createdAt: '2026-08-02T17:42:09Z',
+    },
+    // The payload sequence is zero in the live lifecycle; these values model
+    // distinct SSE cursors after materialization. The item ID suffix is the
+    // durable progress identity and must remain the only trace key.
+    {
+      id: 'commentary-assistant-lifecycle-7', turnID: 'run-lifecycle', type: 'agentMessage', phase: 'commentary', status: 'in_progress',
+      assistantMessageID: 'assistant-lifecycle', content: 'Checking the project.', sequence: 12,
+      createdAt: '2026-08-02T17:42:10Z',
+    },
+    {
+      id: 'commentary-assistant-lifecycle-7', turnID: 'run-lifecycle', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      assistantMessageID: 'assistant-lifecycle', content: 'Checking the project.', sequence: 13,
+      createdAt: '2026-08-02T17:42:10Z',
+    },
+    {
+      id: 'commentary-assistant-lifecycle-9', turnID: 'run-lifecycle', type: 'agentMessage', phase: 'commentary', status: 'completed',
+      assistantMessageID: 'assistant-lifecycle', content: 'Checking the project.', sequence: 14,
+      createdAt: '2026-08-02T17:42:11Z',
+    },
+    {
+      id: 'assistant-lifecycle', turnID: 'run-lifecycle', type: 'agentMessage', phase: 'final_answer', status: 'completed',
+      assistantMessageID: 'assistant-lifecycle', content: 'Done.', sequence: 15,
+      data: { assistantProgress: { version: 1, messages: ['Checking the project.'], messageSequences: [7], workedDurationMs: 900 } },
+      createdAt: '2026-08-02T17:42:12Z',
+    },
+  ], 'demo')
+
+  const owner = messages.find(({ id }) => id === 'assistant-lifecycle')
+  assert.deepEqual(owner.metadata.assistantProgress.messages, ['Checking the project.', 'Checking the project.'])
+  assert.deepEqual(owner.metadata.assistantProgress.messageSequences, [7, 9])
+  assert.deepEqual(hideCommentaryRepresentedInTrace(messages).map(({ id }) => id), ['assistant-lifecycle'])
 })
 
 test('keeps commentary visible until its owner trace contains the same prose', async () => {
@@ -422,4 +520,30 @@ test('retains the first replacement delta when a stale list projection arrives a
   const current = [{ id: 'assistant-2', projectID: 'demo', role: 'assistant', content: 'first replacement delta', metadata: { assistantRevision: 2 }, createdAt: '2026-08-02T17:42:09Z' }]
   const projected = [{ id: 'assistant-2', projectID: 'demo', role: 'assistant', content: '', metadata: { assistantRevision: 2 }, createdAt: '2026-08-02T17:42:09Z' }]
   assert.equal(mergeAssistantThreadMessages(current, projected)[0].content, 'first replacement delta')
+})
+
+test('stale thread refresh keeps newer live commentary progress and actions', async () => {
+  const { mergeAssistantThreadMessages } = await vite.ssrLoadModule('/src/assistantThreadProjection.ts')
+  const current = [{
+    id: 'assistant-live', projectID: 'demo', role: 'assistant', content: '',
+    metadata: {
+      assistantRevision: 2,
+      assistantProgress: { version: 1, messages: ['Live update'], messageSequences: [4], workedDurationMs: 900 },
+      assistantActionFeed: [{ id: 'call-live', kind: 'run', status: 'running', title: 'Run checks', severity: 'normal', sequence: 5 }],
+    },
+    createdAt: '2026-08-02T17:42:09Z',
+  }]
+  const projected = [{
+    id: 'assistant-live', projectID: 'demo', role: 'assistant', content: '',
+    metadata: {
+      assistantRevision: 2,
+      assistantProgress: { version: 1, messages: [], messageSequences: [], workedDurationMs: 0 },
+      assistantActionFeed: [],
+    },
+    createdAt: '2026-08-02T17:42:09Z',
+  }]
+  const merged = mergeAssistantThreadMessages(current, projected)[0]
+  assert.deepEqual(merged.metadata.assistantProgress.messages, ['Live update'])
+  assert.deepEqual(merged.metadata.assistantProgress.messageSequences, [4])
+  assert.deepEqual(merged.metadata.assistantActionFeed.map(({ id }) => id), ['call-live'])
 })

--- a/providers/app-studio/portal/src/assistantThreadProjection.ts
+++ b/providers/app-studio/portal/src/assistantThreadProjection.ts
@@ -6,6 +6,11 @@ import type {
 } from './types'
 import { parseAssistantProgress } from './assistantProgress'
 
+interface AssistantProgressEntry {
+  message: string
+  sequence: number
+}
+
 function assistantStatusForItem(status: unknown): ProjectAssistantRunStatus {
   switch (typeof status === 'string' ? status.trim().toLowerCase() : '') {
     case 'completed':
@@ -36,6 +41,114 @@ function isCommentaryItem(item: ProjectAssistantThreadItem): boolean {
   return isAssistantItem(item) && item.phase === 'commentary'
 }
 
+type CommentaryProjectionItem = Pick<ProjectAssistantThreadItem, 'content' | 'sequence'> &
+  Partial<Pick<ProjectAssistantThreadItem, 'id' | 'assistantMessageID'>>
+
+/**
+ * Return the domain progress sequence, not the thread event cursor. The
+ * mirror assigns commentary IDs from the durable progress sequence, while
+ * `item.sequence` in a materialized thread (and often in an SSE payload) is
+ * the lifecycle event sequence. Using that cursor here makes item.started,
+ * item.completed, and reconnect replay look like separate progress entries.
+ */
+function commentarySequence(item: CommentaryProjectionItem): number {
+  const itemID = typeof item.id === 'string' ? item.id.trim() : ''
+  const ownerID = typeof item.assistantMessageID === 'string' ? item.assistantMessageID.trim() : ''
+  const prefix = ownerID ? `commentary-${ownerID}-` : 'commentary-'
+  if (itemID.startsWith(prefix)) {
+    const suffix = itemID.slice(prefix.length)
+    if (/^\d+$/u.test(suffix)) {
+      const sequence = Number(suffix)
+      if (Number.isSafeInteger(sequence) && sequence > 0) return sequence
+    }
+  }
+  // Historical records can omit assistantMessageID but retain the canonical
+  // commentary ID. Keep that ID-derived identity before considering any
+  // payload field; never fall back to an SSE event cursor.
+  const suffix = /-(\d+)$/u.exec(itemID)?.[1]
+  if (suffix) {
+    const sequence = Number(suffix)
+    if (Number.isSafeInteger(sequence) && sequence > 0) return sequence
+  }
+  return 0
+}
+
+function commentaryOwnerID(itemID: string): string {
+  const match = /^commentary-(.+)-(\d+)$/u.exec(itemID.trim())
+  return match?.[1]?.trim() || ''
+}
+
+function mergeAssistantProgressCommentary(
+  current: unknown,
+  commentary: CommentaryProjectionItem,
+): unknown {
+  const content = typeof commentary.content === 'string' ? commentary.content.trim() : ''
+  const sequence = commentarySequence(commentary)
+  if (!content || !sequence) return current
+
+  const progress = parseAssistantProgress(current)
+  const entries: AssistantProgressEntry[] = progress
+    ? progress.messages.map((message, index) => ({ message, sequence: progress.messageSequences[index] }))
+    : []
+  // Mirror restarts can replay the same commentary item. Replace a matching
+  // sequence, but retain identical prose at distinct sequence positions: each
+  // accepted report_progress event is a separate trace entry.
+  const sameSequence = entries.findIndex((entry) => entry.sequence === sequence)
+  if (sameSequence >= 0) entries[sameSequence] = { message: content, sequence }
+  else entries.push({ message: content, sequence })
+  entries.sort((left, right) => left.sequence - right.sequence)
+  // The server bounds progress to 32 entries. Retain the newest entries when
+  // a stale client snapshot and a live commentary item are merged locally.
+  const bounded = entries.slice(-32)
+  return {
+    version: 1,
+    messages: bounded.map((entry) => entry.message),
+    messageSequences: bounded.map((entry) => entry.sequence),
+    workedDurationMs: progress?.workedDurationMs ?? 0,
+  }
+}
+
+function mergeAssistantProgressValues(current: unknown, projected: unknown, projectedWinsConflicts = false): unknown {
+  const currentProgress = parseAssistantProgress(current)
+  const projectedProgress = parseAssistantProgress(projected)
+  if (!currentProgress) return projectedProgress ?? current
+  if (!projectedProgress) return currentProgress
+
+  const entries = new Map<number, string>()
+  currentProgress.messageSequences.forEach((sequence, index) => entries.set(sequence, currentProgress.messages[index]))
+  projectedProgress.messageSequences.forEach((sequence, index) => {
+    if (projectedWinsConflicts || !entries.has(sequence)) entries.set(sequence, projectedProgress.messages[index])
+  })
+  const ordered = [...entries.entries()].sort(([left], [right]) => left - right).slice(-32)
+  return {
+    version: 1,
+    messages: ordered.map(([, message]) => message),
+    messageSequences: ordered.map(([sequence]) => sequence),
+    workedDurationMs: Math.max(currentProgress.workedDurationMs, projectedProgress.workedDurationMs),
+  }
+}
+
+/**
+ * Add one typed commentary item to its owning assistant segment. Live stream
+ * consumers use this to render the same progress/action trace as reloads,
+ * without first inserting a temporary standalone assistant message.
+ */
+export function appendAssistantCommentaryToMessage(
+  message: ProjectMessage,
+  commentary: CommentaryProjectionItem,
+): ProjectMessage {
+  if (message.role !== 'assistant') return message
+  const assistantProgress = mergeAssistantProgressCommentary(message.metadata?.assistantProgress, commentary)
+  if (assistantProgress === message.metadata?.assistantProgress) return message
+  return {
+    ...message,
+    metadata: {
+      ...(message.metadata ?? {}),
+      assistantProgress,
+    },
+  }
+}
+
 /**
  * Typed commentary is streamed as its own thread item, while the owning
  * assistant message carries the same prose with trace sequence numbers. Once
@@ -46,22 +159,30 @@ function isCommentaryItem(item: ProjectAssistantThreadItem): boolean {
  * standalone commentary until its exact text is represented in the trace.
  */
 export function hideCommentaryRepresentedInTrace(messages: ProjectMessage[]): ProjectMessage[] {
-  const tracedProgressByOwner = new Map<string, Set<string>>()
+  const tracedProgressByOwner = new Map<string, ReturnType<typeof parseAssistantProgress>>()
   for (const message of messages) {
     if (message.role !== 'assistant' || message.metadata?.assistantPhase === 'commentary') continue
     const progress = parseAssistantProgress(message.metadata?.assistantProgress)
     if (!progress) continue
-    const traced = new Set(progress.messages)
-    tracedProgressByOwner.set(message.id, traced)
+    tracedProgressByOwner.set(message.id, progress)
     const assistantMessageID = typeof message.metadata?.assistantMessageID === 'string'
       ? message.metadata.assistantMessageID.trim()
       : ''
-    if (assistantMessageID) tracedProgressByOwner.set(assistantMessageID, traced)
+    if (assistantMessageID) tracedProgressByOwner.set(assistantMessageID, progress)
   }
   return messages.filter((message) => {
     if (message.role !== 'assistant' || message.metadata?.assistantPhase !== 'commentary') return true
     const ownerID = typeof message.metadata?.assistantMessageID === 'string' ? message.metadata.assistantMessageID.trim() : ''
-    return !ownerID || !tracedProgressByOwner.get(ownerID)?.has(message.content)
+    const progress = ownerID ? tracedProgressByOwner.get(ownerID) : undefined
+    if (!progress) return true
+    const commentarySequence = typeof message.metadata?.assistantCommentarySequence === 'number'
+      ? message.metadata.assistantCommentarySequence
+      : 0
+    if (commentarySequence > 0) {
+      const sequenceIndex = progress.messageSequences.indexOf(commentarySequence)
+      if (sequenceIndex >= 0) return progress.messages[sequenceIndex] !== message.content
+    }
+    return !progress.messages.includes(message.content)
   })
 }
 
@@ -70,7 +191,7 @@ function itemOwnMessageID(item: ProjectAssistantThreadItem): string {
 }
 
 function itemAssistantMessageID(item: ProjectAssistantThreadItem): string {
-  return item.assistantMessageID?.trim() || item.id
+  return item.assistantMessageID?.trim() || (isCommentaryItem(item) ? commentaryOwnerID(item.id) || item.id : item.id)
 }
 
 /**
@@ -131,6 +252,9 @@ export function mergeAssistantThreadMessages(current: ProjectMessage[], projecte
       : { ...(existing.metadata ?? {}), ...(next.metadata ?? {}) }
     if (existing.metadata?.assistantActionFeed || next.metadata?.assistantActionFeed) {
       metadata.assistantActionFeed = mergeActionFeeds(existing.metadata?.assistantActionFeed, next.metadata?.assistantActionFeed)
+    }
+    if (existing.metadata?.assistantProgress || next.metadata?.assistantProgress) {
+      metadata.assistantProgress = mergeAssistantProgressValues(existing.metadata?.assistantProgress, next.metadata?.assistantProgress, nextRevision > existingRevision)
     }
     const existingContentIsLivePrefix = existing.content.length >= next.content.length && existing.content.startsWith(next.content)
     return {
@@ -209,10 +333,34 @@ export function assistantThreadItemsToMessages(items: ProjectAssistantThreadItem
       if (item.turnID) metadata.assistantTurnID = item.turnID
       if (item.mode) metadata.assistantMode = item.mode
       if (item.phase) metadata.assistantPhase = item.phase
+      if (isCommentaryItem(item)) {
+        const sequence = commentarySequence(item)
+        if (sequence > 0) metadata.assistantCommentarySequence = sequence
+      }
       if (item.error) metadata.assistantError = item.error
       if (item.data?.assistantProgress) metadata.assistantProgress = item.data.assistantProgress
+      const existingIndex = !isCommentaryItem(item) ? assistantByID.get(itemOwnMessageID(item)) : undefined
+      if (existingIndex !== undefined) {
+        const existing = result[existingIndex]
+        const existingMetadata = { ...(existing.metadata ?? {}) }
+        const mergedMetadata = { ...existingMetadata, ...metadata }
+        if (existingMetadata.assistantProgress || metadata.assistantProgress) {
+          mergedMetadata.assistantProgress = mergeAssistantProgressValues(existingMetadata.assistantProgress, metadata.assistantProgress, true)
+        }
+        result[existingIndex] = {
+          ...existing,
+          content: item.content || existing.content,
+          metadata: mergedMetadata,
+          createdAt: existing.createdAt || item.createdAt,
+        }
+        assistantByID.set(itemOwnMessageID(item), existingIndex)
+        assistantByID.set(itemAssistantMessageID(item), existingIndex)
+        if (item.turnID) latestAssistantByTurn.set(item.turnID, existingIndex)
+        continue
+      }
       const index = result.length
       assistantByID.set(itemOwnMessageID(item), index)
+      if (!isCommentaryItem(item)) assistantByID.set(itemAssistantMessageID(item), index)
       if (!isCommentaryItem(item) && item.turnID) latestAssistantByTurn.set(item.turnID, index)
     }
     result.push({
@@ -228,9 +376,23 @@ export function assistantThreadItemsToMessages(items: ProjectAssistantThreadItem
   const precedingAssistantByTurn = new Map<string, number>()
   for (const item of ordered) {
     if (item.type === 'agentMessage') {
-      if (!isCommentaryItem(item)) {
-        const index = assistantByID.get(itemOwnMessageID(item))
-        if (index !== undefined && item.turnID) precedingAssistantByTurn.set(item.turnID, index)
+      const index = isCommentaryItem(item)
+        ? (item.assistantMessageID
+          ? assistantByID.get(item.assistantMessageID)
+          : item.turnID ? precedingAssistantByTurn.get(item.turnID) ?? latestAssistantByTurn.get(item.turnID) : undefined)
+        : assistantByID.get(itemOwnMessageID(item))
+      if (isCommentaryItem(item)) {
+        if (index !== undefined) {
+          const message = result[index]
+          const metadata = { ...(message.metadata ?? {}) }
+          const progress = mergeAssistantProgressCommentary(metadata.assistantProgress, item)
+          if (progress !== metadata.assistantProgress) {
+            metadata.assistantProgress = progress
+            result[index] = { ...message, metadata }
+          }
+        }
+      } else if (index !== undefined && item.turnID) {
+        precedingAssistantByTurn.set(item.turnID, index)
       }
       continue
     }

--- a/providers/app-studio/portal/src/conversationResilience.test.mjs
+++ b/providers/app-studio/portal/src/conversationResilience.test.mjs
@@ -26,6 +26,63 @@ test('normalizeAssistantRunStatus validates and normalizes persisted display sta
   assert.equal(state.normalizeAssistantRunStatus(undefined), undefined)
 })
 
+test('Q&A request and resolution reconcile one run before its terminal snapshot', () => {
+  const initial = snapshot(1, 'waiting').run
+  const requested = state.reconcileAssistantRunInterrupt(initial, 'input.requested', 'request-1')
+  assert.equal(requested.status, 'pending_input')
+  assert.equal(requested.requestID, 'request-1')
+  assert.equal(requested.revision, 2)
+
+  const resolved = state.reconcileAssistantRunInterrupt(requested, 'input.resolved', 'request-1')
+  assert.equal(resolved.status, 'running')
+  assert.equal(resolved.requestID, undefined)
+  assert.equal(resolved.revision, 3)
+
+  const completed = state.reconcileAssistantRunTerminal(resolved, 'completed')
+  assert.equal(completed.status, 'completed')
+  assert.equal(completed.revision, 4)
+  assert.equal(state.assistantRunRequiresLiveControls(completed), false)
+})
+
+test('replayed Q&A events are idempotent and terminal state cannot be reopened', () => {
+  const requested = state.reconcileAssistantRunInterrupt(snapshot(1, 'waiting').run, 'input.requested', 'request-1')
+  assert.strictEqual(state.reconcileAssistantRunInterrupt(requested, 'input.requested', 'request-1'), requested)
+  const completed = state.reconcileAssistantRunTerminal(requested, 'completed')
+  assert.strictEqual(state.reconcileAssistantRunInterrupt(completed, 'input.resolved', 'request-1'), completed)
+})
+
+test('a stale resolution cannot clear a newer pending Q&A request', () => {
+  const requestA = state.reconcileAssistantRunInterrupt(snapshot(1, 'waiting').run, 'input.requested', 'request-a')
+  const requestB = state.reconcileAssistantRunInterrupt(requestA, 'input.requested', 'request-b')
+  const staleResolution = state.reconcileAssistantRunInterrupt(requestB, 'input.resolved', 'request-a')
+
+  assert.strictEqual(staleResolution, requestB)
+  assert.equal(staleResolution.status, 'pending_input')
+  assert.equal(staleResolution.requestID, 'request-b')
+  assert.equal(staleResolution.revision, requestB.revision)
+})
+
+test('replayed resolution for an already-running request is idempotent', () => {
+  const requested = state.reconcileAssistantRunInterrupt(snapshot(1, 'waiting').run, 'input.requested', 'request-1')
+  const resolved = state.reconcileAssistantRunInterrupt(requested, 'input.resolved', 'request-1')
+  const replay = state.reconcileAssistantRunInterrupt(resolved, 'input.resolved', 'request-1')
+
+  assert.strictEqual(replay, resolved)
+  assert.equal(replay.status, 'running')
+  assert.equal(replay.requestID, undefined)
+  assert.equal(replay.revision, 3)
+})
+
+test('replayed request events without a request ID remain idempotent', () => {
+  const first = state.reconcileAssistantRunInterrupt(snapshot(1, 'waiting').run, 'input.requested')
+  const replay = state.reconcileAssistantRunInterrupt(first, 'input.requested')
+
+  assert.strictEqual(replay, first)
+  assert.equal(replay.status, 'pending_input')
+  assert.equal(replay.requestID, undefined)
+  assert.equal(replay.revision, 2)
+})
+
 test('mergeConversationSnapshot keeps the stable assistant message ID and rejects older or duplicate revisions', () => {
   const initial = { messages: [message('u-1', 'hello'), message('a-1', 'old')], runs: {} }
   const current = state.mergeConversationSnapshot(initial, snapshot(2, 'new'))

--- a/providers/app-studio/portal/src/conversationResilience.ts
+++ b/providers/app-studio/portal/src/conversationResilience.ts
@@ -9,6 +9,7 @@ export interface AssistantRun {
   clientRequestID?: string
   userMessageID?: string
   error?: { message: string; errorInfo?: string }
+  requestID?: string
   abortReason?: 'interrupted' | 'replaced' | 'budget_limited' | 'iteration_limited'
 }
 
@@ -124,6 +125,45 @@ export function assistantRunCanImplementPlan(run: AssistantRun | null | undefine
     normalizeAssistantRunStatus(run.status) === 'completed' &&
     !run.error?.message?.trim(),
   )
+}
+
+export type AssistantInterruptTransition = 'approval.requested' | 'input.requested' | 'approval.resolved' | 'input.resolved'
+
+/**
+ * Apply the durable Q&A/approval lifecycle to local run controls. Stream
+ * reconnects can replay a request or its resolution, so already-applied
+ * transitions are idempotent and do not manufacture revisions.
+ */
+export function reconcileAssistantRunInterrupt(
+  run: AssistantRun,
+  transition: AssistantInterruptTransition,
+  requestID = '',
+): AssistantRun {
+  if (assistantRunTerminal(run.status)) return run
+  const normalizedRequestID = requestID.trim()
+  const pendingStatus = transition === 'approval.requested'
+    ? 'pending_permission'
+    : transition === 'input.requested'
+    ? 'pending_input'
+    : undefined
+  if (pendingStatus) {
+    if (run.status === pendingStatus && run.requestID === (normalizedRequestID || undefined)) return run
+    return { ...run, status: pendingStatus, requestID: normalizedRequestID || undefined, revision: run.revision + 1 }
+  }
+  // A resolution for an older request must not reopen a newer pending
+  // request. Missing request IDs are also ambiguous while one is pending;
+  // retain the pending state until a matching durable resolution arrives.
+  if (run.requestID && run.requestID !== normalizedRequestID) return run
+  if (run.status === 'running' && !run.requestID) return run
+  return { ...run, status: 'running', requestID: undefined, revision: run.revision + 1 }
+}
+
+export function reconcileAssistantRunTerminal(
+  run: AssistantRun,
+  status: Extract<AssistantRun['status'], 'completed' | 'failed' | 'interrupted' | 'aborted'>,
+): AssistantRun {
+  if (run.status === status) return run
+  return { ...run, status, requestID: undefined, revision: run.revision + 1 }
 }
 
 // Control hydration is deliberately separate from message merge: a reload may


### PR DESCRIPTION
## Summary

- Harden assistant lifecycle state, checkpointing, reduction, and tool recovery paths
- Add bounded mutation recovery behavior and lifecycle helper coverage
- Improve portal progress and thread projections across reconnects and partial updates
- Add conversation resilience handling and focused regression tests

## Testing

- Added and ran focused unit tests for assistant mutation recovery, progress projection, thread projection, and conversation resilience