### PR TITLE
Scale the hub to multiple replicas; fix published-app sign-in and package crawl

### DIFF
--- a/deploy/charts/faros-hub/templates/workload.yaml
+++ b/deploy/charts/faros-hub/templates/workload.yaml
@@ -3,12 +3,16 @@ Workload kind depends on the kcp mode:
   - Embedded kcp (default): StatefulSet. kcp's embedded etcd lives on a
     per-replica PVC (volumeClaimTemplates) and needs a stable network identity
     (headless serviceName) so the embedded kcp TLS cert stays valid across
-    restarts.
-  - External kcp: Deployment. The hub is stateless (no embedded etcd, no
-    persistent data-dir), so it needs no PVC and no stable identity. Uses the
-    Recreate strategy because the hub runs controllers without leader election;
-    a rolling update would briefly run two active instances.
+    restarts. Each replica would be its own control plane, so this mode is
+    always single-replica.
+  - External kcp: Deployment, scalable via replicaCount. The hub keeps no local
+    state: singleton controllers run behind a kcp-held leader-election Lease,
+    and browser sessions / app-access codes live in a shared kcp-backed store,
+    so any replica can serve any request.
 */ -}}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.kcp.external.enabled) }}
+{{- fail "replicaCount > 1 requires kcp.external.enabled=true: embedded kcp keeps a per-replica etcd on its own PVC and cannot be scaled." }}
+{{- end }}
 apiVersion: apps/v1
 {{- if .Values.kcp.external.enabled }}
 kind: Deployment
@@ -22,11 +26,12 @@ metadata:
 spec:
   {{- if .Values.kcp.external.enabled }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+  replicas: {{ .Values.replicaCount }}
   {{- else }}
   serviceName: {{ include "faros-hub.fullname" . }}-kcp
-  {{- end }}
   replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       {{- include "faros-hub.selectorLabels" . | nindent 6 }}

--- a/deploy/charts/faros-hub/values.yaml
+++ b/deploy/charts/faros-hub/values.yaml
@@ -9,6 +9,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Number of faros-hub replicas.
+# Only honoured with kcp.external.enabled=true. Embedded kcp runs a per-replica
+# etcd on its own PVC, so that mode is always a single-replica StatefulSet and
+# the chart refuses replicaCount > 1.
+replicaCount: 1
+
 # -- kcp settings
 kcp:
   # -- Embedded kcp (default, runs in-process with faros-hub)

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -166,6 +166,54 @@ ingress:
 
 ---
 
+## Scaling the hub
+
+The hub runs as a single-replica StatefulSet by default because embedded kcp
+keeps its etcd on a per-replica PVC — each replica would be its own control
+plane. Scaling requires external kcp:
+
+```yaml
+kcp:
+  embedded:
+    enabled: false
+  external:
+    enabled: true
+    existingSecret: faros-kcp-kubeconfig
+
+replicaCount: 3
+```
+
+With `kcp.external.enabled=true` the chart renders a `Deployment` with a
+`RollingUpdate` strategy. The chart refuses `replicaCount > 1` alongside
+embedded kcp rather than rendering something that cannot work.
+
+Every replica serves the full request surface — API proxy, portal, provider
+proxies, GraphQL — and no request is pinned to a pod, so no session affinity is
+needed on the ingress. Three pieces of hub state are what make that true:
+
+- **Singleton controllers** (provider provisioning, MCPServer, organization
+  bootstrap, soft-delete) run only on the replica holding the
+  `faros-hub-controllers` Lease in `root:faros:system:controllers`. The provider
+  *catalog* controller is deliberately exempt: it maintains the routing table
+  the request path reads, so it runs everywhere.
+- **Browser sessions and published-app authorization codes** live in
+  kcp-backed Secrets in the same workspace, so a cookie minted by one replica
+  resolves — and revokes — on all of them.
+- **Provider heartbeats** are recorded on `CatalogEntry.status`, so liveness
+  observed by the replica that received the beat reaches the others over the
+  catalog watch instead of each replica timing the provider out on its own.
+
+Two things cost more per replica rather than less:
+
+- The per-IP auth rate limiter is per replica, so N replicas admit up to N times
+  the configured burst. Enforce a hard global bound at the ingress if you need
+  one.
+- `hub.embeddedGraphQL` runs a schema listener per replica, so each one watches
+  the APIExportEndpointSlice and rebuilds schemas independently. Correct, but N
+  times the discovery load on kcp.
+
+---
+
 ## Operations
 
 ### Checking Logs

--- a/pkg/browsersession/session.go
+++ b/pkg/browsersession/session.go
@@ -21,9 +21,16 @@ limitations under the License.
 // key and the identity server-side.  This package deliberately has no OIDC,
 // Kubernetes, or hub dependencies so every HTTP boundary can share the same
 // session contract without creating an import cycle.
+//
+// Where the server-side records live is a Backend decision.  The default is
+// process-local memory, which is correct for a single hub replica.  A hub
+// scaled to several replicas must supply a shared Backend (see
+// pkg/hub/sharedstore): a cookie is issued by whichever replica handled the
+// login, and every other replica has to resolve and revoke it.
 package browsersession
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -90,45 +97,56 @@ type Session struct {
 	ExpiresAt time.Time
 }
 
-// storedSession is deliberately separate from Session: the raw opaque handle
-// is returned transiently to the caller that needs to set a cookie, but the
-// in-memory store retains only the hash-keyed identity and lifecycle fields.
-type storedSession struct {
+// Record is what a Backend persists for one session.  The raw opaque handle is
+// returned transiently to the caller that needs to set a cookie; a Backend only
+// ever sees the hash-derived key, never the handle itself.
+type Record struct {
 	Identity  Identity
 	IssuedAt  time.Time
 	ExpiresAt time.Time
 }
 
+// Backend is the authoritative store for session records.  Implementations are
+// keyed by an opaque, already-hashed lookup key and must be safe for concurrent
+// use.
+//
+// Get reports ErrNotFound, ErrExpired, or ErrRevoked; any other error is
+// treated as a store failure and fails the request closed.
+type Backend interface {
+	Put(ctx context.Context, key string, record Record) error
+	Get(ctx context.Context, key string) (Record, error)
+	// Revoke invalidates key.  It is idempotent, which makes logout safe to
+	// retry.  expiresAt is the horizon past which the implementation may drop
+	// any tombstone it keeps.
+	Revoke(ctx context.Context, key string, expiresAt time.Time) error
+}
+
 // Config configures a Store.  Now and Random are test seams; production uses
-// time.Now and crypto/rand.Reader.  MaxEntries bounds process-local memory so
-// an unbounded stream of logins cannot grow the store indefinitely.
+// time.Now and crypto/rand.Reader.  MaxEntries bounds the default in-memory
+// backend so an unbounded stream of logins cannot grow it indefinitely; it is
+// ignored when Backend is supplied.
 type Config struct {
 	TTL        time.Duration
 	MaxEntries int
 	Now        func() time.Time
 	Random     io.Reader
+	// Backend, when set, replaces the process-local memory backend.  Required
+	// for a hub running more than one replica.
+	Backend Backend
 }
 
-// Store is a concurrency-safe, process-local browser-session store.  It is
-// intentionally an in-memory implementation: deployments that need durable
-// sessions can replace the store behind the same HTTP integration without
-// changing the browser contract.
+// Store is the concurrency-safe front end for browser sessions: it owns handle
+// generation, the cookie contract, and TTL policy, and delegates record storage
+// to a Backend.
 type Store struct {
-	mu         sync.Mutex
-	ttl        time.Duration
-	maxEntries int
-	now        func() time.Time
-	random     io.Reader
-	sessions   map[string]storedSession
-	revoked    map[string]time.Time
-	// revokedUnknown identifies markers created for handles that did not map
-	// to a live session. Unknown markers are the first entries evicted when
-	// the bounded revocation map reaches capacity, preserving known logout
-	// revocations during arbitrary-cookie floods.
-	revokedUnknown map[string]struct{}
+	ttl     time.Duration
+	now     func() time.Time
+	random  io.Reader
+	backend Backend
 }
 
-// New creates a bounded browser-session store.
+// New creates a browser-session store.  Without Config.Backend it keeps records
+// in bounded process-local memory.
 func New(config Config) *Store {
 	ttl := config.TTL
 	if ttl <= 0 {
@@ -146,11 +164,11 @@ func New(config Config) *Store {
 	if random == nil {
 		random = rand.Reader
 	}
-	return &Store{
-		ttl: ttl, maxEntries: maxEntries, now: now, random: random,
-		sessions: make(map[string]storedSession), revoked: make(map[string]time.Time),
-		revokedUnknown: make(map[string]struct{}),
+	backend := config.Backend
+	if backend == nil {
+		backend = newMemoryBackend(maxEntries, now)
 	}
+	return &Store{ttl: ttl, now: now, random: random, backend: backend}
 }
 
 // TTL returns the configured lifetime for newly issued sessions.
@@ -164,14 +182,11 @@ func (s *Store) TTL() time.Duration {
 // Issue stores identity and returns the opaque cookie value plus its
 // server-side view.  It rejects empty stable identities so callers cannot
 // accidentally mint an anonymous session.
-func (s *Store) Issue(identity Identity) (string, Session, error) {
+func (s *Store) Issue(ctx context.Context, identity Identity) (string, Session, error) {
 	if s == nil || strings.TrimSpace(identity.UserID) == "" {
 		return "", Session{}, fmt.Errorf("%w: user id is required", ErrInvalid)
 	}
 	now := s.now()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.cleanupLocked(now)
 	for attempt := 0; attempt < maxIssueAttempts; attempt++ {
 		raw, err := s.randomSecret()
 		if err != nil {
@@ -181,18 +196,17 @@ func (s *Store) Issue(identity Identity) (string, Session, error) {
 		// Never overwrite a live session or resurrect a revoked handle.  A
 		// collision is exceptionally unlikely with crypto/rand, but the
 		// bounded retry keeps the invariant true even with a faulty source.
-		if _, exists := s.sessions[key]; exists {
+		if _, err := s.backend.Get(ctx, key); err == nil ||
+			errors.Is(err, ErrRevoked) || errors.Is(err, ErrExpired) {
 			continue
+		} else if !errors.Is(err, ErrNotFound) {
+			return "", Session{}, fmt.Errorf("checking browser session handle: %w", err)
 		}
-		if _, revoked := s.revoked[key]; revoked {
-			continue
+		record := Record{Identity: identity, IssuedAt: now, ExpiresAt: now.Add(s.ttl)}
+		if err := s.backend.Put(ctx, key, record); err != nil {
+			return "", Session{}, fmt.Errorf("storing browser session: %w", err)
 		}
-		if len(s.sessions) >= s.maxEntries {
-			s.evictOldestLocked()
-		}
-		session := Session{ID: raw, Identity: identity, IssuedAt: now, ExpiresAt: now.Add(s.ttl)}
-		s.sessions[key] = storedSession{Identity: identity, IssuedAt: now, ExpiresAt: session.ExpiresAt}
-		return raw, session, nil
+		return raw, Session{ID: raw, Identity: identity, IssuedAt: record.IssuedAt, ExpiresAt: record.ExpiresAt}, nil
 	}
 	return "", Session{}, fmt.Errorf("generating browser session secret: no fresh handle after %d attempts", maxIssueAttempts)
 }
@@ -208,8 +222,8 @@ func setCookie(w http.ResponseWriter, value string, maxAge int) {
 }
 
 // IssueHTTP creates a session and writes its secure cookie.
-func (s *Store) IssueHTTP(w http.ResponseWriter, identity Identity) (Session, error) {
-	value, session, err := s.Issue(identity)
+func (s *Store) IssueHTTP(ctx context.Context, w http.ResponseWriter, identity Identity) (Session, error) {
+	value, session, err := s.Issue(ctx, identity)
 	if err != nil {
 		return Session{}, err
 	}
@@ -222,29 +236,18 @@ func (s *Store) IssueHTTP(w http.ResponseWriter, identity Identity) (Session, er
 }
 
 // Resolve returns a live session for an opaque cookie value.
-func (s *Store) Resolve(value string) (Session, error) {
+func (s *Store) Resolve(ctx context.Context, value string) (Session, error) {
 	if s == nil || strings.TrimSpace(value) == "" {
 		return Session{}, ErrNotFound
 	}
-	now := s.now()
-	key := tokenKey(value)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Inspect the requested entry before sweeping the rest of the bounded
-	// store so callers can distinguish an expired cookie from an unknown one.
-	if stored, ok := s.sessions[key]; ok {
-		if !now.Before(stored.ExpiresAt) {
-			delete(s.sessions, key)
-			return Session{}, ErrExpired
-		}
-		s.cleanupLocked(now)
-		return Session{ID: value, Identity: stored.Identity, IssuedAt: stored.IssuedAt, ExpiresAt: stored.ExpiresAt}, nil
+	record, err := s.backend.Get(ctx, tokenKey(value))
+	if err != nil {
+		return Session{}, err
 	}
-	if _, ok := s.revoked[key]; ok {
-		return Session{}, ErrRevoked
+	if !s.now().Before(record.ExpiresAt) {
+		return Session{}, ErrExpired
 	}
-	s.cleanupLocked(now)
-	return Session{}, ErrNotFound
+	return Session{ID: value, Identity: record.Identity, IssuedAt: record.IssuedAt, ExpiresAt: record.ExpiresAt}, nil
 }
 
 // ResolveRequest resolves the shared cookie from an HTTP request.
@@ -256,29 +259,16 @@ func (s *Store) ResolveRequest(r *http.Request) (Session, error) {
 	if err != nil {
 		return Session{}, ErrNotFound
 	}
-	return s.Resolve(cookie.Value)
+	return s.Resolve(r.Context(), cookie.Value)
 }
 
 // Revoke invalidates a session immediately.  Repeated revocation is
 // idempotent, which makes logout safe to retry.
-func (s *Store) Revoke(value string) error {
+func (s *Store) Revoke(ctx context.Context, value string) error {
 	if s == nil || strings.TrimSpace(value) == "" {
 		return nil
 	}
-	now := s.now()
-	key := tokenKey(value)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.cleanupLocked(now)
-	if session, ok := s.sessions[key]; ok {
-		delete(s.sessions, key)
-		s.addRevocationLocked(key, session.ExpiresAt, false)
-		return nil
-	}
-	// Keep a short marker for an unknown value so a stale cookie cannot be
-	// accepted if a random-value collision ever occurs after logout.
-	s.addRevocationLocked(key, now.Add(s.ttl), true)
-	return nil
+	return s.backend.Revoke(ctx, tokenKey(value), s.now().Add(s.ttl))
 }
 
 // RevokeRequest revokes the shared cookie, if one is present, and emits an
@@ -286,7 +276,7 @@ func (s *Store) Revoke(value string) error {
 func (s *Store) RevokeRequest(w http.ResponseWriter, r *http.Request) {
 	if r != nil {
 		if cookie, err := r.Cookie(CookieName); err == nil {
-			_ = s.Revoke(cookie.Value)
+			_ = s.Revoke(r.Context(), cookie.Value)
 		}
 	}
 	if w != nil {
@@ -315,16 +305,87 @@ func tokenKey(value string) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-func (s *Store) cleanupLocked(now time.Time) {
-	for key, session := range s.sessions {
-		if !now.Before(session.ExpiresAt) {
-			delete(s.sessions, key)
+// memoryBackend is the default, process-local Backend.  It is correct for a
+// single hub replica only; see the package doc.
+type memoryBackend struct {
+	mu         sync.Mutex
+	maxEntries int
+	now        func() time.Time
+	sessions   map[string]Record
+	revoked    map[string]time.Time
+	// revokedUnknown identifies markers created for handles that did not map
+	// to a live session. Unknown markers are the first entries evicted when
+	// the bounded revocation map reaches capacity, preserving known logout
+	// revocations during arbitrary-cookie floods.
+	revokedUnknown map[string]struct{}
+}
+
+func newMemoryBackend(maxEntries int, now func() time.Time) *memoryBackend {
+	return &memoryBackend{
+		maxEntries: maxEntries, now: now,
+		sessions: map[string]Record{}, revoked: map[string]time.Time{},
+		revokedUnknown: map[string]struct{}{},
+	}
+}
+
+func (m *memoryBackend) Put(_ context.Context, key string, record Record) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanupLocked(m.now())
+	if len(m.sessions) >= m.maxEntries {
+		m.evictOldestLocked()
+	}
+	m.sessions[key] = record
+	return nil
+}
+
+func (m *memoryBackend) Get(_ context.Context, key string) (Record, error) {
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Inspect the requested entry before sweeping the rest of the bounded
+	// store so callers can distinguish an expired cookie from an unknown one.
+	if record, ok := m.sessions[key]; ok {
+		if !now.Before(record.ExpiresAt) {
+			delete(m.sessions, key)
+			return Record{}, ErrExpired
+		}
+		m.cleanupLocked(now)
+		return record, nil
+	}
+	if _, ok := m.revoked[key]; ok {
+		return Record{}, ErrRevoked
+	}
+	m.cleanupLocked(now)
+	return Record{}, ErrNotFound
+}
+
+func (m *memoryBackend) Revoke(_ context.Context, key string, expiresAt time.Time) error {
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanupLocked(now)
+	if record, ok := m.sessions[key]; ok {
+		delete(m.sessions, key)
+		m.addRevocationLocked(key, record.ExpiresAt, false)
+		return nil
+	}
+	// Keep a short marker for an unknown value so a stale cookie cannot be
+	// accepted if a random-value collision ever occurs after logout.
+	m.addRevocationLocked(key, expiresAt, true)
+	return nil
+}
+
+func (m *memoryBackend) cleanupLocked(now time.Time) {
+	for key, record := range m.sessions {
+		if !now.Before(record.ExpiresAt) {
+			delete(m.sessions, key)
 		}
 	}
-	for key, expiresAt := range s.revoked {
+	for key, expiresAt := range m.revoked {
 		if !now.Before(expiresAt) {
-			delete(s.revoked, key)
-			delete(s.revokedUnknown, key)
+			delete(m.revoked, key)
+			delete(m.revokedUnknown, key)
 		}
 	}
 }
@@ -334,53 +395,53 @@ func (s *Store) cleanupLocked(now time.Time) {
 // must not create an unbounded memory sink. Unknown markers are preferentially
 // evicted; if the map contains only known logout revocations, a new unknown
 // marker is dropped rather than weakening those revocations.
-func (s *Store) addRevocationLocked(key string, expiresAt time.Time, unknown bool) {
-	if _, exists := s.revoked[key]; exists {
-		s.revoked[key] = expiresAt
+func (m *memoryBackend) addRevocationLocked(key string, expiresAt time.Time, unknown bool) {
+	if _, exists := m.revoked[key]; exists {
+		m.revoked[key] = expiresAt
 		if !unknown {
-			delete(s.revokedUnknown, key)
+			delete(m.revokedUnknown, key)
 		}
 		return
 	}
-	if len(s.revoked) >= s.maxEntries {
-		if !s.evictUnknownRevocationLocked() && unknown {
+	if len(m.revoked) >= m.maxEntries {
+		if !m.evictUnknownRevocationLocked() && unknown {
 			return
 		}
-		if len(s.revoked) >= s.maxEntries {
+		if len(m.revoked) >= m.maxEntries {
 			// A newly revoked live session takes precedence over an older
 			// marker once every slot is occupied by known revocations.
-			for oldestKey := range s.revoked {
-				delete(s.revoked, oldestKey)
-				delete(s.revokedUnknown, oldestKey)
+			for oldestKey := range m.revoked {
+				delete(m.revoked, oldestKey)
+				delete(m.revokedUnknown, oldestKey)
 				break
 			}
 		}
 	}
-	s.revoked[key] = expiresAt
+	m.revoked[key] = expiresAt
 	if unknown {
-		s.revokedUnknown[key] = struct{}{}
+		m.revokedUnknown[key] = struct{}{}
 	}
 }
 
-func (s *Store) evictUnknownRevocationLocked() bool {
-	for key := range s.revokedUnknown {
-		delete(s.revokedUnknown, key)
-		delete(s.revoked, key)
+func (m *memoryBackend) evictUnknownRevocationLocked() bool {
+	for key := range m.revokedUnknown {
+		delete(m.revokedUnknown, key)
+		delete(m.revoked, key)
 		return true
 	}
 	return false
 }
 
-func (s *Store) evictOldestLocked() {
+func (m *memoryBackend) evictOldestLocked() {
 	var oldestKey string
 	var oldest time.Time
-	for key, session := range s.sessions {
-		if oldestKey == "" || session.IssuedAt.Before(oldest) {
-			oldestKey, oldest = key, session.IssuedAt
+	for key, record := range m.sessions {
+		if oldestKey == "" || record.IssuedAt.Before(oldest) {
+			oldestKey, oldest = key, record.IssuedAt
 		}
 	}
 	if oldestKey != "" {
-		delete(s.sessions, oldestKey)
+		delete(m.sessions, oldestKey)
 	}
 }
 

--- a/pkg/browsersession/session_test.go
+++ b/pkg/browsersession/session_test.go
@@ -18,6 +18,7 @@ package browsersession
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -53,7 +54,7 @@ func TestIssueUsesOpaqueHostOnlyCookieAndServerSideIdentity(t *testing.T) {
 	clock := &testClock{now: time.Unix(100, 0)}
 	store := New(Config{TTL: time.Hour, Now: clock.Now})
 	response := httptest.NewRecorder()
-	session, err := store.IssueHTTP(response, Identity{UserID: "user-1", Email: "one@example.test", AuthType: "oidc"})
+	session, err := store.IssueHTTP(context.Background(), response, Identity{UserID: "user-1", Email: "one@example.test", AuthType: "oidc"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,9 +69,9 @@ func TestIssueUsesOpaqueHostOnlyCookieAndServerSideIdentity(t *testing.T) {
 	if !cookie.Secure || !cookie.HttpOnly || cookie.Path != "/" || cookie.Domain != "" || cookie.SameSite != http.SameSiteLaxMode {
 		t.Fatalf("cookie security attributes = %#v", cookie)
 	}
-	stored, ok := store.sessions[tokenKey(cookie.Value)]
-	if !ok {
-		t.Fatalf("stored session missing for issued cookie")
+	stored, err := store.backend.Get(context.Background(), tokenKey(cookie.Value))
+	if err != nil {
+		t.Fatalf("stored session missing for issued cookie: %v", err)
 	}
 	if strings.Contains(fmt.Sprintf("%#v", stored), cookie.Value) {
 		t.Fatalf("raw cookie handle retained in stored session: %#v", stored)
@@ -91,7 +92,7 @@ func TestIssueHTTPCookieMaxAgeMatchesStoreTTL(t *testing.T) {
 	const ttl = time.Hour
 	store := New(Config{TTL: ttl, Now: clock.Now})
 	response := httptest.NewRecorder()
-	if _, err := store.IssueHTTP(response, Identity{UserID: "user-1"}); err != nil {
+	if _, err := store.IssueHTTP(context.Background(), response, Identity{UserID: "user-1"}); err != nil {
 		t.Fatal(err)
 	}
 	cookies := response.Result().Cookies()
@@ -106,22 +107,22 @@ func TestIssueHTTPCookieMaxAgeMatchesStoreTTL(t *testing.T) {
 func TestExpiryAndRevokeAreAuthoritative(t *testing.T) {
 	clock := &testClock{now: time.Unix(200, 0)}
 	store := New(Config{TTL: time.Minute, Now: clock.Now})
-	value, _, err := store.Issue(Identity{UserID: "user-1"})
+	value, _, err := store.Issue(context.Background(), Identity{UserID: "user-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Revoke(value); err != nil {
+	if err := store.Revoke(context.Background(), value); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Resolve(value); !errors.Is(err, ErrRevoked) {
+	if _, err := store.Resolve(context.Background(), value); !errors.Is(err, ErrRevoked) {
 		t.Fatalf("revoked resolve error = %v, want ErrRevoked", err)
 	}
-	value, _, err = store.Issue(Identity{UserID: "user-1"})
+	value, _, err = store.Issue(context.Background(), Identity{UserID: "user-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	clock.now = clock.now.Add(2 * time.Minute)
-	if _, err := store.Resolve(value); !errors.Is(err, ErrExpired) {
+	if _, err := store.Resolve(context.Background(), value); !errors.Is(err, ErrExpired) {
 		t.Fatalf("expired resolve error = %v, want ErrExpired", err)
 	}
 }
@@ -129,19 +130,19 @@ func TestExpiryAndRevokeAreAuthoritative(t *testing.T) {
 func TestStoreEvictsOldestAtBound(t *testing.T) {
 	clock := &testClock{now: time.Unix(300, 0)}
 	store := New(Config{TTL: time.Hour, MaxEntries: 1, Now: clock.Now})
-	first, _, err := store.Issue(Identity{UserID: "first"})
+	first, _, err := store.Issue(context.Background(), Identity{UserID: "first"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	clock.now = clock.now.Add(time.Second)
-	second, _, err := store.Issue(Identity{UserID: "second"})
+	second, _, err := store.Issue(context.Background(), Identity{UserID: "second"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Resolve(first); !errors.Is(err, ErrNotFound) {
+	if _, err := store.Resolve(context.Background(), first); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("evicted first session error = %v, want ErrNotFound", err)
 	}
-	if _, err := store.Resolve(second); err != nil {
+	if _, err := store.Resolve(context.Background(), second); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -150,11 +151,15 @@ func TestRevokedValuesAreBounded(t *testing.T) {
 	clock := &testClock{now: time.Unix(400, 0)}
 	store := New(Config{TTL: time.Hour, MaxEntries: 2, Now: clock.Now})
 	for _, value := range []string{"unknown-1", "unknown-2", "unknown-3"} {
-		if err := store.Revoke(value); err != nil {
+		if err := store.Revoke(context.Background(), value); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if got, want := len(store.revoked), 2; got > want {
+	memory, ok := store.backend.(*memoryBackend)
+	if !ok {
+		t.Fatalf("default backend = %T, want *memoryBackend", store.backend)
+	}
+	if got, want := len(memory.revoked), 2; got > want {
 		t.Fatalf("revoked entries = %d, want at most %d", got, want)
 	}
 }
@@ -163,22 +168,22 @@ func TestIssueRetriesExistingCollisionWithoutOverwriting(t *testing.T) {
 	clock := &testClock{now: time.Unix(500, 0)}
 	random := bytes.NewReader(append(append(secretBytes(1), secretBytes(1)...), secretBytes(2)...))
 	store := New(Config{TTL: time.Hour, Now: clock.Now, Random: random})
-	first, _, err := store.Issue(Identity{UserID: "first"})
+	first, _, err := store.Issue(context.Background(), Identity{UserID: "first"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, _, err := store.Issue(Identity{UserID: "second"})
+	second, _, err := store.Issue(context.Background(), Identity{UserID: "second"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if first == second {
 		t.Fatalf("collision retry returned the existing handle %q", first)
 	}
-	resolvedFirst, err := store.Resolve(first)
+	resolvedFirst, err := store.Resolve(context.Background(), first)
 	if err != nil || resolvedFirst.Identity.UserID != "first" {
 		t.Fatalf("first session after collision = %#v, err=%v", resolvedFirst, err)
 	}
-	resolvedSecond, err := store.Resolve(second)
+	resolvedSecond, err := store.Resolve(context.Background(), second)
 	if err != nil || resolvedSecond.Identity.UserID != "second" {
 		t.Fatalf("second session after collision = %#v, err=%v", resolvedSecond, err)
 	}
@@ -188,24 +193,24 @@ func TestIssueRetriesRevokedCollisionWithoutResurrection(t *testing.T) {
 	clock := &testClock{now: time.Unix(600, 0)}
 	random := bytes.NewReader(append(append(secretBytes(3), secretBytes(3)...), secretBytes(4)...))
 	store := New(Config{TTL: time.Hour, Now: clock.Now, Random: random})
-	revoked, _, err := store.Issue(Identity{UserID: "revoked"})
+	revoked, _, err := store.Issue(context.Background(), Identity{UserID: "revoked"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Revoke(revoked); err != nil {
+	if err := store.Revoke(context.Background(), revoked); err != nil {
 		t.Fatal(err)
 	}
-	fresh, _, err := store.Issue(Identity{UserID: "fresh"})
+	fresh, _, err := store.Issue(context.Background(), Identity{UserID: "fresh"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if fresh == revoked {
 		t.Fatalf("collision retry resurrected revoked handle %q", revoked)
 	}
-	if _, err := store.Resolve(revoked); !errors.Is(err, ErrRevoked) {
+	if _, err := store.Resolve(context.Background(), revoked); !errors.Is(err, ErrRevoked) {
 		t.Fatalf("revoked handle after collision = %v, want ErrRevoked", err)
 	}
-	resolved, err := store.Resolve(fresh)
+	resolved, err := store.Resolve(context.Background(), fresh)
 	if err != nil || resolved.Identity.UserID != "fresh" {
 		t.Fatalf("fresh session after revoked collision = %#v, err=%v", resolved, err)
 	}
@@ -215,17 +220,17 @@ func TestIssueFailsClosedAfterBoundedCollisions(t *testing.T) {
 	clock := &testClock{now: time.Unix(700, 0)}
 	random := &repeatingSecretReader{secret: secretBytes(5)}
 	store := New(Config{TTL: time.Hour, Now: clock.Now, Random: random})
-	first, _, err := store.Issue(Identity{UserID: "first"})
+	first, _, err := store.Issue(context.Background(), Identity{UserID: "first"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := store.Issue(Identity{UserID: "second"}); err == nil {
+	if _, _, err := store.Issue(context.Background(), Identity{UserID: "second"}); err == nil {
 		t.Fatal("repeated token collision unexpectedly issued a session")
 	}
 	if got, want := random.reads, 1+maxIssueAttempts; got != want {
 		t.Fatalf("random reads after collision exhaustion = %d, want %d", got, want)
 	}
-	resolved, err := store.Resolve(first)
+	resolved, err := store.Resolve(context.Background(), first)
 	if err != nil || resolved.Identity.UserID != "first" {
 		t.Fatalf("first session after collision exhaustion = %#v, err=%v", resolved, err)
 	}

--- a/pkg/hub/appauth/appauth.go
+++ b/pkg/hub/appauth/appauth.go
@@ -142,6 +142,12 @@ type Config struct {
 	// (e.g. "apps.faros.example"). Redirects are only issued to hosts
 	// directly under this zone. Empty disables the endpoints.
 	AppsDomain string
+	// Codes persists the one-use authorization codes. It defaults to a
+	// bounded process-local map, which is only correct for a single hub
+	// replica: authorize and exchange are separate requests and a scaled hub
+	// serves them from different pods. Supply a shared store (see
+	// pkg/hub/sharedstore) whenever the hub runs more than one replica.
+	Codes CodeStore
 	// LoginPath is the hub-relative path of the interactive login page an
 	// unauthenticated browser is sent to. Defaults to "/ui/login" (the
 	// portal SPA is mounted under /ui/).
@@ -159,16 +165,26 @@ type Handler struct {
 	loginPath  string
 	now        func() time.Time
 	random     io.Reader
-
-	mu    sync.Mutex
-	codes map[string]codeRecord
+	codes      CodeStore
 }
 
-type codeRecord struct {
-	ref          InstanceRef
-	redirectHost string
-	identity     browsersession.Identity
-	expiresAt    time.Time
+// CodeRecord is what authorize binds a code to and exchange verifies against.
+// It carries identity metadata only — never a credential.
+type CodeRecord struct {
+	Ref          InstanceRef
+	RedirectHost string
+	Identity     browsersession.Identity
+	ExpiresAt    time.Time
+}
+
+// CodeStore persists one-use authorization codes between the browser's
+// authorize hop and the access proxy's server-to-server exchange.
+//
+// Take MUST be atomic across every hub replica: a code that two callers can
+// redeem is a replayable app sign-in.
+type CodeStore interface {
+	Put(ctx context.Context, code string, record CodeRecord) error
+	Take(ctx context.Context, code string) (CodeRecord, bool)
 }
 
 // New validates cfg and returns a Handler.
@@ -190,7 +206,7 @@ func New(cfg Config) (*Handler, error) {
 		loginPath:  cfg.LoginPath,
 		now:        cfg.Now,
 		random:     cfg.Random,
-		codes:      map[string]codeRecord{},
+		codes:      cfg.Codes,
 	}
 	if h.loginPath == "" {
 		h.loginPath = "/ui/login"
@@ -200,6 +216,11 @@ func New(cfg Config) (*Handler, error) {
 	}
 	if h.random == nil {
 		h.random = rand.Reader
+	}
+	if h.codes == nil {
+		// Read the clock through the handler rather than capturing it, so a
+		// test that swaps h.now after construction also moves the store's clock.
+		h.codes = newMemoryCodeStore(func() time.Time { return h.now() })
 	}
 	return h, nil
 }
@@ -265,7 +286,7 @@ func (h *Handler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// gate exchanges with its configured external host verbatim (e.g.
 	// "app.example:10443" behind a port-forwarded local Gateway), and a
 	// hostname-only binding would 410 every exchange and loop the browser.
-	code, err := h.mintCode(ref, redirect.Host, session.Identity)
+	code, err := h.mintCode(r.Context(), ref, redirect.Host, session.Identity)
 	if err != nil {
 		h.renderError(w, http.StatusInternalServerError, "App access is unavailable",
 			"The platform could not complete sign-in. Try again shortly.")
@@ -316,8 +337,8 @@ func (h *Handler) HandleExchange(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "malformed exchange request", http.StatusBadRequest)
 		return
 	}
-	record, ok := h.consumeCode(req.Code)
-	if !ok || record.ref.key() != ref.key() || !strings.EqualFold(record.redirectHost, req.Host) {
+	record, ok := h.codes.Take(r.Context(), req.Code)
+	if !ok || record.Ref.key() != ref.key() || !strings.EqualFold(record.RedirectHost, req.Host) {
 		// Expired, replayed, or bound to different coordinates. 410 tells the
 		// proxy to restart the authorize flow rather than retry.
 		http.Error(w, "sign-in expired", http.StatusGone)
@@ -326,9 +347,9 @@ func (h *Handler) HandleExchange(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(ExchangeResponse{
 		Allowed:           true,
-		UserID:            record.identity.UserID,
-		Email:             record.identity.Email,
-		Name:              record.identity.Name,
+		UserID:            record.Identity.UserID,
+		Email:             record.Identity.Email,
+		Name:              record.Identity.Name,
 		SessionTTLSeconds: int64(sessionTTL / time.Second),
 	})
 }
@@ -393,61 +414,82 @@ func (h *Handler) validateRedirect(raw string) (*url.URL, error) {
 	return u, nil
 }
 
-func (h *Handler) mintCode(ref InstanceRef, redirectHost string, identity browsersession.Identity) (string, error) {
+func (h *Handler) mintCode(ctx context.Context, ref InstanceRef, redirectHost string, identity browsersession.Identity) (string, error) {
 	buf := make([]byte, 32)
 	if _, err := io.ReadFull(h.random, buf); err != nil {
 		return "", err
 	}
 	code := base64.RawURLEncoding.EncodeToString(buf)
-	now := h.now()
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.cleanupLocked(now)
-	for len(h.codes) >= maxCodes {
-		h.evictOldestLocked()
+	record := CodeRecord{
+		Ref:          ref,
+		RedirectHost: strings.ToLower(redirectHost),
+		Identity:     identity,
+		ExpiresAt:    h.now().Add(codeTTL),
 	}
-	h.codes[code] = codeRecord{
-		ref:          ref,
-		redirectHost: strings.ToLower(redirectHost),
-		identity:     identity,
-		expiresAt:    now.Add(codeTTL),
+	if err := h.codes.Put(ctx, code, record); err != nil {
+		return "", err
 	}
 	return code, nil
 }
 
-func (h *Handler) consumeCode(code string) (codeRecord, bool) {
-	now := h.now()
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	record, ok := h.codes[code]
-	if !ok {
-		return codeRecord{}, false
+// memoryCodeStore is the default, process-local CodeStore. Correct for a
+// single hub replica only — see Config.Codes.
+type memoryCodeStore struct {
+	now func() time.Time
+
+	mu    sync.Mutex
+	codes map[string]CodeRecord
+}
+
+func newMemoryCodeStore(now func() time.Time) *memoryCodeStore {
+	return &memoryCodeStore{now: now, codes: map[string]CodeRecord{}}
+}
+
+func (m *memoryCodeStore) Put(_ context.Context, code string, record CodeRecord) error {
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanupLocked(now)
+	for len(m.codes) >= maxCodes {
+		m.evictOldestLocked()
 	}
-	delete(h.codes, code)
-	if now.After(record.expiresAt) {
-		return codeRecord{}, false
+	m.codes[code] = record
+	return nil
+}
+
+func (m *memoryCodeStore) Take(_ context.Context, code string) (CodeRecord, bool) {
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	record, ok := m.codes[code]
+	if !ok {
+		return CodeRecord{}, false
+	}
+	delete(m.codes, code)
+	if now.After(record.ExpiresAt) {
+		return CodeRecord{}, false
 	}
 	return record, true
 }
 
-func (h *Handler) cleanupLocked(now time.Time) {
-	for k, v := range h.codes {
-		if now.After(v.expiresAt) {
-			delete(h.codes, k)
+func (m *memoryCodeStore) cleanupLocked(now time.Time) {
+	for k, v := range m.codes {
+		if now.After(v.ExpiresAt) {
+			delete(m.codes, k)
 		}
 	}
 }
 
-func (h *Handler) evictOldestLocked() {
+func (m *memoryCodeStore) evictOldestLocked() {
 	var oldestKey string
 	var oldest time.Time
-	for k, v := range h.codes {
-		if oldestKey == "" || v.expiresAt.Before(oldest) {
-			oldestKey, oldest = k, v.expiresAt
+	for k, v := range m.codes {
+		if oldestKey == "" || v.ExpiresAt.Before(oldest) {
+			oldestKey, oldest = k, v.ExpiresAt
 		}
 	}
 	if oldestKey != "" {
-		delete(h.codes, oldestKey)
+		delete(m.codes, oldestKey)
 	}
 }
 

--- a/pkg/hub/appauth/appauth_test.go
+++ b/pkg/hub/appauth/appauth_test.go
@@ -18,6 +18,7 @@ package appauth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -74,7 +75,7 @@ func newFixture(t *testing.T) *fixture {
 func (f *fixture) loggedInRequest(t *testing.T, target string) *http.Request {
 	t.Helper()
 	rec := httptest.NewRecorder()
-	if _, err := f.sessions.IssueHTTP(rec, browsersession.Identity{UserID: "user-abc", Email: "abc@example.com", Name: "Ab C", RBACIdentity: "faros:abc@example.com"}); err != nil {
+	if _, err := f.sessions.IssueHTTP(context.Background(), rec, browsersession.Identity{UserID: "user-abc", Email: "abc@example.com", Name: "Ab C", RBACIdentity: "faros:abc@example.com"}); err != nil {
 		t.Fatalf("issue session: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodGet, target, nil)
@@ -186,7 +187,7 @@ func TestAuthorizeMintsCodeAndExchangeReturnsIdentity(t *testing.T) {
 func TestAuthorizeWorksForStaticTokenSessions(t *testing.T) {
 	f := newFixture(t)
 	rec := httptest.NewRecorder()
-	if _, err := f.sessions.IssueHTTP(rec, browsersession.Identity{
+	if _, err := f.sessions.IssueHTTP(context.Background(), rec, browsersession.Identity{
 		UserID: "static-user", RBACIdentity: "faros:static:0123456789abcdef", AuthType: "static-token",
 	}); err != nil {
 		t.Fatalf("issue static-token session: %v", err)
@@ -337,14 +338,18 @@ func TestCodeExpires(t *testing.T) {
 func TestCodeStoreIsBounded(t *testing.T) {
 	f := newFixture(t)
 	for i := 0; i < maxCodes+50; i++ {
-		if _, err := f.handler.mintCode(InstanceRef{Cluster: "c1", Group: "g", Resource: "r", Name: "n"},
+		if _, err := f.handler.mintCode(context.Background(), InstanceRef{Cluster: "c1", Group: "g", Resource: "r", Name: "n"},
 			"h."+testAppsDomain, browsersession.Identity{UserID: "u"}); err != nil {
 			t.Fatalf("mint %d: %v", i, err)
 		}
 	}
-	f.handler.mu.Lock()
-	defer f.handler.mu.Unlock()
-	if len(f.handler.codes) > maxCodes {
-		t.Fatalf("codes = %d, want <= %d", len(f.handler.codes), maxCodes)
+	memory, ok := f.handler.codes.(*memoryCodeStore)
+	if !ok {
+		t.Fatalf("default code store = %T, want *memoryCodeStore", f.handler.codes)
+	}
+	memory.mu.Lock()
+	defer memory.mu.Unlock()
+	if len(memory.codes) > maxCodes {
+		t.Fatalf("codes = %d, want <= %d", len(memory.codes), maxCodes)
 	}
 }

--- a/pkg/hub/bootstrap/installer.go
+++ b/pkg/hub/bootstrap/installer.go
@@ -25,8 +25,10 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
@@ -61,20 +63,33 @@ func InstallCRDs(ctx context.Context, config *rest.Config) error {
 			return fmt.Errorf("unmarshaling CRD %s: %w", entry.Name(), err)
 		}
 
-		existing, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating CRD", "name", crd.Name)
-			if _, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, &crd, metav1.CreateOptions{}); err != nil {
-				return fmt.Errorf("creating CRD %s: %w", crd.Name, err)
+		// Every hub replica installs the CRDs at startup, so create and update
+		// both race their peers. AlreadyExists and Conflict simply mean another
+		// replica got there first with byte-identical content; retrying on the
+		// freshly observed resource version converges instead of crash-looping
+		// the replica that lost the race.
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			desired := *crd.DeepCopy()
+			existing, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, desired.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				logger.Info("Creating CRD", "name", desired.Name)
+				_, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, &desired, metav1.CreateOptions{})
+				if apierrors.IsAlreadyExists(err) {
+					// Lost the create race; fall through to the update path.
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+						desired.Name, err)
+				}
+				return err
+			} else if err != nil {
+				return err
 			}
-		} else if err != nil {
-			return fmt.Errorf("getting CRD %s: %w", crd.Name, err)
-		} else {
-			logger.Info("Updating CRD", "name", crd.Name)
-			crd.ResourceVersion = existing.ResourceVersion
-			if _, err := client.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, &crd, metav1.UpdateOptions{}); err != nil {
-				return fmt.Errorf("updating CRD %s: %w", crd.Name, err)
-			}
+			logger.Info("Updating CRD", "name", desired.Name)
+			desired.ResourceVersion = existing.ResourceVersion
+			_, err = client.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, &desired, metav1.UpdateOptions{})
+			return err
+		}); err != nil {
+			return fmt.Errorf("installing CRD %s: %w", crd.Name, err)
 		}
 	}
 

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -257,7 +257,51 @@ func (b *Bootstrapper) Bootstrap(ctx context.Context) error {
 		return fmt.Errorf("binding tenants.faros.sh in system:tenants: %w", err)
 	}
 
+	// 7. Namespace in system:controllers for the hub's own replica-coordination
+	//    objects (leader-election Lease, shared session/code Secrets). Every hub
+	//    replica needs it before it can join the election, so it is created
+	//    during bootstrap rather than lazily.
+	logger.Info("Ensuring hub coordination namespace in system:controllers")
+	if err := b.EnsureHubSystemNamespace(ctx); err != nil {
+		return fmt.Errorf("ensuring hub coordination namespace: %w", err)
+	}
+
 	logger.Info("kcp bootstrap complete")
+	return nil
+}
+
+// HubSystemNamespace is the namespace inside root:faros:system:controllers that
+// holds the hub's cross-replica coordination state: the controller
+// leader-election Lease and the shared browser-session / app-access-code
+// Secrets. It is hub-internal — no tenant, provider, or user identity is ever
+// granted access to system:controllers.
+const HubSystemNamespace = "faros-hub"
+
+// ControllersConfig returns a rest.Config targeting root:faros:system:controllers,
+// where the platform APIExports and the hub's own coordination objects live.
+func (b *Bootstrapper) ControllersConfig() *rest.Config {
+	return configForPath(b.config, kcppaths.SystemControllers)
+}
+
+// EnsureHubSystemNamespace creates HubSystemNamespace in system:controllers.
+// Idempotent on AlreadyExists, so every replica can call it concurrently at
+// startup.
+func (b *Bootstrapper) EnsureHubSystemNamespace(ctx context.Context) error {
+	client, err := dynamic.NewForConfig(b.ControllersConfig())
+	if err != nil {
+		return fmt.Errorf("creating system:controllers client: %w", err)
+	}
+	ns := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata":   map[string]interface{}{"name": HubSystemNamespace},
+		},
+	}
+	if _, err := client.Resource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}).
+		Create(ctx, ns, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating namespace %s: %w", HubSystemNamespace, err)
+	}
 	return nil
 }
 

--- a/pkg/hub/leaderelection/leaderelection.go
+++ b/pkg/hub/leaderelection/leaderelection.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leaderelection gates the hub's singleton controllers so a hub scaled
+// to multiple replicas still reconciles each object exactly once.
+//
+// The lock is a coordination.k8s.io/v1 Lease held in a kcp workspace (kcp
+// serves Leases inside every logical cluster), which keeps the hub's only hard
+// dependency kcp — no host-cluster ServiceAccount or RBAC is required, and the
+// hub works unchanged when it runs outside Kubernetes.
+//
+// Only *write* loops belong behind this gate. State that the request path reads
+// — most importantly the provider routing registry, which the catalog
+// controller keeps in sync — must be maintained on every replica, or a
+// non-leader would serve requests against an empty routing table.
+package leaderelection
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog/v2"
+)
+
+// Default lease timings. They match controller-runtime's defaults, which are
+// tuned for a control plane that may briefly stall (kcp shard restart, front
+// proxy failover) without triggering a spurious failover.
+const (
+	DefaultLeaseDuration = 15 * time.Second
+	DefaultRenewDeadline = 10 * time.Second
+	DefaultRetryPeriod   = 2 * time.Second
+)
+
+// Options configures a single election.
+type Options struct {
+	// Config must already target the workspace holding the Lease (i.e. its
+	// Host carries the /clusters/<path> segment).
+	Config *rest.Config
+	// Namespace and Name identify the Lease object.
+	Namespace string
+	Name      string
+	// Identity distinguishes this replica. Defaults to the pod hostname plus
+	// the process ID, which stays unique if two replicas ever share a host.
+	Identity string
+
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+}
+
+func (o *Options) defaults() error {
+	if o.Config == nil {
+		return fmt.Errorf("leaderelection: Config is required")
+	}
+	return o.defaultsWithoutConfig()
+}
+
+func (o *Options) defaultsWithoutConfig() error {
+	if o.Namespace == "" || o.Name == "" {
+		return fmt.Errorf("leaderelection: Namespace and Name are required")
+	}
+	if o.Identity == "" {
+		host, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("leaderelection: resolving hostname for identity: %w", err)
+		}
+		o.Identity = fmt.Sprintf("%s_%d", host, os.Getpid())
+	}
+	if o.LeaseDuration <= 0 {
+		o.LeaseDuration = DefaultLeaseDuration
+	}
+	if o.RenewDeadline <= 0 {
+		o.RenewDeadline = DefaultRenewDeadline
+	}
+	if o.RetryPeriod <= 0 {
+		o.RetryPeriod = DefaultRetryPeriod
+	}
+	return nil
+}
+
+// Run campaigns for the lease and calls run every time this replica is elected,
+// with a context that is cancelled the moment leadership is lost. It blocks
+// until ctx is done, re-entering the election after each loss, so a transient
+// kcp hiccup costs the hub a controller pause rather than a process restart —
+// the same replica keeps serving API-proxy, portal, and provider traffic
+// throughout.
+//
+// run must return promptly once its context is cancelled: the next leader may
+// already be reconciling.
+func Run(ctx context.Context, opts Options, run func(context.Context)) error {
+	if err := (&opts).defaults(); err != nil {
+		return err
+	}
+	client, err := kubernetes.NewForConfig(opts.Config)
+	if err != nil {
+		return fmt.Errorf("leaderelection: building client: %w", err)
+	}
+	return runWithClient(ctx, opts, client, run)
+}
+
+// runWithClient is Run with the client injected, so tests can drive the whole
+// election loop against a fake API.
+func runWithClient(ctx context.Context, opts Options, client kubernetes.Interface, run func(context.Context)) error {
+	if err := (&opts).defaultsWithoutConfig(); err != nil {
+		return err
+	}
+	logger := klog.FromContext(ctx).WithName("leaderelection").
+		WithValues("lease", opts.Namespace+"/"+opts.Name, "identity", opts.Identity)
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  metav1.ObjectMeta{Namespace: opts.Namespace, Name: opts.Name},
+		Client:     client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{Identity: opts.Identity},
+	}
+
+	// The election callback only hands the term's context back; run itself is
+	// invoked on this goroutine below. client-go launches OnStartedLeading in a
+	// goroutine it never joins, so calling run from there would let a new term
+	// begin while the previous term's controllers are still draining.
+	terms := make(chan context.Context, 1)
+
+	config := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: opts.LeaseDuration,
+		RenewDeadline: opts.RenewDeadline,
+		RetryPeriod:   opts.RetryPeriod,
+		// Hand the lease back on a clean shutdown so a rolling update promotes
+		// the next replica immediately instead of after LeaseDuration.
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(termCtx context.Context) { terms <- termCtx },
+			OnStoppedLeading: func() {
+				logger.Info("Lost leadership; controllers stopping, will campaign again")
+			},
+			OnNewLeader: func(identity string) {
+				if identity != opts.Identity {
+					logger.V(2).Info("Observed new leader", "leader", identity)
+				}
+			},
+		},
+	}
+
+	for {
+		elector, err := leaderelection.NewLeaderElector(config)
+		if err != nil {
+			return fmt.Errorf("leaderelection: creating elector: %w", err)
+		}
+		logger.V(2).Info("Campaigning for leadership")
+
+		// Scoped to this term so we can step down deliberately: if run returns
+		// while the lease is still held — a controller failed to start, say —
+		// holding the lease would stall the platform, because no other replica
+		// can take over work this one is no longer doing. Cancelling here
+		// releases the lease and lets a peer win the next round.
+		electionCtx, endTerm := context.WithCancel(ctx)
+		electorDone := make(chan struct{})
+		go func() {
+			defer close(electorDone)
+			elector.Run(electionCtx)
+		}()
+
+		select {
+		case termCtx := <-terms:
+			logger.Info("Acquired leadership")
+			run(termCtx)
+			if termCtx.Err() == nil {
+				logger.Info("Controllers stopped while still leader; releasing the lease")
+			}
+			endTerm()
+			<-electorDone
+		case <-electorDone:
+			// Never won this round, or ctx was cancelled while campaigning.
+		}
+		endTerm()
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(opts.RetryPeriod):
+		}
+	}
+}

--- a/pkg/hub/leaderelection/leaderelection_test.go
+++ b/pkg/hub/leaderelection/leaderelection_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNamespace = "faros-hub"
+	testLease     = "faros-hub-controllers"
+)
+
+// fastOptions keeps the election responsive enough for a unit test while
+// preserving the real ordering constraints.
+func fastOptions(identity string) Options {
+	return Options{
+		Namespace:     testNamespace,
+		Name:          testLease,
+		Identity:      identity,
+		LeaseDuration: time.Second,
+		RenewDeadline: 500 * time.Millisecond,
+		RetryPeriod:   50 * time.Millisecond,
+	}
+}
+
+func TestRunInvokesCallbackWhenElected(t *testing.T) {
+	client := kubefake.NewClientset()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	elected := make(chan struct{})
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		_ = runWithClient(ctx, fastOptions("replica-a"), client, func(termCtx context.Context) {
+			close(elected)
+			<-termCtx.Done()
+		})
+	}()
+
+	select {
+	case <-elected:
+	case <-ctx.Done():
+		t.Fatal("never elected")
+	}
+
+	cancel()
+	select {
+	case <-released:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// Exactly one replica may run the singleton controllers at a time — that is the
+// whole point of the lease.
+func TestOnlyOneReplicaLeadsAtATime(t *testing.T) {
+	client := kubefake.NewClientset()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		running int
+		maxSeen int
+	)
+	leading := make(chan string, 2)
+
+	var wg sync.WaitGroup
+	for _, identity := range []string{"replica-a", "replica-b"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = runWithClient(ctx, fastOptions(identity), client, func(termCtx context.Context) {
+				mu.Lock()
+				running++
+				if running > maxSeen {
+					maxSeen = running
+				}
+				mu.Unlock()
+				leading <- identity
+				<-termCtx.Done()
+				mu.Lock()
+				running--
+				mu.Unlock()
+			})
+		}()
+	}
+
+	select {
+	case <-leading:
+	case <-ctx.Done():
+		t.Fatal("neither replica was elected")
+	}
+	// Give the loser ample opportunity to wrongly acquire as well.
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	got := maxSeen
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("concurrent leaders = %d, want 1", got)
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+// A leader whose controllers fail to start must not sit on the lease: no peer
+// could take over the work it is no longer doing.
+func TestLeaderStepsDownWhenCallbackReturnsEarly(t *testing.T) {
+	client := kubefake.NewClientset()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	terms := make(chan struct{}, 8)
+	go func() {
+		_ = runWithClient(ctx, fastOptions("replica-a"), client, func(context.Context) {
+			// Simulates a controller that failed to start: return immediately
+			// while the lease is still held.
+			terms <- struct{}{}
+		})
+	}()
+
+	// Stepping down and re-campaigning must produce repeated terms rather than
+	// one term that holds the lease forever.
+	for i := range 2 {
+		select {
+		case <-terms:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d term(s) observed; leader kept the lease after failing", i)
+		}
+	}
+}
+
+func TestRunRequiresLeaseCoordinates(t *testing.T) {
+	client := kubefake.NewClientset()
+	err := runWithClient(context.Background(), Options{Identity: "replica-a"}, client, func(context.Context) {})
+	if err == nil {
+		t.Fatal("expected an error when Namespace and Name are unset")
+	}
+}

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -23,11 +23,13 @@ import (
 	"sort"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -121,6 +123,14 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		return ctrl.Result{}, err
 	}
 
+	// Snapshot the status as observed. Every hub replica runs this reconciler
+	// (the registry it maintains is request-path state, so it cannot be
+	// leader-gated), which makes an unconditional status write a cross-replica
+	// write storm: each Update bumps the resource version, every other
+	// replica's watch fires, and they all write again. Every exit path below
+	// goes through updateStatusIfChanged, which writes only a real diff.
+	observedStatus := *entry.Status.DeepCopy()
+
 	// Validate the action map before any endpoint is admitted into the
 	// registry. A malformed declaration must fail closed: keeping a previous
 	// registry record would allow an action whose contract no longer matches
@@ -137,11 +147,10 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 			LastTransitionTime: now,
 			ObservedGeneration: entry.Generation,
 		})
-		if statusErr := c.Status().Update(ctx, &entry); statusErr != nil {
-			if apierrors.IsConflict(statusErr) {
-				return ctrl.Result{Requeue: true}, nil
-			}
+		if requeue, statusErr := updateStatusIfChanged(ctx, c, &entry, observedStatus); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating invalid-action status: %w", statusErr)
+		} else if requeue {
+			return ctrl.Result{Requeue: true}, nil
 		}
 		logger.Info("Rejected invalid provider action declarations", "error", err.Error())
 		return ctrl.Result{}, nil
@@ -161,6 +170,13 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		Version:      entry.Spec.Version,
 	}
 	prov.EdgeProxyAccess = entry.Spec.EdgeProxyAccess
+	// Liveness travels through status so it reaches every hub replica, not just
+	// the one whose heartbeat endpoint the provider happened to hit.
+	if entry.Status.LastHeartbeat != nil {
+		prov.LastHeartbeat = entry.Status.LastHeartbeat.Time
+		prov.HeartbeatRequired = true
+		prov.ReportedVersion = entry.Status.ReportedVersion
+	}
 	if entry.Spec.APIExport != nil {
 		prov.APIExportName = entry.Spec.APIExport.Name
 		prov.APIExportPath = providersParentWorkspace + ":" + entry.Name
@@ -199,11 +215,10 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 			LastTransitionTime: now,
 			ObservedGeneration: entry.Generation,
 		})
-		if statusErr := c.Status().Update(ctx, &entry); statusErr != nil {
-			if apierrors.IsConflict(statusErr) {
-				return ctrl.Result{Requeue: true}, nil
-			}
+		if requeue, statusErr := updateStatusIfChanged(ctx, c, &entry, observedStatus); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating invalid-action-schema status: %w", statusErr)
+		} else if requeue {
+			return ctrl.Result{Requeue: true}, nil
 		}
 		logger.Info("Rejected provider action schemas", "error", actionSchemaErr.Error())
 		return ctrl.Result{}, nil
@@ -345,13 +360,34 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	}
 	setCondition(&entry.Status.Conditions, cond)
 
-	if err := c.Status().Update(ctx, &entry); err != nil {
-		if apierrors.IsConflict(err) {
-			return ctrl.Result{Requeue: true}, nil
-		}
+	if requeue, err := updateStatusIfChanged(ctx, c, &entry, observedStatus); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
+	} else if requeue {
+		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// updateStatusIfChanged writes entry's status only when it differs from what
+// was observed, and reports whether the caller should requeue after a conflict.
+// Skipping no-op writes is what keeps N hub replicas reconciling the same
+// CatalogEntry from bumping its resource version in a loop.
+func updateStatusIfChanged(
+	ctx context.Context,
+	c client.Client,
+	entry *providersv1alpha1.CatalogEntry,
+	observed providersv1alpha1.CatalogEntryStatus,
+) (requeue bool, err error) {
+	if equality.Semantic.DeepEqual(observed, entry.Status) {
+		return false, nil
+	}
+	if err := c.Status().Update(ctx, entry); err != nil {
+		if apierrors.IsConflict(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 // urlString renders a *url.URL for logging, returning "" for nil (a nil

--- a/pkg/hub/providers/controller_test.go
+++ b/pkg/hub/providers/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -194,5 +195,89 @@ func TestCatalogReconcilerOmitsInvalidAssistantSkillAndKeepsValidSibling(t *test
 	}
 	if len(got.AssistantSkills) != 1 || got.AssistantSkills[0].PackageName != "valid" || got.AssistantSkills[0].Digest != digest {
 		t.Fatalf("assistant skills = %#v, want only valid sibling", got.AssistantSkills)
+	}
+}
+
+// Every replica runs the catalog reconciler, so an unconditional status write
+// is a cross-replica write storm: each Update bumps the resource version, every
+// peer's watch fires, and they all write again. A steady-state reconcile must
+// therefore leave the object untouched.
+func TestCatalogReconcilerDoesNotRewriteUnchangedStatus(t *testing.T) {
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost"},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			DisplayName: "Cost",
+			Backend:     &providersv1alpha1.ProviderBackend{URL: "http://cost.invalid"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+
+	r := &CatalogReconciler{mgr: testfakes.NewManager(c), reg: reg, noKCP: true}
+	req := testfakes.NewRequest("cluster", "", "cost")
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	var afterFirst providersv1alpha1.CatalogEntry
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "cost"}, &afterFirst); err != nil {
+		t.Fatalf("get after first reconcile: %v", err)
+	}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	var afterSecond providersv1alpha1.CatalogEntry
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "cost"}, &afterSecond); err != nil {
+		t.Fatalf("get after second reconcile: %v", err)
+	}
+
+	if afterFirst.ResourceVersion != afterSecond.ResourceVersion {
+		t.Fatalf("status rewritten with no change: resourceVersion %s -> %s",
+			afterFirst.ResourceVersion, afterSecond.ResourceVersion)
+	}
+}
+
+// The status heartbeat is how a beat served by one replica reaches the others;
+// the reconciler has to carry it into the registry.
+func TestCatalogReconcilerAdoptsStatusHeartbeat(t *testing.T) {
+	beat := metav1.NewTime(time.Now().Add(-time.Second).Truncate(time.Second))
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost"},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			Backend: &providersv1alpha1.ProviderBackend{URL: "http://cost.invalid"},
+		},
+		Status: providersv1alpha1.CatalogEntryStatus{
+			LastHeartbeat:   &beat,
+			ReportedVersion: "v4.5.6",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+
+	r := &CatalogReconciler{mgr: testfakes.NewManager(c), reg: reg, noKCP: true}
+	if _, err := r.Reconcile(context.Background(), testfakes.NewRequest("cluster", "", "cost")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, ok := reg.Get("cost")
+	if !ok {
+		t.Fatal("cost missing from registry")
+	}
+	if !got.LastHeartbeat.Equal(beat.Time) || got.ReportedVersion != "v4.5.6" || !got.HeartbeatRequired {
+		t.Fatalf("registry did not adopt status heartbeat: %+v", got)
+	}
+	if !got.Ready() {
+		t.Fatal("provider with a fresh heartbeat should be Ready on every replica")
 	}
 }

--- a/pkg/hub/providers/heartbeat.go
+++ b/pkg/hub/providers/heartbeat.go
@@ -37,13 +37,32 @@ type heartbeatRequest struct {
 	Status  string `json:"status,omitempty"`
 }
 
+// HeartbeatRecorder persists a heartbeat to the provider's CatalogEntry status.
+//
+// A heartbeat reaches exactly one hub replica — whichever the load balancer
+// picked — but every replica routes provider traffic and therefore needs the
+// liveness signal. Writing it to CatalogEntry.status is what fans it back out:
+// each replica's catalog watch delivers the update and refreshes its own
+// registry. Without this, non-receiving replicas would mark a perfectly healthy
+// provider stale after HeartbeatTTL and start refusing to proxy to it.
+type HeartbeatRecorder func(ctx context.Context, name, version string, at time.Time) error
+
+// heartbeatPersistThreshold suppresses a status write when the recorded
+// timestamp is already this fresh. It bounds API churn from a provider that
+// heartbeats far more often than intended, while staying well under
+// HeartbeatTTL so a normally-paced provider persists every beat.
+const heartbeatPersistThreshold = HeartbeatTTL / 6
+
 // NewHeartbeatHandler returns an http.Handler serving
 // POST /api/providers/{name}/heartbeat. Auth is enforced by the faros auth
 // middleware mounted upstream of this handler — any bearer token faros
 // accepts will be accepted as a valid heartbeat sender in Phase 1C. Phase
 // 1D will tighten this to "must be the provider's own SA token" once SA
 // minting is in place.
-func NewHeartbeatHandler(reg *Registry, log logr.Logger) http.Handler {
+//
+// record may be nil (no kcp configured), in which case liveness stays local to
+// this process and the hub must not be scaled beyond one replica.
+func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, log logr.Logger) http.Handler {
 	logger := log.WithName("heartbeat")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -62,9 +81,22 @@ func NewHeartbeatHandler(reg *Registry, log logr.Logger) http.Handler {
 				return
 			}
 		}
-		if !reg.Heartbeat(name, body.Version, time.Now()) {
+		now := time.Now()
+		// Apply locally first so this replica routes to the provider without
+		// waiting for the watch to loop the status write back around.
+		previous, known := reg.Get(name)
+		if !reg.Heartbeat(name, body.Version, now) {
 			http.Error(w, "provider not found: "+name, http.StatusNotFound)
 			return
+		}
+		if record != nil && (!known || now.Sub(previous.LastHeartbeat) >= heartbeatPersistThreshold) {
+			if err := record(r.Context(), name, body.Version, now); err != nil {
+				// Fail the beat rather than silently leaving other replicas to
+				// time the provider out; the provider retries on its next tick.
+				logger.Error(err, "persisting heartbeat failed", "provider", name)
+				http.Error(w, "recording heartbeat failed", http.StatusInternalServerError)
+				return
+			}
 		}
 		logger.V(2).Info("heartbeat received", "provider", name, "version", body.Version)
 		w.Header().Set("Content-Type", "application/json")
@@ -92,8 +124,10 @@ func parseHeartbeatPath(p string) (string, bool) {
 }
 
 // RunSweeper periodically marks providers stale when their last heartbeat
-// is older than HeartbeatTTL. Designed to run as a single goroutine for the
-// lifetime of the hub process. Returns when ctx is done.
+// is older than HeartbeatTTL. It derives staleness purely from the timestamps
+// already in the registry, so every hub replica runs its own copy and they all
+// reach the same verdict — this is deliberately NOT leader-gated. Returns when
+// ctx is done.
 func RunSweeper(ctx context.Context, reg *Registry, log logr.Logger) {
 	logger := log.WithName("heartbeat-sweeper")
 	logger.Info("starting", "interval", SweepInterval, "ttl", HeartbeatTTL)

--- a/pkg/hub/providers/heartbeat_recorder.go
+++ b/pkg/hub/providers/heartbeat_recorder.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/faroshq/faros/pkg/apiurl"
+	"github.com/faroshq/faros/pkg/kcppaths"
+)
+
+var catalogEntryGVR = schema.GroupVersionResource{
+	Group: "providers.faros.sh", Version: "v1alpha1", Resource: "catalogentries",
+}
+
+// NewCatalogHeartbeatRecorder returns a HeartbeatRecorder that stamps
+// CatalogEntry.status in root:faros:system:providers, where the entries live.
+//
+// A merge patch (rather than a read-modify-write) keeps concurrent beats from
+// different providers — and a beat racing the catalog reconciler's own status
+// write — from conflicting.
+func NewCatalogHeartbeatRecorder(kcpConfig *rest.Config) (HeartbeatRecorder, error) {
+	if kcpConfig == nil {
+		return nil, fmt.Errorf("kcp config is required")
+	}
+	cfg := rest.CopyConfig(kcpConfig)
+	cfg.Host = apiurl.KCPClusterURL(cfg.Host, kcppaths.SystemProviders)
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating system:providers client: %w", err)
+	}
+	return func(ctx context.Context, name, version string, at time.Time) error {
+		// metav1.Time serialises as RFC3339 at second precision; match it
+		// exactly so the round trip through the API is lossless.
+		status := map[string]any{"lastHeartbeat": at.UTC().Format(time.RFC3339)}
+		if version != "" {
+			status["reportedVersion"] = version
+		}
+		patch, err := json.Marshal(map[string]any{"status": status})
+		if err != nil {
+			return fmt.Errorf("encoding heartbeat patch: %w", err)
+		}
+		if _, err := client.Resource(catalogEntryGVR).Patch(
+			ctx, name, types.MergePatchType, patch, metav1.PatchOptions{}, "status",
+		); err != nil {
+			return fmt.Errorf("patching CatalogEntry %q status: %w", name, err)
+		}
+		return nil
+	}, nil
+}

--- a/pkg/hub/providers/heartbeat_test.go
+++ b/pkg/hub/providers/heartbeat_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func heartbeatRequestFor(name string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, PathProviderHeartbeat+"/"+name+"/heartbeat", nil)
+}
+
+// A heartbeat reaches one replica but must become visible to all of them, which
+// is what persisting it to CatalogEntry status buys.
+func TestHeartbeatIsPersistedForOtherReplicas(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+
+	var recorded []string
+	handler := NewHeartbeatHandler(reg, func(_ context.Context, name, version string, _ time.Time) error {
+		recorded = append(recorded, name+"@"+version)
+		return nil
+	}, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost,
+		PathProviderHeartbeat+"/cost/heartbeat", strings.NewReader(`{"version":"v1.2.3"}`))
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if len(recorded) != 1 || recorded[0] != "cost@v1.2.3" {
+		t.Fatalf("recorded = %v, want [cost@v1.2.3]", recorded)
+	}
+	if got, _ := reg.Get("cost"); !got.HeartbeatRequired || got.LastHeartbeat.IsZero() {
+		t.Fatalf("local registry not updated: %+v", got)
+	}
+}
+
+// A provider that beats far faster than intended must not turn into a stream of
+// API writes; the local registry still records every beat.
+func TestHeartbeatPersistIsThrottled(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+
+	writes := 0
+	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
+		writes++
+		return nil
+	}, logr.Discard())
+
+	for range 5 {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, heartbeatRequestFor("cost"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	}
+	if writes != 1 {
+		t.Fatalf("status writes = %d, want 1 (first beat only)", writes)
+	}
+}
+
+// If the beat cannot be shared, reporting success would leave every other
+// replica timing out a healthy provider with nothing in the logs.
+func TestHeartbeatFailsWhenPersistFails(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+
+	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
+		return fmt.Errorf("kcp unavailable")
+	}, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestFor("cost"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestHeartbeatUnknownProviderIsNotPersisted(t *testing.T) {
+	reg := NewRegistry()
+	persisted := false
+	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
+		persisted = true
+		return nil
+	}, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestFor("nope"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if persisted {
+		t.Fatal("persisted a heartbeat for a provider that is not registered")
+	}
+}
+
+// Without a recorder (no kcp) the handler still works process-locally.
+func TestHeartbeatWithoutRecorder(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+	handler := NewHeartbeatHandler(reg, nil, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestFor("cost"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got, _ := reg.Get("cost"); !got.HeartbeatRequired {
+		t.Fatal("local registry not updated")
+	}
+}

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -96,9 +96,11 @@ type Provider struct {
 	// The catalog controller sets this; the sweeper does not touch it.
 	EndpointsValid bool
 
-	// LastHeartbeat is updated by the POST /api/providers/{name}/heartbeat
-	// handler. Zero until the first heartbeat (or for providers that don't
-	// heartbeat at all).
+	// LastHeartbeat is the provider's most recent beat. It is set both by the
+	// POST /api/providers/{name}/heartbeat handler on the replica that served
+	// it and by the catalog reconciler from CatalogEntry.status.lastHeartbeat,
+	// which is how the signal reaches replicas that did not serve the beat.
+	// Zero until the first heartbeat (or for providers that don't heartbeat).
 	LastHeartbeat time.Time
 	// ReportedVersion is the version string the provider pod sent in its
 	// most recent heartbeat — may diverge from Version during a chart
@@ -401,16 +403,28 @@ func (r *Registry) List() []Provider {
 }
 
 // Upsert replaces the spec-derived fields of the registry record for p.Name
-// (or inserts a new record). Heartbeat-tracked fields (LastHeartbeat,
-// ReportedVersion, HeartbeatRequired, HeartbeatStale) are preserved across
-// upserts so reconcile churn doesn't lose a provider's liveness state.
+// (or inserts a new record).
+//
+// Liveness is merged, not overwritten. p.LastHeartbeat carries what the
+// CatalogEntry status says (the cross-replica signal); the record may already
+// hold a newer beat this replica served directly, or one whose status write was
+// throttled. Taking the later of the two keeps the merge monotone, so neither
+// source can move a provider backwards in time and flip it stale. HeartbeatStale
+// stays a purely local verdict, recomputed by the sweeper from these timestamps.
 func (r *Registry) Upsert(p Provider) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if existing, ok := r.byName[p.Name]; ok {
-		p.LastHeartbeat = existing.LastHeartbeat
-		p.ReportedVersion = existing.ReportedVersion
-		p.HeartbeatRequired = existing.HeartbeatRequired
+		if existing.LastHeartbeat.After(p.LastHeartbeat) {
+			// The reported version belongs to the beat it arrived with, so it
+			// travels with the timestamp that wins.
+			p.LastHeartbeat = existing.LastHeartbeat
+			if existing.ReportedVersion != "" {
+				p.ReportedVersion = existing.ReportedVersion
+			}
+		}
+		// A provider that has ever heartbeated is expected to keep doing so.
+		p.HeartbeatRequired = p.HeartbeatRequired || existing.HeartbeatRequired
 		p.HeartbeatStale = existing.HeartbeatStale
 		if p.WorkspaceCluster == "" {
 			// Provisioning sets this after the Upsert in the same reconcile;

--- a/pkg/hub/providers/registry_test.go
+++ b/pkg/hub/providers/registry_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -68,5 +69,70 @@ func TestParseProviderActionsRejectsExternalSchemaReferences(t *testing.T) {
 	}})
 	if err == nil || !strings.Contains(err.Error(), "local fragment") {
 		t.Fatalf("external schema reference error = %v, want local-fragment rejection", err)
+	}
+}
+
+// The registry receives liveness from two directions: the beat this replica
+// served directly, and CatalogEntry status arriving over the catalog watch.
+// Merging them must be monotone, or a status write that predates a local beat
+// (or was throttled away entirely) would drag the provider backwards and let
+// the sweeper mark a healthy provider stale.
+func TestUpsertKeepsNewestHeartbeat(t *testing.T) {
+	base := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	reg := NewRegistry()
+
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+	reg.Heartbeat("cost", "v2", base.Add(time.Minute))
+
+	// A status update carrying an older (throttled) timestamp arrives.
+	reg.Upsert(Provider{
+		Name: "cost", EndpointsValid: true,
+		LastHeartbeat: base, HeartbeatRequired: true, ReportedVersion: "v1",
+	})
+
+	got, ok := reg.Get("cost")
+	if !ok {
+		t.Fatal("cost missing from registry")
+	}
+	if !got.LastHeartbeat.Equal(base.Add(time.Minute)) {
+		t.Fatalf("LastHeartbeat = %v, want the newer local beat %v", got.LastHeartbeat, base.Add(time.Minute))
+	}
+	if got.ReportedVersion != "v2" {
+		t.Fatalf("ReportedVersion = %q, want v2", got.ReportedVersion)
+	}
+}
+
+// The converse: a replica that never served a beat learns liveness purely from
+// status, which is the whole point of routing it through the API.
+func TestUpsertAdoptsHeartbeatFromStatus(t *testing.T) {
+	beat := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+
+	reg.Upsert(Provider{
+		Name: "cost", EndpointsValid: true,
+		LastHeartbeat: beat, HeartbeatRequired: true, ReportedVersion: "v9",
+	})
+
+	got, _ := reg.Get("cost")
+	if !got.LastHeartbeat.Equal(beat) || got.ReportedVersion != "v9" || !got.HeartbeatRequired {
+		t.Fatalf("registry did not adopt status heartbeat: %+v", got)
+	}
+	if !got.Ready() {
+		t.Fatal("provider with a fresh status heartbeat should be Ready")
+	}
+}
+
+// HeartbeatRequired must never regress: a provider that has beaten once is
+// expected to keep beating, whichever replica observed the first one.
+func TestUpsertKeepsHeartbeatRequired(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+	reg.Heartbeat("cost", "", time.Now())
+
+	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
+
+	if got, _ := reg.Get("cost"); !got.HeartbeatRequired {
+		t.Fatal("HeartbeatRequired regressed to false on a spec-only upsert")
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -56,10 +56,12 @@ import (
 	"github.com/faroshq/faros/pkg/hub/controllers/organization"
 	"github.com/faroshq/faros/pkg/hub/controllers/softdelete"
 	"github.com/faroshq/faros/pkg/hub/kcp"
+	"github.com/faroshq/faros/pkg/hub/leaderelection"
 	"github.com/faroshq/faros/pkg/hub/mcpaggregate"
 	"github.com/faroshq/faros/pkg/hub/providers"
 	"github.com/faroshq/faros/pkg/hub/restapi"
 	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
+	"github.com/faroshq/faros/pkg/hub/sharedstore"
 	"github.com/faroshq/faros/pkg/hub/tenant"
 	"github.com/faroshq/faros/pkg/hub/workloadidentity"
 	"github.com/faroshq/faros/pkg/kcppaths"
@@ -68,6 +70,19 @@ import (
 	pkgversion "github.com/faroshq/faros/pkg/version"
 
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+)
+
+const (
+	// controllerLeaseName is the Lease every hub replica campaigns for before
+	// running the singleton (write-side) controllers. One lease covers all of
+	// them: they are started and stopped as a unit, so splitting the lock per
+	// manager would only add failure modes.
+	controllerLeaseName = "faros-hub-controllers"
+
+	// sharedStoreGCInterval is how often the leader reclaims expired session
+	// and authorization-code records. Readers already refuse expired entries,
+	// so this cadence only affects storage, never correctness.
+	sharedStoreGCInterval = 10 * time.Minute
 )
 
 // Server is the faros hub server orchestrator.
@@ -90,11 +105,6 @@ func (s *Server) Run(ctx context.Context) error {
 		"listenAddr", s.opts.ListenAddr,
 		"embeddedKCP", s.opts.EmbeddedKCP,
 	)
-	// One process-wide store backs the host-only portal cookie, app-access SSO,
-	// and static-token login. Credentials remain in the existing auth/proxy
-	// paths; this store contains only bounded opaque handles and user metadata.
-	browserSessionStore := browsersession.New(browsersession.Config{})
-
 	// Validate --providers BEFORE any expensive init (embedded kcp takes
 	// ~60s to bootstrap). A typo or dep violation should error in
 	// milliseconds, not after the user watches kcp boot.
@@ -286,7 +296,15 @@ func (s *Server) Run(ctx context.Context) error {
 	userClient := farosClient
 	if kcpConfig != nil {
 		bootstrapper = kcp.NewBootstrapper(kcpConfig).WithEnabledProviders(s.opts.Providers)
-		if err := bootstrapper.Bootstrap(ctx); err != nil {
+		// Retry for the same reason InstallCRDs does: sibling replicas bootstrap
+		// the same idempotent objects concurrently, so a lost write race is a
+		// transient condition, not a fatal one.
+		if err := runStartupStepWithRetry(ctx, startupRetryPolicy{
+			Name:      "bootstrap kcp",
+			Interval:  5 * time.Second,
+			Timeout:   10 * time.Minute,
+			Retryable: isRetriableKCPBootstrapError,
+		}, bootstrapper.Bootstrap); err != nil {
 			return fmt.Errorf("bootstrapping kcp: %w", err)
 		}
 		logger.Info("kcp bootstrap complete")
@@ -304,6 +322,37 @@ func (s *Server) Run(ctx context.Context) error {
 			return fmt.Errorf("creating user dynamic client: %w", err)
 		}
 		userClient = farosclient.NewFromDynamic(userDynamic)
+	}
+
+	// One process-wide store backs the host-only portal cookie, app-access SSO,
+	// and static-token login. Credentials remain in the existing auth/proxy
+	// paths; this store contains only bounded opaque handles and user metadata.
+	//
+	// A cookie is minted by whichever replica served the login and resolved by
+	// whichever replica the load balancer picks next, so once kcp is available
+	// the records go into a shared kcp-backed store. Only a hub with no kcp at
+	// all — which cannot be scaled anyway — falls back to process-local memory.
+	var (
+		browserSessionStore *browsersession.Store
+		appCodeStore        *sharedstore.AppCodeStore
+		sharedStores        []*sharedstore.Store
+	)
+	if kcpConfig != nil {
+		sessionBackend, err := sharedstore.NewSessionBackend(bootstrapper.ControllersConfig(), kcp.HubSystemNamespace)
+		if err != nil {
+			return fmt.Errorf("creating shared browser-session store: %w", err)
+		}
+		appCodeStore, err = sharedstore.NewAppCodeStore(bootstrapper.ControllersConfig(), kcp.HubSystemNamespace)
+		if err != nil {
+			return fmt.Errorf("creating shared app-code store: %w", err)
+		}
+		browserSessionStore = browsersession.New(browsersession.Config{Backend: sessionBackend})
+		sharedStores = append(sharedStores, sessionBackend.Store(), appCodeStore.Store())
+		logger.Info("Browser sessions and app-access codes are shared across replicas",
+			"workspace", kcppaths.SystemControllers, "namespace", kcp.HubSystemNamespace)
+	} else {
+		browserSessionStore = browsersession.New(browsersession.Config{})
+		logger.Info("Browser sessions are process-local (no kcp configured); do not run more than one hub replica")
 	}
 
 	// Create HTTP mux
@@ -360,8 +409,21 @@ func (s *Server) Run(ctx context.Context) error {
 	router.Handle(providers.PathListProviders, providers.NewListHandler(providerRegistry)).Methods("GET")
 	// Heartbeat endpoint matches /api/providers/{name}/heartbeat. The
 	// parsing happens inside the handler; gorilla/mux just needs the prefix.
-	router.PathPrefix(providers.PathProviderHeartbeat + "/").Handler(providers.NewHeartbeatHandler(providerRegistry, logger)).Methods("POST")
-	// Background sweeper marks providers stale when heartbeats stop.
+	// A heartbeat lands on exactly one replica but every replica routes provider
+	// traffic, so the recorder persists it to CatalogEntry.status and the catalog
+	// watch fans it back out. Without that, replicas that never saw the beat
+	// would time a healthy provider out and start refusing to proxy to it.
+	var heartbeatRecorder providers.HeartbeatRecorder
+	if kcpConfig != nil {
+		heartbeatRecorder, err = providers.NewCatalogHeartbeatRecorder(kcpConfig)
+		if err != nil {
+			return fmt.Errorf("creating provider heartbeat recorder: %w", err)
+		}
+	}
+	router.PathPrefix(providers.PathProviderHeartbeat + "/").Handler(providers.NewHeartbeatHandler(providerRegistry, heartbeatRecorder, logger)).Methods("POST")
+	// Background sweeper marks providers stale when heartbeats stop. Every
+	// replica runs one: it only reads timestamps the registry already holds, so
+	// all replicas reach the same verdict without coordinating.
 	go providers.RunSweeper(ctx, providerRegistry, logger)
 
 	// Aggregate MCP endpoint — a base-layer hub capability, always on. It
@@ -502,11 +564,18 @@ func (s *Server) Run(ctx context.Context) error {
 				}
 				return clientset.AuthorizationV1().SubjectAccessReviews(), nil
 			}
-			appAuth, err := appauth.New(appauth.Config{
+			appAuthCfg := appauth.Config{
 				Sessions:   browserSessionStore,
 				SARClient:  sarFactory,
 				AppsDomain: s.opts.PublishedAppsDomain,
-			})
+			}
+			if appCodeStore != nil {
+				// authorize and exchange are separate requests that a scaled hub
+				// serves from different replicas; the shared store makes the code
+				// redeemable exactly once, wherever it lands.
+				appAuthCfg.Codes = appCodeStore
+			}
+			appAuth, err := appauth.New(appAuthCfg)
 			if err != nil {
 				return fmt.Errorf("creating published-app auth handler: %w", err)
 			}
@@ -708,96 +777,132 @@ func (s *Server) Run(ctx context.Context) error {
 			}
 		}()
 
-		// MCPServer reconciler: MCPServer is a built-in, core-hosted provider —
-		// its CRD is distributed to tenants via core.faros.sh, so we re-introduce
-		// a core.faros.sh multicluster manager (removed in the edge extraction)
-		// to run it. It provisions each server's identity across all tenant
-		// workspaces. The aggregate serving lives in pkg/hub/mcpaggregate.
-		coreExportProvider, err := apiexport.New(providersConfig, "core.faros.sh", apiexport.Options{Scheme: scheme})
-		if err != nil {
-			return fmt.Errorf("creating core.faros.sh multicluster provider: %w", err)
-		}
-		coreMgr, err := mcmanager.New(providersConfig, coreExportProvider, manager.Options{
-			Scheme:  scheme,
-			Metrics: metricsserver.Options{BindAddress: "0"},
-		})
-		if err != nil {
-			return fmt.Errorf("creating core multicluster manager: %w", err)
-		}
-		if err := mcpserver.SetupWithManager(coreMgr, kcpConfig, s.opts.HubExternalURL, mcpProviderEnumerator); err != nil {
-			return fmt.Errorf("setting up mcpserver controller: %w", err)
-		}
-		go func() {
-			logger.Info("Starting core multicluster manager (mcpserver)")
-			if err := coreMgr.Start(ctx); err != nil {
-				logger.Error(err, "Core multicluster manager failed")
-			}
-		}()
+		// Everything below writes: it provisions workspaces, mints identities,
+		// seeds organizations, and purges soft-deleted objects. Running it on
+		// every replica of a scaled hub would mean N reconcilers racing on the
+		// same objects, so it is gated behind a single lease.
+		//
+		// The catalog manager above is deliberately NOT gated: the registry it
+		// maintains is request-path state, and a non-leader with an empty
+		// routing table would 404 every provider request it served.
+		startLeaderOnlyControllers := func(ctx context.Context) {
+			logger.Info("Elected leader; starting singleton controllers")
 
-		// Provider provisioning reconciler: the declarative replacement for
-		// the former admin "onboard" call. Provisions each provider's
-		// sub-workspace + ServiceAccount + kubeconfig Secret, then binds the
-		// CatalogEntry export into the sub-workspace so the provider
-		// self-registers. Provider lives in its OWN APIExport
-		// (admin.faros.sh), bound ONLY in root:faros:providers (so
-		// a provider cannot create Provider objects from its own sub-workspace),
-		// hence a THIRD multicluster manager bound to the admin export.
-		adminExportProvider, err := apiexport.New(providersConfig, "admin.faros.sh", apiexport.Options{Scheme: scheme})
-		if err != nil {
-			return fmt.Errorf("creating admin.faros.sh multicluster provider: %w", err)
-		}
-		adminMgr, err := mcmanager.New(providersConfig, adminExportProvider, manager.Options{
-			Scheme:  scheme,
-			Metrics: metricsserver.Options{BindAddress: "0"},
-		})
-		if err != nil {
-			return fmt.Errorf("creating admin multicluster manager: %w", err)
-		}
-		if err := providers.SetupProviderWithManager(adminMgr, kcpConfig, providers.CatalogReconcilerOptions{
-			HubExternalURL:      s.opts.HubExternalURL,
-			ProviderInternalURL: s.opts.ProviderInternalURL,
-		}); err != nil {
-			return fmt.Errorf("setting up provider provisioning controller: %w", err)
-		}
-		go func() {
-			logger.Info("Starting admin multicluster manager")
-			if err := adminMgr.Start(ctx); err != nil {
-				logger.Error(err, "Admin multicluster manager failed")
+			// MCPServer reconciler: MCPServer is a built-in, core-hosted provider —
+			// its CRD is distributed to tenants via core.faros.sh, so we re-introduce
+			// a core.faros.sh multicluster manager (removed in the edge extraction)
+			// to run it. It provisions each server's identity across all tenant
+			// workspaces. The aggregate serving lives in pkg/hub/mcpaggregate.
+			coreExportProvider, err := apiexport.New(providersConfig, "core.faros.sh", apiexport.Options{Scheme: scheme})
+			if err != nil {
+				logger.Error(err, "Creating core.faros.sh multicluster provider failed")
+				return
 			}
-		}()
-
-		// Organization bootstrap controller — runs against root:faros:users
-		// where the User and (companion) Organization CRs live. This is a
-		// single-cluster controller-runtime manager, separate from the
-		// multicluster managers above which serve the kcp-tenant fleet.
-		orgMgr, err := organization.NewManager(bootstrapper.UsersConfig(), scheme)
-		if err != nil {
-			return fmt.Errorf("creating organization manager: %w", err)
-		}
-		if err := organization.SetupWithManager(orgMgr, bootstrapper); err != nil {
-			return fmt.Errorf("setting up organization bootstrap controller: %w", err)
-		}
-		go func() {
-			logger.Info("Starting organization bootstrap manager")
-			if err := orgMgr.Start(ctx); err != nil {
-				logger.Error(err, "Organization bootstrap manager failed")
+			coreMgr, err := mcmanager.New(providersConfig, coreExportProvider, manager.Options{
+				Scheme:  scheme,
+				Metrics: metricsserver.Options{BindAddress: "0"},
+			})
+			if err != nil {
+				logger.Error(err, "Creating core multicluster manager failed")
+				return
 			}
-		}()
+			if err := mcpserver.SetupWithManager(coreMgr, kcpConfig, s.opts.HubExternalURL, mcpProviderEnumerator); err != nil {
+				logger.Error(err, "Setting up mcpserver controller failed")
+				return
+			}
 
-		// Soft-delete reconciler — roadmap step 8 (docs/organizations.md
-		// O-8 + O-13). Separate manager from the bootstrap one so a
-		// soft-delete crash doesn't take the bootstrap workqueue down.
-		softdeleteMgr, err := softdelete.NewManager(bootstrapper.UsersConfig(), scheme)
-		if err != nil {
-			return fmt.Errorf("creating soft-delete manager: %w", err)
+			// Provider provisioning reconciler: the declarative replacement for
+			// the former admin "onboard" call. Provisions each provider's
+			// sub-workspace + ServiceAccount + kubeconfig Secret, then binds the
+			// CatalogEntry export into the sub-workspace so the provider
+			// self-registers. Provider lives in its OWN APIExport
+			// (admin.faros.sh), bound ONLY in root:faros:providers (so
+			// a provider cannot create Provider objects from its own sub-workspace),
+			// hence a separate multicluster manager bound to the admin export.
+			adminExportProvider, err := apiexport.New(providersConfig, "admin.faros.sh", apiexport.Options{Scheme: scheme})
+			if err != nil {
+				logger.Error(err, "Creating admin.faros.sh multicluster provider failed")
+				return
+			}
+			adminMgr, err := mcmanager.New(providersConfig, adminExportProvider, manager.Options{
+				Scheme:  scheme,
+				Metrics: metricsserver.Options{BindAddress: "0"},
+			})
+			if err != nil {
+				logger.Error(err, "Creating admin multicluster manager failed")
+				return
+			}
+			if err := providers.SetupProviderWithManager(adminMgr, kcpConfig, providers.CatalogReconcilerOptions{
+				HubExternalURL:      s.opts.HubExternalURL,
+				ProviderInternalURL: s.opts.ProviderInternalURL,
+			}); err != nil {
+				logger.Error(err, "Setting up provider provisioning controller failed")
+				return
+			}
+
+			// Organization bootstrap controller — runs against root:faros:users
+			// where the User and (companion) Organization CRs live. This is a
+			// single-cluster controller-runtime manager, separate from the
+			// multicluster managers above which serve the kcp-tenant fleet.
+			orgMgr, err := organization.NewManager(bootstrapper.UsersConfig(), scheme)
+			if err != nil {
+				logger.Error(err, "Creating organization manager failed")
+				return
+			}
+			if err := organization.SetupWithManager(orgMgr, bootstrapper); err != nil {
+				logger.Error(err, "Setting up organization bootstrap controller failed")
+				return
+			}
+
+			// Soft-delete reconciler — roadmap step 8 (docs/organizations.md
+			// O-8 + O-13). Separate manager from the bootstrap one so a
+			// soft-delete crash doesn't take the bootstrap workqueue down.
+			softdeleteMgr, err := softdelete.NewManager(bootstrapper.UsersConfig(), scheme)
+			if err != nil {
+				logger.Error(err, "Creating soft-delete manager failed")
+				return
+			}
+			if err := softdelete.SetupWithManager(softdeleteMgr, bootstrapper); err != nil {
+				logger.Error(err, "Setting up soft-delete reconciler failed")
+				return
+			}
+
+			// Expired sessions and authorization codes are already refused on
+			// read; this only reclaims their storage, so one sweeper is enough.
+			if len(sharedStores) > 0 {
+				go sharedstore.RunGC(ctx, sharedStoreGCInterval, sharedStores...)
+			}
+
+			var wg sync.WaitGroup
+			for name, mgr := range map[string]interface{ Start(context.Context) error }{
+				"core multicluster (mcpserver)": coreMgr,
+				"admin multicluster":            adminMgr,
+				"organization bootstrap":        orgMgr,
+				"soft-delete":                   softdeleteMgr,
+			} {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					logger.Info("Starting manager", "manager", name)
+					if err := mgr.Start(ctx); err != nil {
+						logger.Error(err, "Manager failed", "manager", name)
+					}
+				}()
+			}
+			// Block until leadership ends so the lease is not released while
+			// these managers are still draining.
+			wg.Wait()
 		}
-		if err := softdelete.SetupWithManager(softdeleteMgr, bootstrapper); err != nil {
-			return fmt.Errorf("setting up soft-delete reconciler: %w", err)
-		}
+
+		leaseConfig := rest.CopyConfig(kcpConfig)
+		leaseConfig.Host = apiurl.KCPClusterURL(leaseConfig.Host, kcppaths.SystemControllers)
 		go func() {
-			logger.Info("Starting soft-delete manager")
-			if err := softdeleteMgr.Start(ctx); err != nil {
-				logger.Error(err, "Soft-delete manager failed")
+			if err := leaderelection.Run(ctx, leaderelection.Options{
+				Config:    leaseConfig,
+				Namespace: kcp.HubSystemNamespace,
+				Name:      controllerLeaseName,
+			}, startLeaderOnlyControllers); err != nil {
+				logger.Error(err, "Controller leader election failed; singleton controllers are not running")
 			}
 		}()
 	}

--- a/pkg/hub/sharedstore/adapters_test.go
+++ b/pkg/hub/sharedstore/adapters_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedstore
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/faroshq/faros/pkg/browsersession"
+	"github.com/faroshq/faros/pkg/hub/appauth"
+)
+
+// twoReplicaSessions returns two browsersession Stores backed by one API, which
+// is exactly the shape of a hub scaled to two pods.
+func twoReplicaSessions(t *testing.T) (*browsersession.Store, *browsersession.Store) {
+	t.Helper()
+	clientset := kubefake.NewClientset()
+	newReplica := func() *browsersession.Store {
+		backend := &SessionBackend{store: &Store{
+			client: clientset, namespace: testNamespace, kind: SessionKind, now: time.Now,
+		}}
+		return browsersession.New(browsersession.Config{Backend: backend})
+	}
+	return newReplica(), newReplica()
+}
+
+// The portal cookie is minted by whichever replica served the login and
+// presented to whichever replica the load balancer picks next.
+func TestSessionIssuedOnOneReplicaResolvesOnAnother(t *testing.T) {
+	replicaA, replicaB := twoReplicaSessions(t)
+
+	response := httptest.NewRecorder()
+	if _, err := replicaA.IssueHTTP(context.Background(), response, browsersession.Identity{
+		UserID: "user-1", Email: "one@example.test", RBACIdentity: "faros:one@example.test",
+	}); err != nil {
+		t.Fatalf("issue on replica A: %v", err)
+	}
+	cookies := response.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies = %#v", cookies)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookies[0])
+	session, err := replicaB.ResolveRequest(req)
+	if err != nil {
+		t.Fatalf("resolve on replica B: %v", err)
+	}
+	if session.Identity.UserID != "user-1" || session.Identity.RBACIdentity != "faros:one@example.test" {
+		t.Fatalf("identity = %#v", session.Identity)
+	}
+}
+
+// Logout has to mean logout everywhere; a per-process revocation would leave
+// the cookie live on every other replica.
+func TestRevokeOnOneReplicaAppliesToAnother(t *testing.T) {
+	replicaA, replicaB := twoReplicaSessions(t)
+	ctx := context.Background()
+
+	value, _, err := replicaA.Issue(ctx, browsersession.Identity{UserID: "user-1"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if _, err := replicaB.Resolve(ctx, value); err != nil {
+		t.Fatalf("resolve before revoke: %v", err)
+	}
+	if err := replicaA.Revoke(ctx, value); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := replicaB.Resolve(ctx, value); !errors.Is(err, browsersession.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound after revocation on a peer", err)
+	}
+}
+
+func TestSessionExpiryIsEnforcedAcrossReplicas(t *testing.T) {
+	clientset := kubefake.NewClientset()
+	now := time.Unix(2000, 0)
+	backend := &SessionBackend{store: &Store{
+		client: clientset, namespace: testNamespace, kind: SessionKind,
+		now: func() time.Time { return now },
+	}}
+	writer := browsersession.New(browsersession.Config{
+		TTL: time.Minute, Backend: backend, Now: func() time.Time { return now },
+	})
+	reader := browsersession.New(browsersession.Config{
+		TTL: time.Minute, Backend: backend, Now: func() time.Time { return now },
+	})
+
+	value, _, err := writer.Issue(context.Background(), browsersession.Identity{UserID: "user-1"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, err := reader.Resolve(context.Background(), value); err == nil {
+		t.Fatal("expired session resolved on a peer replica")
+	}
+}
+
+func newTestAppCodeStore(clientset *kubefake.Clientset) *AppCodeStore {
+	return &AppCodeStore{store: &Store{
+		client: clientset, namespace: testNamespace, kind: AppCodeKind, now: time.Now,
+	}}
+}
+
+// A published-app code is minted during the browser's authorize hop and
+// redeemed by the access proxy in a separate server-to-server request, which a
+// scaled hub will serve from a different replica.
+func TestAppCodeMintedOnOneReplicaRedeemsOnAnother(t *testing.T) {
+	clientset := kubefake.NewClientset()
+	replicaA := newTestAppCodeStore(clientset)
+	replicaB := newTestAppCodeStore(clientset)
+	ctx := context.Background()
+
+	record := appauth.CodeRecord{
+		Ref: appauth.InstanceRef{
+			Cluster: "abc123cluster", Group: "infrastructure.faros.sh",
+			Resource: "applications", Name: "my-shop",
+		},
+		RedirectHost: "my-shop-abcdef123456.apps.test.faros",
+		Identity: browsersession.Identity{
+			UserID: "user-1", Email: "one@example.test", Name: "One",
+			RBACIdentity: "faros:one@example.test",
+		},
+		ExpiresAt: time.Now().Add(2 * time.Minute),
+	}
+	if err := replicaA.Put(ctx, "code-1", record); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, ok := replicaB.Take(ctx, "code-1")
+	if !ok {
+		t.Fatal("code minted on replica A could not be redeemed on replica B")
+	}
+	if got.Ref != record.Ref {
+		t.Fatalf("ref = %#v, want %#v", got.Ref, record.Ref)
+	}
+	if got.RedirectHost != record.RedirectHost {
+		t.Fatalf("redirectHost = %q, want %q", got.RedirectHost, record.RedirectHost)
+	}
+	if got.Identity.UserID != "user-1" || got.Identity.Name != "One" ||
+		got.Identity.RBACIdentity != "faros:one@example.test" {
+		t.Fatalf("identity = %#v", got.Identity)
+	}
+
+	if _, ok := replicaA.Take(ctx, "code-1"); ok {
+		t.Fatal("code was redeemable twice")
+	}
+}

--- a/pkg/hub/sharedstore/appcode.go
+++ b/pkg/hub/sharedstore/appcode.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"github.com/faroshq/faros/pkg/browsersession"
+	"github.com/faroshq/faros/pkg/hub/appauth"
+)
+
+// AppCodeKind is the shared-store collection holding published-app
+// authorization codes.
+const AppCodeKind = "faros-appcode"
+
+// AppCodeStore adapts Store to appauth.CodeStore, so a code minted on the
+// replica that served the browser's authorize hop can be redeemed on whichever
+// replica the access proxy reaches for the exchange.
+//
+// Single-use is enforced by Store.Take's resource-version-guarded delete: two
+// concurrent exchanges of one code produce exactly one success, no matter which
+// replicas run them.
+type AppCodeStore struct {
+	store *Store
+}
+
+// NewAppCodeStore builds the shared authorization-code store. config must
+// target the workspace holding the entries.
+func NewAppCodeStore(config *rest.Config, namespace string) (*AppCodeStore, error) {
+	store, err := New(config, namespace, AppCodeKind)
+	if err != nil {
+		return nil, err
+	}
+	return &AppCodeStore{store: store}, nil
+}
+
+// Store exposes the underlying collection so the leader can sweep it.
+func (s *AppCodeStore) Store() *Store { return s.store }
+
+// storedCode is the wire form of an authorization code record.
+type storedCode struct {
+	Cluster      string    `json:"cluster"`
+	Group        string    `json:"group"`
+	Resource     string    `json:"resource"`
+	Name         string    `json:"name"`
+	RedirectHost string    `json:"redirectHost"`
+	UserID       string    `json:"userID"`
+	Email        string    `json:"email,omitempty"`
+	DisplayName  string    `json:"displayName,omitempty"`
+	RBACIdentity string    `json:"rbacIdentity,omitempty"`
+	Issuer       string    `json:"issuer,omitempty"`
+	Subject      string    `json:"subject,omitempty"`
+	AuthType     string    `json:"authType,omitempty"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+func (s *AppCodeStore) Put(ctx context.Context, code string, record appauth.CodeRecord) error {
+	value, err := json.Marshal(storedCode{
+		Cluster:      record.Ref.Cluster,
+		Group:        record.Ref.Group,
+		Resource:     record.Ref.Resource,
+		Name:         record.Ref.Name,
+		RedirectHost: record.RedirectHost,
+		UserID:       record.Identity.UserID,
+		Email:        record.Identity.Email,
+		DisplayName:  record.Identity.Name,
+		RBACIdentity: record.Identity.RBACIdentity,
+		Issuer:       record.Identity.Issuer,
+		Subject:      record.Identity.Subject,
+		AuthType:     record.Identity.AuthType,
+		ExpiresAt:    record.ExpiresAt,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding app authorization code: %w", err)
+	}
+	return s.store.Put(ctx, code, value, record.ExpiresAt)
+}
+
+func (s *AppCodeStore) Take(ctx context.Context, code string) (appauth.CodeRecord, bool) {
+	value, err := s.store.Take(ctx, code)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			// A store failure must not be reported as "code accepted"; log it
+			// so an outage is distinguishable from an expired code.
+			klog.FromContext(ctx).Error(err, "Redeeming app authorization code failed")
+		}
+		return appauth.CodeRecord{}, false
+	}
+	var stored storedCode
+	if err := json.Unmarshal(value, &stored); err != nil {
+		return appauth.CodeRecord{}, false
+	}
+	return appauth.CodeRecord{
+		Ref: appauth.InstanceRef{
+			Cluster:  stored.Cluster,
+			Group:    stored.Group,
+			Resource: stored.Resource,
+			Name:     stored.Name,
+		},
+		RedirectHost: stored.RedirectHost,
+		Identity: browsersession.Identity{
+			UserID:       stored.UserID,
+			Email:        stored.Email,
+			Name:         stored.DisplayName,
+			RBACIdentity: stored.RBACIdentity,
+			Issuer:       stored.Issuer,
+			Subject:      stored.Subject,
+			AuthType:     stored.AuthType,
+		},
+		ExpiresAt: stored.ExpiresAt,
+	}, true
+}

--- a/pkg/hub/sharedstore/browsersession.go
+++ b/pkg/hub/sharedstore/browsersession.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/faroshq/faros/pkg/browsersession"
+)
+
+// SessionKind is the shared-store collection holding browser sessions.
+const SessionKind = "faros-session"
+
+// SessionBackend adapts Store to browsersession.Backend so every hub replica
+// resolves and revokes the same cookies.
+//
+// Revocation is a delete, not a tombstone: a handle is 32 bytes of crypto/rand,
+// so the collision the in-memory backend's tombstones guard against cannot
+// occur, and a delete propagates to every replica immediately instead of
+// depending on a per-process marker.
+type SessionBackend struct {
+	store *Store
+}
+
+// NewSessionBackend builds the shared browser-session backend. config must
+// target the workspace holding the entries.
+func NewSessionBackend(config *rest.Config, namespace string) (*SessionBackend, error) {
+	store, err := New(config, namespace, SessionKind)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionBackend{store: store}, nil
+}
+
+// Store exposes the underlying collection so the leader can sweep it.
+func (b *SessionBackend) Store() *Store { return b.store }
+
+// storedSession is the wire form of a session record. It deliberately mirrors
+// browsersession.Record rather than embedding it, so a field added to the
+// in-memory type cannot silently change the persisted encoding.
+type storedSession struct {
+	UserID       string    `json:"userID"`
+	Email        string    `json:"email,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	RBACIdentity string    `json:"rbacIdentity,omitempty"`
+	Issuer       string    `json:"issuer,omitempty"`
+	Subject      string    `json:"subject,omitempty"`
+	AuthType     string    `json:"authType,omitempty"`
+	IssuedAt     time.Time `json:"issuedAt"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+func (b *SessionBackend) Put(ctx context.Context, key string, record browsersession.Record) error {
+	value, err := json.Marshal(storedSession{
+		UserID:       record.Identity.UserID,
+		Email:        record.Identity.Email,
+		Name:         record.Identity.Name,
+		RBACIdentity: record.Identity.RBACIdentity,
+		Issuer:       record.Identity.Issuer,
+		Subject:      record.Identity.Subject,
+		AuthType:     record.Identity.AuthType,
+		IssuedAt:     record.IssuedAt,
+		ExpiresAt:    record.ExpiresAt,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding browser session: %w", err)
+	}
+	return b.store.Put(ctx, key, value, record.ExpiresAt)
+}
+
+func (b *SessionBackend) Get(ctx context.Context, key string) (browsersession.Record, error) {
+	value, err := b.store.Get(ctx, key)
+	if errors.Is(err, ErrNotFound) {
+		return browsersession.Record{}, browsersession.ErrNotFound
+	}
+	if err != nil {
+		return browsersession.Record{}, err
+	}
+	var stored storedSession
+	if err := json.Unmarshal(value, &stored); err != nil {
+		// A record we cannot decode is not a session we can authorize on.
+		return browsersession.Record{}, browsersession.ErrNotFound
+	}
+	return browsersession.Record{
+		Identity: browsersession.Identity{
+			UserID:       stored.UserID,
+			Email:        stored.Email,
+			Name:         stored.Name,
+			RBACIdentity: stored.RBACIdentity,
+			Issuer:       stored.Issuer,
+			Subject:      stored.Subject,
+			AuthType:     stored.AuthType,
+		},
+		IssuedAt:  stored.IssuedAt,
+		ExpiresAt: stored.ExpiresAt,
+	}, nil
+}
+
+func (b *SessionBackend) Revoke(ctx context.Context, key string, _ time.Time) error {
+	return b.store.Delete(ctx, key)
+}

--- a/pkg/hub/sharedstore/sharedstore.go
+++ b/pkg/hub/sharedstore/sharedstore.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sharedstore is the hub's cross-replica key/value store for short-lived
+// login state: browser sessions and published-app authorization codes.
+//
+// Both are minted by whichever replica served the request and redeemed by
+// whichever replica the load balancer picks next, so process-local maps break as
+// soon as the hub runs more than one pod. Entries live as Secrets in
+// root:faros:system:controllers — a hub-internal workspace no tenant, provider,
+// or user identity can reach — which keeps the hub's only hard dependency kcp.
+//
+// Values are opaque to this package. Keys are hashed into the object name, so
+// neither a session handle nor an authorization code is recoverable from
+// resource names in logs, audit records, or metrics.
+package sharedstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+// ErrNotFound is returned when a key is absent, expired, or already redeemed.
+var ErrNotFound = errors.New("sharedstore: entry not found")
+
+const (
+	// LabelKind marks every Secret this package owns and names the logical
+	// collection, so the sweeper can list one kind without touching the other.
+	LabelKind = "faros.sh/shared-store"
+
+	dataKeyValue     = "value"
+	dataKeyExpiresAt = "expiresAt"
+)
+
+// Store is one logical collection of entries (all sharing a `kind`) inside a
+// single kcp workspace namespace. It is safe for concurrent use — it holds no
+// state beyond its client.
+type Store struct {
+	client    kubernetes.Interface
+	namespace string
+	kind      string
+	now       func() time.Time
+}
+
+// New builds a Store. config must already target the workspace holding the
+// entries (its Host carries the /clusters/<path> segment). kind must be a valid
+// label value and DNS-name prefix — it namespaces one collection from another
+// inside the same Kubernetes namespace.
+func New(config *rest.Config, namespace, kind string) (*Store, error) {
+	if config == nil {
+		return nil, fmt.Errorf("sharedstore: config is required")
+	}
+	if namespace == "" || kind == "" {
+		return nil, fmt.Errorf("sharedstore: namespace and kind are required")
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("sharedstore: building client: %w", err)
+	}
+	return &Store{client: client, namespace: namespace, kind: kind, now: time.Now}, nil
+}
+
+// Put writes value under key, replacing any existing entry, and stamps the
+// expiry the reader enforces.
+func (s *Store) Put(ctx context.Context, key string, value []byte, expiresAt time.Time) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.objectName(key),
+			Namespace: s.namespace,
+			Labels:    map[string]string{LabelKind: s.kind},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			dataKeyValue:     value,
+			dataKeyExpiresAt: []byte(expiresAt.UTC().Format(time.RFC3339Nano)),
+		},
+	}
+	_, err := s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		_, err = s.client.CoreV1().Secrets(s.namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("sharedstore: writing %s entry: %w", s.kind, err)
+	}
+	return nil
+}
+
+// Get returns the value stored under key. An expired entry reports ErrNotFound
+// and is deleted opportunistically, so a stale record cannot outlive its expiry
+// even if the sweeper is not running.
+func (s *Store) Get(ctx context.Context, key string) ([]byte, error) {
+	name := s.objectName(key)
+	secret, err := s.client.CoreV1().Secrets(s.namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sharedstore: reading %s entry: %w", s.kind, err)
+	}
+	if s.expired(secret) {
+		_ = s.deleteExact(ctx, secret)
+		return nil, ErrNotFound
+	}
+	return secret.Data[dataKeyValue], nil
+}
+
+// Take returns the value stored under key and removes it in the same breath.
+// The delete is guarded by the resource version observed on read, so exactly one
+// caller across every replica can redeem a given key — the guarantee a
+// single-use authorization code depends on.
+func (s *Store) Take(ctx context.Context, key string) ([]byte, error) {
+	name := s.objectName(key)
+	secret, err := s.client.CoreV1().Secrets(s.namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sharedstore: reading %s entry: %w", s.kind, err)
+	}
+	if err := s.deleteExact(ctx, secret); err != nil {
+		// NotFound or Conflict means another replica redeemed it first; either
+		// way this caller must not receive the value.
+		if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("sharedstore: redeeming %s entry: %w", s.kind, err)
+	}
+	if s.expired(secret) {
+		return nil, ErrNotFound
+	}
+	return secret.Data[dataKeyValue], nil
+}
+
+// Delete removes an entry. It is idempotent, which makes logout safe to retry.
+func (s *Store) Delete(ctx context.Context, key string) error {
+	err := s.client.CoreV1().Secrets(s.namespace).Delete(ctx, s.objectName(key), metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("sharedstore: deleting %s entry: %w", s.kind, err)
+	}
+	return nil
+}
+
+// GC deletes every expired entry of this kind and returns how many it removed.
+// Readers already refuse expired entries, so this only reclaims space — run it
+// on the elected replica.
+func (s *Store) GC(ctx context.Context) (int, error) {
+	list, err := s.client.CoreV1().Secrets(s.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: LabelKind + "=" + s.kind,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("sharedstore: listing %s entries: %w", s.kind, err)
+	}
+	deleted := 0
+	for i := range list.Items {
+		secret := &list.Items[i]
+		if !s.expired(secret) {
+			continue
+		}
+		if err := s.deleteExact(ctx, secret); err != nil &&
+			!apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+			return deleted, fmt.Errorf("sharedstore: deleting expired %s entry: %w", s.kind, err)
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+// RunGC sweeps expired entries on interval until ctx is done. Intended to run
+// only on the leader; a second sweeper would merely duplicate deletes.
+func RunGC(ctx context.Context, interval time.Duration, stores ...*Store) {
+	logger := klog.FromContext(ctx).WithName("sharedstore-gc")
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, store := range stores {
+				n, err := store.GC(ctx)
+				if err != nil {
+					logger.Error(err, "Sweeping expired entries failed", "kind", store.kind)
+					continue
+				}
+				if n > 0 {
+					logger.V(2).Info("Swept expired entries", "kind", store.kind, "count", n)
+				}
+			}
+		}
+	}
+}
+
+// deleteExact deletes exactly the object version that was read. The
+// preconditions are what make Take single-use across replicas.
+func (s *Store) deleteExact(ctx context.Context, secret *corev1.Secret) error {
+	return s.client.CoreV1().Secrets(s.namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID:             &secret.UID,
+			ResourceVersion: &secret.ResourceVersion,
+		},
+	})
+}
+
+func (s *Store) expired(secret *corev1.Secret) bool {
+	raw, ok := secret.Data[dataKeyExpiresAt]
+	if !ok {
+		// An entry without an expiry stamp is malformed; treat it as expired so
+		// it cannot linger indefinitely.
+		return true
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, string(raw))
+	if err != nil {
+		return true
+	}
+	return !s.now().Before(expiresAt)
+}
+
+// objectName maps an arbitrary key onto a stable, collision-resistant, DNS-safe
+// Secret name. Hashing is what keeps the key itself out of resource names.
+func (s *Store) objectName(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return s.kind + "-" + hex.EncodeToString(sum[:])
+}

--- a/pkg/hub/sharedstore/sharedstore_test.go
+++ b/pkg/hub/sharedstore/sharedstore_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedstore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const testNamespace = "faros-hub"
+
+// newTestStore returns a Store over a fake API, plus a clock the test drives.
+// Two Stores sharing one clientset stand in for two hub replicas talking to the
+// same kcp workspace.
+func newTestStore(t *testing.T, clientset *kubefake.Clientset, now *time.Time) *Store {
+	t.Helper()
+	return &Store{
+		client:    clientset,
+		namespace: testNamespace,
+		kind:      "test-kind",
+		now:       func() time.Time { return *now },
+	}
+}
+
+func TestPutGetRoundTrip(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := newTestStore(t, kubefake.NewClientset(), &now)
+	ctx := context.Background()
+
+	if err := store.Put(ctx, "handle-1", []byte("payload"), now.Add(time.Hour)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err := store.Get(ctx, "handle-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("value = %q, want payload", got)
+	}
+}
+
+// The whole reason this store exists: an entry written by one replica must be
+// readable by another.
+func TestEntryIsVisibleToAnotherReplica(t *testing.T) {
+	now := time.Unix(1000, 0)
+	clientset := kubefake.NewClientset()
+	replicaA := newTestStore(t, clientset, &now)
+	replicaB := newTestStore(t, clientset, &now)
+	ctx := context.Background()
+
+	if err := replicaA.Put(ctx, "handle-1", []byte("payload"), now.Add(time.Hour)); err != nil {
+		t.Fatalf("put on replica A: %v", err)
+	}
+	got, err := replicaB.Get(ctx, "handle-1")
+	if err != nil {
+		t.Fatalf("get on replica B: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("replica B read %q, want payload", got)
+	}
+}
+
+func TestGetMissingReportsNotFound(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := newTestStore(t, kubefake.NewClientset(), &now)
+	if _, err := store.Get(context.Background(), "absent"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// An expired entry must never be served, whether or not the sweeper has run.
+func TestExpiredEntryIsRefusedAndRemoved(t *testing.T) {
+	now := time.Unix(1000, 0)
+	clientset := kubefake.NewClientset()
+	store := newTestStore(t, clientset, &now)
+	ctx := context.Background()
+
+	if err := store.Put(ctx, "handle-1", []byte("payload"), now.Add(time.Minute)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+
+	if _, err := store.Get(ctx, "handle-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+	list, err := clientset.CoreV1().Secrets(testNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expired entry still stored: %d secrets", len(list.Items))
+	}
+}
+
+// Take is what makes an app authorization code single-use. A second redemption
+// must fail even though it runs against a different replica.
+func TestTakeRedeemsOnceAcrossReplicas(t *testing.T) {
+	now := time.Unix(1000, 0)
+	clientset := kubefake.NewClientset()
+	replicaA := newTestStore(t, clientset, &now)
+	replicaB := newTestStore(t, clientset, &now)
+	ctx := context.Background()
+
+	if err := replicaA.Put(ctx, "code-1", []byte("grant"), now.Add(time.Minute)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err := replicaB.Take(ctx, "code-1")
+	if err != nil {
+		t.Fatalf("first take: %v", err)
+	}
+	if string(got) != "grant" {
+		t.Fatalf("value = %q, want grant", got)
+	}
+	if _, err := replicaA.Take(ctx, "code-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("second take err = %v, want ErrNotFound (a code must be single-use)", err)
+	}
+}
+
+func TestTakeRefusesExpiredEntry(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := newTestStore(t, kubefake.NewClientset(), &now)
+	ctx := context.Background()
+
+	if err := store.Put(ctx, "code-1", []byte("grant"), now.Add(time.Minute)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, err := store.Take(ctx, "code-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteIsIdempotent(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := newTestStore(t, kubefake.NewClientset(), &now)
+	ctx := context.Background()
+
+	if err := store.Put(ctx, "handle-1", []byte("payload"), now.Add(time.Hour)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	for i := range 2 {
+		if err := store.Delete(ctx, "handle-1"); err != nil {
+			t.Fatalf("delete %d: %v", i, err)
+		}
+	}
+	if _, err := store.Get(ctx, "handle-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGCRemovesOnlyExpiredEntriesOfItsKind(t *testing.T) {
+	now := time.Unix(1000, 0)
+	clientset := kubefake.NewClientset()
+	store := newTestStore(t, clientset, &now)
+	other := &Store{client: clientset, namespace: testNamespace, kind: "other-kind", now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	if err := store.Put(ctx, "stale", []byte("a"), now.Add(time.Minute)); err != nil {
+		t.Fatalf("put stale: %v", err)
+	}
+	if err := store.Put(ctx, "live", []byte("b"), now.Add(time.Hour)); err != nil {
+		t.Fatalf("put live: %v", err)
+	}
+	if err := other.Put(ctx, "stale", []byte("c"), now.Add(time.Minute)); err != nil {
+		t.Fatalf("put other: %v", err)
+	}
+
+	now = now.Add(2 * time.Minute)
+	deleted, err := store.GC(ctx)
+	if err != nil {
+		t.Fatalf("gc: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if _, err := store.Get(ctx, "live"); err != nil {
+		t.Fatalf("live entry removed by gc: %v", err)
+	}
+	list, err := clientset.CoreV1().Secrets(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: LabelKind + "=other-kind",
+	})
+	if err != nil {
+		t.Fatalf("list other kind: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("gc crossed into another kind: %d secrets left", len(list.Items))
+	}
+}
+
+// A handle is a credential-adjacent secret; it must not end up in a resource
+// name that shows up in logs, audit records, or metrics.
+func TestObjectNameDoesNotContainKey(t *testing.T) {
+	now := time.Unix(1000, 0)
+	store := newTestStore(t, kubefake.NewClientset(), &now)
+	name := store.objectName("super-secret-handle")
+	if strings.Contains(name, "super-secret-handle") {
+		t.Fatalf("object name leaks the key: %q", name)
+	}
+	if name != store.objectName("super-secret-handle") {
+		t.Fatal("object name is not stable for the same key")
+	}
+	if name == store.objectName("another-handle") {
+		t.Fatal("distinct keys collided")
+	}
+}
+
+// Two replicas can read the same code before either deletes it. Real kcp
+// resolves that with the resource-version precondition on the delete, failing
+// the loser with a conflict — the fake clientset does not enforce
+// preconditions, so simulate the conflict directly. The loser must come away
+// empty-handed rather than treating the value it already read as redeemed.
+func TestTakeYieldsNothingWhenAnotherReplicaWinsTheDelete(t *testing.T) {
+	now := time.Unix(1000, 0)
+	clientset := kubefake.NewClientset()
+	store := newTestStore(t, clientset, &now)
+	ctx := context.Background()
+
+	if err := store.Put(ctx, "code-1", []byte("grant"), now.Add(time.Minute)); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	clientset.PrependReactor("delete", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Resource: "secrets"}, action.(k8stesting.DeleteAction).GetName(),
+			errors.New("resource version mismatch"))
+	})
+
+	if _, err := store.Take(ctx, "code-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound when another replica redeemed first", err)
+	}
+}

--- a/pkg/hub/startup_retry.go
+++ b/pkg/hub/startup_retry.go
@@ -96,6 +96,12 @@ func isRetriableKCPBootstrapError(err error) bool {
 		apierrors.IsInternalError(err) {
 		return true
 	}
+	// Hub replicas bootstrap concurrently and every bootstrap write is
+	// idempotent, so losing a write race to a peer is a retry, not a failure.
+	// Without this a second replica starting alongside the first crash-loops.
+	if apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err) {
+		return true
+	}
 
 	lowerErr := strings.ToLower(err.Error())
 	if apierrors.IsForbidden(err) && strings.Contains(lowerErr, "not yet ready") {

--- a/pkg/server/auth/handler.go
+++ b/pkg/server/auth/handler.go
@@ -389,7 +389,7 @@ func (h *Handler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	encoded := base64.URLEncoding.EncodeToString(respJSON)
 	redirectURL := authCode.RedirectURL + "?response=" + encoded
 	if h.browserSessions != nil {
-		if _, sessionErr := h.browserSessions.IssueHTTP(w, browsersession.Identity{
+		if _, sessionErr := h.browserSessions.IssueHTTP(ctx, w, browsersession.Identity{
 			UserID: userID, Email: claims.Email, Name: claims.Name,
 			// Matches what seedUser reconciles onto the User CR; workspace
 			// RBAC and app-access authorization key off this string.
@@ -437,7 +437,7 @@ func (h *Handler) HandleSessionBootstrap(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "authentication required", http.StatusUnauthorized)
 		return
 	}
-	session, issueErr := h.browserSessions.IssueHTTP(w, identity)
+	session, issueErr := h.browserSessions.IssueHTTP(r.Context(), w, identity)
 	if issueErr != nil {
 		http.Error(w, "failed to create browser session", http.StatusInternalServerError)
 		return

--- a/pkg/server/auth/ratelimit.go
+++ b/pkg/server/auth/ratelimit.go
@@ -27,6 +27,13 @@ import (
 
 // rateLimiter implements a per-IP rate limiter for authentication endpoints.
 // It uses a sliding window rate limiter to prevent brute force attacks.
+//
+// The budget is per hub replica, so a hub scaled to N replicas admits up to N
+// times the configured burst for a client the load balancer spreads across
+// pods. That is a deliberate trade: a shared counter would put a control-plane
+// round trip on every unauthenticated request, and this limiter is defence in
+// depth behind bearer-token and OIDC verification, not the primary control.
+// Deployments that need a hard global bound should enforce it at the ingress.
 type rateLimiter struct {
 	limiters map[string]*rate.Limiter
 	mu       sync.RWMutex

--- a/pkg/server/auth/session_test.go
+++ b/pkg/server/auth/session_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -68,14 +69,14 @@ func TestBrowserSessionBootstrapAndLogout(t *testing.T) {
 	if logout.Code != http.StatusNoContent {
 		t.Fatalf("logout status = %d; body=%s", logout.Code, logout.Body.String())
 	}
-	if _, err := store.Resolve(cookie.Value); err == nil {
+	if _, err := store.Resolve(context.Background(), cookie.Value); err == nil {
 		t.Fatal("logout left browser session live")
 	}
 }
 
 func TestBrowserSessionBootstrapFallsBackToLiveCookieWhenBearerIsUnavailable(t *testing.T) {
 	store := browsersession.New(browsersession.Config{TTL: time.Hour})
-	value, _, err := store.Issue(browsersession.Identity{UserID: "user-1", Email: "one@example.test"})
+	value, _, err := store.Issue(context.Background(), browsersession.Identity{UserID: "user-1", Email: "one@example.test"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +110,7 @@ func TestBrowserSessionBootstrapFallsBackToLiveCookieWhenBearerIsUnavailable(t *
 
 func TestBrowserSessionLogoutGETRedirectsAndExpiresCookie(t *testing.T) {
 	store := browsersession.New(browsersession.Config{TTL: time.Hour})
-	value, _, err := store.Issue(browsersession.Identity{UserID: "user-1"})
+	value, _, err := store.Issue(context.Background(), browsersession.Identity{UserID: "user-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +136,7 @@ func TestBrowserSessionLogoutGETRedirectsAndExpiresCookie(t *testing.T) {
 	if cookie.Name != browsersession.CookieName || cookie.MaxAge != -1 || !cookie.Secure || !cookie.HttpOnly || cookie.Path != "/" {
 		t.Fatalf("logout cookie = %#v", cookie)
 	}
-	if _, err := store.Resolve(value); !errors.Is(err, browsersession.ErrRevoked) {
+	if _, err := store.Resolve(context.Background(), value); !errors.Is(err, browsersession.ErrRevoked) {
 		t.Fatalf("logout session error = %v, want ErrRevoked", err)
 	}
 }

--- a/pkg/server/proxy/proxy.go
+++ b/pkg/server/proxy/proxy.go
@@ -1014,7 +1014,7 @@ func (p *KCPProxy) HandleTokenLogin(w http.ResponseWriter, r *http.Request) {
 		UserID:     user.Name,
 	}
 	if p.browserSessions != nil {
-		if _, sessionErr := p.browserSessions.IssueHTTP(w, browsersession.Identity{
+		if _, sessionErr := p.browserSessions.IssueHTTP(r.Context(), w, browsersession.Identity{
 			UserID: user.Name, Email: user.Spec.Email, Name: user.Spec.Name,
 			RBACIdentity: user.Spec.RBACIdentity,
 			AuthType:     "static-token",

--- a/providers/code/controller/packages/controller.go
+++ b/providers/code/controller/packages/controller.go
@@ -46,10 +46,13 @@ import (
 )
 
 // defaultCrawlInterval is how often each Repository is re-crawled for packages.
-// Short enough that the portal sees fresh artifacts soon after a push, long
-// enough that a workspace full of repos stays well under the host's rate limit.
-// Override with CODE_PACKAGE_CRAWL_INTERVAL (any time.ParseDuration string).
-const defaultCrawlInterval = 2 * time.Minute
+// Kept short so App Studio's publish check sees a build's images promptly after
+// GitHub Actions pushes them — at 2m the lag read as "no images published" for
+// minutes after a successful build. The cost is one host package listing per
+// repository per interval, so a workspace with many repos may need this raised
+// to stay under the host's rate limit: override with CODE_PACKAGE_CRAWL_INTERVAL
+// (any time.ParseDuration string).
+const defaultCrawlInterval = 30 * time.Second
 
 // Reconciler crawls each Repository's host packages into Package CRs.
 type Reconciler struct {

--- a/providers/infrastructure/accessproxy/config.go
+++ b/providers/infrastructure/accessproxy/config.go
@@ -28,6 +28,11 @@ limitations under the License.
 //     then maintains its own bounded in-memory session for the granted TTL.
 //     A hub outage leaves existing sessions working; only new sign-ins fail.
 //
+// An in-flight sign-in carries its own state in the browser's return cookie, so
+// it completes against any pod — including one that started after the redirect
+// was issued. Established sessions are still process-local: a restart signs
+// users out and they sign back in, it does not strand them mid-flow.
+//
 // The proxy holds no credentials of any kind: no service-account token, no
 // kubeconfig, no signing keys. Access policy is kcp RBAC evaluated by the hub
 // at sign-in time (SubjectAccessReview on the instance's `access`
@@ -48,9 +53,12 @@ const (
 	// SessionCookieName is intentionally a __Host cookie: Secure, Path=/, and
 	// no Domain attribute are mandatory.  The app proxy never forwards it.
 	SessionCookieName = "__Host-faros-app-session"
-	// ReturnCookieName is a short-lived opaque handle for the original clean
-	// path while the browser completes the hub sign-in flow.
-	ReturnCookieName = "faros-app-return"
+	// ReturnCookieName carries the whole sign-in state — nonce, clean return
+	// path and expiry — while the browser completes the hub flow, so no
+	// server-side handle has to survive between the authorize redirect and the
+	// callback (see consumeReturnState). Also a __Host cookie: host-only, so a
+	// sibling app under the same published-apps zone cannot plant one.
+	ReturnCookieName = "__Host-faros-app-return"
 	// CallbackPath is the reserved platform path on the app host. It must stay
 	// in lockstep with the hub's appauth.CallbackPath.
 	CallbackPath = "/__faros/auth/callback"
@@ -148,6 +156,12 @@ type Config struct {
 	// client with a bounded timeout and optional TLS verification skip.
 	HubClient *http.Client
 	Random    RandomSource
+
+	// Logf receives the proxy's operational messages — today only the reason a
+	// sign-in callback was rejected, which is otherwise invisible because every
+	// rejection is the same opaque 400 to the browser. Nil logs through the
+	// standard logger with the binary's prefix.
+	Logf func(format string, args ...any)
 
 	HubTimeout time.Duration
 }

--- a/providers/infrastructure/accessproxy/proxy.go
+++ b/providers/infrastructure/accessproxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -38,14 +39,20 @@ import (
 const (
 	// stateTTL bounds the authorize round-trip through the hub and IdP.
 	stateTTL = 5 * time.Minute
-	// maxReturnStates / maxSessions bound the two in-memory maps. Return
-	// states are minted for unauthenticated traffic, so the cap plus the
-	// time-gated sweep keeps anonymous request floods from growing the map or
-	// buying O(N) work per request.
-	maxReturnStates = 5000
-	maxSessions     = 20000
+	// maxUsedStates / maxSessions bound the two in-memory maps. Used states are
+	// only recorded for callbacks that already matched their cookie, so the cap
+	// plus the time-gated sweep keeps anonymous request floods from growing the
+	// map or buying O(N) work per request.
+	maxUsedStates = 5000
+	maxSessions   = 20000
 	// sweepInterval gates how often either map is fully swept.
 	sweepInterval = 30 * time.Second
+	// maxReturnPathBytes caps the deep link carried in the return cookie so the
+	// cookie stays well inside browser size limits. A longer path resumes at
+	// "/" — resuming the exact deep link is a convenience, signing in is not.
+	maxReturnPathBytes = 1024
+	// maxReturnCookieBytes bounds the work a forged cookie can buy.
+	maxReturnCookieBytes = 4096
 )
 
 // Proxy is a host-bound reverse proxy for one published template instance.
@@ -56,15 +63,20 @@ type Proxy struct {
 	random RandomSource
 
 	mu               sync.Mutex
-	returnStates     map[string]returnState
+	usedStates       map[string]time.Time
 	sessions         map[string]appSession
-	lastReturnSweep  time.Time
+	lastUsedSweep    time.Time
 	lastSessionSweep time.Time
 }
 
-type returnState struct {
-	path      string
-	expiresAt time.Time
+// returnStatePayload is the entire content of the return cookie: the nonce
+// echoed to the hub as `state`, the clean path to resume on success, and the
+// absolute expiry. Keeping it in the cookie rather than a server-side map is
+// what lets a sign-in survive a gate restart or land on a different replica.
+type returnStatePayload struct {
+	Nonce     string `json:"n"`
+	Path      string `json:"p"`
+	ExpiresAt int64  `json:"e"`
 }
 
 type appSession struct {
@@ -96,11 +108,11 @@ func New(config Config) (*Proxy, error) {
 		return nil, err
 	}
 	proxy := &Proxy{
-		config:       normalized,
-		now:          time.Now,
-		random:       config.Random,
-		returnStates: make(map[string]returnState),
-		sessions:     make(map[string]appSession),
+		config:     normalized,
+		now:        time.Now,
+		random:     config.Random,
+		usedStates: make(map[string]time.Time),
+		sessions:   make(map[string]appSession),
 	}
 	if proxy.random == nil {
 		proxy.random = rand.Reader
@@ -227,19 +239,19 @@ func (p *Proxy) forward(w http.ResponseWriter, r *http.Request, route normalized
 	proxy.ServeHTTP(w, r)
 }
 
-// redirectToAuthorize starts the hub login flow: it parks the clean return
-// path server-side under a one-use state handle, mirrors the handle in a
-// short-lived cookie, and sends the browser to the hub authorize endpoint.
+// redirectToAuthorize starts the hub login flow: it packs the clean return
+// path and a fresh nonce into a short-lived cookie, echoes the nonce to the hub
+// as `state`, and sends the browser to the hub authorize endpoint.
 func (p *Proxy) redirectToAuthorize(w http.ResponseWriter, r *http.Request, path string) {
 	if path == "" {
 		path = "/"
 	}
-	handle, err := p.putReturnState(path)
+	handle, cookieValue, err := p.newReturnState(path)
 	if err != nil {
 		http.Error(w, "app access state unavailable", http.StatusInternalServerError)
 		return
 	}
-	p.setReturnCookie(w, handle)
+	p.setReturnCookie(w, cookieValue)
 	callbackURL := p.config.publicScheme + "://" + p.config.host + CallbackPath
 	query := url.Values{}
 	query.Set("cluster", p.config.Instance.Cluster)
@@ -293,6 +305,11 @@ func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
 	request.Header.Set("Content-Type", "application/json")
 	response, err := p.config.hubClient.Do(request)
 	if err != nil {
+		// Includes the TLS case: a hub certificate that does not cover the
+		// in-cluster URL this gate was configured with fails every sign-in
+		// here, and the 502 reaches the browser as a generic bad-gateway page
+		// with no hint of the cause. Name the URL and the error.
+		p.logf("app access exchange failed: %s is unreachable from this gate (host=%s): %v", p.config.hubURL+hubExchangePath, p.config.host, err)
 		p.clearReturnCookie(w)
 		p.clearSessionCookie(w)
 		http.Error(w, "app access exchange unavailable", http.StatusBadGateway)
@@ -307,13 +324,21 @@ func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		p.logf("app access exchange refused: hub answered %d (host=%s)", response.StatusCode, p.config.host)
 		p.clearReturnCookie(w)
 		p.clearSessionCookie(w)
 		http.Error(w, "app access exchange denied", http.StatusBadGateway)
 		return
 	}
 	var exchange exchangeResponse
-	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&exchange); err != nil || !exchange.Allowed || strings.TrimSpace(exchange.UserID) == "" {
+	if err := json.NewDecoder(io.LimitReader(response.Body, 64<<10)).Decode(&exchange); err != nil {
+		p.logf("app access exchange returned an unreadable body (host=%s): %v", p.config.host, err)
+		p.clearReturnCookie(w)
+		http.Error(w, "invalid app access exchange", http.StatusBadGateway)
+		return
+	}
+	if !exchange.Allowed || strings.TrimSpace(exchange.UserID) == "" {
+		p.logf("app access exchange returned no grant: allowed=%t userID-empty=%t (host=%s)", exchange.Allowed, strings.TrimSpace(exchange.UserID) == "", p.config.host)
 		p.clearReturnCookie(w)
 		http.Error(w, "invalid app access exchange", http.StatusBadGateway)
 		return
@@ -337,64 +362,115 @@ func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, returnPath, http.StatusFound)
 }
 
-// consumeReturnState binds a callback to a browser that completed the app's
-// authorization redirect. The cookie is only an opaque lookup key; the live
-// server-side state is the authority. Taking the state under the map lock
-// consumes it exactly once, so copied callback URLs, forged cookies, expired
-// handles, and replayed callbacks cannot reach the hub exchange endpoint.
-// A mismatched cookie/state pair deliberately does NOT consume the victim's
-// live state.
+// consumeReturnState binds a callback to the browser that started the app's
+// authorization redirect. The cookie carries the state itself, so the check is
+// purely local: a callback completes against whichever pod happens to serve it,
+// including one that started after the redirect was issued. Copied callback
+// URLs (no cookie), forged or mismatched pairs, and expired states are all
+// rejected before the hub exchange is reached.
+//
+// The state is nonce-bound but deliberately unsigned — the proxy holds no keys
+// (see the package doc), and every field is either compared against the query
+// parameter or re-sanitised here, so a tampered cookie can only produce a
+// same-origin return path.
+//
+// A mismatched cookie/state pair does NOT clear the cookie: the browser may
+// still be able to complete its own sign-in. Single use is enforced by the
+// usedStates cache below, which is a best-effort optimisation rather than the
+// authority — see markStateUsed.
 func (p *Proxy) consumeReturnState(w http.ResponseWriter, r *http.Request, state string) (string, bool) {
 	cookie, err := r.Cookie(ReturnCookieName)
 	if err != nil {
+		p.logf("app access callback rejected: request carried no %s cookie (host=%s) — a copied callback URL, or the cookie was blocked", ReturnCookieName, p.config.host)
 		p.clearReturnCookie(w)
 		return "", false
 	}
-	handle := strings.TrimSpace(cookie.Value)
-	if state == "" || subtle.ConstantTimeCompare([]byte(handle), []byte(state)) != 1 {
-		return "", false
-	}
-	path, ok := p.takeReturnState(handle)
+	payload, ok := decodeReturnState(cookie.Value)
 	if !ok {
+		p.logf("app access callback rejected: %s cookie is malformed (host=%s)", ReturnCookieName, p.config.host)
 		p.clearReturnCookie(w)
 		return "", false
+	}
+	if state == "" || subtle.ConstantTimeCompare([]byte(payload.Nonce), []byte(state)) != 1 {
+		p.logf("app access callback rejected: state parameter does not match the %s cookie (host=%s)", ReturnCookieName, p.config.host)
+		return "", false
+	}
+	if !p.now().Before(time.Unix(payload.ExpiresAt, 0)) {
+		p.logf("app access callback rejected: sign-in state expired (host=%s) — the round trip through the hub took longer than %s", p.config.host, stateTTL)
+		p.clearReturnCookie(w)
+		return "", false
+	}
+	if !p.markStateUsed(payload.Nonce, time.Unix(payload.ExpiresAt, 0)) {
+		p.logf("app access callback rejected: sign-in state already used (host=%s) — replayed callback", p.config.host)
+		p.clearReturnCookie(w)
+		return "", false
+	}
+	// Re-sanitise rather than trust: the path round-tripped through a cookie.
+	path := cleanReturnPath(payload.Path)
+	if path == "" {
+		path = "/"
 	}
 	return path, true
 }
 
-func (p *Proxy) putReturnState(path string) (string, error) {
+// newReturnState mints the nonce echoed to the hub and the cookie value that
+// carries the whole state back to the callback.
+func (p *Proxy) newReturnState(path string) (nonce, cookieValue string, err error) {
 	if path == "" {
-		return "", errors.New("empty return path")
+		return "", "", errors.New("empty return path")
 	}
-	handle, err := p.randomString(32)
+	if len(path) > maxReturnPathBytes {
+		path = "/"
+	}
+	nonce, err = p.randomString(32)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	now := p.now()
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.sweepReturnStatesLocked(now)
-	for len(p.returnStates) >= maxReturnStates {
-		evictOldestReturnLocked(p.returnStates)
+	raw, err := json.Marshal(returnStatePayload{
+		Nonce:     nonce,
+		Path:      path,
+		ExpiresAt: p.now().Add(stateTTL).Unix(),
+	})
+	if err != nil {
+		return "", "", err
 	}
-	p.returnStates[handle] = returnState{path: path, expiresAt: now.Add(stateTTL)}
-	return handle, nil
+	return nonce, base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
-func (p *Proxy) takeReturnState(handle string) (string, bool) {
-	if handle == "" {
-		return "", false
+func decodeReturnState(value string) (returnStatePayload, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > maxReturnCookieBytes {
+		return returnStatePayload{}, false
 	}
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return returnStatePayload{}, false
+	}
+	var payload returnStatePayload
+	if err := json.Unmarshal(raw, &payload); err != nil || payload.Nonce == "" || payload.ExpiresAt == 0 {
+		return returnStatePayload{}, false
+	}
+	return payload, true
+}
+
+// markStateUsed records a nonce as spent and reports whether it was still
+// unused. Unlike the map it replaces, losing this cache costs nothing but
+// replay detection: the hub's authorization code is itself one-use, so a replay
+// that slips through a restart or an eviction is answered with 410 and simply
+// restarts the flow.
+func (p *Proxy) markStateUsed(nonce string, expiresAt time.Time) bool {
 	now := p.now()
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	state, ok := p.returnStates[handle]
-	if !ok || !now.Before(state.expiresAt) {
-		delete(p.returnStates, handle)
-		return "", false
+	p.sweepUsedStatesLocked(now)
+	if _, used := p.usedStates[nonce]; used {
+		return false
 	}
-	delete(p.returnStates, handle)
-	return state.path, true
+	for len(p.usedStates) >= maxUsedStates {
+		evictOldestUsedLocked(p.usedStates)
+	}
+	p.usedStates[nonce] = expiresAt
+	return true
 }
 
 func (p *Proxy) putSession(userID string, ttlSeconds int64) (string, error) {
@@ -420,17 +496,17 @@ func (p *Proxy) putSession(userID string, ttlSeconds int64) (string, error) {
 	return value, nil
 }
 
-// sweepReturnStatesLocked and sweepSessionsLocked are time-gated full sweeps:
+// sweepUsedStatesLocked and sweepSessionsLocked are time-gated full sweeps:
 // at most one O(N) pass per sweepInterval, so per-request work stays O(1)
 // even under an anonymous request flood.
-func (p *Proxy) sweepReturnStatesLocked(now time.Time) {
-	if now.Sub(p.lastReturnSweep) < sweepInterval && len(p.returnStates) < maxReturnStates {
+func (p *Proxy) sweepUsedStatesLocked(now time.Time) {
+	if now.Sub(p.lastUsedSweep) < sweepInterval && len(p.usedStates) < maxUsedStates {
 		return
 	}
-	p.lastReturnSweep = now
-	for handle, state := range p.returnStates {
-		if !now.Before(state.expiresAt) {
-			delete(p.returnStates, handle)
+	p.lastUsedSweep = now
+	for nonce, expiresAt := range p.usedStates {
+		if !now.Before(expiresAt) {
+			delete(p.usedStates, nonce)
 		}
 	}
 }
@@ -447,12 +523,12 @@ func (p *Proxy) sweepSessionsLocked(now time.Time) {
 	}
 }
 
-func evictOldestReturnLocked(states map[string]returnState) {
+func evictOldestUsedLocked(states map[string]time.Time) {
 	var oldestKey string
 	var oldest time.Time
-	for key, state := range states {
-		if oldestKey == "" || state.expiresAt.Before(oldest) {
-			oldestKey, oldest = key, state.expiresAt
+	for key, expiresAt := range states {
+		if oldestKey == "" || expiresAt.Before(oldest) {
+			oldestKey, oldest = key, expiresAt
 		}
 	}
 	if oldestKey != "" {
@@ -471,6 +547,18 @@ func evictOldestSessionLocked(sessions map[string]appSession) {
 	if oldestKey != "" {
 		delete(sessions, oldestKey)
 	}
+}
+
+// logf reports an operational event. Callback rejections are otherwise
+// invisible: the browser sees one opaque 400 whichever check failed, so the
+// reason has to reach the operator through the log.  Never log the nonce or
+// the state parameter — they are the browser's binding secret.
+func (p *Proxy) logf(format string, args ...any) {
+	if p.config.Logf != nil {
+		p.config.Logf(format, args...)
+		return
+	}
+	log.Printf("faros-access-proxy: "+format, args...)
 }
 
 func sessionKey(value string) string {

--- a/providers/infrastructure/accessproxy/proxy_test.go
+++ b/providers/infrastructure/accessproxy/proxy_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package accessproxy
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -135,6 +137,10 @@ func newUpstream(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *ups
 func newProxy(t *testing.T, config Config) *Proxy {
 	t.Helper()
 	config.AllowNonClusterTargets = true // httptest targets are 127.0.0.1
+	if config.Logf == nil {
+		// Rejection reasons belong with the failing test, not on stderr.
+		config.Logf = t.Logf
+	}
 	proxy, err := New(config)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -602,12 +608,13 @@ func TestConfigValidation(t *testing.T) {
 	}
 }
 
-func TestReturnStateMapIsBoundedWithO1RequestCost(t *testing.T) {
+func TestAnonymousFloodStoresNothingServerSide(t *testing.T) {
 	upstream, _ := newUpstream(t, nil)
 	hub := newFakeHub("code-1")
 	p := newProxy(t, privateConfig(upstream.URL, hub))
-	// Simulate an anonymous flood far past the cap.
-	for i := 0; i < maxReturnStates+500; i++ {
+	// Simulate an anonymous flood far past the old cap. Sign-in state now
+	// rides the browser's cookie, so none of this can grow the process.
+	for i := 0; i < maxUsedStates+500; i++ {
 		rec := doRequest(p, appRequest("/"))
 		if rec.Code != http.StatusFound {
 			t.Fatalf("request %d status = %d", i, rec.Code)
@@ -615,8 +622,150 @@ func TestReturnStateMapIsBoundedWithO1RequestCost(t *testing.T) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if len(p.returnStates) > maxReturnStates {
-		t.Fatalf("returnStates = %d, want <= %d", len(p.returnStates), maxReturnStates)
+	if len(p.usedStates) != 0 {
+		t.Fatalf("usedStates = %d, want 0 — unauthenticated traffic must not allocate", len(p.usedStates))
+	}
+}
+
+func TestUsedStateCacheIsBounded(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	p := newProxy(t, privateConfig(upstream.URL, hub))
+	expiry := p.now().Add(stateTTL)
+	for i := 0; i < maxUsedStates+500; i++ {
+		if !p.markStateUsed(fmt.Sprintf("nonce-%d", i), expiry) {
+			t.Fatalf("nonce %d reported as already used", i)
+		}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.usedStates) > maxUsedStates {
+		t.Fatalf("usedStates = %d, want <= %d", len(p.usedStates), maxUsedStates)
+	}
+}
+
+// The bug this replaced: the gate's state lived in a per-pod map, so any
+// restart between the authorize redirect and the callback failed the sign-in
+// with "invalid app access state". Flipping an app's access mode rolls the
+// deployment, which made it routine.
+func TestCallbackCompletesOnAFreshProcess(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	config := privateConfig(upstream.URL, hub)
+
+	before := newProxy(t, config)
+	first := doRequest(before, appRequest("/deep/link?q=1"))
+	if first.Code != http.StatusFound {
+		t.Fatalf("initial request status = %d, want 302", first.Code)
+	}
+	returnCookie := cookieFromResponse(t, first, ReturnCookieName)
+	state := mustQuery(t, first.Header().Get("Location"), "state")
+
+	// The pod is replaced; the replacement shares no memory with it.
+	after := newProxy(t, config)
+	callback := doRequest(after, appRequest(CallbackPath+"?code="+hub.code+"&state="+state, returnCookie))
+	if callback.Code != http.StatusFound {
+		t.Fatalf("callback on fresh process = %d body=%q, want 302", callback.Code, callback.Body.String())
+	}
+	if got := callback.Header().Get("Location"); got != "/deep/link?q=1" {
+		t.Fatalf("post-login redirect = %q, want the original deep link", got)
+	}
+	if cookieFromResponse(t, callback, SessionCookieName) == nil {
+		t.Fatal("callback minted no session cookie")
+	}
+}
+
+func TestReturnCookieWithTamperedPathRedirectsSameOrigin(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	p := newProxy(t, privateConfig(upstream.URL, hub))
+
+	first := doRequest(p, appRequest("/"))
+	state := mustQuery(t, first.Header().Get("Location"), "state")
+
+	// An off-origin return path in a hand-built cookie must not survive the
+	// re-sanitisation on the callback.
+	raw, err := json.Marshal(returnStatePayload{
+		Nonce:     state,
+		Path:      "https://evil.example/steal",
+		ExpiresAt: p.now().Add(stateTTL).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	forged := &http.Cookie{Name: ReturnCookieName, Value: base64.RawURLEncoding.EncodeToString(raw)}
+
+	callback := doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state, forged))
+	if callback.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want 302", callback.Code)
+	}
+	if got := callback.Header().Get("Location"); got != "/" {
+		t.Fatalf("post-login redirect = %q, want / (off-origin path discarded)", got)
+	}
+}
+
+func TestExpiredReturnStateIsRejected(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	p := newProxy(t, privateConfig(upstream.URL, hub))
+
+	first := doRequest(p, appRequest("/"))
+	returnCookie := cookieFromResponse(t, first, ReturnCookieName)
+	state := mustQuery(t, first.Header().Get("Location"), "state")
+
+	// The browser dawdles at the IdP for longer than the state TTL.
+	base := p.now()
+	p.now = func() time.Time { return base.Add(stateTTL + time.Second) }
+
+	rec := doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state, returnCookie))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if hub.exchangeCount() != 0 {
+		t.Fatalf("expired state reached the hub exchange")
+	}
+}
+
+func TestCallbackRejectionsAreLoggedWithReasons(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	config := privateConfig(upstream.URL, hub)
+
+	var logged []string
+	config.Logf = func(format string, args ...any) {
+		logged = append(logged, fmt.Sprintf(format, args...))
+	}
+	p := newProxy(t, config)
+
+	first := doRequest(p, appRequest("/"))
+	returnCookie := cookieFromResponse(t, first, ReturnCookieName)
+	state := mustQuery(t, first.Header().Get("Location"), "state")
+
+	// No cookie, bad cookie, mismatched state, then a successful use followed
+	// by a replay — four distinct reasons, all surfaced as the same 400.
+	doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state))
+	doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state,
+		&http.Cookie{Name: ReturnCookieName, Value: "not-base64-at-all!!"}))
+	doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state=someone-elses", returnCookie))
+	doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state, returnCookie))
+	doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state, returnCookie))
+
+	for _, want := range []string{"carried no", "malformed", "does not match", "already used"} {
+		found := false
+		for _, line := range logged {
+			if strings.Contains(line, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("no log line mentioning %q; got %q", want, logged)
+		}
+	}
+	for _, line := range logged {
+		if strings.Contains(line, state) {
+			t.Errorf("log line leaks the state nonce: %q", line)
+		}
 	}
 }
 


### PR DESCRIPTION
Two independent lines of work, both needed to run the hub as more than one pod and to keep published apps signing in while it rolls.

## Hub HA

`replicaCount` is honoured with external kcp and refused alongside embedded kcp, which keeps etcd on a per-replica PVC and would otherwise give each replica its own control plane.

- **Singleton controllers** (provider provisioning, MCPServer, org bootstrap, soft-delete) run only on the replica holding the `faros-hub-controllers` Lease. The provider *catalog* controller stays exempt — it maintains the routing table the request path reads, so every replica needs it.
- **Browser sessions and published-app authorization codes** move to kcp-backed Secrets, so a cookie or code minted by one replica resolves and revokes on all of them. `authorize` and `exchange` are separate requests, and a scaled hub serves them from different pods.
- **Provider heartbeats** are recorded on `CatalogEntry.status` instead of per-replica memory, so liveness observed by one replica reaches the others over the catalog watch.

`docs/helm.md` documents the two things that cost more per replica rather than less: the per-IP auth rate limiter is per replica, and `hub.embeddedGraphQL` runs a schema listener per replica.

## Access proxy: survive a gate restart mid-sign-in

An in-flight sign-in kept its return path in a per-pod map, so any restart between the authorize redirect and the callback failed with `invalid app access state`. Flipping an app's access mode rolls the gate deployment, which made that routine — it is what prompted this change.

The state now travels in the browser's return cookie (nonce, clean path, expiry) and is validated locally, so a callback completes against whichever pod serves it. Nothing in the cookie is trusted: the nonce is only compared against the `state` parameter and the path is re-sanitised, so a tampered cookie can at most produce a same-origin redirect. No signing key is involved, which keeps the proxy free of credentials.

Single use becomes a best-effort cache of spent nonces rather than the authority — losing it costs replay detection only, because the hub's code is itself one-use. The return cookie also gains the `__Host-` prefix, so a sibling app under the same published-apps zone cannot plant one.

**Diagnosability.** Callback rejections were one opaque 400 and exchange failures one opaque 502, neither logged. Both now name the reason, including the unreachable hub URL — which is what a hub certificate that does not cover the gate's configured address looks like from the outside, and it took a cluster-side probe to find. The nonce is never logged.

## Code provider: crawl packages every 30s

At 2m, App Studio's publish check reported "no component images are published" for minutes after a successful build. The cost is one host package listing per repository per interval; `CODE_PACKAGE_CRAWL_INTERVAL` raises it for workspaces with many repositories.

## Test plan

- `go build ./...` and `go test ./pkg/...` on the main module
- `go build ./... && go test ./...` on `providers/code` and `providers/infrastructure`
- New access-proxy tests: callback completes on a fresh process (the regression this fixes), tampered cookie path, expired state, rejection reasons logged without leaking the nonce, used-state cache bounded, anonymous flood allocates nothing
- Pre-existing security assertions unchanged: stolen callback, mismatched pair does not consume the victim's state, replay rejected, hub outage fails closed

## Notes for the reviewer

- The return cookie was renamed, so sign-ins in flight across the rollout restart once.
- Established app sessions are still process-local: a gate restart signs users out rather than stranding them mid-flow. Making those survive needs either a signing key or a shared store, and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
