### PR TITLE
Guide fresh workspaces through their first providers

### DIFF
--- a/pkg/hub/controllers/membershipindex/controller.go
+++ b/pkg/hub/controllers/membershipindex/controller.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package membershipindex implements the UMI invariant reconciler: a
+// controller that watches UserMembershipIndex CRs in root:faros:users and
+// repairs rows that strand a user.
+//
+// The invariant: every workspace-scope row implies an org-scope row for the
+// same Organization. The portal's org switcher is built exclusively from
+// org-scope rows (restapi.listOrgs), and every workspace lives inside an
+// org — so a UMI holding a workspace-scope row with no matching org-scope
+// row describes a workspace the user has been granted but can never reach.
+// They see nothing, while every individual object (RBAC binding, UMI row,
+// Membership CR) looks correct in isolation.
+//
+// The REST layer keeps writing both rows on the happy path
+// (restapi.addWorkspaceMembership cascades the org membership), but the
+// index is maintained by dual writes across failure domains — a handler
+// crash between writes, a partial rollout, or an older hub can all leave
+// the index inconsistent. Following the model in platform-mesh's
+// tenancy-operator (RFC 010), consistency of derived state is a
+// controller's job, not a property every writer must individually
+// guarantee: handlers record intent, this reconciler converges the index,
+// and drift heals on the next resync instead of persisting until someone
+// files a bug.
+//
+// What it deliberately does NOT do:
+//   - Invent workspace rows from Membership CRs (the workspace-scope
+//     source of truth IS the UMI; there is nothing to reconcile against).
+//   - Resurrect rows for Organizations that no longer exist or are
+//     soft-deleted — teardown is the softdelete reconciler's domain, and
+//     healing must never race it back to life.
+//   - Touch roles on existing rows (the REST layer owns role changes).
+package membershipindex
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+const controllerName = "membership-index-invariants"
+
+// MembershipEnsurer is the one Bootstrapper capability this controller
+// needs: recording the org-scope Membership CR that mirrors the healed
+// index row. Narrow so tests fake it without an embedded kcp.
+//
+// Implemented by *pkg/hub/kcp.Bootstrapper.
+type MembershipEnsurer interface {
+	// EnsureOrgMembership creates an org-scope Membership CR inside the
+	// Organization workspace granting userName the given role. Idempotent.
+	EnsureOrgMembership(ctx context.Context, orgUUID, userName, role string) error
+}
+
+// Reconciler enforces the ws-row→org-row invariant on one
+// UserMembershipIndex per reconcile.
+type Reconciler struct {
+	client  client.Client
+	ensurer MembershipEnsurer
+}
+
+// SetupWithManager registers the UserMembershipIndex watch with mgr.
+func SetupWithManager(mgr manager.Manager, ensurer MembershipEnsurer) error {
+	r := &Reconciler{
+		client:  mgr.GetClient(),
+		ensurer: ensurer,
+	}
+	klog.Info("Registering membership-index invariant controller")
+	return builder.ControllerManagedBy(mgr).
+		Named(controllerName).
+		For(&tenancyv1alpha1.UserMembershipIndex{}).
+		Complete(r)
+}
+
+// NewManager constructs a controller-runtime manager bound to the
+// root:faros:users workspace config (Bootstrapper.UsersConfig), matching
+// the organization and softdelete managers. Separate manager so an
+// invariant-repair crash can't take their workqueues down.
+func NewManager(cfg *rest.Config, scheme *runtime.Scheme) (manager.Manager, error) {
+	return manager.New(cfg, manager.Options{
+		Scheme: scheme,
+		Metrics: server.Options{
+			// Hub serves its own /metrics; disable controller-runtime's.
+			BindAddress: "0",
+		},
+		HealthProbeBindAddress: "0",
+	})
+}
+
+// Reconcile heals one user's index: for every org that appears only in
+// workspace-scope rows, write the org-scope Membership CR + index row that
+// make the org (and therefore those workspaces) reachable in the portal.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := klog.FromContext(ctx).WithValues("umi", req.Name)
+
+	var idx tenancyv1alpha1.UserMembershipIndex
+	if err := r.client.Get(ctx, req.NamespacedName, &idx); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("getting UserMembershipIndex: %w", err)
+	}
+
+	// Orgs with an org-scope row (any role, including soft-deleted rows —
+	// a soft-deleted org row means teardown owns this org, not us).
+	orgRows := map[string]bool{}
+	for _, e := range idx.Spec.Entries {
+		if e.WorkspaceUUID == "" {
+			orgRows[e.OrgUUID] = true
+		}
+	}
+
+	// Orgs reachable only through live workspace-scope rows → violations.
+	missing := map[string]bool{}
+	for _, e := range idx.Spec.Entries {
+		if e.WorkspaceUUID != "" && e.SoftDeletedAt == nil && !orgRows[e.OrgUUID] {
+			missing[e.OrgUUID] = true
+		}
+	}
+	if len(missing) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	healed := idx.DeepCopy()
+	changed := false
+	for orgUUID := range missing {
+		var org tenancyv1alpha1.Organization
+		if err := r.client.Get(ctx, client.ObjectKey{Name: orgUUID}, &org); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Org is gone; the stale ws rows are softdelete's cleanup,
+				// not ours to either heal or remove.
+				logger.Info("Skipping heal for missing Organization", "org", orgUUID)
+				continue
+			}
+			return ctrl.Result{}, fmt.Errorf("getting Organization %s: %w", orgUUID, err)
+		}
+		if org.Status.DeletionRequestedAt != nil {
+			// Org is inside its grace window — healing visibility into a
+			// dying org would fight the softdelete reconciler.
+			continue
+		}
+
+		// Intent first (Membership CR in the org workspace), index second —
+		// the same order the REST layer writes, so a crash between the two
+		// leaves the recoverable state (CR without row) rather than a row
+		// claiming a membership that was never recorded.
+		if err := r.ensurer.EnsureOrgMembership(ctx, orgUUID, idx.Name, tenancyv1alpha1.MembershipRoleMember); err != nil {
+			return ctrl.Result{}, fmt.Errorf("ensuring org Membership for %s in %s: %w", idx.Name, orgUUID, err)
+		}
+		healed.Spec.Entries = append(healed.Spec.Entries, tenancyv1alpha1.MembershipIndexEntry{
+			OrgUUID:        orgUUID,
+			OrgDisplayName: org.Spec.DisplayName,
+			OrgCreatedAt:   org.CreationTimestamp,
+			Role:           tenancyv1alpha1.MembershipRoleMember,
+			Personal:       org.Spec.Personal,
+		})
+		changed = true
+		logger.Info("Healed org-scope index row", "org", orgUUID)
+	}
+	if !changed {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.client.Update(ctx, healed); err != nil {
+		if apierrors.IsConflict(err) {
+			// Somebody (likely the REST layer) rewrote the index; re-run
+			// against the fresh copy. EnsureOrgMembership already committed
+			// and is idempotent, so the retry converges.
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("updating UserMembershipIndex: %w", err)
+	}
+	return ctrl.Result{}, nil
+}

--- a/pkg/hub/controllers/membershipindex/controller_test.go
+++ b/pkg/hub/controllers/membershipindex/controller_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package membershipindex
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+type fakeEnsurer struct {
+	// org → user → role
+	memberships map[string]map[string]string
+}
+
+func (f *fakeEnsurer) EnsureOrgMembership(_ context.Context, orgUUID, userName, role string) error {
+	if f.memberships == nil {
+		f.memberships = map[string]map[string]string{}
+	}
+	if f.memberships[orgUUID] == nil {
+		f.memberships[orgUUID] = map[string]string{}
+	}
+	f.memberships[orgUUID][userName] = role
+	return nil
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) (*Reconciler, *fakeEnsurer, client.Client) {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := tenancyv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	e := &fakeEnsurer{}
+	return &Reconciler{client: c, ensurer: e}, e, c
+}
+
+func reconcile(t *testing.T, r *Reconciler, name string) {
+	t.Helper()
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+}
+
+func getIndex(t *testing.T, c client.Client, name string) *tenancyv1alpha1.UserMembershipIndex {
+	t.Helper()
+	var idx tenancyv1alpha1.UserMembershipIndex
+	if err := c.Get(context.Background(), types.NamespacedName{Name: name}, &idx); err != nil {
+		t.Fatalf("get UMI: %v", err)
+	}
+	return &idx
+}
+
+// The bug this controller exists for: a workspace-scope row with no
+// org-scope row (user added to a workspace without ever being added to the
+// org). The portal org switcher shows nothing; the reconciler must write
+// the Membership CR and the org-scope row.
+func TestHealsWorkspaceRowWithoutOrgRow(t *testing.T) {
+	org := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A", Personal: true},
+	}
+	idx := &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-bob"},
+		Spec: tenancyv1alpha1.UserMembershipIndexSpec{Entries: []tenancyv1alpha1.MembershipIndexEntry{
+			{OrgUUID: "org-a", WorkspaceUUID: "ws-1", Role: "member"},
+		}},
+	}
+	r, e, c := newTestReconciler(t, org, idx)
+
+	reconcile(t, r, "user-bob")
+
+	if e.memberships["org-a"]["user-bob"] != tenancyv1alpha1.MembershipRoleMember {
+		t.Errorf("org Membership CR not ensured: %v", e.memberships)
+	}
+	healed := getIndex(t, c, "user-bob")
+	var orgRow *tenancyv1alpha1.MembershipIndexEntry
+	for i := range healed.Spec.Entries {
+		e := &healed.Spec.Entries[i]
+		if e.OrgUUID == "org-a" && e.WorkspaceUUID == "" {
+			orgRow = e
+		}
+	}
+	if orgRow == nil {
+		t.Fatalf("org-scope row not healed: %#v", healed.Spec.Entries)
+	}
+	if orgRow.Role != tenancyv1alpha1.MembershipRoleMember || orgRow.OrgDisplayName != "A" || !orgRow.Personal {
+		t.Errorf("healed row fields: %#v", orgRow)
+	}
+}
+
+// A consistent index is left alone — no Membership writes, no update.
+func TestConsistentIndexUntouched(t *testing.T) {
+	org := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A"},
+	}
+	idx := &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-bob"},
+		Spec: tenancyv1alpha1.UserMembershipIndexSpec{Entries: []tenancyv1alpha1.MembershipIndexEntry{
+			{OrgUUID: "org-a", Role: "admin"},
+			{OrgUUID: "org-a", WorkspaceUUID: "ws-1", Role: "member"},
+		}},
+	}
+	r, e, c := newTestReconciler(t, org, idx)
+
+	reconcile(t, r, "user-bob")
+
+	if len(e.memberships) != 0 {
+		t.Errorf("unexpected Membership writes: %v", e.memberships)
+	}
+	if got := len(getIndex(t, c, "user-bob").Spec.Entries); got != 2 {
+		t.Errorf("entries changed: %d, want 2", got)
+	}
+}
+
+// Orgs that are gone or in their soft-delete grace window are not healed:
+// teardown belongs to the softdelete reconciler and healing must not race
+// it. Soft-deleted workspace rows are equally not evidence of access.
+func TestSkipsDeletedAndDyingOrgs(t *testing.T) {
+	now := metav1.Now()
+	dying := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-dying"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "Dying"},
+		Status:     tenancyv1alpha1.OrganizationStatus{DeletionRequestedAt: &now},
+	}
+	idx := &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-bob"},
+		Spec: tenancyv1alpha1.UserMembershipIndexSpec{Entries: []tenancyv1alpha1.MembershipIndexEntry{
+			// Org CR does not exist at all.
+			{OrgUUID: "org-gone", WorkspaceUUID: "ws-1", Role: "member"},
+			// Org exists but is inside its grace window.
+			{OrgUUID: "org-dying", WorkspaceUUID: "ws-2", Role: "member"},
+			// Workspace row itself soft-deleted → not evidence of access.
+			{OrgUUID: "org-dying", WorkspaceUUID: "ws-3", Role: "member", SoftDeletedAt: &now},
+		}},
+	}
+	r, e, c := newTestReconciler(t, dying, idx)
+
+	reconcile(t, r, "user-bob")
+
+	if len(e.memberships) != 0 {
+		t.Errorf("unexpected Membership writes: %v", e.memberships)
+	}
+	if got := len(getIndex(t, c, "user-bob").Spec.Entries); got != 3 {
+		t.Errorf("entries changed: %d, want 3", got)
+	}
+}
+
+// A soft-deleted ORG-scope row counts as "the org row exists": undelete
+// restores it, and healing a second live row next to it would leave the
+// index with two rows for one org.
+func TestSoftDeletedOrgRowBlocksHeal(t *testing.T) {
+	now := metav1.Now()
+	org := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A"},
+	}
+	idx := &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-bob"},
+		Spec: tenancyv1alpha1.UserMembershipIndexSpec{Entries: []tenancyv1alpha1.MembershipIndexEntry{
+			{OrgUUID: "org-a", Role: "member", SoftDeletedAt: &now},
+			{OrgUUID: "org-a", WorkspaceUUID: "ws-1", Role: "member"},
+		}},
+	}
+	r, e, c := newTestReconciler(t, org, idx)
+
+	reconcile(t, r, "user-bob")
+
+	if len(e.memberships) != 0 {
+		t.Errorf("unexpected Membership writes: %v", e.memberships)
+	}
+	if got := len(getIndex(t, c, "user-bob").Spec.Entries); got != 2 {
+		t.Errorf("entries changed: %d, want 2", got)
+	}
+}

--- a/pkg/hub/providers/api.go
+++ b/pkg/hub/providers/api.go
@@ -36,6 +36,10 @@ const PathListProviders = "/api/providers"
 type providerDTO struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`
+	// Description is CatalogEntry.spec.description — the one-line "what is
+	// this" the portal shows on catalog cards and in the first-run welcome
+	// flow. Empty for entries that declare none.
+	Description string `json:"description,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Ready       bool   `json:"ready"`
 	HasUI       bool   `json:"hasUI"`
@@ -244,6 +248,7 @@ func NewListHandler(reg *Registry) http.Handler {
 			items = append(items, providerDTO{
 				Name:             p.Name,
 				DisplayName:      displayName,
+				Description:      p.Description,
 				Version:          p.Version,
 				Ready:            p.Ready(),
 				HasUI:            p.UIURL != nil || p.BuiltinRoute != "" || p.LocalUIAssets != nil,

--- a/pkg/hub/providers/api_test.go
+++ b/pkg/hub/providers/api_test.go
@@ -145,6 +145,56 @@ func TestListHandlerIncludesActionDiscoveryMetadataWithoutTransportURLs(t *testi
 	}
 }
 
+// The description is the only thing in the catalog response that tells a new
+// user what a provider actually does — the portal's first-run welcome flow and
+// the catalog cards both render it, and both degrade to a bare resource name
+// without it. It reaches the registry from CatalogEntry.spec.description.
+func TestListHandlerProjectsDescription(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{
+		Name:           "edges",
+		DisplayName:    "Edges",
+		Description:    "Connect Kubernetes clusters and Linux servers as edges.",
+		EndpointsValid: true,
+		UIURL:          mustProviderURL(t, "https://provider.example/ui"),
+	})
+	// A provider whose CatalogEntry declares no description must omit the
+	// field rather than emit an empty string, so the portal can tell "not
+	// published" from "published as blank".
+	reg.Upsert(Provider{
+		Name:           "silent",
+		DisplayName:    "Silent",
+		EndpointsValid: true,
+		UIURL:          mustProviderURL(t, "https://provider.example/ui"),
+	})
+
+	r := httptest.NewRequest(http.MethodGet, PathListProviders, nil)
+	w := httptest.NewRecorder()
+	NewListHandler(reg).ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var raw struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	byName := map[string]map[string]any{}
+	for _, it := range raw.Items {
+		name, _ := it["name"].(string)
+		byName[name] = it
+	}
+
+	if got := byName["edges"]["description"]; got != "Connect Kubernetes clusters and Linux servers as edges." {
+		t.Errorf("edges description = %#v, want the registry value", got)
+	}
+	if _, ok := byName["silent"]["description"]; ok {
+		t.Errorf("silent emitted a description key: %#v", byName["silent"])
+	}
+}
+
 func mustProviderURL(t *testing.T, raw string) *url.URL {
 	t.Helper()
 	u, err := url.Parse(raw)

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -164,6 +164,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	prov := Provider{
 		Name:         entry.Name,
 		DisplayName:  entry.Spec.DisplayName,
+		Description:  entry.Spec.Description,
 		IconURL:      entry.Spec.IconURL,
 		Category:     entry.Spec.Category,
 		Dependencies: dependencies,

--- a/pkg/hub/providers/controller_test.go
+++ b/pkg/hub/providers/controller_test.go
@@ -64,6 +64,7 @@ func TestCatalogReconciler_PreservesChartOwnedUIRoutingForBuiltinName(t *testing
 		ObjectMeta: metav1.ObjectMeta{Name: "app-studio"},
 		Spec: providersv1alpha1.CatalogEntrySpec{
 			DisplayName: "App Studio from Chart",
+			Description: "Persistent AI project workspace.",
 			Dependencies: []providersv1alpha1.ProviderDependency{
 				{Name: "code"},
 			},
@@ -96,6 +97,11 @@ func TestCatalogReconciler_PreservesChartOwnedUIRoutingForBuiltinName(t *testing
 	}
 	if len(got.Dependencies) != 1 || got.Dependencies[0].Name != "code" {
 		t.Fatalf("Dependencies = %#v, want [code]", got.Dependencies)
+	}
+	// The portal's catalog cards and first-run welcome flow render this; if the
+	// reconciler drops it, both fall back to showing a bare provider name.
+	if got.Description != "Persistent AI project workspace." {
+		t.Fatalf("Description = %q, want the spec value", got.Description)
 	}
 	if !got.EndpointsValid {
 		t.Fatal("expected endpoints to be valid when ui.url is present")

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -49,8 +49,12 @@ const SweepInterval = 30 * time.Second
 // Fields are nil-able to reflect that UI/backend/VW are independently optional
 // in the source ProviderCatalogEntry.
 type Provider struct {
-	Name         string
-	DisplayName  string // human-readable label, surfaced to the portal
+	Name        string
+	DisplayName string // human-readable label, surfaced to the portal
+	// Description is the CatalogEntry's short blurb. The portal renders it on
+	// catalog cards and in the first-run welcome flow, where it is the only
+	// thing telling a new user what the provider actually does.
+	Description  string
 	IconURL      string // optional, defaults to /ui/providers/{name}/icon.svg
 	Category     string // optional grouping in the portal nav; empty = top-level
 	Dependencies []Dependency

--- a/pkg/hub/restapi/memberships.go
+++ b/pkg/hub/restapi/memberships.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
@@ -56,14 +57,19 @@ func (h *Handler) listOrgMemberships(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	rbacByUser := h.mgr.rbacIdentitiesByUserName(r.Context())
+	metaByUser := h.mgr.userMetaByName(r.Context())
 	out := make([]MembershipView, 0, len(users))
 	for _, user := range users {
 		role, err := h.mgr.bootstrapper.GetOrgMembershipRole(r.Context(), orgUUID, user)
 		if err != nil {
 			continue
 		}
-		out = append(out, MembershipView{User: user, RBACIdentity: rbacByUser[user], Role: role, OrgUUID: orgUUID})
+		meta := metaByUser[user]
+		out = append(out, MembershipView{
+			User: user, RBACIdentity: meta.RBACIdentity,
+			Email: meta.Email, UserDisplayName: meta.DisplayName,
+			Role: role, OrgUUID: orgUUID,
+		})
 	}
 	writeJSON(w, http.StatusOK, ListResponse[MembershipView]{Items: out})
 }
@@ -116,6 +122,7 @@ func (h *Handler) addOrgMembership(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusCreated, MembershipView{
 		User: target.Name, RBACIdentity: target.Spec.RBACIdentity,
+		Email: target.Spec.Email, UserDisplayName: target.Spec.Name,
 		Role: req.Role, OrgUUID: orgUUID, OrgDisplayName: org.Spec.DisplayName,
 	})
 }
@@ -243,7 +250,7 @@ func (h *Handler) listWorkspaceMemberships(w http.ResponseWriter, r *http.Reques
 		writeError(w, err)
 		return
 	}
-	rbacByUser := h.mgr.rbacIdentitiesByUserName(r.Context())
+	metaByUser := h.mgr.userMetaByName(r.Context())
 	out := make([]MembershipView, 0)
 	for i := range list.Items {
 		idx := &list.Items[i]
@@ -251,8 +258,11 @@ func (h *Handler) listWorkspaceMemberships(w http.ResponseWriter, r *http.Reques
 			if e.OrgUUID != tc.OrgUUID || e.WorkspaceUUID != tc.WorkspaceUUID || e.SoftDeletedAt != nil {
 				continue
 			}
+			meta := metaByUser[idx.Name]
 			out = append(out, MembershipView{
-				User: idx.Name, RBACIdentity: rbacByUser[idx.Name], Role: e.Role,
+				User: idx.Name, RBACIdentity: meta.RBACIdentity,
+				Email: meta.Email, UserDisplayName: meta.DisplayName,
+				Role: e.Role,
 				OrgUUID: e.OrgUUID, WorkspaceUUID: e.WorkspaceUUID,
 				OrgDisplayName: e.OrgDisplayName, WorkspaceDisplayName: e.WorkspaceDisplayName,
 			})
@@ -292,6 +302,39 @@ func (h *Handler) addWorkspaceMembership(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	dn, _ := h.mgr.bootstrapper.GetWorkspaceDisplayName(r.Context(), tc.OrgUUID, tc.WorkspaceUUID)
+
+	// A workspace grant is unreachable without org visibility: the portal's
+	// org switcher is built from org-scope UMI rows only (listOrgs), so a
+	// user holding a workspace-scope row but no org-scope row cannot select
+	// the org at all — the workspace they were just granted is invisible to
+	// them. Cascade org membership on the way in (as plain member, and via
+	// the CR's actual role when one already exists, so an existing admin is
+	// never downgraded), mirroring the ?cascade=true removal on the way out.
+	orgRole, err := h.mgr.bootstrapper.GetOrgMembershipRole(r.Context(), tc.OrgUUID, target.Name)
+	if apierrors.IsNotFound(err) {
+		orgRole = tenancyv1alpha1.MembershipRoleMember
+		if err := h.mgr.bootstrapper.EnsureOrgMembership(r.Context(), tc.OrgUUID, target.Name, orgRole); err != nil {
+			writeError(w, err)
+			return
+		}
+	} else if err != nil {
+		writeError(w, err)
+		return
+	}
+	// Upsert the org-scope UMI row unconditionally: it also heals the
+	// Membership-CR-exists-but-UMI-row-missing drift, which strands the
+	// user exactly the same way.
+	if err := h.mgr.upsertUMIEntry(r.Context(), target.Name, tenancyv1alpha1.MembershipIndexEntry{
+		OrgUUID:        tc.OrgUUID,
+		OrgDisplayName: org.Spec.DisplayName,
+		OrgCreatedAt:   org.CreationTimestamp,
+		Role:           orgRole,
+		Personal:       org.Spec.Personal,
+	}); err != nil {
+		writeError(w, err)
+		return
+	}
+
 	// Grant the new member RBAC in the workspace's kcp cluster. The UMI
 	// row alone is portal metadata — without a matching kcp CRB the
 	// GraphQL gateway 403s the moment the member tries to switch to
@@ -318,6 +361,7 @@ func (h *Handler) addWorkspaceMembership(w http.ResponseWriter, r *http.Request)
 	}
 	writeJSON(w, http.StatusCreated, MembershipView{
 		User: target.Name, RBACIdentity: target.Spec.RBACIdentity, Role: req.Role,
+		Email: target.Spec.Email, UserDisplayName: target.Spec.Name,
 		OrgUUID: tc.OrgUUID, WorkspaceUUID: tc.WorkspaceUUID,
 		OrgDisplayName: org.Spec.DisplayName, WorkspaceDisplayName: dn,
 	})

--- a/pkg/hub/restapi/memberships.go
+++ b/pkg/hub/restapi/memberships.go
@@ -262,7 +262,7 @@ func (h *Handler) listWorkspaceMemberships(w http.ResponseWriter, r *http.Reques
 			out = append(out, MembershipView{
 				User: idx.Name, RBACIdentity: meta.RBACIdentity,
 				Email: meta.Email, UserDisplayName: meta.DisplayName,
-				Role: e.Role,
+				Role:    e.Role,
 				OrgUUID: e.OrgUUID, WorkspaceUUID: e.WorkspaceUUID,
 				OrgDisplayName: e.OrgDisplayName, WorkspaceDisplayName: e.WorkspaceDisplayName,
 			})

--- a/pkg/hub/restapi/orgs.go
+++ b/pkg/hub/restapi/orgs.go
@@ -77,13 +77,17 @@ func (h *Handler) listOrgs(w http.ResponseWriter, r *http.Request) {
 		}
 		seen[e.OrgUUID] = true
 		// Best-effort fetch the Org CR for canonical fields; if it's
-		// gone (rare race), fall back to UMI-only fields.
+		// gone (rare race), fall back to UMI-only fields. Either way the
+		// caller's own role rides along from the UMI row so the portal
+		// can gate admin-only controls.
 		org, err := h.mgr.client.Organizations().Get(r.Context(), e.OrgUUID, metav1.GetOptions{})
 		if err != nil {
-			out = append(out, OrgView{UUID: e.OrgUUID, DisplayName: e.OrgDisplayName, Personal: e.Personal})
+			out = append(out, OrgView{UUID: e.OrgUUID, DisplayName: e.OrgDisplayName, Personal: e.Personal, Role: e.Role})
 			continue
 		}
-		out = append(out, projectOrg(org))
+		view := projectOrg(org)
+		view.Role = e.Role
+		out = append(out, view)
 	}
 	writeJSON(w, http.StatusOK, ListResponse[OrgView]{Items: out})
 }
@@ -153,13 +157,17 @@ func (h *Handler) createOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, projectOrg(created))
+	view := projectOrg(created)
+	// The creator is seeded as the sole admin (Membership + UMI above).
+	view.Role = tenancyv1alpha1.MembershipRoleAdmin
+	writeJSON(w, http.StatusCreated, view)
 }
 
 // getOrg returns a single Org. Caller must be a member (enforced by
 // the tenant middleware).
 func (h *Handler) getOrg(w http.ResponseWriter, r *http.Request) {
-	if _, ok := h.requireTenantContext(w, r, false, false); !ok {
+	tc, ok := h.requireTenantContext(w, r, false, false)
+	if !ok {
 		return
 	}
 	orgUUID := mux.Vars(r)["org"]
@@ -168,7 +176,10 @@ func (h *Handler) getOrg(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, projectOrg(org))
+	view := projectOrg(org)
+	// tc.Role is the middleware's org-scope resolution for this caller.
+	view.Role = tc.Role
+	writeJSON(w, http.StatusOK, view)
 }
 
 // patchOrg updates editable fields. Admin only.

--- a/pkg/hub/restapi/restapi.go
+++ b/pkg/hub/restapi/restapi.go
@@ -446,13 +446,19 @@ func (m *Manager) mutateUMI(ctx context.Context, userName string, mutator func(*
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting UMI %q: %w", userName, err)
 		}
-		if apierrors.IsNotFound(err) {
+		// Create-vs-update is decided by the Get's NotFound, not by
+		// ResourceVersion emptiness: a real server always stamps RVs but the
+		// dynamicfake used in tests doesn't, and keying on RV there turns
+		// every update into a Create → AlreadyExists → retry loop that
+		// exhausts maxAttempts.
+		notFound := apierrors.IsNotFound(err)
+		if notFound {
 			idx = &tenancyv1alpha1.UserMembershipIndex{ObjectMeta: metav1.ObjectMeta{Name: userName}}
 		}
 		if !mutator(idx) {
 			return nil
 		}
-		if idx.ResourceVersion == "" {
+		if notFound {
 			if _, err := m.client.UserMembershipIndices().Create(ctx, idx, metav1.CreateOptions{}); err != nil {
 				if apierrors.IsAlreadyExists(err) {
 					continue
@@ -563,20 +569,30 @@ func (m *Manager) resolveUser(ctx context.Context, identifier string) (*tenancyv
 		schema.GroupResource{Group: "tenants.faros.sh", Resource: "users"}, identifier)
 }
 
-// rbacIdentitiesByUserName maps User CR names to their kcp usernames
-// (User.Spec.RBACIdentity) in one list call, so membership projections can
-// carry the subject string RBAC consumers must bind. Best-effort: an empty
-// map on error just omits rbacIdentity from the views.
-func (m *Manager) rbacIdentitiesByUserName(ctx context.Context) map[string]string {
-	out := map[string]string{}
+// userMeta is the human-facing slice of a User CR that membership views
+// carry alongside the CR name: the kcp RBAC subject, plus email and display
+// name so member lists can label `static-user-47b9dce0…` as an actual person.
+type userMeta struct {
+	RBACIdentity string
+	Email        string
+	DisplayName  string
+}
+
+// userMetaByName maps User CR names to their projection metadata in one
+// list call. Best-effort: an empty map on error just omits the optional
+// fields from the views.
+func (m *Manager) userMetaByName(ctx context.Context) map[string]userMeta {
+	out := map[string]userMeta{}
 	list, err := m.client.Users().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return out
 	}
 	for i := range list.Items {
 		user := &list.Items[i]
-		if user.Spec.RBACIdentity != "" {
-			out[user.Name] = user.Spec.RBACIdentity
+		out[user.Name] = userMeta{
+			RBACIdentity: user.Spec.RBACIdentity,
+			Email:        user.Spec.Email,
+			DisplayName:  user.Spec.Name,
 		}
 	}
 	return out
@@ -640,6 +656,11 @@ type OrgView struct {
 	WorkspaceQuota       int32      `json:"workspaceQuota,omitempty"`
 	CreatedAt            time.Time  `json:"createdAt"`
 	DeletionRequestedAt  *time.Time `json:"deletionRequestedAt,omitempty"`
+	// Role is the CALLER's org-scope role ("admin" | "member") — what the
+	// tenant middleware will resolve for org-scope requests. The portal
+	// uses it to hide admin-only controls (member management, rename,
+	// delete) instead of rendering buttons that can only 403.
+	Role string `json:"role,omitempty"`
 }
 
 func projectOrg(o *tenancyv1alpha1.Organization) OrgView {
@@ -675,6 +696,12 @@ type WorkspaceView struct {
 	DisplayName         string     `json:"displayName,omitempty"`
 	ClusterName         string     `json:"clusterName,omitempty"`
 	DeletionRequestedAt *time.Time `json:"deletionRequestedAt,omitempty"`
+	// Role is the CALLER's workspace-scope role ("admin" | "member"), or
+	// empty when they hold no workspace-scope row here (possible for org
+	// admins, who can list every workspace but manage only those they are
+	// workspace-admin in — the middleware matches exact (org, ws) rows).
+	// The portal gates workspace-admin controls on it.
+	Role string `json:"role,omitempty"`
 }
 
 // MembershipView is the REST projection of a single org-or-workspace
@@ -685,7 +712,13 @@ type MembershipView struct {
 	// "faros:<email>") — the subject string every tenant-workspace RBAC
 	// binding uses. Consumers writing RBAC (e.g. App Studio's app-access
 	// grants) must bind this, never the User CR name.
-	RBACIdentity         string `json:"rbacIdentity,omitempty"`
+	RBACIdentity string `json:"rbacIdentity,omitempty"`
+	// Email / UserDisplayName label the member as a person — `user` is the
+	// CR name (e.g. "static-user-47b9dce0e91570a1", "user-x2f9…"), which is
+	// meaningless in a member list. Best-effort: pending invites may have
+	// only an email; some accounts may have neither.
+	Email                string `json:"email,omitempty"`
+	UserDisplayName      string `json:"userDisplayName,omitempty"`
 	Role                 string `json:"role"`
 	OrgUUID              string `json:"orgUUID"`
 	WorkspaceUUID        string `json:"workspaceUUID,omitempty"`

--- a/pkg/hub/restapi/restapi_test.go
+++ b/pkg/hub/restapi/restapi_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -112,7 +113,10 @@ func (f *fakeOps) GetOrgMembershipRole(_ context.Context, orgUUID, userName stri
 			return role, nil
 		}
 	}
-	return "", fmt.Errorf("membership %s in org %s not found", userName, orgUUID)
+	// Typed NotFound, matching the real Bootstrapper (whose Get surfaces the
+	// dynamic client's error). addWorkspaceMembership branches on
+	// apierrors.IsNotFound to decide whether to cascade an org membership.
+	return "", apierrors.NewNotFound(schema.GroupResource{Group: "tenants.faros.sh", Resource: "memberships"}, userName)
 }
 
 func (f *fakeOps) PatchOrgMembershipRole(_ context.Context, orgUUID, userName, role string) error {
@@ -759,10 +763,79 @@ func TestWorkspaceMembership_AddGrantsAccess(t *testing.T) {
 	if !ops.workspaceAdmins[wsKey{"org-a", "ws-1"}]["faros:bob@example.com"] {
 		t.Errorf("workspace RBAC not granted: %v", ops.workspaceAdmins)
 	}
-	// UMI ws-scope row keyed by User CR name.
+	// The workspace add cascades an org-scope membership: without it the
+	// portal's org switcher (built from org-scope UMI rows only) never
+	// shows the org, so the workspace bob was just granted is unreachable.
+	if ops.orgMemberships["org-a"]["user-bob"] != "member" {
+		t.Errorf("org membership not cascaded: %v", ops.orgMemberships)
+	}
+	// UMI carries BOTH rows keyed by User CR name: the org-scope row
+	// (WorkspaceUUID=="") that makes the org visible, and the ws-scope row
+	// that makes the workspace visible.
 	idx, err := mgr.client.UserMembershipIndices().Get(context.Background(), "user-bob", metav1.GetOptions{})
-	if err != nil || len(idx.Spec.Entries) != 1 || idx.Spec.Entries[0].WorkspaceUUID != "ws-1" {
-		t.Errorf("UMI ws-row missing: %#v (err %v)", idx, err)
+	if err != nil {
+		t.Fatalf("UMI missing: %v", err)
+	}
+	var hasOrgRow, hasWsRow bool
+	for _, e := range idx.Spec.Entries {
+		if e.OrgUUID != "org-a" {
+			continue
+		}
+		switch e.WorkspaceUUID {
+		case "":
+			hasOrgRow = e.Role == "member"
+		case "ws-1":
+			hasWsRow = true
+		}
+	}
+	if !hasOrgRow || !hasWsRow {
+		t.Errorf("UMI rows: org=%v ws=%v entries=%#v", hasOrgRow, hasWsRow, idx.Spec.Entries)
+	}
+}
+
+// TestWorkspaceMembership_AddKeepsExistingOrgRole covers the non-escalation
+// guard on the cascade: when the target is already an org admin, granting
+// them a workspace must not rewrite their org-scope role to member.
+func TestWorkspaceMembership_AddKeepsExistingOrgRole(t *testing.T) {
+	org := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A"},
+	}
+	bob := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-bob"},
+		Spec:       tenancyv1alpha1.UserSpec{Email: "bob@example.com", RBACIdentity: "faros:bob@example.com"},
+	}
+	mgr, ops, _ := newTestManager(t, org, bob)
+	if err := ops.EnsureChildWorkspace(context.Background(), "org-a", "ws-1"); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := ops.EnsureOrgMembership(context.Background(), "org-a", "user-bob", "admin"); err != nil {
+		t.Fatalf("seed org membership: %v", err)
+	}
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", "ws-1"))
+	defer srv.Close()
+
+	body, _ := json.Marshal(MembershipAddRequest{User: "bob@example.com", Role: "member"})
+	resp, err := http.Post(srv.URL+"/api/orgs/org-a/workspaces/ws-1/memberships", "application/json", jsonBody(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("add status: got %d, want 201", resp.StatusCode)
+	}
+
+	if got := ops.orgMemberships["org-a"]["user-bob"]; got != "admin" {
+		t.Errorf("org role downgraded to %q, want admin preserved", got)
+	}
+	idx, err := mgr.client.UserMembershipIndices().Get(context.Background(), "user-bob", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("UMI missing: %v", err)
+	}
+	for _, e := range idx.Spec.Entries {
+		if e.OrgUUID == "org-a" && e.WorkspaceUUID == "" && e.Role != "admin" {
+			t.Errorf("org-scope UMI row role = %q, want admin", e.Role)
+		}
 	}
 }
 

--- a/pkg/hub/restapi/workspaces.go
+++ b/pkg/hub/restapi/workspaces.go
@@ -53,8 +53,20 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 	}
 	orgUUID := mux.Vars(r)["org"]
 
-	// Org admins: list every child workspace.
+	// Org admins: list every child workspace. Their per-workspace role
+	// still comes from their own UMI rows — the middleware matches exact
+	// (org, ws) rows, so an org admin manages only workspaces they hold a
+	// workspace-admin row in, and the projected role must say so rather
+	// than let the portal render controls that 403.
 	if tc.Role == tenancyv1alpha1.MembershipRoleAdmin {
+		roleByWS := map[string]string{}
+		if idx, err := h.mgr.client.UserMembershipIndices().Get(r.Context(), tc.User, metav1.GetOptions{}); err == nil {
+			for _, e := range idx.Spec.Entries {
+				if e.OrgUUID == orgUUID && e.WorkspaceUUID != "" && e.SoftDeletedAt == nil {
+					roleByWS[e.WorkspaceUUID] = e.Role
+				}
+			}
+		}
 		names, err := h.mgr.bootstrapper.ListChildWorkspaces(r.Context(), orgUUID)
 		if err != nil {
 			writeError(w, err)
@@ -66,6 +78,7 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				continue
 			}
+			view.Role = roleByWS[wsUUID]
 			out = append(out, view)
 		}
 		writeJSON(w, http.StatusOK, ListResponse[WorkspaceView]{Items: out})
@@ -91,6 +104,7 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			continue
 		}
+		view.Role = e.Role
 		out = append(out, view)
 	}
 	writeJSON(w, http.StatusOK, ListResponse[WorkspaceView]{Items: out})
@@ -187,12 +201,15 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		view = WorkspaceView{UUID: wsUUID, OrgUUID: orgUUID, DisplayName: req.DisplayName}
 	}
+	// The creator was just seeded as workspace admin (UMI row above).
+	view.Role = tenancyv1alpha1.MembershipRoleAdmin
 	writeJSON(w, http.StatusCreated, view)
 }
 
 // getWorkspace returns one Workspace projection.
 func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request) {
-	if _, ok := h.requireTenantContext(w, r, true, false); !ok {
+	tc, ok := h.requireTenantContext(w, r, true, false)
+	if !ok {
 		return
 	}
 	orgUUID := mux.Vars(r)["org"]
@@ -202,6 +219,8 @@ func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusNotFound, "NotFound", "workspace not found")
 		return
 	}
+	// tc.Role is the middleware's exact (org, ws) row match for this caller.
+	view.Role = tc.Role
 	writeJSON(w, http.StatusOK, view)
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/faroshq/faros/pkg/hub/appauth"
 	"github.com/faroshq/faros/pkg/hub/bootstrap"
 	"github.com/faroshq/faros/pkg/hub/controllers/mcpserver"
+	"github.com/faroshq/faros/pkg/hub/controllers/membershipindex"
 	"github.com/faroshq/faros/pkg/hub/controllers/organization"
 	"github.com/faroshq/faros/pkg/hub/controllers/softdelete"
 	"github.com/faroshq/faros/pkg/hub/kcp"
@@ -867,6 +868,24 @@ func (s *Server) Run(ctx context.Context) error {
 				return
 			}
 
+			// Membership-index invariant reconciler — heals UMIs where a
+			// workspace-scope row has no org-scope row (the stranded-user
+			// state: granted a workspace they can never navigate to because
+			// the org switcher only lists org-scope rows). The REST layer
+			// writes both rows on the happy path; this converges everything
+			// else — crashes between the dual writes, rows written by older
+			// hubs, drift. Own manager for the same isolation reason as
+			// soft-delete.
+			umiMgr, err := membershipindex.NewManager(bootstrapper.UsersConfig(), scheme)
+			if err != nil {
+				logger.Error(err, "Creating membership-index manager failed")
+				return
+			}
+			if err := membershipindex.SetupWithManager(umiMgr, bootstrapper); err != nil {
+				logger.Error(err, "Setting up membership-index reconciler failed")
+				return
+			}
+
 			// Expired sessions and authorization codes are already refused on
 			// read; this only reclaims their storage, so one sweeper is enough.
 			if len(sharedStores) > 0 {
@@ -879,6 +898,7 @@ func (s *Server) Run(ctx context.Context) error {
 				"admin multicluster":            adminMgr,
 				"organization bootstrap":        orgMgr,
 				"soft-delete":                   softdeleteMgr,
+				"membership-index invariants":   umiMgr,
 			} {
 				wg.Add(1)
 				go func() {

--- a/portal/src/components/MemberList.vue
+++ b/portal/src/components/MemberList.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+// One member roster: add form + table with per-row role select and remove.
+// The tenant settings page renders this twice — once org-scoped, once
+// workspace-scoped — with identical mechanics and different handlers; the
+// component keeps the two visually and behaviourally in lockstep instead of
+// letting two hand-maintained copies drift.
+//
+// All mutations are emitted upward: the parent owns the store calls, the
+// busy bookkeeping, and the reload. This stays a dumb roster.
+
+import { ref } from 'vue'
+import { Loader2, Plus, Trash2, User as UserIcon } from 'lucide-vue-next'
+import type { MemberRow } from '@/stores/tenant'
+
+const props = defineProps<{
+  members: MemberRow[]
+  loading: boolean
+  // Per-user in-flight flags plus '__new__' for the add form; same shape the
+  // page already tracks for its store calls.
+  busy: Record<string, boolean>
+  // What an added member gains, e.g. "this organization" / "this workspace".
+  // Rendered in the empty state so it never just says "No members." with no
+  // hint about what adding one means.
+  scopeLabel: string
+  // add is a function prop (not an emit) so the component can await the
+  // outcome: the typed identifier is only cleared when the add succeeded,
+  // instead of being thrown away under a failure toast.
+  add: (user: string, role: 'admin' | 'member') => Promise<boolean>
+  // readonly renders the roster without any mutation affordances — no add
+  // form, roles as static badges, no remove. Set for non-admin viewers,
+  // whose writes would only 403 server-side; showing dead buttons and
+  // letting the server reject them reads as a bug, not as permissions.
+  readonly?: boolean
+}>()
+
+const emit = defineEmits<{
+  changeRole: [user: string, role: 'admin' | 'member']
+  remove: [user: string]
+}>()
+
+const newUser = ref('')
+const newRole = ref<'admin' | 'member'>('member')
+
+async function submit() {
+  const u = newUser.value.trim()
+  if (!u || props.busy.__new__) return
+  const ok = await props.add(u, newRole.value)
+  if (ok) {
+    newUser.value = ''
+    newRole.value = 'member'
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div v-if="!readonly" class="flex flex-wrap items-center gap-2">
+      <input
+        v-model="newUser"
+        class="min-w-[200px] flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+        placeholder="email or user UUID"
+        @keyup.enter="submit"
+      />
+      <select
+        v-model="newRole"
+        class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+        title="Admins manage members and settings; members use what's already here."
+      >
+        <option value="member">member</option>
+        <option value="admin">admin</option>
+      </select>
+      <button
+        class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
+        :disabled="!!busy.__new__ || !newUser.trim()"
+        @click="submit"
+      >
+        <Loader2 v-if="busy.__new__" class="h-3 w-3 animate-spin" :stroke-width="2" />
+        <Plus v-else class="h-3 w-3" :stroke-width="2" />
+        Add
+      </button>
+    </div>
+
+    <div v-if="loading" class="mt-3 text-sm text-text-muted">Loading members…</div>
+    <div v-else-if="members.length === 0" class="mt-3 text-sm text-text-muted">
+      No members yet.<template v-if="!readonly"> Anyone you add gains access to {{ scopeLabel }}.</template>
+    </div>
+    <table v-else class="mt-3 w-full text-sm">
+      <thead>
+        <tr class="text-left text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+          <th class="py-2 pr-3">User</th>
+          <th class="py-2 pr-3">Role</th>
+          <th v-if="!readonly" class="py-2 pr-0 text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-border-default/30">
+        <tr v-for="m in members" :key="m.user">
+          <!-- Lead with the person (email, falling back to display name),
+               keep the CR name as a small mono sublabel — it's what API
+               calls and RBAC are keyed on, so it stays visible/copyable,
+               but "static-user-47b9dce0…" must not be the headline. -->
+          <td class="py-2 pr-3">
+            <div class="flex items-start gap-2">
+              <UserIcon class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted/70" :stroke-width="1.75" />
+              <div class="min-w-0">
+                <template v-if="m.email || m.userDisplayName">
+                  <div class="truncate text-[12px] text-text-primary">
+                    {{ m.email || m.userDisplayName }}
+                    <span
+                      v-if="m.userDisplayName && m.email"
+                      class="text-text-muted"
+                    > · {{ m.userDisplayName }}</span>
+                  </div>
+                  <div class="truncate font-mono text-[10px] text-text-muted">{{ m.user }}</div>
+                </template>
+                <span v-else class="font-mono text-[12px] text-text-secondary">{{ m.user }}</span>
+              </div>
+            </div>
+          </td>
+          <td class="py-2 pr-3">
+            <span
+              v-if="readonly"
+              class="rounded-sm border border-border-default/50 bg-surface-overlay px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted"
+            >{{ m.role }}</span>
+            <select
+              v-else
+              class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-[12px] text-text-primary focus:border-accent focus:outline-none disabled:opacity-60"
+              :value="m.role"
+              :disabled="!!busy[m.user]"
+              @change="(e) => emit('changeRole', m.user, (e.target as HTMLSelectElement).value as 'admin' | 'member')"
+            >
+              <option value="member">member</option>
+              <option value="admin">admin</option>
+            </select>
+          </td>
+          <td v-if="!readonly" class="py-2 pr-0 text-right">
+            <button
+              class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
+              :disabled="!!busy[m.user]"
+              @click="emit('remove', m.user)"
+            >
+              <Loader2 v-if="busy[m.user]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
+              <Trash2 v-else class="inline h-3 w-3" :stroke-width="2" />
+              Remove
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/portal/src/components/WelcomeWizard.vue
+++ b/portal/src/components/WelcomeWizard.vue
@@ -1,0 +1,440 @@
+<script setup lang="ts">
+// First-run onboarding for a workspace that has nothing enabled yet.
+//
+// A fresh account lands on the dashboard with an empty grid and an empty side
+// nav, because every provider ships as a CatalogEntry with an APIExport and
+// must be explicitly enabled per workspace. The old empty state was a single
+// grey line pointing at /providers, which assumes the reader already knows
+// what a provider *is*. This replaces it with a three-step flow:
+//
+//   1. Concepts — what an org / workspace / provider / edge actually are.
+//   2. Catalog — the enableable providers, each with its CatalogEntry
+//      description, enabled in place through the normal consent dialog.
+//   3. Done   — what changed and where to go next.
+//
+// Enabling always goes through ProviderEnableDialog: permission claims are a
+// consent decision, and the welcome flow must not become a way to skip it.
+//
+// Dismissal is per workspace (workspaces are independent clusters, so setting
+// one up says nothing about the next) and lives in localStorage — this is a
+// presentation preference, not state worth a round-trip to the hub.
+
+import { computed, ref } from 'vue'
+import {
+  AlertCircle,
+  ArrowLeft,
+  ArrowRight,
+  Boxes,
+  Building2,
+  Check,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  Plus,
+  Puzzle,
+  Rocket,
+  Server,
+  Sparkles,
+} from 'lucide-vue-next'
+import ProviderEnableDialog from '@/components/ProviderEnableDialog.vue'
+import { useProvidersStore, type ProviderDTO, type PermissionClaim } from '@/stores/providers'
+import { useTenantStore } from '@/stores/tenant'
+import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
+
+const emit = defineEmits<{
+  // Raised when the user skips or finishes. The dashboard swaps back to the
+  // normal (now possibly populated) grid.
+  dismiss: []
+}>()
+
+const providers = useProvidersStore()
+const tenant = useTenantStore()
+
+const step = ref(0)
+const steps = ['Concepts', 'Providers', 'Done'] as const
+
+// --- Step 1: concepts -------------------------------------------------------
+
+// Deliberately four cards, in dependency order: you are in an org, which holds
+// workspaces, which hold providers, one of which connects edges. Each line
+// answers "what is it" and "why do I care", nothing more — the docs handle depth.
+const concepts = [
+  {
+    icon: Building2,
+    title: 'Organization',
+    body: 'Who you share with. Members, billing, and access all hang off the org. You always have a personal one.',
+  },
+  {
+    icon: Boxes,
+    title: 'Workspace',
+    body: 'An isolated control plane inside the org. Everything you create — edges, apps, resources — lives in exactly one workspace.',
+  },
+  {
+    icon: Puzzle,
+    title: 'Provider',
+    body: 'An extension that adds APIs and a UI. Enabling one binds its APIs into this workspace and puts it in the side nav. Nothing is on by default.',
+  },
+  {
+    icon: Server,
+    title: 'Edge',
+    body: 'A Kubernetes cluster or Linux host connected back to the hub through a reverse tunnel, so you can reach it without inbound firewall rules.',
+  },
+]
+
+// --- Step 2: catalog --------------------------------------------------------
+
+const catalog = computed(() => providers.enableable)
+const enabledCount = computed(() => catalog.value.filter((p) => providers.isEnabled(p.name)).length)
+
+// Per-provider in-flight flag, so one Enable spinning doesn't disable the rest.
+const busy = ref<Record<string, boolean>>({})
+const actionError = ref<string | null>(null)
+const dialogProvider = ref<ProviderDTO | null>(null)
+
+function categoryIcon(name: string | undefined): unknown {
+  if (!name) return fallbackCategoryIcon
+  const registered = providers.categories.find((c) => c.name === name)
+  if (!registered?.icon) return fallbackCategoryIcon
+  return categoryIcons[registered.icon] ?? fallbackCategoryIcon
+}
+
+function dependencyNotice(p: ProviderDTO): string {
+  const missing = providers.missingDependencies(p)
+  if (missing.length === 0) return ''
+  return `Enable ${providers.dependencyLabels(missing).join(', ')} first.`
+}
+
+function openEnableDialog(p: ProviderDTO) {
+  actionError.value = null
+  if (providers.hasMissingDependencies(p)) {
+    actionError.value = dependencyNotice(p)
+    return
+  }
+  dialogProvider.value = p
+}
+
+async function onDialogConfirm(accept: PermissionClaim[]) {
+  const p = dialogProvider.value
+  if (!p) return
+  busy.value = { ...busy.value, [p.name]: true }
+  actionError.value = null
+  try {
+    await providers.enable(p, accept)
+    dialogProvider.value = null
+  } catch (e) {
+    actionError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    const next = { ...busy.value }
+    delete next[p.name]
+    busy.value = next
+  }
+}
+
+// --- Navigation -------------------------------------------------------------
+
+function next() {
+  if (step.value < steps.length - 1) step.value += 1
+}
+function back() {
+  if (step.value > 0) step.value -= 1
+}
+
+// The provider a "start here" link should point at once the user is done. The
+// first thing they enabled beats an arbitrary pick, so the final step sends
+// them somewhere that actually exists in their nav.
+const firstEnabled = computed(() => catalog.value.find((p) => providers.isEnabled(p.name)) ?? null)
+</script>
+
+<template>
+  <div class="mx-auto w-full max-w-3xl pb-10 pt-6">
+    <!-- Hero -->
+    <div class="mb-6 flex items-start gap-4">
+      <div class="relative flex h-12 w-12 shrink-0 items-center justify-center">
+        <div class="absolute inset-0 rounded-xl bg-accent/20 blur-md" />
+        <div class="relative flex h-12 w-12 items-center justify-center rounded-xl border border-accent/25 bg-surface-overlay">
+          <Rocket class="h-6 w-6 text-accent" :stroke-width="1.5" />
+        </div>
+      </div>
+      <div class="flex-1">
+        <h1 class="flex items-center gap-2 text-[18px] font-bold text-text-primary">
+          Welcome to Faros
+          <Sparkles class="h-4 w-4 text-accent" :stroke-width="1.75" />
+        </h1>
+        <p class="mt-1 text-[12px] text-text-muted">
+          <span class="font-mono text-text-secondary">{{ tenant.activeWorkspace?.displayName || 'This workspace' }}</span>
+          is empty. Two minutes here and it won't be — or
+          <button class="text-text-secondary underline decoration-dotted underline-offset-2 hover:text-text-primary" @click="emit('dismiss')">
+            skip and explore on your own</button>.
+        </p>
+      </div>
+    </div>
+
+    <!-- Step rail. Steps are clickable both ways: this is an intro, not a
+         transaction, so there is no reason to trap someone on step 2. -->
+    <ol class="mb-4 flex items-center gap-2">
+      <li v-for="(label, i) in steps" :key="label" class="flex flex-1 items-center gap-2">
+        <button
+          type="button"
+          class="flex items-center gap-2 text-left"
+          @click="step = i"
+        >
+          <span
+            class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold transition-colors"
+            :class="
+              i < step
+                ? 'border-accent/40 bg-accent/15 text-accent'
+                : i === step
+                  ? 'border-accent bg-accent text-white'
+                  : 'border-border-default bg-surface-overlay text-text-muted'
+            "
+          >
+            <Check v-if="i < step" class="h-3 w-3" :stroke-width="2.5" />
+            <template v-else>{{ i + 1 }}</template>
+          </span>
+          <span
+            class="text-[11px] font-medium transition-colors"
+            :class="i === step ? 'text-text-primary' : 'text-text-muted'"
+          >
+            {{ label }}
+          </span>
+        </button>
+        <span v-if="i < steps.length - 1" class="h-px flex-1 bg-border-subtle" />
+      </li>
+    </ol>
+
+    <div class="rounded-xl border border-border-default shadow-sm">
+      <div class="rounded-xl border border-border-subtle bg-surface-raised/80 p-6 backdrop-blur">
+        <!-- ── Step 1: concepts ─────────────────────────────────────────── -->
+        <template v-if="step === 0">
+          <h2 class="text-[13px] font-semibold text-text-primary">The four things worth knowing</h2>
+          <p class="mt-1 text-[11px] text-text-muted">
+            Faros is a control plane you extend. Here is the whole vocabulary.
+          </p>
+
+          <ul class="mt-4 grid gap-3 sm:grid-cols-2">
+            <li
+              v-for="c in concepts"
+              :key="c.title"
+              class="rounded-xl border border-border-subtle bg-surface-overlay/40 p-4"
+            >
+              <div class="flex items-center gap-2">
+                <component :is="c.icon" class="h-4 w-4 text-accent" :stroke-width="1.75" />
+                <h3 class="text-[12px] font-semibold text-text-primary">{{ c.title }}</h3>
+              </div>
+              <p class="mt-1.5 text-[11px] leading-relaxed text-text-muted">{{ c.body }}</p>
+            </li>
+          </ul>
+
+          <p class="mt-4 rounded-lg border border-border-subtle bg-surface-overlay/30 px-3 py-2 text-[11px] text-text-muted">
+            Providers are enabled <strong class="font-semibold text-text-secondary">per workspace</strong>.
+            Turning one on here leaves your other workspaces untouched, and you can turn it
+            back off at any time from the catalog.
+          </p>
+        </template>
+
+        <!-- ── Step 2: catalog ──────────────────────────────────────────── -->
+        <template v-else-if="step === 1">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h2 class="text-[13px] font-semibold text-text-primary">Pick what this workspace does</h2>
+              <p class="mt-1 text-[11px] text-text-muted">
+                Enable one or several. Each asks you to review what it can access before anything is bound.
+              </p>
+            </div>
+            <span
+              v-if="catalog.length"
+              class="shrink-0 rounded-md border border-border-subtle bg-surface-overlay px-2 py-1 text-[10px] font-medium text-text-muted"
+            >
+              {{ enabledCount }} / {{ catalog.length }} enabled
+            </span>
+          </div>
+
+          <div
+            v-if="actionError"
+            class="mt-4 flex items-start gap-2 rounded-lg border border-danger/30 bg-danger-subtle px-3 py-2 text-[11px] text-danger"
+          >
+            <AlertCircle class="mt-0.5 h-3.5 w-3.5 shrink-0" :stroke-width="1.75" />
+            <span>{{ actionError }}</span>
+          </div>
+
+          <!-- No enableable providers at all: an operator-side situation the
+               user can't fix from here, so say so plainly instead of showing
+               an empty list that reads like a loading bug. -->
+          <div
+            v-if="catalog.length === 0"
+            class="mt-4 rounded-xl border border-border-subtle bg-surface-overlay/40 p-4 text-[11px] text-text-muted"
+          >
+            <div class="font-medium text-text-secondary">No providers are installed on this instance yet.</div>
+            <div class="mt-1">
+              Providers are installed by whoever operates this hub, as Helm charts that register a
+              CatalogEntry. Until one is installed there is nothing to enable here.
+            </div>
+          </div>
+
+          <ul v-else class="mt-4 space-y-2">
+            <li
+              v-for="p in catalog"
+              :key="p.name"
+              class="rounded-xl border bg-surface-overlay/40 p-4 transition-colors"
+              :class="providers.isEnabled(p.name) ? 'border-accent/30' : 'border-border-subtle hover:border-accent/25'"
+            >
+              <div class="flex items-start gap-3">
+                <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-surface-raised">
+                  <img
+                    v-if="p.iconURL"
+                    :src="p.iconURL"
+                    alt=""
+                    class="h-5 w-5"
+                    @error="(e) => ((e.target as HTMLImageElement).style.display = 'none')"
+                  />
+                  <Puzzle v-else class="h-4 w-4 text-text-muted" :stroke-width="1.75" />
+                </div>
+
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <h3 class="text-[12px] font-semibold text-text-primary">{{ p.displayName }}</h3>
+                    <span
+                      v-if="p.category"
+                      class="inline-flex items-center gap-1 rounded-sm border border-border-subtle px-1.5 py-px text-[9px] font-medium text-text-muted"
+                    >
+                      <component :is="categoryIcon(p.category)" class="h-2.5 w-2.5" :stroke-width="2" />
+                      {{ p.category }}
+                    </span>
+                    <span
+                      v-if="providers.isEnabled(p.name)"
+                      class="inline-flex items-center gap-1 rounded-sm border border-accent/30 bg-accent/10 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-accent"
+                    >
+                      <Check class="h-2.5 w-2.5" :stroke-width="2.5" />
+                      Enabled
+                    </span>
+                  </div>
+
+                  <!-- The description is the entire point of this screen: it is
+                       what turns an opaque name into a decision. Fall back to
+                       something honest rather than rendering an empty line. -->
+                  <p class="mt-1 text-[11px] leading-relaxed text-text-muted">
+                    {{ p.description || 'No description published by this provider.' }}
+                  </p>
+
+                  <p v-if="dependencyNotice(p) && !providers.isEnabled(p.name)" class="mt-1.5 text-[10px] text-warning">
+                    {{ dependencyNotice(p) }}
+                  </p>
+                </div>
+
+                <div class="shrink-0">
+                  <router-link
+                    v-if="providers.isEnabled(p.name) && p.hasUI"
+                    :to="`/providers/${p.name}`"
+                    class="inline-flex items-center gap-1 rounded-lg border border-border-subtle px-2.5 py-1 text-[11px] font-medium text-text-secondary transition-colors hover:border-accent/30 hover:text-accent"
+                  >
+                    Open
+                    <ExternalLink class="h-3 w-3" :stroke-width="2" />
+                  </router-link>
+                  <span
+                    v-else-if="providers.isEnabled(p.name)"
+                    class="inline-flex items-center gap-1 text-[11px] font-medium text-accent"
+                  >
+                    <CheckCircle2 class="h-3.5 w-3.5" :stroke-width="2" />
+                  </span>
+                  <button
+                    v-else
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
+                    :disabled="!!busy[p.name] || providers.hasMissingDependencies(p)"
+                    :title="dependencyNotice(p)"
+                    @click="openEnableDialog(p)"
+                  >
+                    <Loader2 v-if="busy[p.name]" class="h-3 w-3 animate-spin" :stroke-width="2" />
+                    <Plus v-else class="h-3 w-3" :stroke-width="2" />
+                    Enable
+                  </button>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </template>
+
+        <!-- ── Step 3: done ─────────────────────────────────────────────── -->
+        <template v-else>
+          <div class="flex items-start gap-3">
+            <CheckCircle2
+              class="mt-0.5 h-5 w-5 shrink-0"
+              :class="enabledCount > 0 ? 'text-success' : 'text-text-muted'"
+              :stroke-width="1.75"
+            />
+            <div>
+              <h2 class="text-[13px] font-semibold text-text-primary">
+                {{ enabledCount > 0 ? 'Your workspace is set up' : 'Nothing enabled yet — that’s fine' }}
+              </h2>
+              <p class="mt-1 text-[11px] leading-relaxed text-text-muted">
+                <template v-if="enabledCount > 0">
+                  {{ enabledCount }} provider{{ enabledCount === 1 ? '' : 's' }}
+                  {{ enabledCount === 1 ? 'is' : 'are' }} now bound to this workspace. They appear in the
+                  side nav, and any that publish a dashboard tile show up on the dashboard.
+                </template>
+                <template v-else>
+                  You can enable providers whenever you want from the catalog. The dashboard stays
+                  empty until at least one is on.
+                </template>
+              </p>
+            </div>
+          </div>
+
+          <ul class="mt-4 space-y-2 text-[11px] text-text-muted">
+            <li class="flex items-start gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2">
+              <Puzzle class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" :stroke-width="1.75" />
+              <span>
+                <router-link to="/providers" class="font-medium text-accent hover:text-accent-hover">Providers</router-link>
+                — the full catalog. Enable and disable anything, any time.
+              </span>
+            </li>
+            <li v-if="firstEnabled?.hasUI" class="flex items-start gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2">
+              <ArrowRight class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" :stroke-width="1.75" />
+              <span>
+                <router-link
+                  :to="`/providers/${firstEnabled.name}`"
+                  class="font-medium text-accent hover:text-accent-hover"
+                >{{ firstEnabled.displayName }}</router-link>
+                — jump straight into what you just enabled.
+              </span>
+            </li>
+            <li class="flex items-start gap-2 rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2">
+              <Boxes class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" :stroke-width="1.75" />
+              <span>
+                <router-link to="/tenant" class="font-medium text-accent hover:text-accent-hover">Settings</router-link>
+                — add more workspaces, or invite people to the org.
+              </span>
+            </li>
+          </ul>
+        </template>
+      </div>
+
+      <!-- Footer: same controls on every step so the escape hatch never moves. -->
+      <div class="flex items-center justify-between gap-3 border-t border-border-subtle px-6 py-4">
+        <button
+          type="button"
+          class="flex items-center gap-1.5 text-[11px] font-medium text-text-muted transition-colors hover:text-text-secondary"
+          @click="step === 0 ? emit('dismiss') : back()"
+        >
+          <ArrowLeft v-if="step > 0" class="h-3 w-3" :stroke-width="2" />
+          {{ step === 0 ? 'Skip for now' : 'Back' }}
+        </button>
+
+        <button
+          type="button"
+          class="group flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-[12px] font-semibold text-white shadow-[0_0_16px_var(--color-accent-glow)] transition-all hover:bg-accent-hover active:scale-[0.98]"
+          @click="step === steps.length - 1 ? emit('dismiss') : next()"
+        >
+          <span>{{ step === steps.length - 1 ? 'Go to dashboard' : 'Continue' }}</span>
+          <ArrowRight class="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" :stroke-width="2" />
+        </button>
+      </div>
+    </div>
+
+    <ProviderEnableDialog
+      :provider="dialogProvider"
+      @cancel="dialogProvider = null"
+      @confirm="onDialogConfirm"
+    />
+  </div>
+</template>

--- a/portal/src/pages/DashboardPage.vue
+++ b/portal/src/pages/DashboardPage.vue
@@ -4,10 +4,11 @@ import { storeToRefs } from 'pinia'
 import { GridLayout, GridItem } from 'grid-layout-plus'
 import AppLayout from '@/components/AppLayout.vue'
 import DashboardTile from '@/components/DashboardTile.vue'
+import WelcomeWizard from '@/components/WelcomeWizard.vue'
 import { useProvidersStore } from '@/stores/providers'
 import { useTenantStore } from '@/stores/tenant'
 import { useDashboardLayoutStore } from '@/stores/dashboardLayout'
-import { Puzzle, Plus, RotateCcw, Check, LayoutGrid } from 'lucide-vue-next'
+import { Puzzle, Plus, RotateCcw, Check, LayoutGrid, Rocket } from 'lucide-vue-next'
 
 // The dashboard iterates the catalog and mounts one <DashboardTile> per
 // ready provider. Each provider may register a
@@ -90,6 +91,102 @@ watch(
 // renders synchronously, so the grid appears already settled.
 const initializing = computed(() => providers.loading)
 
+// --- First-run welcome ---
+//
+// Nothing is enabled by default: every provider ships as a CatalogEntry with an
+// APIExport that must be bound per workspace. So a fresh account's dashboard and
+// side nav are both genuinely empty, and the plain "no providers enabled" line
+// that used to sit here assumed the reader already knew what a provider was.
+// When the workspace has zero bindings we show the guided intro instead.
+//
+// Dismissal is per workspace and local-only: workspaces are independent
+// clusters, so having set one up says nothing about the next, and a display
+// preference doesn't warrant server-side state. Dismissing does not disable the
+// entry point — the header keeps a "Getting started" button so the flow is
+// reachable again, which also makes the local-only storage harmless if it is
+// cleared or the user switches browsers.
+const WELCOME_KEY = 'faros:portal:welcome-dismissed'
+
+function readDismissed(): string[] {
+  try {
+    const raw = localStorage.getItem(WELCOME_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+const dismissedWorkspaces = ref<string[]>(readDismissed())
+
+// Explicitly re-opened from the header. Outranks both the dismissal list and
+// the has-bindings check, so the intro stays reachable once set up.
+const welcomeForced = ref(false)
+
+const welcomeDismissed = computed(() =>
+  !!tenant.workspaceUUID && dismissedWorkspaces.value.includes(tenant.workspaceUUID),
+)
+
+// An empty binding map only means "nothing enabled here" once we know it was
+// fetched for the workspace we're looking at — otherwise the boot fetch and
+// every workspace switch would briefly flash the welcome flow at users who are
+// already set up. `providers.loaded` is not enough: load() flips it before it
+// awaits the bindings call.
+const bindingsCurrent = computed(
+  () => !!tenant.workspaceUUID && providers.bindingsWorkspace === tenant.workspaceUUID,
+)
+
+// Latched, not derived. Enabling a provider from inside step 2 flips
+// hasAnyEnabled, and a plain computed would unmount the wizard the instant the
+// first Enable succeeded — dropping the user onto the dashboard mid-flow,
+// before they ever saw the step confirming what they just turned on. So the
+// condition only ever opens the flow; closing it is the user's decision.
+const welcomeOpen = ref(false)
+
+watch(
+  [
+    () => providers.loaded,
+    bindingsCurrent,
+    () => providers.hasAnyEnabled,
+    welcomeDismissed,
+  ] as const,
+  ([loaded, current, anyEnabled, dismissed]) => {
+    if (loaded && current && !anyEnabled && !dismissed) welcomeOpen.value = true
+  },
+  { immediate: true },
+)
+
+const showWelcome = computed(() => welcomeOpen.value || welcomeForced.value)
+
+function dismissWelcome() {
+  welcomeForced.value = false
+  welcomeOpen.value = false
+  const ws = tenant.workspaceUUID
+  if (!ws || dismissedWorkspaces.value.includes(ws)) return
+  // Cap the list: it grows one entry per workspace ever visited, and only the
+  // recent tail can still matter.
+  const next = [...dismissedWorkspaces.value, ws].slice(-50)
+  dismissedWorkspaces.value = next
+  try {
+    localStorage.setItem(WELCOME_KEY, JSON.stringify(next))
+  } catch {
+    // Private-mode/quota failures only cost a repeat showing.
+  }
+}
+
+// Switching workspaces re-evaluates from scratch: the new workspace may be
+// freshly created and needs its own intro, and the latch above must not carry
+// the previous workspace's decision over. bindingsCurrent goes false until the
+// refetch for the new workspace lands, so the latch re-arms on real data.
+watch(
+  () => tenant.workspaceUUID,
+  () => {
+    welcomeForced.value = false
+    welcomeOpen.value = false
+  },
+)
+
 const providerFor = (name: string) => providers.byName(name)
 
 // --- Customize mode ---
@@ -128,12 +225,17 @@ function onLayoutUpdated() {
     </div>
 
     <template v-else>
-      <div v-if="gated.length === 0" class="flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-raised/60 p-4 text-[13px] text-text-muted">
+      <!-- Fresh workspace: the guided intro replaces the grid entirely. It is
+           the page at that point, not a banner above an empty one. -->
+      <WelcomeWizard v-if="showWelcome" @dismiss="dismissWelcome" />
+
+      <div v-else-if="gated.length === 0" class="flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-raised/60 p-4 text-[13px] text-text-muted">
         <Puzzle class="mt-0.5 h-4 w-4 text-text-muted" :stroke-width="1.75" />
         <div>
           <div class="font-medium text-text-secondary">No providers enabled in this workspace</div>
           <div class="mt-1 text-xs">
-            Enable a provider from the <router-link to="/providers" class="text-accent hover:text-accent-hover">catalog</router-link> to see a dashboard summary.
+            Enable a provider from the <router-link to="/providers" class="text-accent hover:text-accent-hover">catalog</router-link> to see a dashboard summary,
+            or walk through the <button class="text-accent hover:text-accent-hover" @click="welcomeForced = true">getting started guide</button>.
             Each provider is enabled per workspace.
           </div>
         </div>
@@ -186,14 +288,24 @@ function onLayoutUpdated() {
                 <Check class="h-3.5 w-3.5" :stroke-width="2" /> Done
               </button>
             </template>
-            <button
-              v-else
-              type="button"
-              class="flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-raised px-3 py-1.5 text-[12px] font-medium text-text-secondary transition-colors hover:text-text-primary"
-              @click="toggleEdit"
-            >
-              <LayoutGrid class="h-3.5 w-3.5" :stroke-width="2" /> Customize
-            </button>
+            <template v-else>
+              <!-- Re-entry point for the intro. Kept out of edit mode so the
+                   customize controls stay a single coherent group. -->
+              <button
+                type="button"
+                class="flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-raised px-3 py-1.5 text-[12px] font-medium text-text-secondary transition-colors hover:text-text-primary"
+                @click="welcomeForced = true"
+              >
+                <Rocket class="h-3.5 w-3.5" :stroke-width="2" /> Getting started
+              </button>
+              <button
+                type="button"
+                class="flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface-raised px-3 py-1.5 text-[12px] font-medium text-text-secondary transition-colors hover:text-text-primary"
+                @click="toggleEdit"
+              >
+                <LayoutGrid class="h-3.5 w-3.5" :stroke-width="2" /> Customize
+              </button>
+            </template>
           </div>
         </div>
 

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -280,6 +280,12 @@ function dependencyNotice(p: ProviderDTO): string {
             </div>
           </div>
 
+          <!-- CatalogEntry.spec.description. Clamped so a long blurb can't make
+               one card in the grid taller than its row neighbours. -->
+          <p v-if="p.description" class="mt-3 line-clamp-3 text-[11px] leading-relaxed text-text-muted">
+            {{ p.description }}
+          </p>
+
           <div class="mt-3 flex flex-wrap items-center gap-2 text-[10px] text-text-muted">
             <button
               type="button"

--- a/portal/src/pages/TenantSettingsPage.vue
+++ b/portal/src/pages/TenantSettingsPage.vue
@@ -48,6 +48,7 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import AppLayout from '@/components/AppLayout.vue'
 import MemberList from '@/components/MemberList.vue'
 import { useTenantStore, type AppAccessGrantRow, type MemberRow, type SARow, type TokenResponse, type WorkspaceRow } from '@/stores/tenant'
+import { useProvidersStore } from '@/stores/providers'
 import { confirmDialog } from '@/portalkit/confirm'
 import { toast } from '@/portalkit/toast'
 import {
@@ -70,6 +71,7 @@ import {
 } from 'lucide-vue-next'
 
 const tenant = useTenantStore()
+const providers = useProvidersStore()
 
 // ===== Selection ============================================================
 
@@ -562,6 +564,18 @@ async function onRemoveWsMember(user: string) {
 const appAccessGrants = ref<AppAccessGrantRow[]>([])
 const appAccessLoading = ref(false)
 const appAccessBusy = ref<Record<string, boolean>>({})
+
+// The card renders only when it's relevant to THIS workspace: App Studio is
+// enabled here, or grants actually exist. The second clause is load-bearing —
+// disabling App Studio does not delete previously-written grants (they're
+// plain workspace RBAC), and access that keeps working must stay visible and
+// revocable rather than becoming invisible the moment the provider goes away.
+// Without the first clause the card advertises an App Studio feature in
+// workspaces that never had it, which reads as a leak even though the list
+// itself is always scoped to this workspace's own grants.
+const showAppAccess = computed(
+  () => appAccessGrants.value.length > 0 || providers.isEnabled('app-studio'),
+)
 
 async function reloadAppAccessGrants() {
   if (sel.value?.kind !== 'ws') {
@@ -1208,7 +1222,7 @@ function fmtDate(s?: string | null): string {
             </section>
 
             <!-- App access grants -->
-            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+            <section v-if="showAppAccess" class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
               <h3 class="mb-1 text-sm font-semibold text-text-primary">App access</h3>
               <p class="mb-3 text-[12px] text-text-muted">
                 People invited to open <span class="font-medium text-text-secondary">private published apps</span>

--- a/portal/src/pages/TenantSettingsPage.vue
+++ b/portal/src/pages/TenantSettingsPage.vue
@@ -15,103 +15,196 @@ limitations under the License.
 -->
 
 <!--
-Tenant settings page. Single surface for all tenancy management — the
-sidebar used to host an Org/Workspace dropdown but that was hiding the
-fact that there is a much richer set of operations (create/delete/rename
-Org, manage Workspaces, manage memberships, mint service-account tokens)
-that needs real screen real estate.
+Tenant settings page — master/detail over the tenancy tree.
 
-Layout: left rail switches the active Org/Workspace; the main pane is
-split into sections (Organization, Workspaces, Members, Service Accounts)
-that each operate on the active selection. Members and SAs are scoped
-differently — members are Org-scoped, SAs are Workspace-scoped — and the
-UI reflects that.
+The previous layout was four tabs under two context dropdowns, and it made
+scope genuinely hard to read: the "Members" tab alone stacked org members,
+workspace members, and app-access grants — three different scopes — with
+copy referring to a "left rail" that no longer existed. Nothing on screen
+showed that workspaces live INSIDE orgs, or which of the two dropdowns a
+given section actually obeyed.
+
+This version makes the hierarchy the navigation:
+
+  left  — the tenancy tree. Orgs, each expandable to its workspaces, plus
+          inline create affordances ("+ workspace" per org, "New
+          organization" at the bottom). Clicking a node selects it here
+          AND switches the portal's active context (same coupling the old
+          dropdowns had — the tree is a clearer presentation of the same
+          selection, not a second selection mechanism).
+  right — settings for exactly the selected node, labeled with its scope.
+          Org node: overview/rename/danger, org members. Workspace node:
+          overview/rename/kubeconfig/danger, workspace members, app
+          access, service accounts.
+
+Every card on the right applies to the one node highlighted on the left —
+that invariant replaces the per-section "which scope is this?" prose.
+Action feedback goes through the portalkit toast bus instead of inline
+flash strips, matching the rest of the portal.
 -->
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import AppLayout from '@/components/AppLayout.vue'
-import { useTenantStore, type AppAccessGrantRow, type MemberRow, type SARow, type TokenResponse } from '@/stores/tenant'
+import MemberList from '@/components/MemberList.vue'
+import { useTenantStore, type AppAccessGrantRow, type MemberRow, type SARow, type TokenResponse, type WorkspaceRow } from '@/stores/tenant'
 import { confirmDialog } from '@/portalkit/confirm'
+import { toast } from '@/portalkit/toast'
 import {
   Building2,
-  FolderTree,
-  Users,
-  KeyRound,
-  Plus,
-  Trash2,
-  RotateCcw,
-  Pencil,
-  X,
   Check,
+  ChevronDown,
+  ChevronRight,
   Copy,
-  AlertCircle,
-  Loader2,
-  ShieldCheck,
   Download,
+  FolderTree,
+  KeyRound,
+  Loader2,
+  Pencil,
+  Plus,
+  RotateCcw,
+  ShieldCheck,
+  Trash2,
   User as UserIcon,
+  X,
 } from 'lucide-vue-next'
 
 const tenant = useTenantStore()
 
-const tab = ref<'org' | 'workspaces' | 'members' | 'sas'>('org')
-const actionError = ref<string | null>(null)
-const actionInfo = ref<string | null>(null)
+// ===== Selection ============================================================
 
-function flash(kind: 'error' | 'info', msg: string) {
-  if (kind === 'error') {
-    actionError.value = msg
-    actionInfo.value = null
+// The node whose settings the right pane shows. Coupled to the global active
+// org/workspace (clicking here switches the portal context, exactly like the
+// old dropdowns did), but kept as its own value because an org node can be
+// selected while some workspace stays globally active — the global pair alone
+// can't express "I'm looking at the org itself".
+type SelNode = { kind: 'org'; org: string } | { kind: 'ws'; org: string; ws: string }
+const sel = ref<SelNode | null>(null)
+
+// Expanded orgs in the tree. Held as an array (not Set) for Vue reactivity.
+const expanded = ref<string[]>([])
+
+function isExpanded(org: string): boolean {
+  return expanded.value.includes(org)
+}
+
+function workspacesOf(org: string): WorkspaceRow[] {
+  return tenant.workspacesByOrg[org] ?? []
+}
+
+// Fetch-once guard for tree expansion: the store caches per org, so this is a
+// no-op after the first expand.
+async function ensureWorkspaces(org: string): Promise<void> {
+  if (!tenant.workspacesByOrg[org]) await tenant.fetchWorkspaces(org)
+}
+
+async function toggleExpand(org: string) {
+  if (isExpanded(org)) {
+    expanded.value = expanded.value.filter((o) => o !== org)
   } else {
-    actionInfo.value = msg
-    actionError.value = null
+    expanded.value = [...expanded.value, org]
+    await ensureWorkspaces(org)
   }
 }
+
+// suppressSync stops the global-context watcher from re-pointing sel while a
+// tree click is the thing driving the context change. Without it, clicking an
+// org node would select the org's first workspace globally (store behavior)
+// and the watcher would immediately bounce sel onto that workspace — the org
+// pane would be unreachable. Reset on nextTick (after the watcher flush)
+// rather than inside the watcher: a click that doesn't actually change the
+// global pair never fires the watcher, and a flag latched until "the next
+// fire" would swallow a later, legitimate external context change.
+let suppressSync = false
+
+function beginLocalNav() {
+  suppressSync = true
+  void nextTick(() => {
+    suppressSync = false
+  })
+}
+
+async function clickOrg(org: string) {
+  // Ensure the workspace list is cached BEFORE selectOrg so its cached
+  // (synchronous) branch runs — the async branch would set the active
+  // workspace on a later tick, after the suppress window closed.
+  await ensureWorkspaces(org)
+  beginLocalNav()
+  tenant.selectOrg(org)
+  sel.value = { kind: 'org', org }
+  if (!isExpanded(org)) expanded.value = [...expanded.value, org]
+}
+
+async function clickWorkspace(org: string, ws: string) {
+  if (tenant.orgUUID !== org) await ensureWorkspaces(org)
+  beginLocalNav()
+  if (tenant.orgUUID !== org) tenant.selectOrg(org)
+  tenant.selectWorkspace(ws)
+  sel.value = { kind: 'ws', org, ws }
+}
+
+// Follow context changes made elsewhere (TenantContextChip, store fallbacks
+// after a delete). Tree clicks set suppressSync and win.
+watch(
+  [() => tenant.orgUUID, () => tenant.workspaceUUID],
+  ([o, w]) => {
+    if (suppressSync) return
+    if (!o) {
+      sel.value = null
+      return
+    }
+    sel.value = w ? { kind: 'ws', org: o, ws: w } : { kind: 'org', org: o }
+    if (!isExpanded(o)) expanded.value = [...expanded.value, o]
+  },
+)
 
 onMounted(async () => {
   await tenant.fetchOrgs()
   if (tenant.orgUUID) {
-    await tenant.fetchWorkspaces(tenant.orgUUID)
+    await ensureWorkspaces(tenant.orgUUID)
+    if (!isExpanded(tenant.orgUUID)) expanded.value = [...expanded.value, tenant.orgUUID]
+    sel.value = tenant.workspaceUUID
+      ? { kind: 'ws', org: tenant.orgUUID, ws: tenant.workspaceUUID }
+      : { kind: 'org', org: tenant.orgUUID }
   }
 })
 
-// Reload workspaces when the active org switches (the store also does this
-// lazily, but the page wants the list in the Workspaces tab regardless).
-watch(
-  () => tenant.orgUUID,
-  (id) => {
-    if (id) void tenant.fetchWorkspaces(id)
-  },
+// Resolved rows for the selected node. Null while the underlying lists are
+// still loading or the node vanished (deleted elsewhere).
+const selOrg = computed(() =>
+  sel.value ? tenant.orgs.find((o) => o.uuid === sel.value!.org) ?? null : null,
 )
+const selWs = computed<WorkspaceRow | null>(() => {
+  const s = sel.value
+  if (!s || s.kind !== 'ws') return null
+  return workspacesOf(s.org).find((w) => w.uuid === s.ws) ?? null
+})
 
-// ===== Organization tab =====
+// Capability gates, mirroring the server's authorization exactly so no
+// control is ever rendered that can only 403:
+//  - org admin-only:   member management, rename, delete/restore
+//  - ws admin-only:    member management, rename, delete/restore,
+//                      app-access revoke, ALL service-account endpoints
+//  - any org member:   leave org, view member list
+//  - any ws member:    kubeconfig, view member list, view app access
+// The roles ride on the org/workspace REST projections (the caller's own
+// UMI rows) — the same rows the tenant middleware resolves server-side.
+const canManageOrg = computed(() => selOrg.value?.role === 'admin')
+const canManageWs = computed(() => selWs.value?.role === 'admin')
 
-const editingOrgName = ref(false)
-const orgNameDraft = ref('')
+// Workspace creation obeys Organization.spec.workspaceCreation: admins
+// always; members only when the org opts in ("members").
+function canCreateWorkspaceIn(orgUUID: string): boolean {
+  const o = tenant.orgs.find((x) => x.uuid === orgUUID)
+  if (!o) return false
+  return o.role === 'admin' || o.workspaceCreation === 'members'
+}
+
+// ===== Tree: create org / workspace ========================================
+
+const newOrgOpen = ref(false)
 const newOrgName = ref('')
 const orgBusy = ref(false)
-
-function startEditOrgName() {
-  if (!tenant.activeOrg) return
-  orgNameDraft.value = tenant.activeOrg.displayName
-  editingOrgName.value = true
-}
-
-async function saveOrgName() {
-  if (!tenant.orgUUID || !orgNameDraft.value.trim()) return
-  orgBusy.value = true
-  try {
-    const ok = await tenant.patchOrgDisplayName(tenant.orgUUID, orgNameDraft.value.trim())
-    if (ok) {
-      flash('info', 'Organization renamed.')
-      editingOrgName.value = false
-    } else {
-      flash('error', tenant.error ?? 'Failed to rename organization.')
-    }
-  } finally {
-    orgBusy.value = false
-  }
-}
 
 async function onCreateOrg() {
   const name = newOrgName.value.trim()
@@ -120,10 +213,71 @@ async function onCreateOrg() {
   try {
     const created = await tenant.createOrg(name)
     if (created) {
-      flash('info', `Created organization "${created.displayName}".`)
+      toast('ok', `Created organization "${created.displayName}".`)
       newOrgName.value = ''
+      newOrgOpen.value = false
+      // createOrg selects the new org; land on its org pane.
+      sel.value = { kind: 'org', org: created.uuid }
+      if (!isExpanded(created.uuid)) expanded.value = [...expanded.value, created.uuid]
     } else {
-      flash('error', tenant.error ?? 'Failed to create organization.')
+      toast('error', tenant.error ?? 'Failed to create organization.')
+    }
+  } finally {
+    orgBusy.value = false
+  }
+}
+
+// Which org's inline "+ workspace" input is open (one at a time).
+const newWsFor = ref<string | null>(null)
+const newWsName = ref('')
+const newWsBusy = ref(false)
+
+function openNewWs(org: string) {
+  newWsFor.value = org
+  newWsName.value = ''
+}
+
+async function onCreateWorkspace() {
+  const org = newWsFor.value
+  const name = newWsName.value.trim()
+  if (!org || !name) return
+  newWsBusy.value = true
+  try {
+    const created = await tenant.createWorkspace(org, name)
+    if (created) {
+      toast('ok', `Created workspace "${created.displayName}".`)
+      newWsFor.value = null
+      // Jump straight into the new workspace's settings.
+      await clickWorkspace(org, created.uuid)
+    } else {
+      toast('error', tenant.error ?? 'Failed to create workspace.')
+    }
+  } finally {
+    newWsBusy.value = false
+  }
+}
+
+// ===== Org pane: rename / danger zone ======================================
+
+const editingOrgName = ref(false)
+const orgNameDraft = ref('')
+
+function startEditOrgName() {
+  if (!selOrg.value) return
+  orgNameDraft.value = selOrg.value.displayName
+  editingOrgName.value = true
+}
+
+async function saveOrgName() {
+  if (!selOrg.value || !orgNameDraft.value.trim()) return
+  orgBusy.value = true
+  try {
+    const ok = await tenant.patchOrgDisplayName(selOrg.value.uuid, orgNameDraft.value.trim())
+    if (ok) {
+      toast('ok', 'Organization renamed.')
+      editingOrgName.value = false
+    } else {
+      toast('error', tenant.error ?? 'Failed to rename organization.')
     }
   } finally {
     orgBusy.value = false
@@ -131,349 +285,247 @@ async function onCreateOrg() {
 }
 
 async function onDeleteOrg() {
-  if (!tenant.activeOrg) return
-  if (tenant.activeOrg.personal) {
-    flash('error', 'Personal organizations cannot be deleted.')
-    return
-  }
-  if (!(await confirmDialog({ title: `Delete organization "${tenant.activeOrg.displayName}"?`, message: 'It enters a 30-day grace window and can be restored.', danger: true, confirmLabel: 'Delete' }))) return
+  const org = selOrg.value
+  if (!org || org.personal) return
+  if (!(await confirmDialog({ title: `Delete organization "${org.displayName}"?`, message: 'It enters a 30-day grace window and can be restored.', danger: true, confirmLabel: 'Delete' }))) return
   orgBusy.value = true
   try {
-    const ok = await tenant.deleteOrg(tenant.activeOrg.uuid)
-    if (ok) flash('info', 'Organization deletion requested.')
-    else flash('error', tenant.error ?? 'Failed to delete organization.')
+    const ok = await tenant.deleteOrg(org.uuid)
+    if (ok) toast('ok', 'Organization deletion requested. It can be restored for 30 days.')
+    else toast('error', tenant.error ?? 'Failed to delete organization.')
   } finally {
     orgBusy.value = false
   }
 }
 
 async function onUndeleteOrg() {
-  if (!tenant.activeOrg) return
+  if (!selOrg.value) return
   orgBusy.value = true
   try {
-    const ok = await tenant.undeleteOrg(tenant.activeOrg.uuid)
-    if (ok) flash('info', 'Organization restored.')
-    else flash('error', tenant.error ?? 'Failed to restore organization.')
+    const ok = await tenant.undeleteOrg(selOrg.value.uuid)
+    if (ok) toast('ok', 'Organization restored.')
+    else toast('error', tenant.error ?? 'Failed to restore organization.')
   } finally {
     orgBusy.value = false
   }
 }
 
-// ===== Workspaces tab =====
-
-const newWorkspaceName = ref('')
-const wsBusy = ref<Record<string, boolean>>({})
-const editingWS = ref<string | null>(null)
-const wsNameDraft = ref('')
-
-const workspaces = computed(() =>
-  tenant.orgUUID ? tenant.workspacesByOrg[tenant.orgUUID] ?? [] : [],
-)
-
-async function onCreateWorkspace() {
-  if (!tenant.orgUUID || !newWorkspaceName.value.trim()) return
-  const name = newWorkspaceName.value.trim()
-  wsBusy.value = { ...wsBusy.value, '__new__': true }
+async function onLeaveOrg() {
+  const org = selOrg.value
+  if (!org || org.personal) return
+  if (!(await confirmDialog({ title: `Leave organization "${org.displayName}"?`, confirmLabel: 'Leave' }))) return
+  orgBusy.value = true
   try {
-    const created = await tenant.createWorkspace(tenant.orgUUID, name)
-    if (created) {
-      flash('info', `Created workspace "${created.displayName}".`)
-      newWorkspaceName.value = ''
-    } else {
-      flash('error', tenant.error ?? 'Failed to create workspace.')
-    }
+    const ok = await tenant.leaveOrg(org.uuid)
+    if (ok) toast('ok', 'You have left the organization.')
+    else toast('error', tenant.error ?? 'Failed to leave organization.')
   } finally {
-    const next = { ...wsBusy.value }
-    delete next['__new__']
-    wsBusy.value = next
+    orgBusy.value = false
   }
 }
 
-function startEditWS(uuid: string, current: string | undefined) {
-  editingWS.value = uuid
-  // The default workspace has no display-name annotation, so the REST
-  // projection omits the field entirely — passing undefined here would
-  // make the v-model + .trim() bindings throw.
-  wsNameDraft.value = current ?? ''
+// ===== Org pane: members ====================================================
+
+const orgMembers = ref<MemberRow[]>([])
+const orgMembersLoading = ref(false)
+const orgMemberBusy = ref<Record<string, boolean>>({})
+
+async function reloadOrgMembers() {
+  const org = sel.value?.org
+  if (!org) {
+    orgMembers.value = []
+    return
+  }
+  orgMembersLoading.value = true
+  try {
+    orgMembers.value = await tenant.listOrgMembers(org)
+  } finally {
+    orgMembersLoading.value = false
+  }
 }
 
-async function saveWSName(uuid: string) {
-  if (!tenant.orgUUID || !wsNameDraft.value.trim()) return
-  wsBusy.value = { ...wsBusy.value, [uuid]: true }
+async function onAddOrgMember(user: string, role: 'admin' | 'member'): Promise<boolean> {
+  const org = sel.value?.org
+  if (!org) return false
+  orgMemberBusy.value = { ...orgMemberBusy.value, __new__: true }
   try {
-    const ok = await tenant.patchWorkspaceDisplayName(tenant.orgUUID, uuid, wsNameDraft.value.trim())
+    const ok = await tenant.addOrgMember(org, user, role)
     if (ok) {
-      flash('info', 'Workspace renamed.')
-      editingWS.value = null
+      toast('ok', `Added ${user} to the organization as ${role}.`)
+      await reloadOrgMembers()
     } else {
-      flash('error', tenant.error ?? 'Failed to rename workspace.')
+      toast('error', tenant.error ?? 'Failed to add member.')
+    }
+    return ok
+  } finally {
+    const next = { ...orgMemberBusy.value }
+    delete next.__new__
+    orgMemberBusy.value = next
+  }
+}
+
+async function onChangeOrgMemberRole(user: string, role: 'admin' | 'member') {
+  const org = sel.value?.org
+  if (!org) return
+  orgMemberBusy.value = { ...orgMemberBusy.value, [user]: true }
+  try {
+    const ok = await tenant.patchOrgMemberRole(org, user, role)
+    if (ok) {
+      toast('ok', `Updated ${user}'s role to ${role}.`)
+      await reloadOrgMembers()
+    } else {
+      toast('error', tenant.error ?? 'Failed to update role.')
     }
   } finally {
-    const next = { ...wsBusy.value }
-    delete next[uuid]
-    wsBusy.value = next
+    const next = { ...orgMemberBusy.value }
+    delete next[user]
+    orgMemberBusy.value = next
   }
 }
 
-async function onDeleteWorkspace(uuid: string, name: string | undefined) {
-  if (!tenant.orgUUID) return
-  const label = name || uuid
+async function onRemoveOrgMember(user: string) {
+  const org = sel.value?.org
+  if (!org) return
+  // cascade=true is the safe default for the UI: leaving workspace
+  // memberships behind after an org removal would be surprising. Org-only
+  // removal stays available through the API.
+  if (!(await confirmDialog({ title: `Remove ${user} from the organization?`, message: 'They will also be removed from every workspace in this org.', danger: true, confirmLabel: 'Remove' }))) return
+  orgMemberBusy.value = { ...orgMemberBusy.value, [user]: true }
+  try {
+    const ok = await tenant.removeOrgMember(org, user, true)
+    if (ok) {
+      toast('ok', `Removed ${user}.`)
+      await reloadOrgMembers()
+    } else {
+      toast('error', tenant.error ?? 'Failed to remove member.')
+    }
+  } finally {
+    const next = { ...orgMemberBusy.value }
+    delete next[user]
+    orgMemberBusy.value = next
+  }
+}
+
+// ===== Workspace pane: rename / kubeconfig / danger zone ===================
+
+const editingWsName = ref(false)
+const wsNameDraft = ref('')
+const wsBusy = ref(false)
+const kubeconfigBusy = ref(false)
+
+function startEditWsName() {
+  if (!selWs.value) return
+  // The default workspace has no display-name annotation, so the REST
+  // projection omits the field — guard against undefined.
+  wsNameDraft.value = selWs.value.displayName ?? ''
+  editingWsName.value = true
+}
+
+async function saveWsName() {
+  if (sel.value?.kind !== 'ws' || !wsNameDraft.value.trim()) return
+  wsBusy.value = true
+  try {
+    const ok = await tenant.patchWorkspaceDisplayName(sel.value.org, sel.value.ws, wsNameDraft.value.trim())
+    if (ok) {
+      toast('ok', 'Workspace renamed.')
+      editingWsName.value = false
+    } else {
+      toast('error', tenant.error ?? 'Failed to rename workspace.')
+    }
+  } finally {
+    wsBusy.value = false
+  }
+}
+
+async function onDeleteWorkspace() {
+  if (sel.value?.kind !== 'ws') return
+  const label = selWs.value?.displayName || sel.value.ws
   if (!(await confirmDialog({ title: `Delete workspace "${label}"?`, message: 'It enters a 30-day grace window and can be restored.', danger: true, confirmLabel: 'Delete' }))) return
-  wsBusy.value = { ...wsBusy.value, [uuid]: true }
+  wsBusy.value = true
   try {
-    const ok = await tenant.deleteWorkspace(tenant.orgUUID, uuid)
-    if (ok) flash('info', 'Workspace deletion requested.')
-    else flash('error', tenant.error ?? 'Failed to delete workspace.')
+    const ok = await tenant.deleteWorkspace(sel.value.org, sel.value.ws)
+    if (ok) toast('ok', 'Workspace deletion requested. It can be restored for 30 days.')
+    else toast('error', tenant.error ?? 'Failed to delete workspace.')
   } finally {
-    const next = { ...wsBusy.value }
-    delete next[uuid]
-    wsBusy.value = next
+    wsBusy.value = false
   }
 }
 
-async function onUndeleteWorkspace(uuid: string) {
-  if (!tenant.orgUUID) return
-  wsBusy.value = { ...wsBusy.value, [uuid]: true }
+async function onUndeleteWorkspace() {
+  if (sel.value?.kind !== 'ws') return
+  wsBusy.value = true
   try {
-    const ok = await tenant.undeleteWorkspace(tenant.orgUUID, uuid)
-    if (ok) flash('info', 'Workspace restored.')
-    else flash('error', tenant.error ?? 'Failed to restore workspace.')
+    const ok = await tenant.undeleteWorkspace(sel.value.org, sel.value.ws)
+    if (ok) toast('ok', 'Workspace restored.')
+    else toast('error', tenant.error ?? 'Failed to restore workspace.')
   } finally {
-    const next = { ...wsBusy.value }
-    delete next[uuid]
-    wsBusy.value = next
+    wsBusy.value = false
   }
 }
 
-async function onDownloadKubeconfig(uuid: string) {
-  if (!tenant.orgUUID) return
-  // Use a `kc:` prefix so the busy spinner on the row's other actions
-  // (rename/delete) isn't blocked by an in-flight download.
-  const key = `kc:${uuid}`
-  wsBusy.value = { ...wsBusy.value, [key]: true }
+async function onDownloadKubeconfig() {
+  if (sel.value?.kind !== 'ws') return
+  kubeconfigBusy.value = true
   try {
     // Reuse the install variant the user picked in the TenantContextChip
-    // (persisted under the same key) so the per-row download in this
-    // page matches the chip's dropdown. Defaults to 'faros'.
+    // (persisted under the same key) so this download matches the chip's
+    // dropdown. Defaults to 'faros'.
     const install = (localStorage.getItem('faros:portal:kubeconfig:install') === 'krew' ? 'krew' : 'faros') as 'faros' | 'krew'
-    const ok = await tenant.downloadKubeconfig(tenant.orgUUID, uuid, install)
-    if (!ok) flash('error', tenant.error ?? 'Failed to download kubeconfig.')
+    const ok = await tenant.downloadKubeconfig(sel.value.org, sel.value.ws, install)
+    if (!ok) toast('error', tenant.error ?? 'Failed to download kubeconfig.')
   } finally {
-    const next = { ...wsBusy.value }
-    delete next[key]
-    wsBusy.value = next
+    kubeconfigBusy.value = false
   }
 }
 
-// ===== Members tab =====
-
-const members = ref<MemberRow[]>([])
-const membersLoading = ref(false)
-const newMemberUser = ref('')
-const newMemberRole = ref<'admin' | 'member'>('member')
-const memberBusy = ref<Record<string, boolean>>({})
-
-async function reloadMembers() {
-  if (!tenant.orgUUID) {
-    members.value = []
-    return
-  }
-  membersLoading.value = true
-  try {
-    members.value = await tenant.listOrgMembers(tenant.orgUUID)
-  } finally {
-    membersLoading.value = false
-  }
-}
-
-watch([() => tenant.orgUUID, tab], async ([id, t]) => {
-  if (t === 'members' && id) await reloadMembers()
-})
-
-async function onAddMember() {
-  const u = newMemberUser.value.trim()
-  if (!u || !tenant.orgUUID) return
-  memberBusy.value = { ...memberBusy.value, '__new__': true }
-  try {
-    const ok = await tenant.addOrgMember(tenant.orgUUID, u, newMemberRole.value)
-    if (ok) {
-      flash('info', `Added ${u} as ${newMemberRole.value}.`)
-      newMemberUser.value = ''
-      newMemberRole.value = 'member'
-      await reloadMembers()
-    } else {
-      flash('error', tenant.error ?? 'Failed to add member.')
-    }
-  } finally {
-    const next = { ...memberBusy.value }
-    delete next['__new__']
-    memberBusy.value = next
-  }
-}
-
-async function onChangeMemberRole(user: string, role: 'admin' | 'member') {
-  if (!tenant.orgUUID) return
-  memberBusy.value = { ...memberBusy.value, [user]: true }
-  try {
-    const ok = await tenant.patchOrgMemberRole(tenant.orgUUID, user, role)
-    if (ok) {
-      flash('info', `Updated ${user}'s role to ${role}.`)
-      await reloadMembers()
-    } else {
-      flash('error', tenant.error ?? 'Failed to update role.')
-    }
-  } finally {
-    const next = { ...memberBusy.value }
-    delete next[user]
-    memberBusy.value = next
-  }
-}
-
-async function onRemoveMember(user: string) {
-  if (!tenant.orgUUID) return
-  // Single confirm. cascade=true is the safe default for the UI: leaving a
-  // workspace membership behind after removing someone from the org would
-  // be surprising. Power users wanting org-only removal go through the API.
-  if (!(await confirmDialog({ title: `Remove ${user} from the organization?`, message: 'They will also be removed from every workspace in this org.', danger: true, confirmLabel: 'Remove' }))) return
-  memberBusy.value = { ...memberBusy.value, [user]: true }
-  try {
-    const ok = await tenant.removeOrgMember(tenant.orgUUID, user, true)
-    if (ok) {
-      flash('info', `Removed ${user}.`)
-      await reloadMembers()
-    } else {
-      flash('error', tenant.error ?? 'Failed to remove member.')
-    }
-  } finally {
-    const next = { ...memberBusy.value }
-    delete next[user]
-    memberBusy.value = next
-  }
-}
-
-async function onLeaveOrg() {
-  if (!tenant.activeOrg) return
-  if (tenant.activeOrg.personal) {
-    flash('error', 'You cannot leave your personal organization.')
-    return
-  }
-  if (!(await confirmDialog({ title: `Leave organization "${tenant.activeOrg.displayName}"?`, confirmLabel: 'Leave' }))) return
-  memberBusy.value = { ...memberBusy.value, __self__: true }
-  try {
-    const ok = await tenant.leaveOrg(tenant.activeOrg.uuid)
-    if (ok) flash('info', 'You have left the organization.')
-    else flash('error', tenant.error ?? 'Failed to leave organization.')
-  } finally {
-    const next = { ...memberBusy.value }
-    delete next['__self__']
-    memberBusy.value = next
-  }
-}
-
-// ===== Workspace members (scoped to the active workspace) =====
+// ===== Workspace pane: members =============================================
 
 const wsMembers = ref<MemberRow[]>([])
 const wsMembersLoading = ref(false)
-const newWsMemberUser = ref('')
-const newWsMemberRole = ref<'admin' | 'member'>('member')
 const wsMemberBusy = ref<Record<string, boolean>>({})
 
 async function reloadWsMembers() {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) {
+  if (sel.value?.kind !== 'ws') {
     wsMembers.value = []
     return
   }
   wsMembersLoading.value = true
   try {
-    wsMembers.value = await tenant.listWorkspaceMembers(tenant.orgUUID, tenant.workspaceUUID)
+    wsMembers.value = await tenant.listWorkspaceMembers(sel.value.org, sel.value.ws)
   } finally {
     wsMembersLoading.value = false
   }
 }
 
-// Reload when the Members tab is active and the org/workspace changes.
-watch([() => tenant.orgUUID, () => tenant.workspaceUUID, tab], async ([org, ws, t]) => {
-  if (t === 'members' && org && ws) await Promise.all([reloadWsMembers(), reloadAppAccessGrants()])
-})
-
-// ===== App access grants (private published apps) =====
-// Plain workspace RBAC (labeled ClusterRoleBindings) written by App Studio's
-// share dialog; listed here so invitations are visible and revocable in the
-// faros UI. Granting stays app-scoped in the share dialog, where the app and
-// member context live.
-const appAccessGrants = ref<AppAccessGrantRow[]>([])
-const appAccessLoading = ref(false)
-const appAccessBusy = ref<Record<string, boolean>>({})
-
-async function reloadAppAccessGrants() {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) {
-    appAccessGrants.value = []
-    return
-  }
-  appAccessLoading.value = true
-  try {
-    appAccessGrants.value = await tenant.listAppAccessGrants(tenant.orgUUID, tenant.workspaceUUID)
-  } finally {
-    appAccessLoading.value = false
-  }
-}
-
-async function onRevokeAppAccess(grant: AppAccessGrantRow) {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) return
-  const confirmed = await confirmDialog({
-    title: 'Revoke app access',
-    message: `Remove ${grant.user}'s access to “${grant.app}”? They can be re-invited from the app's share dialog.`,
-    confirmLabel: 'Revoke',
-    danger: true,
-  })
-  if (!confirmed) return
-  appAccessBusy.value = { ...appAccessBusy.value, [grant.binding]: true }
-  try {
-    const ok = await tenant.revokeAppAccessGrant(tenant.orgUUID, tenant.workspaceUUID, grant.binding)
-    if (ok) {
-      flash('info', `Revoked ${grant.user}'s access to ${grant.app}.`)
-      await reloadAppAccessGrants()
-    } else {
-      flash('error', tenant.error || 'Failed to revoke app access.')
-    }
-  } finally {
-    const next = { ...appAccessBusy.value }
-    delete next[grant.binding]
-    appAccessBusy.value = next
-  }
-}
-
-async function onAddWsMember() {
-  const u = newWsMemberUser.value.trim()
-  if (!u || !tenant.orgUUID || !tenant.workspaceUUID) return
+async function onAddWsMember(user: string, role: 'admin' | 'member'): Promise<boolean> {
+  if (sel.value?.kind !== 'ws') return false
   wsMemberBusy.value = { ...wsMemberBusy.value, __new__: true }
   try {
-    const ok = await tenant.addWorkspaceMember(tenant.orgUUID, tenant.workspaceUUID, u, newWsMemberRole.value)
+    const ok = await tenant.addWorkspaceMember(sel.value.org, sel.value.ws, user, role)
     if (ok) {
-      flash('info', `Added ${u} to the workspace as ${newWsMemberRole.value}.`)
-      newWsMemberUser.value = ''
-      newWsMemberRole.value = 'member'
+      toast('ok', `Added ${user} to the workspace as ${role}.`)
       await reloadWsMembers()
     } else {
-      flash('error', tenant.error ?? 'Failed to add workspace member.')
+      toast('error', tenant.error ?? 'Failed to add workspace member.')
     }
+    return ok
   } finally {
     const next = { ...wsMemberBusy.value }
-    delete next['__new__']
+    delete next.__new__
     wsMemberBusy.value = next
   }
 }
 
 async function onChangeWsMemberRole(user: string, role: 'admin' | 'member') {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) return
+  if (sel.value?.kind !== 'ws') return
   wsMemberBusy.value = { ...wsMemberBusy.value, [user]: true }
   try {
-    const ok = await tenant.patchWorkspaceMemberRole(tenant.orgUUID, tenant.workspaceUUID, user, role)
+    const ok = await tenant.patchWorkspaceMemberRole(sel.value.org, sel.value.ws, user, role)
     if (ok) {
-      flash('info', `Updated ${user}'s workspace role to ${role}.`)
+      toast('ok', `Updated ${user}'s workspace role to ${role}.`)
       await reloadWsMembers()
     } else {
-      flash('error', tenant.error ?? 'Failed to update role.')
+      toast('error', tenant.error ?? 'Failed to update role.')
     }
   } finally {
     const next = { ...wsMemberBusy.value }
@@ -483,16 +535,16 @@ async function onChangeWsMemberRole(user: string, role: 'admin' | 'member') {
 }
 
 async function onRemoveWsMember(user: string) {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) return
+  if (sel.value?.kind !== 'ws') return
   if (!(await confirmDialog({ title: `Remove ${user} from this workspace?`, danger: true, confirmLabel: 'Remove' }))) return
   wsMemberBusy.value = { ...wsMemberBusy.value, [user]: true }
   try {
-    const ok = await tenant.removeWorkspaceMember(tenant.orgUUID, tenant.workspaceUUID, user)
+    const ok = await tenant.removeWorkspaceMember(sel.value.org, sel.value.ws, user)
     if (ok) {
-      flash('info', `Removed ${user} from the workspace.`)
+      toast('ok', `Removed ${user} from the workspace.`)
       await reloadWsMembers()
     } else {
-      flash('error', tenant.error ?? 'Failed to remove workspace member.')
+      toast('error', tenant.error ?? 'Failed to remove workspace member.')
     }
   } finally {
     const next = { ...wsMemberBusy.value }
@@ -501,7 +553,55 @@ async function onRemoveWsMember(user: string) {
   }
 }
 
-// ===== Service Accounts tab =====
+// ===== Workspace pane: app access grants ===================================
+// Plain workspace RBAC (labeled ClusterRoleBindings) written by App Studio's
+// share dialog; listed here so invitations are visible and revocable in the
+// faros UI. Granting stays app-scoped in the share dialog, where the app and
+// member context live.
+
+const appAccessGrants = ref<AppAccessGrantRow[]>([])
+const appAccessLoading = ref(false)
+const appAccessBusy = ref<Record<string, boolean>>({})
+
+async function reloadAppAccessGrants() {
+  if (sel.value?.kind !== 'ws') {
+    appAccessGrants.value = []
+    return
+  }
+  appAccessLoading.value = true
+  try {
+    appAccessGrants.value = await tenant.listAppAccessGrants(sel.value.org, sel.value.ws)
+  } finally {
+    appAccessLoading.value = false
+  }
+}
+
+async function onRevokeAppAccess(grant: AppAccessGrantRow) {
+  if (sel.value?.kind !== 'ws') return
+  const confirmed = await confirmDialog({
+    title: 'Revoke app access',
+    message: `Remove ${grant.user}'s access to “${grant.app}”? They can be re-invited from the app's share dialog.`,
+    confirmLabel: 'Revoke',
+    danger: true,
+  })
+  if (!confirmed) return
+  appAccessBusy.value = { ...appAccessBusy.value, [grant.binding]: true }
+  try {
+    const ok = await tenant.revokeAppAccessGrant(sel.value.org, sel.value.ws, grant.binding)
+    if (ok) {
+      toast('ok', `Revoked ${grant.user}'s access to ${grant.app}.`)
+      await reloadAppAccessGrants()
+    } else {
+      toast('error', tenant.error || 'Failed to revoke app access.')
+    }
+  } finally {
+    const next = { ...appAccessBusy.value }
+    delete next[grant.binding]
+    appAccessBusy.value = next
+  }
+}
+
+// ===== Workspace pane: service accounts ====================================
 
 const sas = ref<SARow[]>([])
 const sasLoading = ref(false)
@@ -512,62 +612,53 @@ const issuedToken = ref<TokenResponse | null>(null)
 const issuedTokenSA = ref<string | null>(null)
 
 async function reloadSAs() {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) {
+  // Every SA endpoint (list included) requires workspace admin; for
+  // members the card renders an explanation instead, so don't fire a
+  // request that can only 403.
+  if (sel.value?.kind !== 'ws' || selWs.value?.role !== 'admin') {
     sas.value = []
     return
   }
   sasLoading.value = true
   try {
-    sas.value = await tenant.listServiceAccounts(tenant.orgUUID, tenant.workspaceUUID)
+    sas.value = await tenant.listServiceAccounts(sel.value.org, sel.value.ws)
   } finally {
     sasLoading.value = false
   }
 }
 
-watch(
-  [() => tenant.orgUUID, () => tenant.workspaceUUID, tab],
-  async ([o, w, t]) => {
-    if (t === 'sas' && o && w) await reloadSAs()
-  },
-)
-
 async function onCreateSA() {
   const name = newSAName.value.trim()
-  if (!name || !tenant.orgUUID || !tenant.workspaceUUID) return
-  saBusy.value = { ...saBusy.value, '__new__': true }
+  if (!name || sel.value?.kind !== 'ws') return
+  saBusy.value = { ...saBusy.value, __new__: true }
   try {
-    const created = await tenant.createServiceAccount(
-      tenant.orgUUID,
-      tenant.workspaceUUID,
-      name,
-      newSARole.value,
-    )
+    const created = await tenant.createServiceAccount(sel.value.org, sel.value.ws, name, newSARole.value)
     if (created) {
-      flash('info', `Created service account "${created.displayName}".`)
+      toast('ok', `Created service account "${created.displayName}".`)
       newSAName.value = ''
       newSARole.value = 'member'
       await reloadSAs()
     } else {
-      flash('error', tenant.error ?? 'Failed to create service account.')
+      toast('error', tenant.error ?? 'Failed to create service account.')
     }
   } finally {
     const next = { ...saBusy.value }
-    delete next['__new__']
+    delete next.__new__
     saBusy.value = next
   }
 }
 
 async function onDeleteSA(uuid: string, name: string) {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) return
+  if (sel.value?.kind !== 'ws') return
   if (!(await confirmDialog({ title: `Delete service account "${name}"?`, message: 'Active tokens will stop working.', danger: true, confirmLabel: 'Delete' }))) return
   saBusy.value = { ...saBusy.value, [uuid]: true }
   try {
-    const ok = await tenant.deleteServiceAccount(tenant.orgUUID, tenant.workspaceUUID, uuid)
+    const ok = await tenant.deleteServiceAccount(sel.value.org, sel.value.ws, uuid)
     if (ok) {
-      flash('info', `Deleted service account "${name}".`)
+      toast('ok', `Deleted service account "${name}".`)
       await reloadSAs()
     } else {
-      flash('error', tenant.error ?? 'Failed to delete service account.')
+      toast('error', tenant.error ?? 'Failed to delete service account.')
     }
   } finally {
     const next = { ...saBusy.value }
@@ -577,16 +668,16 @@ async function onDeleteSA(uuid: string, name: string) {
 }
 
 async function onIssueToken(uuid: string, name: string) {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) return
+  if (sel.value?.kind !== 'ws') return
   saBusy.value = { ...saBusy.value, [uuid]: true }
   try {
-    const tok = await tenant.issueSAToken(tenant.orgUUID, tenant.workspaceUUID, uuid)
+    const tok = await tenant.issueSAToken(sel.value.org, sel.value.ws, uuid)
     if (tok) {
       issuedToken.value = tok
       issuedTokenSA.value = name
       await reloadSAs()
     } else {
-      flash('error', tenant.error ?? 'Failed to issue token.')
+      toast('error', tenant.error ?? 'Failed to issue token.')
     }
   } finally {
     const next = { ...saBusy.value }
@@ -596,16 +687,16 @@ async function onIssueToken(uuid: string, name: string) {
 }
 
 async function onRevokeTokens(uuid: string, name: string) {
-  if (!tenant.orgUUID || !tenant.workspaceUUID) return
+  if (sel.value?.kind !== 'ws') return
   if (!(await confirmDialog({ title: `Revoke all tokens for "${name}"?`, message: 'Existing token holders will be locked out.', danger: true, confirmLabel: 'Revoke' }))) return
   saBusy.value = { ...saBusy.value, [uuid]: true }
   try {
-    const ok = await tenant.revokeSATokens(tenant.orgUUID, tenant.workspaceUUID, uuid)
+    const ok = await tenant.revokeSATokens(sel.value.org, sel.value.ws, uuid)
     if (ok) {
-      flash('info', `Revoked tokens for "${name}".`)
+      toast('ok', `Revoked tokens for "${name}".`)
       await reloadSAs()
     } else {
-      flash('error', tenant.error ?? 'Failed to revoke tokens.')
+      toast('error', tenant.error ?? 'Failed to revoke tokens.')
     }
   } finally {
     const next = { ...saBusy.value }
@@ -632,6 +723,33 @@ function dismissToken() {
   copiedToken.value = false
 }
 
+// ===== Data loading per selected node ======================================
+
+// One watcher drives all detail fetches: whatever node is selected gets its
+// rosters loaded, and edit state from the previous node is discarded so a
+// half-open rename never carries across nodes.
+watch(
+  sel,
+  async (node) => {
+    editingOrgName.value = false
+    editingWsName.value = false
+    if (!node) return
+    if (node.kind === 'org') {
+      await reloadOrgMembers()
+    } else {
+      await Promise.all([reloadWsMembers(), reloadAppAccessGrants(), reloadSAs()])
+    }
+  },
+  { immediate: true },
+)
+
+// The SA list is gated on workspace-admin; if the viewer's role flips while
+// the node is open (workspaces refetch after a grant), fetch or clear
+// accordingly — the sel watcher alone won't refire.
+watch(canManageWs, () => {
+  if (sel.value?.kind === 'ws') void reloadSAs()
+})
+
 function fmtDate(s?: string | null): string {
   if (!s) return '—'
   try {
@@ -645,657 +763,610 @@ function fmtDate(s?: string | null): string {
 <template>
   <AppLayout>
     <div>
-      <header class="mb-5 flex items-start justify-between gap-4">
-        <div>
-          <h1 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
-            <Building2 class="h-5 w-5 text-accent" :stroke-width="1.75" />
-            Tenant settings
-          </h1>
-          <p class="mt-1 text-sm text-text-muted">
-            Manage your organizations, workspaces, members, and service-account tokens.
-          </p>
-        </div>
+      <header class="mb-5">
+        <h1 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
+          <Building2 class="h-5 w-5 text-accent" :stroke-width="1.75" />
+          Tenancy
+        </h1>
+        <p class="mt-1 text-sm text-text-muted">
+          Organizations contain workspaces; workspaces are isolated control planes where providers,
+          edges, and apps live. Select a node to manage it — org membership grants access to the org,
+          but each workspace keeps its own member list.
+        </p>
       </header>
 
-      <!-- Active-context selector. Drives every section below. -->
-      <div class="mb-4 grid gap-3 sm:grid-cols-2">
-        <div>
-          <label class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-            Active organization
-          </label>
-          <select
-            class="mt-1 w-full rounded-lg border border-border-default/50 bg-surface-overlay/60 px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-            :value="tenant.orgUUID ?? ''"
-            :disabled="tenant.orgs.length === 0"
-            @change="(e) => tenant.selectOrg((e.target as HTMLSelectElement).value)"
-          >
-            <option v-if="tenant.orgs.length === 0" value="">No organizations</option>
-            <option v-for="o in tenant.orgs" :key="o.uuid" :value="o.uuid">
-              {{ o.displayName }}{{ o.personal ? ' (personal)' : '' }}{{ o.deletionRequestedAt ? ' — deleting' : '' }}
-            </option>
-          </select>
-        </div>
-        <div>
-          <label class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-            Active workspace
-          </label>
-          <select
-            class="mt-1 w-full rounded-lg border border-border-default/50 bg-surface-overlay/60 px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-            :value="tenant.workspaceUUID ?? ''"
-            :disabled="!tenant.orgUUID || workspaces.length === 0"
-            @change="(e) => tenant.selectWorkspace((e.target as HTMLSelectElement).value)"
-          >
-            <option v-if="!tenant.orgUUID || workspaces.length === 0" value="">No workspaces</option>
-            <option v-for="w in workspaces" :key="w.uuid" :value="w.uuid">
-              {{ w.displayName || w.uuid }}{{ w.deletionRequestedAt ? ' — deleting' : '' }}
-            </option>
-          </select>
-        </div>
-      </div>
-
-      <!-- Tab strip -->
-      <div class="mb-4 flex flex-wrap gap-1 border-b border-border-default/40">
-        <button
-          v-for="t in [
-            { id: 'org', label: 'Organization', icon: Building2 },
-            { id: 'workspaces', label: 'Workspaces', icon: FolderTree },
-            { id: 'members', label: 'Members', icon: Users },
-            { id: 'sas', label: 'Service accounts', icon: KeyRound },
-          ]"
-          :key="t.id"
-          class="-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12px] font-medium transition-colors"
-          :class="
-            tab === t.id
-              ? 'border-accent text-accent'
-              : 'border-transparent text-text-muted hover:text-text-secondary'
-          "
-          @click="tab = t.id as typeof tab"
-        >
-          <component :is="t.icon" class="h-3.5 w-3.5" :stroke-width="2" />
-          {{ t.label }}
-        </button>
-      </div>
-
-      <!-- Global flash strips -->
-      <div
-        v-if="actionError"
-        class="mb-3 flex items-start gap-2 rounded-lg border border-danger/30 bg-danger-subtle px-3 py-2 text-sm text-danger"
-      >
-        <AlertCircle class="mt-0.5 h-4 w-4 flex-shrink-0" :stroke-width="1.75" />
-        <span class="flex-1">{{ actionError }}</span>
-        <button class="text-danger/70 hover:text-danger" @click="actionError = null">
-          <X class="h-3.5 w-3.5" />
-        </button>
-      </div>
-      <div
-        v-if="actionInfo"
-        class="mb-3 flex items-start gap-2 rounded-lg border border-success/30 bg-success-subtle px-3 py-2 text-sm text-success"
-      >
-        <Check class="mt-0.5 h-4 w-4 flex-shrink-0" :stroke-width="1.75" />
-        <span class="flex-1">{{ actionInfo }}</span>
-        <button class="text-success/70 hover:text-success" @click="actionInfo = null">
-          <X class="h-3.5 w-3.5" />
-        </button>
-      </div>
-
-      <!-- ====== Organization tab ====== -->
-      <section v-if="tab === 'org'" class="space-y-5">
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 text-sm font-semibold text-text-primary">Current organization</h2>
-          <div v-if="!tenant.activeOrg" class="text-sm text-text-muted">No organization selected.</div>
-          <div v-else class="space-y-3">
-            <div class="grid gap-3 sm:grid-cols-2">
-              <div>
-                <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">UUID</div>
-                <div class="font-mono text-[12px] text-text-secondary">{{ tenant.activeOrg.uuid }}</div>
-              </div>
-              <div>
-                <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Type</div>
-                <div class="text-[12px] text-text-secondary">
-                  {{ tenant.activeOrg.personal ? 'Personal' : 'Shared' }}
-                </div>
-              </div>
-              <div>
-                <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Created</div>
-                <div class="text-[12px] text-text-secondary">{{ fmtDate(tenant.activeOrg.createdAt) }}</div>
-              </div>
-              <div v-if="tenant.activeOrg.deletionRequestedAt">
-                <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Deletion requested</div>
-                <div class="text-[12px] text-warning">{{ fmtDate(tenant.activeOrg.deletionRequestedAt) }}</div>
-              </div>
+      <div class="flex flex-col gap-5 lg:flex-row">
+        <!-- ================= Left: tenancy tree ================= -->
+        <nav class="w-full shrink-0 lg:w-72">
+          <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-2">
+            <div v-if="tenant.orgs.length === 0" class="px-3 py-4 text-sm text-text-muted">
+              {{ tenant.loading ? 'Loading organizations…' : 'No organizations.' }}
             </div>
 
-            <div class="border-t border-border-default/30 pt-3">
-              <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Display name</div>
-              <div v-if="!editingOrgName" class="mt-1 flex items-center gap-2">
-                <span class="text-sm text-text-primary">{{ tenant.activeOrg.displayName }}</span>
-                <button
-                  class="rounded-md border border-border-subtle px-2 py-0.5 text-[11px] text-text-muted transition-colors hover:border-accent/30 hover:text-accent"
-                  :disabled="!!tenant.activeOrg.deletionRequestedAt"
-                  @click="startEditOrgName"
+            <ul v-else class="space-y-0.5">
+              <li v-for="o in tenant.orgs" :key="o.uuid">
+                <!-- Org row -->
+                <div
+                  class="group flex items-center gap-1 rounded-lg px-1.5 py-1.5 transition-colors"
+                  :class="
+                    sel?.kind === 'org' && sel.org === o.uuid
+                      ? 'bg-accent/10 text-accent'
+                      : 'text-text-secondary hover:bg-surface-overlay/60'
+                  "
                 >
-                  <Pencil class="inline h-3 w-3" :stroke-width="2" /> Rename
-                </button>
-              </div>
-              <div v-else class="mt-1 flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="rounded p-0.5 text-text-muted hover:text-text-secondary"
+                    :aria-label="isExpanded(o.uuid) ? 'Collapse' : 'Expand'"
+                    @click="toggleExpand(o.uuid)"
+                  >
+                    <ChevronDown v-if="isExpanded(o.uuid)" class="h-3.5 w-3.5" :stroke-width="2" />
+                    <ChevronRight v-else class="h-3.5 w-3.5" :stroke-width="2" />
+                  </button>
+                  <button
+                    type="button"
+                    class="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    @click="clickOrg(o.uuid)"
+                  >
+                    <Building2 class="h-4 w-4 shrink-0" :stroke-width="1.75" />
+                    <span class="truncate text-[13px] font-medium">{{ o.displayName }}</span>
+                    <span
+                      v-if="o.personal"
+                      class="shrink-0 rounded-sm border border-border-default/50 bg-surface-overlay px-1 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted"
+                    >personal</span>
+                    <span
+                      v-if="o.deletionRequestedAt"
+                      class="shrink-0 rounded-sm border border-warning/30 bg-warning-subtle px-1 py-px text-[9px] font-semibold uppercase tracking-wider text-warning"
+                    >deleting</span>
+                  </button>
+                </div>
+
+                <!-- Workspace rows -->
+                <ul v-if="isExpanded(o.uuid)" class="ml-4 space-y-0.5 border-l border-border-default/30 pl-2">
+                  <li v-for="w in workspacesOf(o.uuid)" :key="w.uuid">
+                    <button
+                      type="button"
+                      class="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors"
+                      :class="
+                        sel?.kind === 'ws' && sel.ws === w.uuid
+                          ? 'bg-accent/10 text-accent'
+                          : 'text-text-secondary hover:bg-surface-overlay/60'
+                      "
+                      @click="clickWorkspace(o.uuid, w.uuid)"
+                    >
+                      <FolderTree class="h-3.5 w-3.5 shrink-0" :stroke-width="1.75" />
+                      <span class="truncate text-[12px]">{{ w.displayName || w.uuid }}</span>
+                      <!-- Dot = the portal's globally active workspace; clicking
+                           tree nodes moves it, so show where it currently is. -->
+                      <span
+                        v-if="tenant.workspaceUUID === w.uuid"
+                        class="h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
+                        title="Active workspace — the rest of the portal operates here"
+                      />
+                      <span
+                        v-if="w.deletionRequestedAt"
+                        class="shrink-0 rounded-sm border border-warning/30 bg-warning-subtle px-1 py-px text-[9px] font-semibold uppercase tracking-wider text-warning"
+                      >deleting</span>
+                    </button>
+                  </li>
+
+                  <!-- Inline "+ workspace". Only when the caller may actually
+                       create one here (org admin, or the org opted members in
+                       via workspaceCreation) — otherwise the create would 403. -->
+                  <li v-if="canCreateWorkspaceIn(o.uuid)">
+                    <div v-if="newWsFor === o.uuid" class="flex items-center gap-1 px-2 py-1">
+                      <input
+                        v-model="newWsName"
+                        class="w-full min-w-0 flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-[12px] text-text-primary focus:border-accent focus:outline-none"
+                        placeholder="Workspace name"
+                        autofocus
+                        @keyup.enter="onCreateWorkspace"
+                        @keyup.esc="newWsFor = null"
+                      />
+                      <button
+                        class="rounded-md border border-accent/30 bg-accent/10 p-1 text-accent hover:bg-accent/20 disabled:opacity-50"
+                        :disabled="newWsBusy || !newWsName.trim()"
+                        aria-label="Create workspace"
+                        @click="onCreateWorkspace"
+                      >
+                        <Loader2 v-if="newWsBusy" class="h-3 w-3 animate-spin" :stroke-width="2" />
+                        <Check v-else class="h-3 w-3" :stroke-width="2" />
+                      </button>
+                      <button
+                        class="rounded-md border border-border-subtle p-1 text-text-muted hover:text-text-secondary"
+                        aria-label="Cancel"
+                        @click="newWsFor = null"
+                      >
+                        <X class="h-3 w-3" :stroke-width="2" />
+                      </button>
+                    </div>
+                    <button
+                      v-else
+                      type="button"
+                      class="flex w-full items-center gap-2 rounded-lg px-2 py-1 text-left text-[11px] text-text-muted transition-colors hover:bg-surface-overlay/60 hover:text-text-secondary"
+                      @click="openNewWs(o.uuid)"
+                    >
+                      <Plus class="h-3 w-3" :stroke-width="2" />
+                      New workspace
+                    </button>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+
+            <!-- New organization -->
+            <div class="mt-2 border-t border-border-default/30 pt-2">
+              <div v-if="newOrgOpen" class="flex items-center gap-1 px-1.5 py-1">
                 <input
-                  v-model="orgNameDraft"
-                  class="flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-sm text-text-primary focus:border-accent focus:outline-none"
-                  @keyup.enter="saveOrgName"
+                  v-model="newOrgName"
+                  class="w-full min-w-0 flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-[12px] text-text-primary focus:border-accent focus:outline-none"
+                  placeholder="Organization name"
+                  autofocus
+                  @keyup.enter="onCreateOrg"
+                  @keyup.esc="newOrgOpen = false"
                 />
                 <button
-                  class="rounded-md border border-success/30 bg-success-subtle px-2 py-1 text-[11px] font-medium text-success transition-colors hover:bg-success/15 disabled:opacity-60"
-                  :disabled="orgBusy || !orgNameDraft.trim()"
-                  @click="saveOrgName"
+                  class="rounded-md border border-accent/30 bg-accent/10 p-1 text-accent hover:bg-accent/20 disabled:opacity-50"
+                  :disabled="orgBusy || !newOrgName.trim()"
+                  aria-label="Create organization"
+                  @click="onCreateOrg"
                 >
-                  <Loader2 v-if="orgBusy" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                  <Check v-else class="inline h-3 w-3" :stroke-width="2" /> Save
+                  <Loader2 v-if="orgBusy" class="h-3 w-3 animate-spin" :stroke-width="2" />
+                  <Check v-else class="h-3 w-3" :stroke-width="2" />
                 </button>
                 <button
-                  class="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text-secondary"
-                  @click="editingOrgName = false"
+                  class="rounded-md border border-border-subtle p-1 text-text-muted hover:text-text-secondary"
+                  aria-label="Cancel"
+                  @click="newOrgOpen = false"
                 >
-                  Cancel
+                  <X class="h-3 w-3" :stroke-width="2" />
                 </button>
               </div>
-            </div>
-
-            <div class="flex flex-wrap gap-2 border-t border-border-default/30 pt-3">
-              <button
-                v-if="!tenant.activeOrg.deletionRequestedAt"
-                class="inline-flex items-center gap-1 rounded-lg border border-danger/30 bg-danger-subtle px-2.5 py-1 text-[11px] font-medium text-danger transition-colors hover:bg-danger/15 disabled:opacity-50"
-                :disabled="orgBusy || tenant.activeOrg.personal"
-                :title="tenant.activeOrg.personal ? 'Personal organizations cannot be deleted' : 'Soft-delete with 30-day grace'"
-                @click="onDeleteOrg"
-              >
-                <Trash2 class="h-3 w-3" :stroke-width="2" /> Delete organization
-              </button>
               <button
                 v-else
-                class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-50"
-                :disabled="orgBusy"
-                @click="onUndeleteOrg"
+                type="button"
+                class="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[12px] font-medium text-text-muted transition-colors hover:bg-surface-overlay/60 hover:text-text-secondary"
+                @click="newOrgOpen = true"
               >
-                <RotateCcw class="h-3 w-3" :stroke-width="2" /> Restore organization
+                <Plus class="h-3.5 w-3.5" :stroke-width="2" />
+                New organization
               </button>
             </div>
           </div>
-        </div>
+        </nav>
 
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 text-sm font-semibold text-text-primary">Create a new organization</h2>
-          <p class="mb-3 text-[12px] text-text-muted">
-            New organizations start with a single default workspace and you as the sole admin.
-          </p>
-          <div class="flex flex-wrap items-center gap-2">
-            <input
-              v-model="newOrgName"
-              class="flex-1 min-w-[200px] rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              placeholder="Organization name"
-              @keyup.enter="onCreateOrg"
-            />
-            <button
-              class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
-              :disabled="orgBusy || !newOrgName.trim()"
-              @click="onCreateOrg"
-            >
-              <Loader2 v-if="orgBusy" class="h-3 w-3 animate-spin" :stroke-width="2" />
-              <Plus v-else class="h-3 w-3" :stroke-width="2" />
-              Create organization
-            </button>
-          </div>
-        </div>
-      </section>
-
-      <!-- ====== Workspaces tab ====== -->
-      <section v-if="tab === 'workspaces'" class="space-y-5">
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 text-sm font-semibold text-text-primary">Create workspace</h2>
-          <div v-if="!tenant.orgUUID" class="text-sm text-text-muted">Select an organization first.</div>
-          <div v-else class="flex flex-wrap items-center gap-2">
-            <input
-              v-model="newWorkspaceName"
-              class="flex-1 min-w-[200px] rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              placeholder="Workspace name"
-              @keyup.enter="onCreateWorkspace"
-            />
-            <button
-              class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
-              :disabled="!!wsBusy.__new__ || !newWorkspaceName.trim()"
-              @click="onCreateWorkspace"
-            >
-              <Loader2 v-if="wsBusy.__new__" class="h-3 w-3 animate-spin" :stroke-width="2" />
-              <Plus v-else class="h-3 w-3" :stroke-width="2" />
-              Create workspace
-            </button>
-          </div>
-        </div>
-
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 text-sm font-semibold text-text-primary">Workspaces</h2>
-          <div v-if="!tenant.orgUUID" class="text-sm text-text-muted">Select an organization first.</div>
-          <div v-else-if="workspaces.length === 0" class="text-sm text-text-muted">No workspaces in this organization.</div>
-          <ul v-else class="divide-y divide-border-default/30">
-            <li v-for="w in workspaces" :key="w.uuid" class="flex items-center gap-3 py-2">
-              <FolderTree class="h-4 w-4 text-text-muted/70" :stroke-width="1.75" />
-              <div class="min-w-0 flex-1">
-                <div v-if="editingWS !== w.uuid" class="flex items-center gap-2">
-                  <span class="truncate text-sm text-text-primary">{{ w.displayName || w.uuid }}</span>
-                  <span
-                    v-if="w.deletionRequestedAt"
-                    class="rounded-sm border border-warning/30 bg-warning-subtle px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-warning"
-                  >Deleting</span>
-                </div>
-                <div v-else class="flex items-center gap-2">
-                  <input
-                    v-model="wsNameDraft"
-                    class="flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-sm text-text-primary focus:border-accent focus:outline-none"
-                    @keyup.enter="saveWSName(w.uuid)"
-                  />
-                  <button
-                    class="rounded-md border border-success/30 bg-success-subtle px-2 py-1 text-[11px] font-medium text-success hover:bg-success/15"
-                    :disabled="!!wsBusy[w.uuid] || !wsNameDraft.trim()"
-                    @click="saveWSName(w.uuid)"
-                  >
-                    Save
-                  </button>
-                  <button
-                    class="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted"
-                    @click="editingWS = null"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div class="font-mono text-[10px] text-text-muted">{{ w.uuid }}</div>
-              </div>
-              <div class="flex items-center gap-1">
-                <button
-                  v-if="editingWS !== w.uuid && !w.deletionRequestedAt"
-                  class="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:border-accent/30 hover:text-accent disabled:opacity-50"
-                  :disabled="!!wsBusy[`kc:${w.uuid}`]"
-                  :title="`Download kubeconfig for ${w.displayName || w.uuid}`"
-                  @click="onDownloadKubeconfig(w.uuid)"
-                >
-                  <Loader2 v-if="wsBusy[`kc:${w.uuid}`]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                  <Download v-else class="inline h-3 w-3" :stroke-width="2" />
-                </button>
-                <button
-                  v-if="editingWS !== w.uuid && !w.deletionRequestedAt"
-                  class="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:border-accent/30 hover:text-accent"
-                  @click="startEditWS(w.uuid, w.displayName)"
-                >
-                  <Pencil class="inline h-3 w-3" :stroke-width="2" />
-                </button>
-                <button
-                  v-if="!w.deletionRequestedAt"
-                  class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
-                  :disabled="!!wsBusy[w.uuid]"
-                  @click="onDeleteWorkspace(w.uuid, w.displayName)"
-                >
-                  <Loader2 v-if="wsBusy[w.uuid]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                  <Trash2 v-else class="inline h-3 w-3" :stroke-width="2" />
-                </button>
-                <button
-                  v-else
-                  class="rounded-md border border-accent/30 bg-accent/10 px-2 py-1 text-[11px] font-medium text-accent hover:bg-accent/20 disabled:opacity-50"
-                  :disabled="!!wsBusy[w.uuid]"
-                  @click="onUndeleteWorkspace(w.uuid)"
-                >
-                  <Loader2 v-if="wsBusy[w.uuid]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                  <RotateCcw v-else class="inline h-3 w-3" :stroke-width="2" />
-                  Restore
-                </button>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <!-- ====== Members tab ====== -->
-      <section v-if="tab === 'members'" class="space-y-5">
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 text-sm font-semibold text-text-primary">Add member</h2>
-          <p class="mb-3 text-[12px] text-text-muted">
-            Adding a member to the organization grants them access to the org context; per-workspace
-            access is managed inside each workspace. The person must have signed in at least once so
-            their account exists.
-          </p>
-          <div v-if="!tenant.orgUUID" class="text-sm text-text-muted">Select an organization first.</div>
-          <div v-else class="flex flex-wrap items-center gap-2">
-            <input
-              v-model="newMemberUser"
-              class="flex-1 min-w-[200px] rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              placeholder="email or user UUID"
-              @keyup.enter="onAddMember"
-            />
-            <select
-              v-model="newMemberRole"
-              class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-            >
-              <option value="member">member</option>
-              <option value="admin">admin</option>
-            </select>
-            <button
-              class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
-              :disabled="!!memberBusy.__new__ || !newMemberUser.trim()"
-              @click="onAddMember"
-            >
-              <Loader2 v-if="memberBusy.__new__" class="h-3 w-3 animate-spin" :stroke-width="2" />
-              <Plus v-else class="h-3 w-3" :stroke-width="2" />
-              Add
-            </button>
-          </div>
-        </div>
-
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <div class="mb-3 flex items-center justify-between">
-            <h2 class="text-sm font-semibold text-text-primary">Members</h2>
-            <button
-              v-if="tenant.activeOrg && !tenant.activeOrg.personal"
-              class="inline-flex items-center gap-1 rounded-lg border border-warning/30 bg-warning-subtle px-2 py-1 text-[11px] font-medium text-warning hover:bg-warning/15 disabled:opacity-50"
-              :disabled="!!memberBusy.__self__"
-              @click="onLeaveOrg"
-            >
-              <Loader2 v-if="memberBusy.__self__" class="h-3 w-3 animate-spin" :stroke-width="2" />
-              Leave organization
-            </button>
+        <!-- ================= Right: detail pane ================= -->
+        <div class="min-w-0 flex-1 space-y-5">
+          <div
+            v-if="!sel"
+            class="rounded-xl border border-border-subtle bg-surface-raised/60 p-6 text-sm text-text-muted"
+          >
+            Select an organization or workspace on the left.
           </div>
 
-          <div v-if="!tenant.orgUUID" class="text-sm text-text-muted">Select an organization first.</div>
-          <div v-else-if="membersLoading" class="text-sm text-text-muted">Loading members…</div>
-          <div v-else-if="members.length === 0" class="text-sm text-text-muted">No members.</div>
-          <table v-else class="w-full text-sm">
-            <thead>
-              <tr class="text-left text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-                <th class="py-2 pr-3">User</th>
-                <th class="py-2 pr-3">Role</th>
-                <th class="py-2 pr-3 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-border-default/30">
-              <tr v-for="m in members" :key="m.user">
-                <td class="py-2 pr-3">
-                  <div class="flex items-center gap-2">
-                    <UserIcon class="h-3.5 w-3.5 text-text-muted/70" :stroke-width="1.75" />
-                    <span class="font-mono text-[12px] text-text-secondary">{{ m.user }}</span>
+          <!-- ========== Organization detail ========== -->
+          <template v-else-if="sel.kind === 'org' && selOrg">
+            <!-- Overview -->
+            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+              <div class="mb-4 flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">
+                    Organization
                   </div>
-                </td>
-                <td class="py-2 pr-3">
-                  <select
-                    class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-[12px] text-text-primary focus:border-accent focus:outline-none disabled:opacity-60"
-                    :value="m.role"
-                    :disabled="!!memberBusy[m.user]"
-                    @change="(e) => onChangeMemberRole(m.user, (e.target as HTMLSelectElement).value as 'admin' | 'member')"
-                  >
-                    <option value="member">member</option>
-                    <option value="admin">admin</option>
-                  </select>
-                </td>
-                <td class="py-2 pr-0 text-right">
-                  <button
-                    class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
-                    :disabled="!!memberBusy[m.user]"
-                    @click="onRemoveMember(m.user)"
-                  >
-                    <Loader2 v-if="memberBusy[m.user]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                    <Trash2 v-else class="inline h-3 w-3" :stroke-width="2" />
-                    Remove
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <!-- Workspace members: grant access to an existing workspace -->
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-1 text-sm font-semibold text-text-primary">Workspace members</h2>
-          <p class="mb-3 text-[12px] text-text-muted">
-            Grant someone access to the
-            <span v-if="tenant.activeWorkspace" class="font-medium text-text-secondary">
-              “{{ tenant.activeWorkspace.displayName || tenant.activeWorkspace.uuid }}”
-            </span>
-            workspace selected on the left. Org membership alone doesn’t reveal any workspace — a
-            member sees a workspace only after they’re added here.
-          </p>
-
-          <div v-if="!tenant.orgUUID || !tenant.workspaceUUID" class="text-sm text-text-muted">
-            Select an organization and workspace on the left first.
-          </div>
-          <template v-else>
-            <div class="mb-4 flex flex-wrap items-center gap-2">
-              <input
-                v-model="newWsMemberUser"
-                class="flex-1 min-w-[200px] rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-                placeholder="email or user UUID"
-                @keyup.enter="onAddWsMember"
-              />
-              <select
-                v-model="newWsMemberRole"
-                class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              >
-                <option value="member">member</option>
-                <option value="admin">admin</option>
-              </select>
-              <button
-                class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
-                :disabled="!!wsMemberBusy.__new__ || !newWsMemberUser.trim()"
-                @click="onAddWsMember"
-              >
-                <Loader2 v-if="wsMemberBusy.__new__" class="h-3 w-3 animate-spin" :stroke-width="2" />
-                <Plus v-else class="h-3 w-3" :stroke-width="2" />
-                Add
-              </button>
-            </div>
-
-            <div v-if="wsMembersLoading" class="text-sm text-text-muted">Loading members…</div>
-            <div v-else-if="wsMembers.length === 0" class="text-sm text-text-muted">
-              No workspace members yet.
-            </div>
-            <table v-else class="w-full text-sm">
-              <thead>
-                <tr class="text-left text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-                  <th class="py-2 pr-3">User</th>
-                  <th class="py-2 pr-3">Role</th>
-                  <th class="py-2 pr-3 text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-border-default/30">
-                <tr v-for="m in wsMembers" :key="m.user">
-                  <td class="py-2 pr-3">
-                    <div class="flex items-center gap-2">
-                      <UserIcon class="h-3.5 w-3.5 text-text-muted/70" :stroke-width="1.75" />
-                      <span class="font-mono text-[12px] text-text-secondary">{{ m.user }}</span>
-                    </div>
-                  </td>
-                  <td class="py-2 pr-3">
-                    <select
-                      class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-[12px] text-text-primary focus:border-accent focus:outline-none disabled:opacity-60"
-                      :value="m.role"
-                      :disabled="!!wsMemberBusy[m.user]"
-                      @change="(e) => onChangeWsMemberRole(m.user, (e.target as HTMLSelectElement).value as 'admin' | 'member')"
-                    >
-                      <option value="member">member</option>
-                      <option value="admin">admin</option>
-                    </select>
-                  </td>
-                  <td class="py-2 pr-0 text-right">
+                  <div v-if="!editingOrgName" class="mt-1 flex items-center gap-2">
+                    <h2 class="truncate text-lg font-semibold text-text-primary">{{ selOrg.displayName }}</h2>
                     <button
-                      class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
-                      :disabled="!!wsMemberBusy[m.user]"
-                      @click="onRemoveWsMember(m.user)"
+                      v-if="canManageOrg"
+                      class="rounded-md border border-border-subtle px-2 py-0.5 text-[11px] text-text-muted transition-colors hover:border-accent/30 hover:text-accent disabled:opacity-50"
+                      :disabled="!!selOrg.deletionRequestedAt"
+                      @click="startEditOrgName"
                     >
-                      <Loader2 v-if="wsMemberBusy[m.user]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                      <Trash2 v-else class="inline h-3 w-3" :stroke-width="2" />
-                      Remove
+                      <Pencil class="inline h-3 w-3" :stroke-width="2" /> Rename
                     </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </template>
-        </div>
-
-        <!-- App access grants: who can open private published apps. These are
-             plain workspace RBAC (labeled ClusterRoleBindings on the app
-             instance's access subresource) written by App Studio's share
-             dialog — listed here so invitations stay visible and revocable
-             outside the app workbench. -->
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-1 text-sm font-semibold text-text-primary">App access</h2>
-          <p class="mb-3 text-[12px] text-text-muted">
-            Members invited to open <span class="font-medium text-text-secondary">private published apps</span>
-            in this workspace. Each grant is a workspace RBAC role binding on the app instance;
-            invite members from the app's Share dialog in App Studio. Workspace members can open
-            every app here without an explicit grant.
-          </p>
-
-          <div v-if="!tenant.orgUUID || !tenant.workspaceUUID" class="text-sm text-text-muted">
-            Select an organization and workspace on the left first.
-          </div>
-          <template v-else>
-            <div v-if="appAccessLoading" class="text-sm text-text-muted">Loading app access grants…</div>
-            <div v-else-if="appAccessGrants.length === 0" class="text-sm text-text-muted">
-              No app access grants. Public apps need none; private apps grant access per member.
-            </div>
-            <table v-else class="w-full text-sm">
-              <thead>
-                <tr class="text-left text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-                  <th class="py-2 pr-3">App</th>
-                  <th class="py-2 pr-3">User</th>
-                  <th class="py-2 pr-3">Role binding</th>
-                  <th class="py-2 pr-3 text-right">Actions</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-border-default/30">
-                <tr v-for="grant in appAccessGrants" :key="grant.binding">
-                  <td class="py-2 pr-3">
-                    <span class="font-mono text-[12px] text-text-secondary">{{ grant.app }}</span>
-                  </td>
-                  <td class="py-2 pr-3">
-                    <div class="flex items-center gap-2">
-                      <UserIcon class="h-3.5 w-3.5 text-text-muted/70" :stroke-width="1.75" />
-                      <span class="font-mono text-[12px] text-text-secondary">{{ grant.user }}</span>
-                    </div>
-                  </td>
-                  <td class="py-2 pr-3">
-                    <span class="font-mono text-[11px] text-text-muted">{{ grant.binding }}</span>
-                  </td>
-                  <td class="py-2 pr-0 text-right">
+                    <span
+                      v-else
+                      class="rounded-sm border border-border-default/50 bg-surface-overlay px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted"
+                      title="You are a member of this organization; admins manage it"
+                    >member</span>
+                  </div>
+                  <div v-else class="mt-1 flex items-center gap-2">
+                    <input
+                      v-model="orgNameDraft"
+                      class="flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-sm text-text-primary focus:border-accent focus:outline-none"
+                      @keyup.enter="saveOrgName"
+                      @keyup.esc="editingOrgName = false"
+                    />
                     <button
-                      class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
-                      :disabled="!!appAccessBusy[grant.binding]"
-                      @click="onRevokeAppAccess(grant)"
+                      class="rounded-md border border-success/30 bg-success-subtle px-2 py-1 text-[11px] font-medium text-success transition-colors hover:bg-success/15 disabled:opacity-60"
+                      :disabled="orgBusy || !orgNameDraft.trim()"
+                      @click="saveOrgName"
                     >
-                      <Loader2 v-if="appAccessBusy[grant.binding]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                      <Trash2 v-else class="inline h-3 w-3" :stroke-width="2" />
+                      <Loader2 v-if="orgBusy" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
+                      <Check v-else class="inline h-3 w-3" :stroke-width="2" /> Save
+                    </button>
+                    <button
+                      class="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text-secondary"
+                      @click="editingOrgName = false"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">UUID</div>
+                  <div class="font-mono text-[12px] text-text-secondary">{{ selOrg.uuid }}</div>
+                </div>
+                <div>
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Type</div>
+                  <div class="text-[12px] text-text-secondary">{{ selOrg.personal ? 'Personal' : 'Shared' }}</div>
+                </div>
+                <div>
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Created</div>
+                  <div class="text-[12px] text-text-secondary">{{ fmtDate(selOrg.createdAt) }}</div>
+                </div>
+                <div v-if="selOrg.deletionRequestedAt">
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Deletion requested</div>
+                  <div class="text-[12px] text-warning">{{ fmtDate(selOrg.deletionRequestedAt) }}</div>
+                </div>
+              </div>
+
+              <!-- Danger zone. Delete/restore are org-admin; leave is any
+                   member of a shared org — so a plain member still sees the
+                   zone, holding only the action they can actually take. -->
+              <div class="mt-4 rounded-lg border border-danger/20 p-3">
+                <div class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-danger/80">Danger zone</div>
+                <div class="flex flex-wrap gap-2">
+                  <template v-if="canManageOrg">
+                    <button
+                      v-if="!selOrg.deletionRequestedAt"
+                      class="inline-flex items-center gap-1 rounded-lg border border-danger/30 bg-danger-subtle px-2.5 py-1 text-[11px] font-medium text-danger transition-colors hover:bg-danger/15 disabled:opacity-50"
+                      :disabled="orgBusy || selOrg.personal"
+                      :title="selOrg.personal ? 'Personal organizations cannot be deleted' : 'Soft-delete with 30-day grace'"
+                      @click="onDeleteOrg"
+                    >
+                      <Trash2 class="h-3 w-3" :stroke-width="2" /> Delete organization
+                    </button>
+                    <button
+                      v-else
+                      class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-50"
+                      :disabled="orgBusy"
+                      @click="onUndeleteOrg"
+                    >
+                      <RotateCcw class="h-3 w-3" :stroke-width="2" /> Restore organization
+                    </button>
+                  </template>
+                  <button
+                    v-if="!selOrg.personal"
+                    class="inline-flex items-center gap-1 rounded-lg border border-warning/30 bg-warning-subtle px-2.5 py-1 text-[11px] font-medium text-warning transition-colors hover:bg-warning/15 disabled:opacity-50"
+                    :disabled="orgBusy"
+                    @click="onLeaveOrg"
+                  >
+                    Leave organization
+                  </button>
+                  <span v-if="selOrg.personal" class="self-center text-[11px] text-text-muted">
+                    Your personal organization cannot be deleted or left.
+                  </span>
+                </div>
+              </div>
+            </section>
+
+            <!-- Org members -->
+            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+              <h3 class="mb-1 text-sm font-semibold text-text-primary">Organization members</h3>
+              <p class="mb-3 text-[12px] text-text-muted">
+                <template v-if="canManageOrg">
+                  Members can select this organization in the portal, but see a workspace only after
+                  being added to that workspace's own member list. The person must have signed in once
+                  so their account exists.
+                </template>
+                <template v-else>
+                  Only organization admins can add, remove, or change members.
+                </template>
+              </p>
+              <MemberList
+                :members="orgMembers"
+                :loading="orgMembersLoading"
+                :busy="orgMemberBusy"
+                scope-label="this organization"
+                :add="onAddOrgMember"
+                :readonly="!canManageOrg"
+                @change-role="onChangeOrgMemberRole"
+                @remove="onRemoveOrgMember"
+              />
+            </section>
+          </template>
+
+          <!-- ========== Workspace detail ========== -->
+          <template v-else-if="sel.kind === 'ws' && selWs">
+            <!-- Overview -->
+            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+              <div class="mb-4 flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">
+                    Workspace · {{ selOrg?.displayName }}
+                  </div>
+                  <div v-if="!editingWsName" class="mt-1 flex items-center gap-2">
+                    <h2 class="truncate text-lg font-semibold text-text-primary">{{ selWs.displayName || selWs.uuid }}</h2>
+                    <button
+                      v-if="canManageWs"
+                      class="rounded-md border border-border-subtle px-2 py-0.5 text-[11px] text-text-muted transition-colors hover:border-accent/30 hover:text-accent disabled:opacity-50"
+                      :disabled="!!selWs.deletionRequestedAt"
+                      @click="startEditWsName"
+                    >
+                      <Pencil class="inline h-3 w-3" :stroke-width="2" /> Rename
+                    </button>
+                    <span
+                      v-else
+                      class="rounded-sm border border-border-default/50 bg-surface-overlay px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted"
+                      title="You are a member of this workspace; workspace admins manage it"
+                    >member</span>
+                  </div>
+                  <div v-else class="mt-1 flex items-center gap-2">
+                    <input
+                      v-model="wsNameDraft"
+                      class="flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-2 py-1 text-sm text-text-primary focus:border-accent focus:outline-none"
+                      @keyup.enter="saveWsName"
+                      @keyup.esc="editingWsName = false"
+                    />
+                    <button
+                      class="rounded-md border border-success/30 bg-success-subtle px-2 py-1 text-[11px] font-medium text-success transition-colors hover:bg-success/15 disabled:opacity-60"
+                      :disabled="wsBusy || !wsNameDraft.trim()"
+                      @click="saveWsName"
+                    >
+                      <Loader2 v-if="wsBusy" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
+                      <Check v-else class="inline h-3 w-3" :stroke-width="2" /> Save
+                    </button>
+                    <button
+                      class="rounded-md border border-border-subtle px-2 py-1 text-[11px] text-text-muted hover:text-text-secondary"
+                      @click="editingWsName = false"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+                <button
+                  class="inline-flex shrink-0 items-center gap-1 rounded-lg border border-border-subtle px-2.5 py-1 text-[11px] font-medium text-text-muted transition-colors hover:border-accent/30 hover:text-accent disabled:opacity-50"
+                  :disabled="kubeconfigBusy || !!selWs.deletionRequestedAt"
+                  title="Download a kubeconfig targeting this workspace's control plane"
+                  @click="onDownloadKubeconfig"
+                >
+                  <Loader2 v-if="kubeconfigBusy" class="h-3 w-3 animate-spin" :stroke-width="2" />
+                  <Download v-else class="h-3 w-3" :stroke-width="2" />
+                  Kubeconfig
+                </button>
+              </div>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">UUID</div>
+                  <div class="font-mono text-[12px] text-text-secondary">{{ selWs.uuid }}</div>
+                </div>
+                <div>
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Cluster</div>
+                  <div class="font-mono text-[12px] text-text-secondary">
+                    {{ selWs.clusterName || 'provisioning…' }}
+                  </div>
+                </div>
+                <div v-if="selWs.deletionRequestedAt">
+                  <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Deletion requested</div>
+                  <div class="text-[12px] text-warning">{{ fmtDate(selWs.deletionRequestedAt) }}</div>
+                </div>
+              </div>
+
+              <!-- Danger zone — workspace-admin only; members have no
+                   destructive action to take here, so the zone disappears
+                   entirely rather than showing disabled buttons. -->
+              <div v-if="canManageWs" class="mt-4 rounded-lg border border-danger/20 p-3">
+                <div class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-danger/80">Danger zone</div>
+                <div class="flex flex-wrap gap-2">
+                  <button
+                    v-if="!selWs.deletionRequestedAt"
+                    class="inline-flex items-center gap-1 rounded-lg border border-danger/30 bg-danger-subtle px-2.5 py-1 text-[11px] font-medium text-danger transition-colors hover:bg-danger/15 disabled:opacity-50"
+                    :disabled="wsBusy"
+                    title="Soft-delete with 30-day grace"
+                    @click="onDeleteWorkspace"
+                  >
+                    <Trash2 class="h-3 w-3" :stroke-width="2" /> Delete workspace
+                  </button>
+                  <button
+                    v-else
+                    class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-50"
+                    :disabled="wsBusy"
+                    @click="onUndeleteWorkspace"
+                  >
+                    <RotateCcw class="h-3 w-3" :stroke-width="2" /> Restore workspace
+                  </button>
+                </div>
+              </div>
+            </section>
+
+            <!-- Workspace members -->
+            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+              <h3 class="mb-1 text-sm font-semibold text-text-primary">Workspace members</h3>
+              <p class="mb-3 text-[12px] text-text-muted">
+                <template v-if="canManageWs">
+                  Who can open this workspace. Org membership alone doesn't reveal it — people appear
+                  here either by being added directly or via cascade when joining the org's workspaces.
+                </template>
+                <template v-else>
+                  Who can open this workspace. Only workspace admins can add, remove, or change members.
+                </template>
+              </p>
+              <MemberList
+                :members="wsMembers"
+                :loading="wsMembersLoading"
+                :busy="wsMemberBusy"
+                scope-label="this workspace"
+                :add="onAddWsMember"
+                :readonly="!canManageWs"
+                @change-role="onChangeWsMemberRole"
+                @remove="onRemoveWsMember"
+              />
+            </section>
+
+            <!-- App access grants -->
+            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+              <h3 class="mb-1 text-sm font-semibold text-text-primary">App access</h3>
+              <p class="mb-3 text-[12px] text-text-muted">
+                People invited to open <span class="font-medium text-text-secondary">private published apps</span>
+                in this workspace without being workspace members. Invitations are sent from the
+                app's Share dialog in App Studio; this list keeps them visible and revocable.
+                Workspace members can open every app here without a grant.
+              </p>
+
+              <div v-if="appAccessLoading" class="text-sm text-text-muted">Loading app access grants…</div>
+              <div v-else-if="appAccessGrants.length === 0" class="text-sm text-text-muted">
+                No app access grants. Public apps need none; private apps grant access per person.
+              </div>
+              <table v-else class="w-full text-sm">
+                <thead>
+                  <tr class="text-left text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                    <th class="py-2 pr-3">App</th>
+                    <th class="py-2 pr-3">User</th>
+                    <th v-if="canManageWs" class="py-2 pr-0 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-border-default/30">
+                  <tr v-for="grant in appAccessGrants" :key="grant.binding">
+                    <td class="py-2 pr-3">
+                      <span class="font-mono text-[12px] text-text-secondary">{{ grant.app }}</span>
+                    </td>
+                    <td class="py-2 pr-3">
+                      <div class="flex items-center gap-2">
+                        <UserIcon class="h-3.5 w-3.5 text-text-muted/70" :stroke-width="1.75" />
+                        <span class="font-mono text-[12px] text-text-secondary">{{ grant.user }}</span>
+                      </div>
+                    </td>
+                    <!-- Revoke is workspace-admin only (the grant list itself
+                         is visible to every workspace member). -->
+                    <td v-if="canManageWs" class="py-2 pr-0 text-right">
+                      <button
+                        class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
+                        :disabled="!!appAccessBusy[grant.binding]"
+                        @click="onRevokeAppAccess(grant)"
+                      >
+                        <Loader2 v-if="appAccessBusy[grant.binding]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
+                        <Trash2 v-else class="inline h-3 w-3" :stroke-width="2" />
+                        Revoke
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+
+            <!-- Service accounts -->
+            <section class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
+              <h3 class="mb-1 flex items-center gap-2 text-sm font-semibold text-text-primary">
+                <KeyRound class="h-4 w-4 text-accent" :stroke-width="1.75" /> Service accounts
+              </h3>
+              <p class="mb-3 text-[12px] text-text-muted">
+                Machine identities scoped to this workspace, authenticating with short-lived bearer
+                tokens — use them for CI and automation instead of personal credentials. The role
+                controls what faros APIs the token can call.
+              </p>
+
+              <!-- Every SA endpoint (including list) is workspace-admin only,
+                   so members get the explanation, not controls that 403. -->
+              <div v-if="!canManageWs" class="rounded-lg border border-border-subtle bg-surface-overlay/40 px-3 py-2 text-[12px] text-text-muted">
+                Only workspace admins can view and manage service accounts.
+              </div>
+
+              <div v-if="canManageWs" class="mb-4 flex flex-wrap items-center gap-2">
+                <input
+                  v-model="newSAName"
+                  class="min-w-[200px] flex-1 rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+                  placeholder="Service account name"
+                  @keyup.enter="onCreateSA"
+                />
+                <select
+                  v-model="newSARole"
+                  class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+                >
+                  <option value="member">member</option>
+                  <option value="admin">admin</option>
+                </select>
+                <button
+                  class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
+                  :disabled="!!saBusy.__new__ || !newSAName.trim()"
+                  @click="onCreateSA"
+                >
+                  <Loader2 v-if="saBusy.__new__" class="h-3 w-3 animate-spin" :stroke-width="2" />
+                  <Plus v-else class="h-3 w-3" :stroke-width="2" />
+                  Create
+                </button>
+              </div>
+
+              <div v-if="!canManageWs" class="hidden" />
+              <div v-else-if="sasLoading" class="text-sm text-text-muted">Loading service accounts…</div>
+              <div v-else-if="sas.length === 0" class="text-sm text-text-muted">
+                No service accounts in this workspace.
+              </div>
+              <ul v-else class="divide-y divide-border-default/30">
+                <li v-for="s in sas" :key="s.uuid" class="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-2">
+                  <div class="flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay/60">
+                    <ShieldCheck class="h-4 w-4 text-accent" :stroke-width="1.75" />
+                  </div>
+                  <div class="min-w-0">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class="truncate text-sm text-text-primary">{{ s.displayName }}</span>
+                      <span
+                        class="rounded-sm border border-border-default/50 bg-surface-overlay px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted"
+                      >{{ s.role }}</span>
+                    </div>
+                    <div class="font-mono text-[10px] text-text-muted">{{ s.uuid }}</div>
+                    <div class="text-[10px] text-text-muted">
+                      Created {{ fmtDate(s.createdAt) }}
+                      <span v-if="s.lastTokenIssuedAt"> · last token {{ fmtDate(s.lastTokenIssuedAt) }}</span>
+                    </div>
+                  </div>
+                  <div class="flex flex-wrap items-center gap-1">
+                    <button
+                      class="rounded-md border border-accent/30 bg-accent/10 px-2 py-1 text-[11px] font-medium text-accent hover:bg-accent/20 disabled:opacity-50"
+                      :disabled="!!saBusy[s.uuid]"
+                      @click="onIssueToken(s.uuid, s.displayName)"
+                    >
+                      <Loader2 v-if="saBusy[s.uuid]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
+                      <KeyRound v-else class="inline h-3 w-3" :stroke-width="2" />
+                      Issue token
+                    </button>
+                    <button
+                      class="rounded-md border border-warning/30 bg-warning-subtle px-2 py-1 text-[11px] font-medium text-warning hover:bg-warning/15 disabled:opacity-50"
+                      :disabled="!!saBusy[s.uuid]"
+                      @click="onRevokeTokens(s.uuid, s.displayName)"
+                    >
                       Revoke
                     </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                    <button
+                      class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
+                      :disabled="!!saBusy[s.uuid]"
+                      @click="onDeleteSA(s.uuid, s.displayName)"
+                    >
+                      <Trash2 class="inline h-3 w-3" :stroke-width="2" /> Delete
+                    </button>
+                  </div>
+                </li>
+              </ul>
+            </section>
           </template>
-        </div>
-      </section>
 
-      <!-- ====== Service Accounts tab ====== -->
-      <section v-if="tab === 'sas'" class="space-y-5">
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 flex items-center gap-2 text-sm font-semibold text-text-primary">
-            <KeyRound class="h-4 w-4 text-accent" :stroke-width="1.75" /> Create service account
-          </h2>
-          <p class="mb-3 text-[12px] text-text-muted">
-            Service accounts are scoped to the active workspace and authenticate via short-lived
-            bearer tokens. The role controls what faros APIs the token can call.
-          </p>
-          <div v-if="!tenant.orgUUID || !tenant.workspaceUUID" class="text-sm text-text-muted">
-            Select an organization and workspace first.
-          </div>
-          <div v-else class="flex flex-wrap items-center gap-2">
-            <input
-              v-model="newSAName"
-              class="flex-1 min-w-[200px] rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-              placeholder="Service account name"
-              @keyup.enter="onCreateSA"
-            />
-            <select
-              v-model="newSARole"
-              class="rounded-md border border-border-default/50 bg-surface-overlay/60 px-3 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
-            >
-              <option value="member">member</option>
-              <option value="admin">admin</option>
-            </select>
-            <button
-              class="inline-flex items-center gap-1 rounded-lg border border-accent/30 bg-accent/10 px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:bg-accent/20 disabled:opacity-60"
-              :disabled="!!saBusy.__new__ || !newSAName.trim()"
-              @click="onCreateSA"
-            >
-              <Loader2 v-if="saBusy.__new__" class="h-3 w-3 animate-spin" :stroke-width="2" />
-              <Plus v-else class="h-3 w-3" :stroke-width="2" />
-              Create
-            </button>
+          <!-- Node vanished (deleted elsewhere / list refreshed): fall back
+               to a neutral message rather than a half-rendered pane. -->
+          <div
+            v-else
+            class="rounded-xl border border-border-subtle bg-surface-raised/60 p-6 text-sm text-text-muted"
+          >
+            This item is no longer available. Pick another node on the left.
           </div>
         </div>
-
-        <div class="rounded-xl border border-border-subtle bg-surface-raised/60 p-5">
-          <h2 class="mb-3 text-sm font-semibold text-text-primary">Service accounts</h2>
-          <div v-if="!tenant.orgUUID || !tenant.workspaceUUID" class="text-sm text-text-muted">
-            Select an organization and workspace first.
-          </div>
-          <div v-else-if="sasLoading" class="text-sm text-text-muted">Loading service accounts…</div>
-          <div v-else-if="sas.length === 0" class="text-sm text-text-muted">No service accounts in this workspace.</div>
-          <ul v-else class="divide-y divide-border-default/30">
-            <li v-for="s in sas" :key="s.uuid" class="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-2">
-              <div class="flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay/60">
-                <ShieldCheck class="h-4 w-4 text-accent" :stroke-width="1.75" />
-              </div>
-              <div class="min-w-0">
-                <div class="flex flex-wrap items-center gap-2">
-                  <span class="truncate text-sm text-text-primary">{{ s.displayName }}</span>
-                  <span
-                    class="rounded-sm border border-border-default/50 bg-surface-overlay px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted"
-                  >{{ s.role }}</span>
-                </div>
-                <div class="font-mono text-[10px] text-text-muted">{{ s.uuid }}</div>
-                <div class="text-[10px] text-text-muted">
-                  Created {{ fmtDate(s.createdAt) }}
-                  <span v-if="s.lastTokenIssuedAt"> · last token {{ fmtDate(s.lastTokenIssuedAt) }}</span>
-                </div>
-              </div>
-              <div class="flex flex-wrap items-center gap-1">
-                <button
-                  class="rounded-md border border-accent/30 bg-accent/10 px-2 py-1 text-[11px] font-medium text-accent hover:bg-accent/20 disabled:opacity-50"
-                  :disabled="!!saBusy[s.uuid]"
-                  @click="onIssueToken(s.uuid, s.displayName)"
-                >
-                  <Loader2 v-if="saBusy[s.uuid]" class="inline h-3 w-3 animate-spin" :stroke-width="2" />
-                  <KeyRound v-else class="inline h-3 w-3" :stroke-width="2" />
-                  Issue token
-                </button>
-                <button
-                  class="rounded-md border border-warning/30 bg-warning-subtle px-2 py-1 text-[11px] font-medium text-warning hover:bg-warning/15 disabled:opacity-50"
-                  :disabled="!!saBusy[s.uuid]"
-                  @click="onRevokeTokens(s.uuid, s.displayName)"
-                >
-                  Revoke
-                </button>
-                <button
-                  class="rounded-md border border-danger/30 bg-danger-subtle px-2 py-1 text-[11px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50"
-                  :disabled="!!saBusy[s.uuid]"
-                  @click="onDeleteSA(s.uuid, s.displayName)"
-                >
-                  <Trash2 class="inline h-3 w-3" :stroke-width="2" /> Delete
-                </button>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </section>
+      </div>
     </div>
 
-    <!-- Issued-token modal. Only shown once — the token isn't reversible
-         (we don't store the plaintext) so the user must copy it now. -->
+    <!-- Issued-token modal. Only shown once — the token isn't retrievable
+         later (we don't store the plaintext) so the user must copy it now. -->
     <div
       v-if="issuedToken"
       class="fixed inset-0 z-[120] flex items-center justify-center bg-surface/70 backdrop-blur-sm"

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -7,6 +7,10 @@ import { authFetch } from '@/auth/session'
 export interface ProviderDTO {
   name: string
   displayName: string
+  // Short "what is this" blurb from CatalogEntry.spec.description. The
+  // catalog cards and the first-run welcome flow render it; may be absent
+  // on entries that declare none.
+  description?: string
   version?: string
   ready: boolean
   hasUI: boolean
@@ -88,6 +92,16 @@ export const useProvidersStore = defineStore('providers', () => {
   // user's tenant workspace. Empty when the provider is not enabled for
   // this user. Used by the Disable button and the catalog status badge.
   const bindingNamesByProvider = ref<Record<string, string>>({})
+
+  // bindingsWorkspace records which workspace the map above was fetched for,
+  // and is the only safe way to read an *empty* map as "nothing is enabled
+  // here". Two windows make emptiness ambiguous otherwise: load() flips
+  // `loaded` before awaiting refreshBindings, and on a workspace switch the map
+  // holds the previous workspace's answer until the refetch lands. Callers that
+  // branch on emptiness (the first-run welcome flow) must check this matches
+  // the active workspace; callers that only read individual entries (the
+  // sidebar, the Disable button) tolerate the staleness and don't need it.
+  const bindingsWorkspace = ref<string | null>(null)
 
   // ProviderNavItem captures one provider entry plus its declared sub-nav.
   // children[] carries the routes the side-nav renders indented under the
@@ -197,6 +211,42 @@ export const useProvidersStore = defineStore('providers', () => {
     return !!bindingNamesByProvider.value[name]
   }
 
+  // enableable is the set of providers the user can actually turn on in the
+  // current workspace: ready, and declaring an APIExport to bind. Everything
+  // else in the catalog is either still starting up or shows up unconditionally
+  // (built-ins), so neither belongs in a "what can I switch on" list.
+  //
+  // Ordering matches the catalog page: registry categories by declared order,
+  // then ad-hoc categories alphabetically, then uncategorized — which puts the
+  // foundational ones (Edges, AI) in front of the long tail. The welcome flow
+  // leans on that to present a sane reading order without its own ranking.
+  const enableable = computed<ProviderDTO[]>(() => {
+    const known = new Map(categories.value.map((c) => [c.name, c]))
+    const rank = (name: string) => {
+      const c = known.get(name)
+      // Unknown/ad-hoc categories sort after every registered one, and
+      // uncategorized entries after those.
+      if (!name) return Number.MAX_SAFE_INTEGER
+      return c ? (c.order ?? 0) : Number.MAX_SAFE_INTEGER - 1
+    }
+    return items.value
+      .filter((p) => p.ready && !!p.apiExportName)
+      .slice()
+      .sort((a, b) => {
+        const ca = a.category ?? ''
+        const cb = b.category ?? ''
+        return (
+          rank(ca) - rank(cb) ||
+          ca.localeCompare(cb) ||
+          a.displayName.localeCompare(b.displayName)
+        )
+      })
+  })
+
+  // hasAnyEnabled answers "has this workspace been set up at all?". False for a
+  // fresh workspace, which is what triggers the welcome flow on the dashboard.
+  const hasAnyEnabled = computed(() => Object.keys(bindingNamesByProvider.value).length > 0)
+
   function isDependencySatisfied(name: string): boolean {
     const p = byName(name)
     if (!p) return isEnabled(name)
@@ -268,6 +318,7 @@ export const useProvidersStore = defineStore('providers', () => {
     if (!res.ok) throw new Error(`list enabled providers: ${res.status}`)
     const body = (await res.json()) as { bindingNamesByProvider?: Record<string, string> }
     bindingNamesByProvider.value = body.bindingNamesByProvider ?? {}
+    bindingsWorkspace.value = t.workspaceUUID
   }
 
   // enable hits the server-side endpoint
@@ -381,8 +432,11 @@ export const useProvidersStore = defineStore('providers', () => {
     loading,
     error,
     bindingNamesByProvider,
+    bindingsWorkspace,
     enabledNavItems,
     categorizedNavItems,
+    enableable,
+    hasAnyEnabled,
     isEnabled,
     missingDependencies,
     hasMissingDependencies,

--- a/portal/src/stores/tenant.ts
+++ b/portal/src/stores/tenant.ts
@@ -56,6 +56,10 @@ export interface OrgRow {
   catalogEntryCreation?: string
   createdAt?: string
   deletionRequestedAt?: string | null
+  // The CALLER's org-scope role. The tenant settings page hides
+  // admin-only controls (member management, rename, delete) when this
+  // isn't 'admin', instead of rendering buttons that only 403.
+  role?: 'admin' | 'member'
 }
 
 export interface WorkspaceRow {
@@ -70,11 +74,21 @@ export interface WorkspaceRow {
   // in the sidebar; omitted by the hub until the workspace reports Ready.
   clusterName?: string
   deletionRequestedAt?: string | null
+  // The CALLER's workspace-scope role; absent when they hold no
+  // workspace-scope membership here (possible for org admins, who can
+  // list all workspaces but manage only those they're workspace-admin
+  // in). Gates the workspace-admin controls in tenant settings.
+  role?: 'admin' | 'member'
 }
 
 export interface MemberRow {
   user: string
   role: 'admin' | 'member'
+  // Human labels for the member — `user` is the CR name
+  // ("static-user-47b9dce0…"), which is meaningless in a roster. Either
+  // may be absent (pending invites, token users without profile data).
+  email?: string
+  userDisplayName?: string
   orgUUID: string
   workspaceUUID?: string
   orgDisplayName?: string


### PR DESCRIPTION
## Problem

Every provider in this repo ships as a chart-deployed `CatalogEntry` with an `apiExport`, so nothing is enabled by default. A fresh account lands on an empty dashboard *and* an empty side nav, and the empty state was a single grey line pointing at `/providers` — which assumes the reader already knows what a provider is.

Separately, `CatalogEntry.spec.description` was already filled in by every provider chart, but the hub dropped it before it reached the portal. Even the catalog page showed bare resource names.

## What changed

**A three-step first-run flow** ([`WelcomeWizard.vue`](portal/src/components/WelcomeWizard.vue)):
1. The four concepts worth knowing — org, workspace, provider, edge.
2. The enableable providers, each with its description, enabled in place.
3. What changed and where to go next.

Enabling always routes through the existing `ProviderEnableDialog`, so permission-claim consent is never bypassed by the onboarding path. Dismissal is per workspace (workspaces are independent clusters — setting one up says nothing about the next) and local-only, with a **Getting started** button in the dashboard header keeping the flow reachable afterwards.

**Description plumbing** — `registry.Provider.Description` → set from `entry.Spec.Description` in the catalog reconciler → projected into `providerDTO`. Rendered both in the new flow and on the existing catalog cards.

## Two ordering hazards, fixed rather than shipped

- `load()` flips `loaded` *before* it awaits `refreshBindings()`, and the binding map goes stale across a workspace switch. Either window would flash the welcome flow at users who are already set up. The store now records `bindingsWorkspace`, and the dashboard only reads an empty map as "nothing enabled" when it was fetched for the workspace on screen.
- `showWelcome` as a plain computed unmounted the wizard the instant the first Enable succeeded — dropping the user onto the dashboard mid-flow, before they saw the step confirming what they just turned on. It is now latched: the condition opens it, only the user closes it.

## Testing

`go build ./...`, `go test ./pkg/hub/providers/...` (two new tests cover the description path — API projection incl. omit-when-unset, and the spec→registry mapping), and `npm run build` (which runs `vue-tsc`) all pass.

Not yet exercised against a live hub. The concept copy in step 1 is my wording — worth a look to check it matches how Faros is described elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)