### PR TITLE
Persist heartbeats where the entries live; stop the authorize login bounce looping

### DIFF
--- a/pkg/hub/appauth/appauth.go
+++ b/pkg/hub/appauth/appauth.go
@@ -42,6 +42,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,6 +56,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/faroshq/faros/pkg/browsersession"
 )
@@ -238,6 +240,41 @@ func (h *Handler) RegisterRoutes(router *mux.Router, limit func(http.HandlerFunc
 	router.HandleFunc(ExchangePath, wrap(h.HandleExchange)).Methods("POST")
 }
 
+// retriedParam marks an authorize URL that has already been through the login
+// bounce once. It rides in the `next` URL the portal returns to, so it survives
+// exactly one round trip and needs no server-side state.
+const retriedParam = "faros_retried"
+
+// withRetriedMarker returns the request URI with the retry marker set. The
+// marker is additive: cluster/group/resource/name/state/redirect_uri are
+// untouched, so the authorize request that comes back validates identically.
+func withRetriedMarker(u *url.URL) string {
+	marked := *u
+	q := marked.Query()
+	q.Set(retriedParam, "1")
+	marked.RawQuery = q.Encode()
+	return marked.RequestURI()
+}
+
+// resolveFailureReason classifies why a session did not resolve, for the log
+// line only. The three cases have very different causes — no cookie at all
+// points at the browser or a cross-site hop, a missing record points at the
+// store, and an expired one is routine — and they were previously
+// indistinguishable from outside.
+func resolveFailureReason(r *http.Request, err error) string {
+	if _, cookieErr := r.Cookie(browsersession.CookieName); cookieErr != nil {
+		return "request carried no " + browsersession.CookieName + " cookie"
+	}
+	switch {
+	case errors.Is(err, browsersession.ErrExpired):
+		return "session expired"
+	case errors.Is(err, browsersession.ErrNotFound):
+		return "cookie present but no session record found (issued by another store, or already revoked)"
+	default:
+		return "session lookup failed: " + err.Error()
+	}
+}
+
 // HandleAuthorize is the browser entry point.
 //
 //	GET /auth/apps/authorize?cluster=&group=&resource=&name=&redirect_uri=&state=
@@ -261,11 +298,29 @@ func (h *Handler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	session, err := h.sessions.ResolveRequest(r)
 	if err != nil {
+		logger := klog.FromContext(r.Context())
+		// One bounce through login is the normal path for an anonymous browser
+		// (and for every browser at once after the session store changes, when
+		// no existing cookie resolves any more). A SECOND unresolved session on
+		// a request that already came back from login means the hand-off is not
+		// working, and redirecting again spins the browser between the hub and
+		// the portal at request speed — this loop has been observed minting
+		// ~8 sessions/second until the per-IP rate limiter stopped it. Stop it
+		// here instead: the limiter is a backstop, not a control.
+		if q.Get(retriedParam) != "" {
+			logger.Info("app authorize: session still unresolved after login, refusing to bounce again",
+				"reason", resolveFailureReason(r, err), "app", ref.Name)
+			h.renderError(w, http.StatusUnauthorized, "Sign-in could not be completed",
+				"The sign-in did not carry a usable session. Check that cookies are enabled for this site, then open the app again.")
+			return
+		}
 		// No usable shared session: send the browser through the normal hub
 		// login. The portal redirects back to this exact hub-relative URL
 		// afterwards, so the flow resumes with a fresh session cookie.
+		logger.V(2).Info("app authorize: no usable session, sending to login",
+			"reason", resolveFailureReason(r, err), "app", ref.Name)
 		browsersession.ClearCookie(w)
-		next := r.URL.RequestURI() // hub-relative; never an absolute URL
+		next := withRetriedMarker(r.URL) // hub-relative; never an absolute URL
 		http.Redirect(w, r, h.loginPath+"?next="+url.QueryEscape(next), http.StatusFound)
 		return
 	}

--- a/pkg/hub/appauth/appauth_test.go
+++ b/pkg/hub/appauth/appauth_test.go
@@ -121,6 +121,104 @@ func TestAuthorizeRedirectsToLoginWithoutSession(t *testing.T) {
 	}
 }
 
+// The login bounce must carry a marker so the second unresolved attempt can be
+// told apart from the first. Without it the browser ping-pongs between the hub
+// and the portal at request speed.
+func TestAuthorizeLoginBounceCarriesRetryMarker(t *testing.T) {
+	f := newFixture(t)
+	req := httptest.NewRequest(http.MethodGet, authorizeURL(validRedirect()), nil)
+	rec := httptest.NewRecorder()
+	f.handler.HandleAuthorize(rec, req)
+
+	next, err := url.QueryUnescape(strings.TrimPrefix(rec.Header().Get("Location"), "/ui/login?next="))
+	if err != nil {
+		t.Fatalf("unescape next: %v", err)
+	}
+	parsed, err := url.Parse(next)
+	if err != nil {
+		t.Fatalf("parse next: %v", err)
+	}
+	if parsed.Query().Get(retriedParam) != "1" {
+		t.Fatalf("next = %q, want the %s marker", next, retriedParam)
+	}
+	// The marker must be purely additive — every parameter authorize validates
+	// has to survive the round trip unchanged.
+	for _, key := range []string{"cluster", "group", "resource", "name", "redirect_uri", "state"} {
+		if got, want := parsed.Query().Get(key), mustQueryOf(t, authorizeURL(validRedirect()), key); got != want {
+			t.Fatalf("%s = %q after marking, want %q", key, got, want)
+		}
+	}
+}
+
+func TestAuthorizeRefusesToBounceTwice(t *testing.T) {
+	f := newFixture(t)
+	// A request that already came back from login, still with no usable
+	// session: answer it instead of redirecting into a loop.
+	req := httptest.NewRequest(http.MethodGet, authorizeURL(validRedirect())+"&"+retriedParam+"=1", nil)
+	rec := httptest.NewRecorder()
+	f.handler.HandleAuthorize(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("second unresolved attempt redirected to %q", loc)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "cookies") {
+		t.Fatalf("error page does not mention cookies: %q", body)
+	}
+	if len(f.sars) != 0 {
+		t.Fatalf("SAR ran without a session")
+	}
+}
+
+// A browser that does have a session must not be penalised for carrying the
+// marker: the retry itself is the success case.
+func TestAuthorizeWithMarkerAndSessionStillMintsCode(t *testing.T) {
+	f := newFixture(t)
+	req := f.loggedInRequest(t, authorizeURL(validRedirect())+"&"+retriedParam+"=1")
+	rec := httptest.NewRecorder()
+	f.handler.HandleAuthorize(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d body=%q, want 302", rec.Code, rec.Body.String())
+	}
+	loc, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if loc.Query().Get("code") == "" {
+		t.Fatalf("redirect carries no code: %q", rec.Header().Get("Location"))
+	}
+	if got := loc.Query().Get("state"); got != "proxystate123" {
+		t.Fatalf("state = %q, want the proxy's state echoed back", got)
+	}
+}
+
+func TestResolveFailureReasonDistinguishesCauses(t *testing.T) {
+	f := newFixture(t)
+	noCookie := httptest.NewRequest(http.MethodGet, AuthorizePath, nil)
+	if got := resolveFailureReason(noCookie, browsersession.ErrNotFound); !strings.Contains(got, "no "+browsersession.CookieName) {
+		t.Errorf("missing-cookie reason = %q", got)
+	}
+	withCookie := f.loggedInRequest(t, AuthorizePath)
+	if got := resolveFailureReason(withCookie, browsersession.ErrNotFound); !strings.Contains(got, "no session record") {
+		t.Errorf("unknown-record reason = %q", got)
+	}
+	if got := resolveFailureReason(withCookie, browsersession.ErrExpired); !strings.Contains(got, "expired") {
+		t.Errorf("expired reason = %q", got)
+	}
+}
+
+func mustQueryOf(t *testing.T, rawURL, key string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	return u.Query().Get(key)
+}
+
 func TestAuthorizeMintsCodeAndExchangeReturnsIdentity(t *testing.T) {
 	f := newFixture(t)
 	req := f.loggedInRequest(t, authorizeURL(validRedirect()))

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -168,6 +168,10 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		Category:     entry.Spec.Category,
 		Dependencies: dependencies,
 		Version:      entry.Spec.Version,
+		// The cluster this entry was observed in is where a heartbeat must be
+		// written back. Providers register their CatalogEntry in their own
+		// workspace, so there is no single path the recorder could assume.
+		CatalogEntryCluster: string(req.ClusterName),
 	}
 	prov.EdgeProxyAccess = entry.Spec.EdgeProxyAccess
 	// Liveness travels through status so it reaches every hub replica, not just

--- a/pkg/hub/providers/heartbeat_recorder.go
+++ b/pkg/hub/providers/heartbeat_recorder.go
@@ -29,30 +29,53 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/faroshq/faros/pkg/apiurl"
-	"github.com/faroshq/faros/pkg/kcppaths"
 )
 
 var catalogEntryGVR = schema.GroupVersionResource{
 	Group: "providers.faros.sh", Version: "v1alpha1", Resource: "catalogentries",
 }
 
+// ClusterResolver reports the logical cluster a provider's CatalogEntry lives
+// in. The catalog reconciler records it from the cluster it observed the entry
+// in, so the recorder patches the object where it actually is.
+type ClusterResolver interface {
+	CatalogEntryCluster(name string) (string, bool)
+}
+
 // NewCatalogHeartbeatRecorder returns a HeartbeatRecorder that stamps
-// CatalogEntry.status in root:faros:system:providers, where the entries live.
+// CatalogEntry.status in the provider's own workspace
+// (root:faros:providers/<name>), where each provider's `init` self-registers
+// its entry.
+//
+// Addressing the entry by cluster rather than by a fixed path matters: an
+// earlier version wrote to root:faros:system:providers, which serves the API but
+// holds no entries, so every beat 404'd and provider liveness never crossed
+// replicas.
 //
 // A merge patch (rather than a read-modify-write) keeps concurrent beats from
 // different providers — and a beat racing the catalog reconciler's own status
 // write — from conflicting.
-func NewCatalogHeartbeatRecorder(kcpConfig *rest.Config) (HeartbeatRecorder, error) {
+func NewCatalogHeartbeatRecorder(kcpConfig *rest.Config, clusters ClusterResolver) (HeartbeatRecorder, error) {
 	if kcpConfig == nil {
 		return nil, fmt.Errorf("kcp config is required")
 	}
-	cfg := rest.CopyConfig(kcpConfig)
-	cfg.Host = apiurl.KCPClusterURL(cfg.Host, kcppaths.SystemProviders)
-	client, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("creating system:providers client: %w", err)
+	if clusters == nil {
+		return nil, fmt.Errorf("cluster resolver is required")
 	}
 	return func(ctx context.Context, name, version string, at time.Time) error {
+		cluster, ok := clusters.CatalogEntryCluster(name)
+		if !ok || cluster == "" {
+			// The catalog watch has not seen this provider's entry yet. The
+			// beat still landed in the registry; only the cross-replica
+			// broadcast is skipped, and the next beat retries.
+			return fmt.Errorf("no CatalogEntry cluster known for provider %q yet", name)
+		}
+		cfg := rest.CopyConfig(kcpConfig)
+		cfg.Host = apiurl.KCPClusterURL(cfg.Host, cluster)
+		client, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return fmt.Errorf("creating client for cluster %s: %w", cluster, err)
+		}
 		// metav1.Time serialises as RFC3339 at second precision; match it
 		// exactly so the round trip through the API is lossless.
 		status := map[string]any{"lastHeartbeat": at.UTC().Format(time.RFC3339)}
@@ -66,7 +89,7 @@ func NewCatalogHeartbeatRecorder(kcpConfig *rest.Config) (HeartbeatRecorder, err
 		if _, err := client.Resource(catalogEntryGVR).Patch(
 			ctx, name, types.MergePatchType, patch, metav1.PatchOptions{}, "status",
 		); err != nil {
-			return fmt.Errorf("patching CatalogEntry %q status: %w", name, err)
+			return fmt.Errorf("patching CatalogEntry %q status in cluster %s: %w", name, cluster, err)
 		}
 		return nil
 	}, nil

--- a/pkg/hub/providers/heartbeat_test.go
+++ b/pkg/hub/providers/heartbeat_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
 )
 
 func heartbeatRequestFor(name string) *http.Request {
@@ -132,5 +133,60 @@ func TestHeartbeatWithoutRecorder(t *testing.T) {
 	}
 	if got, _ := reg.Get("cost"); !got.HeartbeatRequired {
 		t.Fatal("local registry not updated")
+	}
+}
+
+// The recorder must address a provider's CatalogEntry by the cluster the
+// catalog watch observed it in. An earlier version wrote to a fixed workspace
+// path (root:faros:system:providers) that serves the API but holds no entries,
+// so every beat 404'd and liveness never reached the other replicas.
+func TestCatalogEntryClusterComesFromTheObservedEntry(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "1axwjxprfb96jgta"})
+
+	cluster, ok := reg.CatalogEntryCluster("code")
+	if !ok || cluster != "1axwjxprfb96jgta" {
+		t.Fatalf("CatalogEntryCluster = %q, %t; want the observed cluster", cluster, ok)
+	}
+
+	// A later reconcile that rebuilds the record without the field must not
+	// erase it, exactly as WorkspaceCluster is preserved.
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+	if cluster, ok := reg.CatalogEntryCluster("code"); !ok || cluster != "1axwjxprfb96jgta" {
+		t.Fatalf("after re-upsert: %q, %t; want the cluster preserved", cluster, ok)
+	}
+
+	// Unknown provider, and known provider whose entry has not been seen yet,
+	// both report "not known" so the recorder can say so instead of guessing.
+	if _, ok := reg.CatalogEntryCluster("nope"); ok {
+		t.Fatal("unknown provider reported a cluster")
+	}
+	reg.Upsert(Provider{Name: "fresh", EndpointsValid: true})
+	if _, ok := reg.CatalogEntryCluster("fresh"); ok {
+		t.Fatal("provider with no observed entry reported a cluster")
+	}
+}
+
+func TestCatalogHeartbeatRecorderRequiresAResolver(t *testing.T) {
+	if _, err := NewCatalogHeartbeatRecorder(nil, NewRegistry()); err == nil {
+		t.Fatal("nil kcp config accepted")
+	}
+	if _, err := NewCatalogHeartbeatRecorder(&rest.Config{Host: "https://example.test"}, nil); err == nil {
+		t.Fatal("nil cluster resolver accepted")
+	}
+}
+
+// A beat for a provider whose entry has not been observed yet must fail with a
+// message that names the cause, not a 404 from a workspace that never had it.
+func TestRecorderReportsUnknownCluster(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+	recorder, err := NewCatalogHeartbeatRecorder(&rest.Config{Host: "https://example.test"}, reg)
+	if err != nil {
+		t.Fatalf("NewCatalogHeartbeatRecorder: %v", err)
+	}
+	err = recorder(context.Background(), "code", "v1", time.Now())
+	if err == nil || !strings.Contains(err.Error(), "no CatalogEntry cluster known") {
+		t.Fatalf("err = %v, want an unknown-cluster error", err)
 	}
 }

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -84,6 +84,14 @@ type Provider struct {
 	// via SetWorkspaceCluster after provisioning; empty until then.
 	WorkspaceCluster string
 
+	// CatalogEntryCluster is the logical cluster the provider's CatalogEntry
+	// was observed in, recorded by the catalog reconciler from the multicluster
+	// request. The heartbeat recorder patches the entry there; a fixed
+	// workspace path is wrong, because each provider's `init` registers its
+	// entry in the provider's own workspace. Empty until the catalog watch has
+	// seen the entry.
+	CatalogEntryCluster string
+
 	// LocalUIAssets, when non-nil, is an embedded fs.FS that the UI proxy
 	// serves under /ui/providers/{Name}/* instead of forwarding to UIURL.
 	// Populated for first-party providers whose Vite-built portal/dist is
@@ -431,6 +439,9 @@ func (r *Registry) Upsert(p Provider) {
 			// don't lose it on the next reconcile's fresh Provider value.
 			p.WorkspaceCluster = existing.WorkspaceCluster
 		}
+		if p.CatalogEntryCluster == "" {
+			p.CatalogEntryCluster = existing.CatalogEntryCluster
+		}
 	}
 	cp := p
 	cp.AssistantSkills = cloneProviderAssistantSkills(p.AssistantSkills)
@@ -465,6 +476,19 @@ func cloneProvider(p Provider) Provider {
 	}
 	p.AssistantSkills = cloneProviderAssistantSkills(p.AssistantSkills)
 	return p
+}
+
+// CatalogEntryCluster returns the logical cluster the provider's CatalogEntry
+// lives in, and whether it is known yet. It satisfies the heartbeat recorder's
+// ClusterResolver.
+func (r *Registry) CatalogEntryCluster(name string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.byName[name]
+	if !ok || p.CatalogEntryCluster == "" {
+		return "", false
+	}
+	return p.CatalogEntryCluster, true
 }
 
 // SetWorkspaceCluster records the logical cluster ID of the provider's

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -415,7 +415,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// would time a healthy provider out and start refusing to proxy to it.
 	var heartbeatRecorder providers.HeartbeatRecorder
 	if kcpConfig != nil {
-		heartbeatRecorder, err = providers.NewCatalogHeartbeatRecorder(kcpConfig)
+		heartbeatRecorder, err = providers.NewCatalogHeartbeatRecorder(kcpConfig, providerRegistry)
 		if err != nil {
 			return fmt.Errorf("creating provider heartbeat recorder: %w", err)
 		}


### PR DESCRIPTION
Two defects found while rolling #510 out to a real cluster. Based on that branch.

## Heartbeats never persisted

`NewCatalogHeartbeatRecorder` patched `CatalogEntry` status in `root:faros:system:providers`. That workspace serves the API but holds **no entries** — each provider's `init` self-registers its entry in the provider's own workspace:

```
root:faros:system:providers         → No resources found
root:faros:providers:code           → code            Ready=True
root:faros:providers:infrastructure → infrastructure  Ready=True
```

So every beat 404'd, every 30s, for every provider:

```
E0813 11:01:43 heartbeat.go:96 "persisting heartbeat failed"
  err="patching CatalogEntry \"app-studio\" status: catalogentries.providers.faros.sh \"app-studio\" not found"
```

Liveness therefore never reached `CatalogEntry.status` — the exact mechanism #510 relies on to carry a beat from the replica that received it to the ones that did not.

The catalog reconciler now records the cluster it observed each entry in (`Provider.CatalogEntryCluster`, preserved across re-upserts like `WorkspaceCluster`), and the recorder patches there. Addressing by cluster rather than by a fixed path is the point — there is no single workspace the recorder could assume. A beat for a provider whose entry the catalog watch has not seen yet says so, instead of 404ing against a workspace that never had it; the beat still lands in the local registry, only the cross-replica broadcast waits for the next one.

## Authorize could bounce through login forever

An unresolved browser session redirects to `/ui/login?next=<authorize>`, and the portal returns to that same URL. Nothing bounded it.

Swapping the session backend to the shared store made every pre-existing cookie unresolvable at once (the cookie name and attributes are unchanged, only where records live), and the flow span between hub and portal at roughly eight sessions per second until the per-IP rate limiter cut in — 30 session Secrets created in four seconds, timestamped in kcp:

```
11:01:24Z  3    11:01:26Z 12
11:01:25Z 12    11:01:27Z  3     11:01:53Z 2 (after the limiter)
```

The limiter is a backstop, not a control — and `docs/helm.md` already notes it is per replica, so more replicas mean it spins proportionally longer before stopping anything.

The login bounce now marks the `next` URL, and a second unresolved session on a request already carrying the marker renders the sign-in error page instead of redirecting again.

## Both paths now say why they failed

The authorize bounce distinguishes *no cookie at all* from *a cookie whose record is gone* from *a merely expired session* — three very different causes that were indistinguishable from outside, and the reason the loop above needed a Secret-by-Secret audit to explain.

## How this behaves with replicaCount > 1

Every mechanism here is either per-replica-safe or stateless by construction:

- **The retry marker is in the URL, not in memory.** The two hops can land on different replicas and the breaker still holds. A per-replica counter would not have.
- **One bounce is enough across replicas** because `sharedstore.Store.Get` is a direct API read, not an informer read — a session written by the replica that served the portal bootstrap is visible to whichever replica serves the retry.
- **Every replica can resolve the entry cluster**: the catalog reconciler is deliberately not leader-gated (it maintains request-path state), so each replica's registry learns `CatalogEntryCluster` from its own watch.
- **Concurrent beats stay monotone**: a provider beats one replica at a time, the write is a merge patch, and `Registry.Upsert` takes the later of the stored and incoming timestamps, so no replica can move a provider backwards.

The one ordering case left is a beat arriving at a replica whose catalog watch has not synced yet. It reports the unknown cluster and the next beat retries — bounded by one heartbeat interval, and the local registry has the beat throughout.

## Test plan

- `go build ./...`, `go test ./pkg/...`
- Authorize: marker is added to the login bounce and is purely additive; a second marked attempt returns 401 without redirecting and without running a SAR; a marked request *with* a session still mints a code; resolve-failure reasons are distinguishable
- Heartbeat: entry cluster survives a re-upsert that omits it; unknown and unobserved providers report "not known"; recorder rejects a nil resolver and names the unknown cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)
