### PR TITLE
DRAFT Terraform state lifecycle through KRO and Infrakube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1962,6 +1962,11 @@ KRO_SEED_DIR ?= providers/infrastructure/examples/rgds
 E2E_KRO_KIND_NAME ?= faros-kro-e2e
 E2E_KRO_KUBECONFIG ?= $(CURDIR)/.faros-kro-e2e.kubeconfig
 GATEWAY_API_VERSION ?= v1.2.1
+INFRAKUBE_POC_COMMIT := 2fed999fb3c30e8415da5489eb8cf1eec8b765f0
+INFRAKUBE_POC_IMAGE_TAG := $(shell printf '%s' $(INFRAKUBE_POC_COMMIT) | cut -c1-12)
+INFRAKUBE_POC_CONTROLLER_IMAGE ?= faros/infrakube:$(INFRAKUBE_POC_IMAGE_TAG)
+INFRAKUBE_POC_TASK_IMAGE ?= faros/infrakube-task:$(INFRAKUBE_POC_IMAGE_TAG)
+INFRAKUBE_POC_INSTALL := providers/infrastructure/test/e2e/infrakube/install.sh
 
 ## Bring up the management kro cluster + install kro (fork w/ multicluster) +
 ## register the cluster as a self-member + seed RGDs. Idempotent: re-running
@@ -2095,6 +2100,23 @@ e2e-infrastructure-run: ## Run the infra template RGD-acceptance e2e against $(E
 		go test -tags e2e -count=1 -timeout 15m ./backend/kro/ -run TestE2E -v
 
 e2e-infrastructure: e2e-infrastructure-up e2e-infrastructure-run ## Bring up kro + run the infra template e2e (then `make e2e-infrastructure-down`)
+
+.PHONY: e2e-infrastructure-terraform-state e2e-infrastructure-terraform-state-up e2e-infrastructure-terraform-state-run
+
+e2e-infrastructure-terraform-state-up: e2e-infrastructure-up ## Build + install pinned Infrakube into the infrastructure e2e cluster
+	KUBECONFIG=$(E2E_KRO_KUBECONFIG) \
+	KIND_CLUSTER_NAME=$(E2E_KRO_KIND_NAME) \
+	INFRAKUBE_COMMIT=$(INFRAKUBE_POC_COMMIT) \
+	CONTROLLER_IMAGE=$(INFRAKUBE_POC_CONTROLLER_IMAGE) \
+	TASK_IMAGE=$(INFRAKUBE_POC_TASK_IMAGE) \
+		$(INFRAKUBE_POC_INSTALL)
+
+e2e-infrastructure-terraform-state-run: ## Assess the Kubernetes backend state lifecycle through KRO and Infrakube
+	cd providers/infrastructure && \
+		KUBECONFIG=$(E2E_KRO_KUBECONFIG) FAROS_E2E_INFRAKUBE=1 \
+		go test -tags e2e -count=1 -timeout 20m ./backend/kro/ -run '^TestE2EInfrakubeTerraformStateLifecycle$$' -v
+
+e2e-infrastructure-terraform-state: e2e-infrastructure-terraform-state-up e2e-infrastructure-terraform-state-run ## Run the Terraform state assessment (then `make e2e-infrastructure-down`)
 
 # --- In-cluster variants (no separate kind cluster) ---
 # Used by Tiltfile.cluster, which already manages a kind cluster for kcp.

--- a/providers/infrastructure/backend/kro/e2e_infrakube_state_test.go
+++ b/providers/infrastructure/backend/kro/e2e_infrakube_state_test.go
@@ -1,0 +1,351 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kro
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	infrakubeFinalizer = "finalizer.infrakube.galleybytes.com"
+	infrakubeE2EWait   = 10 * time.Minute
+)
+
+var (
+	terraformGVR = schema.GroupVersionResource{
+		Group:    "infrakube.galleybytes.com",
+		Version:  "v1",
+		Resource: "terraforms",
+	}
+	secretGVR = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "secrets",
+	}
+	leaseGVR = schema.GroupVersionResource{
+		Group:    "coordination.k8s.io",
+		Version:  "v1",
+		Resource: "leases",
+	}
+)
+
+// TestE2EInfrakubeTerraformStateLifecycle isolates the state question from
+// cloud credentials and provider APIs. It proves that the Kubernetes backend
+// persists state in the KRO-selected runtime namespace, updates that state
+// during destroy, and leaves the backend artifacts behind after successful
+// Infrakube finalizer cleanup. The test then removes only its exact Secret and
+// Lease so repeated assessments do not leak state into the shared test cluster.
+func TestE2EInfrakubeTerraformStateLifecycle(t *testing.T) {
+	if os.Getenv("FAROS_E2E_INFRAKUBE") != "1" {
+		t.Skip("run through make e2e-infrastructure-terraform-state")
+	}
+
+	dyn, _ := e2eClients(t)
+	raw, err := os.ReadFile(filepath.Join("..", "..", "install", "templates", "terraform-stack.yaml"))
+	if err != nil {
+		t.Fatalf("read terraform-stack seed template: %v", err)
+	}
+	tmpl := decodeTemplate(t, raw)
+	rgd, err := buildRGD(tmpl, testTokens())
+	if err != nil {
+		t.Fatalf("build terraform-stack RGD: %v", err)
+	}
+	applyRGD(t, dyn, rgd)
+	t.Cleanup(func() {
+		_ = dyn.Resource(rgdGVR).Delete(context.Background(), rgd.GetName(), metav1.DeleteOptions{})
+	})
+	if status, msg := waitGraphAccepted(t, dyn, rgd.GetName()); status != "True" {
+		t.Fatalf("kro rejected terraform-stack RGD: GraphAccepted=%s: %s", status, msg)
+	}
+
+	instGVR := schema.GroupVersionResource{
+		Group:    tmpl.Spec.InstanceCRD.Group,
+		Version:  tmpl.Spec.InstanceCRD.Version,
+		Resource: tmpl.Spec.InstanceCRD.Resource,
+	}
+	inst := e2eInstance(t, tmpl, fmt.Sprintf("%016x", time.Now().UnixNano()))
+	createInstance(t, dyn, instGVR, inst)
+
+	stackName, _, _ := unstructured.NestedString(inst.Object, "spec", "name")
+	terraformName := stackName + "-terraform"
+	stateSecretName := "tfstate-default-" + stackName + "-faros"
+	stateLockName := "lock-" + stateSecretName
+	terraformNamespace := ""
+	cleanupComplete := false
+	t.Cleanup(func() {
+		if cleanupComplete {
+			return
+		}
+		_ = dyn.Resource(instGVR).Delete(context.Background(), inst.GetName(), metav1.DeleteOptions{})
+		if terraformNamespace == "" {
+			terraformNamespace = findTerraformNamespace(dyn, terraformName)
+		}
+		if terraformNamespace == "" || !waitForTerraformCleanup(dyn, terraformNamespace, terraformName) {
+			t.Logf("retaining Terraform recovery artifacts because child cleanup was not verified: namespace=%q secret=%q lease=%q", terraformNamespace, stateSecretName, stateLockName)
+			return
+		}
+		deleteStateArtifact(t, dyn, secretGVR, terraformNamespace, stateSecretName)
+		deleteStateArtifact(t, dyn, leaseGVR, terraformNamespace, stateLockName)
+	})
+
+	tf := waitForTerraformCompleted(t, dyn, terraformName)
+	terraformNamespace = tf.GetNamespace()
+	if terraformNamespace == "" {
+		t.Fatal("materialized Terraform child has no runtime namespace")
+	}
+	if !slices.Contains(tf.GetFinalizers(), infrakubeFinalizer) {
+		t.Fatalf("Terraform child finalizers = %v, want %q before deletion", tf.GetFinalizers(), infrakubeFinalizer)
+	}
+	backend, _, _ := unstructured.NestedString(tf.Object, "spec", "backend")
+	if !strings.Contains(backend, `namespace = "`+terraformNamespace+`"`) {
+		t.Fatalf("Terraform backend did not resolve runtime namespace %q: %q", terraformNamespace, backend)
+	}
+
+	beforeSecret := getStateArtifact(t, dyn, secretGVR, terraformNamespace, stateSecretName)
+	beforeSerial, beforeResources := terraformStateSummary(t, beforeSecret)
+	if beforeResources == 0 {
+		t.Fatal("Terraform state has no resources after apply")
+	}
+	assertStateLock(t, dyn, terraformNamespace, stateLockName, stackName+"-faros")
+	waitForTerraformStackStatus(t, dyn, instGVR, inst.GetName(), terraformNamespace)
+
+	if err := dyn.Resource(instGVR).Delete(context.Background(), inst.GetName(), metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete TerraformStack instance: %v", err)
+	}
+	waitForTerraformDeleted(t, dyn, terraformNamespace, terraformName)
+	waitForNotFound(t, dyn, instGVR, "", inst.GetName(), "KRO TerraformStack instance cleanup")
+
+	afterSecret := getStateArtifact(t, dyn, secretGVR, terraformNamespace, stateSecretName)
+	afterSerial, afterResources := terraformStateSummary(t, afterSecret)
+	if afterResources != 0 {
+		t.Fatalf("Terraform state still contains %d resources after destroy", afterResources)
+	}
+	if afterSerial <= beforeSerial {
+		t.Fatalf("Terraform state serial did not advance during destroy: before=%d after=%d", beforeSerial, afterSerial)
+	}
+	if afterSecret.GetResourceVersion() == beforeSecret.GetResourceVersion() {
+		t.Fatalf("Terraform state Secret resourceVersion did not change during destroy: %s", afterSecret.GetResourceVersion())
+	}
+	assertStateLock(t, dyn, terraformNamespace, stateLockName, stackName+"-faros")
+	t.Logf("state assessment: Secret %s/%s and Lease %s persisted after destroy; state serial advanced %d -> %d and resources reached zero", terraformNamespace, stateSecretName, stateLockName, beforeSerial, afterSerial)
+
+	deleteStateArtifact(t, dyn, secretGVR, terraformNamespace, stateSecretName)
+	deleteStateArtifact(t, dyn, leaseGVR, terraformNamespace, stateLockName)
+	cleanupComplete = true
+}
+
+func waitForTerraformCompleted(t *testing.T, dyn dynamic.Interface, name string) *unstructured.Unstructured {
+	t.Helper()
+	deadline := time.Now().Add(infrakubeE2EWait)
+	var lastPhase string
+	for time.Now().Before(deadline) {
+		list, err := dyn.Resource(terraformGVR).List(context.Background(), metav1.ListOptions{})
+		if err == nil {
+			for i := range list.Items {
+				item := &list.Items[i]
+				if item.GetName() != name {
+					continue
+				}
+				lastPhase, _, _ = unstructured.NestedString(item.Object, "status", "phase")
+				if lastPhase == "completed" {
+					return item.DeepCopy()
+				}
+			}
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	t.Fatalf("Terraform child %q did not complete within %s (last phase %q)", name, infrakubeE2EWait, lastPhase)
+	return nil
+}
+
+func waitForTerraformStackStatus(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, name, wantNamespace string) {
+	t.Helper()
+	deadline := time.Now().Add(infrakubeE2EWait)
+	var last *unstructured.Unstructured
+	for time.Now().Before(deadline) {
+		obj, err := dyn.Resource(gvr).Get(context.Background(), name, metav1.GetOptions{})
+		if err == nil {
+			last = obj
+			phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
+			message, _, _ := unstructured.NestedString(obj.Object, "status", "message")
+			resourceID, _, _ := unstructured.NestedString(obj.Object, "status", "resourceID")
+			runtimeNamespace, _, _ := unstructured.NestedString(obj.Object, "status", "runtimeNamespace")
+			if phase == "completed" && message == "hello from Faros" && resourceID != "" && runtimeNamespace == wantNamespace {
+				if _, found, _ := unstructured.NestedFieldNoCopy(obj.Object, "status", "internal_marker"); found {
+					t.Fatalf("TerraformStack status unexpectedly exposes internal_marker: %v", obj.Object["status"])
+				}
+				return
+			}
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	t.Fatalf("TerraformStack %q never projected completed status in namespace %q; last object: %v", name, wantNamespace, last)
+}
+
+func waitForTerraformDeleted(t *testing.T, dyn dynamic.Interface, namespace, name string) {
+	t.Helper()
+	deadline := time.Now().Add(infrakubeE2EWait)
+	deletePhases := map[string]bool{
+		"initializing-delete": true,
+		"deleting":            true,
+		"deleted":             true,
+	}
+	var lastPhase string
+	var sawDeletePhase bool
+	for time.Now().Before(deadline) {
+		obj, err := dyn.Resource(terraformGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			if !sawDeletePhase {
+				t.Fatalf("Terraform child %s/%s disappeared without an observed delete phase (last phase %q)", namespace, name, lastPhase)
+			}
+			return
+		}
+		if err == nil {
+			lastPhase, _, _ = unstructured.NestedString(obj.Object, "status", "phase")
+			sawDeletePhase = sawDeletePhase || deletePhases[lastPhase]
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	t.Fatalf("Infrakube finalizer cleanup did not finish within %s (last phase %q, observed delete phase=%t)", infrakubeE2EWait, lastPhase, sawDeletePhase)
+}
+
+func waitForNotFound(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, namespace, name, description string) {
+	t.Helper()
+	deadline := time.Now().Add(infrakubeE2EWait)
+	for time.Now().Before(deadline) {
+		_, err := dyn.Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	t.Fatalf("%s did not finish within %s", description, infrakubeE2EWait)
+}
+
+func getStateArtifact(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string) *unstructured.Unstructured {
+	t.Helper()
+	obj, err := dyn.Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get state artifact %s/%s: %v", namespace, name, err)
+	}
+	return obj
+}
+
+func assertStateLock(t *testing.T, dyn dynamic.Interface, namespace, name, suffix string) {
+	t.Helper()
+	lease := getStateArtifact(t, dyn, leaseGVR, namespace, name)
+	labels := lease.GetLabels()
+	if labels["app.kubernetes.io/managed-by"] != "terraform" ||
+		labels["tfstate"] != "true" ||
+		labels["tfstateSecretSuffix"] != suffix ||
+		labels["tfstateWorkspace"] != "default" {
+		t.Fatalf("Terraform state Lease %s/%s has unexpected labels: %v", namespace, name, labels)
+	}
+}
+
+func terraformStateSummary(t *testing.T, secret *unstructured.Unstructured) (int64, int) {
+	t.Helper()
+	encoded, found, err := unstructured.NestedString(secret.Object, "data", "tfstate")
+	if err != nil || !found || encoded == "" {
+		t.Fatalf("Terraform state Secret %s/%s has no data.tfstate: found=%t err=%v", secret.GetNamespace(), secret.GetName(), found, err)
+	}
+	compressed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode Terraform state from Secret %s/%s: %v", secret.GetNamespace(), secret.GetName(), err)
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("open Terraform state gzip from Secret %s/%s: %v", secret.GetNamespace(), secret.GetName(), err)
+	}
+	stateJSON, err := io.ReadAll(reader)
+	if closeErr := reader.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("read Terraform state from Secret %s/%s: %v", secret.GetNamespace(), secret.GetName(), err)
+	}
+	var state struct {
+		Serial    int64             `json:"serial"`
+		Resources []json.RawMessage `json:"resources"`
+	}
+	if err := json.Unmarshal(stateJSON, &state); err != nil {
+		t.Fatalf("decode Terraform state JSON from Secret %s/%s: %v", secret.GetNamespace(), secret.GetName(), err)
+	}
+	return state.Serial, len(state.Resources)
+}
+
+func findTerraformNamespace(dyn dynamic.Interface, name string) string {
+	list, err := dyn.Resource(terraformGVR).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return ""
+	}
+	for i := range list.Items {
+		if list.Items[i].GetName() == name {
+			return list.Items[i].GetNamespace()
+		}
+	}
+	return ""
+}
+
+func waitForTerraformCleanup(dyn dynamic.Interface, namespace, name string) bool {
+	deadline := time.Now().Add(infrakubeE2EWait)
+	for time.Now().Before(deadline) {
+		_, err := dyn.Resource(terraformGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	return false
+}
+
+func deleteStateArtifact(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string) {
+	t.Helper()
+	err := dyn.Resource(gvr).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("delete state artifact %s/%s: %v", namespace, name, err)
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := dyn.Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(e2ePollEvery)
+	}
+	t.Fatalf("state artifact %s/%s was not deleted", namespace, name)
+}

--- a/providers/infrastructure/backend/kro/e2e_test.go
+++ b/providers/infrastructure/backend/kro/e2e_test.go
@@ -139,6 +139,9 @@ func TestE2ESeedTemplates(t *testing.T) {
 				t.Fatalf("read %s: %v", entry.Name(), err)
 			}
 			tmpl := decodeTemplate(t, raw)
+			if tmpl.Name == "terraform-stack" && os.Getenv("FAROS_E2E_INFRAKUBE") != "1" {
+				t.Skip("requires the Infrakube CRDs, controller, and task image; run make e2e-infrastructure-terraform-state")
+			}
 
 			rgd, err := buildRGD(tmpl, testTokens())
 			if err != nil {

--- a/providers/infrastructure/backend/kro/seedtemplates_test.go
+++ b/providers/infrastructure/backend/kro/seedtemplates_test.go
@@ -115,6 +115,75 @@ func TestSeedTemplatesIncludeStandaloneDatabase(t *testing.T) {
 	}
 }
 
+func TestSeedTemplatesIncludeInfrakubeTerraformPOC(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "install", "templates", "terraform-stack.yaml"))
+	if err != nil {
+		t.Fatalf("read terraform-stack seed template: %v", err)
+	}
+	tmpl := decodeTemplate(t, raw)
+	if got, want := tmpl.Name, "terraform-stack"; got != want {
+		t.Fatalf("Template name = %q, want %q", got, want)
+	}
+	if got, want := tmpl.Spec.Backend, Name; got != want {
+		t.Fatalf("backend = %q, want %q", got, want)
+	}
+	if got, want := tmpl.Spec.InstanceCRD.Kind, "TerraformStack"; got != want {
+		t.Fatalf("instance kind = %q, want %q", got, want)
+	}
+
+	rgd, err := buildRGD(tmpl, testTokens())
+	if err != nil {
+		t.Fatalf("buildRGD(terraform-stack): %v", err)
+	}
+	anchor := findResource(t, rgd, "stateNamespace")
+	if anchor == nil {
+		t.Fatal("terraform-stack template missing stateNamespace resource")
+	}
+	tf := findResource(t, rgd, "terraform")
+	if tf == nil {
+		t.Fatal("terraform-stack template missing terraform resource")
+	}
+	if got, _, _ := unstructured.NestedString(tf, "template", "apiVersion"); got != "infrakube.galleybytes.com/v1" {
+		t.Fatalf("Terraform apiVersion = %q, want infrakube.galleybytes.com/v1", got)
+	}
+	if got, _, _ := unstructured.NestedString(tf, "template", "kind"); got != "Terraform" {
+		t.Fatalf("Terraform kind = %q, want Terraform", got)
+	}
+	if got, _, _ := unstructured.NestedString(tf, "template", "spec", "terraformVersion"); got != "1.5.7" {
+		t.Fatalf("Terraform version = %q, want pinned 1.5.7", got)
+	}
+	module, _, _ := unstructured.NestedString(tf, "template", "spec", "terraformModule", "inline")
+	if module == "" || strings.Contains(module, "source =") || !strings.Contains(module, `output "internal_marker"`) {
+		t.Fatalf("Terraform POC module must be controlled inline content, got %q", module)
+	}
+	backend, _, _ := unstructured.NestedString(tf, "template", "spec", "backend")
+	if !strings.Contains(backend, "stateNamespace.metadata.namespace") || !strings.Contains(backend, "schema.spec.name") || strings.Contains(backend, `namespace = \"default\"`) {
+		t.Fatalf("Terraform backend must resolve the KRO-materialized tenant namespace, got %q", backend)
+	}
+	if write, found, _ := unstructured.NestedBool(tf, "template", "spec", "writeOutputsToStatus"); !found || !write {
+		t.Fatalf("writeOutputsToStatus = %t (found=%t), want explicit true", write, found)
+	}
+	outputs, _, _ := unstructured.NestedStringSlice(tf, "template", "spec", "outputsToInclude")
+	if !slices.Equal(outputs, []string{"message", "resource_id"}) {
+		t.Fatalf("outputsToInclude = %v, want only non-sensitive POC outputs", outputs)
+	}
+	if ignoreDelete, found, _ := unstructured.NestedBool(tf, "template", "spec", "ignoreDelete"); !found || ignoreDelete {
+		t.Fatalf("ignoreDelete = %t (found=%t), want explicit false so Infrakube destroys on deletion", ignoreDelete, found)
+	}
+	for _, field := range []string{"phase", "message", "resourceID", "runtimeNamespace"} {
+		if _, found, _ := unstructured.NestedFieldNoCopy(rgd.Object, "spec", "schema", "status", field); !found {
+			t.Fatalf("terraform-stack status missing %s", field)
+		}
+	}
+	status, found, err := unstructured.NestedMap(rgd.Object, "spec", "schema", "status")
+	if err != nil || !found {
+		t.Fatalf("read terraform-stack status: found=%t err=%v", found, err)
+	}
+	if statusJSON := mustJSON(t, status); strings.Contains(statusJSON, "internal_marker") {
+		t.Fatalf("terraform-stack status projects sensitive internal_marker: %s", statusJSON)
+	}
+}
+
 func TestSeedTemplateBuildWorkflowDeclarations(t *testing.T) {
 	dir := filepath.Join("..", "..", "install", "templates")
 	entries, err := os.ReadDir(dir)

--- a/providers/infrastructure/install/templates/terraform-stack.yaml
+++ b/providers/infrastructure/install/templates/terraform-stack.yaml
@@ -1,0 +1,148 @@
+apiVersion: infrastructure.faros.sh/v1alpha1
+kind: Template
+metadata:
+  name: terraform-stack
+spec:
+  displayName: "Terraform stack (Infrakube POC)"
+  description: "Proof-of-concept Terraform execution through an externally installed Infrakube controller. The module is embedded and pinned to Terraform 1.5.7; it creates a terraform_data resource without requiring cloud credentials."
+  category: Infrastructure
+  version: 0.1.0
+  exposure: internal
+  backend: kro
+  sampleValues:
+    name: terraform-poc
+    message: "hello from Faros"
+  agent:
+    usage: |
+      Provisions a small, cloud-free Terraform stack through Infrakube. This is
+      an integration proof of concept, not a general module runner: the
+      Terraform module and Terraform version are fixed by the template.
+
+      INPUTS: name identifies the Infrakube Terraform child and its isolated
+      state; message is stored in a terraform_data resource.
+
+      DELETION: deleting the Faros instance deletes the Terraform child.
+      Infrakube's delete finalizer then runs Terraform destroy because
+      ignoreDelete is explicitly false.
+    prerequisites:
+      - "The KRO runtime cluster has the infrakube.galleybytes.com/v1 Terraform CRD and a healthy Infrakube controller."
+      - "The Infrakube controller is configured with a pinned task image, task pods can download Terraform 1.5.7, and the runtime cluster has a default StorageClass for Infrakube's PVC."
+      - "The Infrakube task ServiceAccount can manage Secrets and Leases in the materialized tenant runtime namespace for the Terraform Kubernetes backend."
+    outputs:
+      - "status.phase is Infrakube's current Terraform workflow phase."
+      - "status.message and status.resourceID are the only Terraform outputs projected into the Faros instance status."
+      - "status.runtimeNamespace identifies the KRO-materialized namespace that also owns this instance's Terraform state."
+  view:
+    columns:
+      - header: Phase
+        path: status.phase
+        type: badge
+      - header: Message
+        path: status.message
+    detail:
+      - title: Terraform
+        fields:
+          - label: Phase
+            path: status.phase
+            type: badge
+          - label: Resource ID
+            path: status.resourceID
+            type: code
+          - label: Runtime namespace
+            path: status.runtimeNamespace
+            type: code
+  instanceCRD:
+    group: infrastructure.faros.sh
+    version: v1alpha1
+    resource: terraformstacks
+    kind: TerraformStack
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+        maxLength: 40
+        description: "Logical stack name; also scopes the Infrakube child and Terraform state within the tenant runtime namespace."
+      message:
+        type: string
+        default: "hello from Faros"
+        description: "Non-sensitive value stored by the POC terraform_data resource and returned in status."
+    required:
+      - name
+  backendConfig:
+    resources:
+      # KRO rewrites namespace: default to the tenant's materialized runtime
+      # namespace. The Terraform Kubernetes backend is an opaque HCL string, so
+      # KRO cannot rewrite a literal namespace inside it. This anchor exposes
+      # the post-rewrite namespace for the backend expression below and also
+      # makes the Terraform child depend on namespace resolution.
+      - id: stateNamespace
+        template:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: ${schema.spec.name}-terraform-state-anchor
+            namespace: default
+          data:
+            purpose: infrakube-kubernetes-backend-namespace-anchor
+      - id: terraform
+        template:
+          apiVersion: infrakube.galleybytes.com/v1
+          kind: Terraform
+          metadata:
+            name: ${schema.spec.name}-terraform
+            namespace: default
+          spec:
+            terraformVersion: "1.5.7"
+            # Keep this POC reproducible and independent of mutable remote
+            # module refs. A future catalog feature can introduce controlled,
+            # immutable external module selection as a separate contract.
+            terraformModule:
+              inline: |
+                terraform {
+                  required_version = "= 1.5.7"
+                }
+
+                variable "message" {
+                  type = string
+                }
+
+                resource "terraform_data" "poc" {
+                  input = var.message
+                }
+
+                output "message" {
+                  value = terraform_data.poc.output
+                }
+
+                output "resource_id" {
+                  value = terraform_data.poc.id
+                }
+
+                # This deliberately exercises the output allowlist. Even a
+                # sensitive module output must never be copied wholesale into
+                # the tenant-visible Faros instance status.
+                output "internal_marker" {
+                  value     = "not-projected"
+                  sensitive = true
+                }
+            backend: ${"terraform {\n  backend \"kubernetes\" {\n    secret_suffix = \"" + schema.spec.name + "-faros\"\n    in_cluster_config = true\n    namespace = \"" + stateNamespace.metadata.namespace + "\"\n  }\n}"}
+            writeOutputsToStatus: true
+            outputsToInclude:
+              - message
+              - resource_id
+            # False is Infrakube's destroy-on-delete path. Keep it explicit so
+            # a future refactor cannot silently turn instance deletion into an
+            # orphaning operation.
+            ignoreDelete: false
+            taskOptions:
+              - for: ["*"]
+                env:
+                  - name: TF_VAR_message
+                    value: ${schema.spec.message}
+    status:
+      phase: ${terraform.status.phase}
+      message: ${terraform.status.outputs.message}
+      resourceID: ${terraform.status.outputs.resource_id}
+      runtimeNamespace: ${terraform.metadata.namespace}

--- a/providers/infrastructure/test/e2e/infrakube/install.sh
+++ b/providers/infrastructure/test/e2e/infrakube/install.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Faros Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${KUBECONFIG:?KUBECONFIG must point at the task-owned infrastructure e2e cluster}"
+: "${KIND_CLUSTER_NAME:?KIND_CLUSTER_NAME is required}"
+: "${INFRAKUBE_COMMIT:?INFRAKUBE_COMMIT is required}"
+: "${CONTROLLER_IMAGE:?CONTROLLER_IMAGE is required}"
+: "${TASK_IMAGE:?TASK_IMAGE is required}"
+
+INFRAKUBE_REPOSITORY="${INFRAKUBE_REPOSITORY:-https://github.com/cwilhit/infrakube-multicluster.git}"
+BUILD_CACHE_ROOT="${CODEX_BUILD_CACHE_ROOT:-/var/tmp/codex-build}"
+
+for tool in docker git kind kubectl sed; do
+  command -v "${tool}" >/dev/null || {
+    echo "${tool} is required for the Infrakube POC e2e" >&2
+    exit 1
+  }
+done
+
+mkdir -p "${BUILD_CACHE_ROOT}"
+source_dir="$(mktemp -d "${BUILD_CACHE_ROOT}/faros-infrakube.XXXXXX")"
+cleanup() {
+  rm -rf -- "${source_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+echo ">>> cloning Infrakube fork and checking out pinned commit ${INFRAKUBE_COMMIT}"
+git clone --quiet "${INFRAKUBE_REPOSITORY}" "${source_dir}"
+git -C "${source_dir}" checkout --quiet --detach "${INFRAKUBE_COMMIT}"
+actual_commit="$(git -C "${source_dir}" rev-parse HEAD)"
+if [[ "${actual_commit}" != "${INFRAKUBE_COMMIT}" ]]; then
+  echo "Infrakube checkout is ${actual_commit}, want ${INFRAKUBE_COMMIT}" >&2
+  exit 1
+fi
+
+# Git records only the executable bit, then applies the caller's umask while
+# checking files out. A restrictive development umask can therefore produce
+# 0700 or 0600 scripts; Docker COPY preserves that mode and the images run as
+# non-root users, making their root-owned entrypoints unreadable. Normalize
+# only the controller/task scripts that the pinned Dockerfiles copy and run.
+chmod 755 \
+  "${source_dir}/build/scripts/infrakube-entrypoint" \
+  "${source_dir}/build/scripts/user_setup" \
+  "${source_dir}/task-container-build-tools/scripts/entrypoint-wrapper.sh" \
+  "${source_dir}/task-container-build-tools/scripts/extract-terraform.sh" \
+  "${source_dir}/task-container-build-tools/scripts/extract-tofu.sh" \
+  "${source_dir}/task-container-build-tools/scripts/usersetup"
+
+case "$(uname -m)" in
+  x86_64 | amd64) target_arch=amd64 ;;
+  aarch64 | arm64) target_arch=arm64 ;;
+  *)
+    echo "unsupported host architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+echo ">>> building pinned Infrakube controller image ${CONTROLLER_IMAGE}"
+DOCKER_BUILDKIT=1 docker build --platform "linux/${target_arch}" -t "${CONTROLLER_IMAGE}" -f "${source_dir}/build/Dockerfile" "${source_dir}"
+
+echo ">>> building pinned Infrakube task image ${TASK_IMAGE}"
+DOCKER_BUILDKIT=1 docker build --platform "linux/${target_arch}" --build-arg "TARGETARCH=${target_arch}" \
+  -t "${TASK_IMAGE}" \
+  -f "${source_dir}/task-container-build-tools/containerfiles/infrakube-task.Containerfile" \
+  "${source_dir}/task-container-build-tools"
+
+echo ">>> loading locally built images into ${KIND_CLUSTER_NAME}"
+kind load docker-image --name "${KIND_CLUSTER_NAME}" "${CONTROLLER_IMAGE}"
+kind load docker-image --name "${KIND_CLUSTER_NAME}" "${TASK_IMAGE}"
+
+echo ">>> installing manifests from pinned Infrakube source"
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/namespace.yaml"
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/crds/"
+kubectl --kubeconfig "${KUBECONFIG}" wait --for=condition=Established \
+  crd/terraforms.infrakube.galleybytes.com crd/tofus.infrakube.galleybytes.com --timeout=120s
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/serviceaccount.yaml"
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/clusterrole.yaml"
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/clusterrolebinding.yaml"
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/pvc.yaml"
+kubectl --kubeconfig "${KUBECONFIG}" apply -f "${source_dir}/deploy/service.yaml"
+
+# Render the deployment with the local pinned image before it reaches the API
+# server. The upstream manifest names :latest, and this POC must never start or
+# pull that mutable image, even briefly.
+sed \
+  -e "s|image: \"ghcr.io/galleybytes/infrakube:latest\"|image: \"${CONTROLLER_IMAGE}\"|" \
+  -e 's|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|' \
+  "${source_dir}/deploy/deployment.yaml" | \
+  kubectl --kubeconfig "${KUBECONFIG}" apply -f -
+
+controller_args="$(printf '[{"op":"replace","path":"/spec/template/spec/containers/0/args","value":["--zap-log-level=debug","--zap-encoder=console","--auto-download=true","--tf-download-base-url=https://releases.hashicorp.com/terraform","--tofu-download-base-url=https://github.com/opentofu/opentofu/releases/download","--task-image=%s"]}]' "${TASK_IMAGE}")"
+kubectl --kubeconfig "${KUBECONFIG}" -n infrakube-system patch deployment infrakube --type=json -p "${controller_args}"
+kubectl --kubeconfig "${KUBECONFIG}" -n infrakube-system rollout status deployment/infrakube --timeout=180s
+
+echo ">>> pinned Infrakube controller and task image are ready"


### PR DESCRIPTION
## What changed

- add an internal Terraform stack template that materializes an Infrakube `Terraform` child through KRO
- pin and install the Infrakube controller and task images for a reproducible local assessment
- add a dedicated E2E target covering Terraform apply, Kubernetes-backed state and locking, finalizer-driven destroy, and cleanup
- add focused template and graph-shape coverage

## Why

Faros needs concrete evidence for the Terraform state lifecycle before deciding how Terraform should fit behind the infrastructure backend abstraction. This POC isolates that question without cloud credentials by using a `terraform_data` resource and the Kubernetes state backend.

## Impact

This adds an opt-in assessment path only. It does not introduce a native Faros Terraform backend or wire the test into standard CI. The template is internal and explicitly identified as an Infrakube POC.

## Validation

- `make e2e-infrastructure-terraform-state`
  - passed `TestE2EInfrakubeTerraformStateLifecycle`
  - state serial advanced from 2 to 3 during destroy
  - state resources reached zero
- `go test -count=1 ./...` from `providers/infrastructure`
- `git diff --check origin/main...HEAD`
