### PR TITLE
Fix Databricks Tilt startup and controller retries

### DIFF
--- a/portal/src/portalkit/dashboardtile.ts
+++ b/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/provider-sdk/portalkit/dashboardtile.ts
+++ b/provider-sdk/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/agents/portal/src/portalkit/dashboardtile.ts
+++ b/providers/agents/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/app-studio/portal/src/portalkit/dashboardtile.ts
+++ b/providers/app-studio/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/code/portal/src/portalkit/dashboardtile.ts
+++ b/providers/code/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/databricks/controller/connection/controller.go
+++ b/providers/databricks/controller/connection/controller.go
@@ -54,6 +54,7 @@ func (r *Reconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	// require broader tenant permissions; healthy connections recheck on the
 	// validation interval and transient Databricks failures use the short retry.
 	return mcbuilder.ControllerManagedBy(mgr).
+		Named("databricks-connection").
 		For(&databricksv1alpha1.Connection{}, mcbuilder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/providers/databricks/controller_manager.go
+++ b/providers/databricks/controller_manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -731,9 +732,15 @@ func newControllerManagerWithReadiness(ctx context.Context, config *rest.Config,
 		initialize:     providerTransportReadiness.Wait,
 		startupTimeout: setupTimeout,
 	}
+	// The lifecycle below reconstructs a manager after readiness loss while
+	// retaining stable controller names for metrics and logs. controller-runtime
+	// keeps its name registry for the process lifetime, so a replacement manager
+	// must skip that process-global check. The three names registered below are
+	// still explicit and distinct within every manager instance.
 	mgr, err := mcmanager.New(config, providerRunnable, manager.Options{
-		Scheme:  scheme,
-		Metrics: metricsserver.Options{BindAddress: "0"},
+		Scheme:     scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: controllerOptionsForRetryableManager(),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating multicluster manager: %w", err)
@@ -754,6 +761,11 @@ func newControllerManagerWithReadiness(ctx context.Context, config *rest.Config,
 		endpointName:   apiExportName,
 		startupTimeout: controllerStartupTimeoutFromEnv(),
 	}, nil
+}
+
+func controllerOptionsForRetryableManager() ctrlconfig.Controller {
+	skipNameValidation := true
+	return ctrlconfig.Controller{SkipNameValidation: &skipNameValidation}
 }
 
 // startControllerManager preserves the small setup API used by local callers:

--- a/providers/databricks/controller_manager_test.go
+++ b/providers/databricks/controller_manager_test.go
@@ -62,6 +62,13 @@ func TestControllerHealthLifecycle(t *testing.T) {
 	}
 }
 
+func TestControllerOptionsForRetryableManagerAllowsStableNames(t *testing.T) {
+	options := controllerOptionsForRetryableManager()
+	if options.SkipNameValidation == nil || !*options.SkipNameValidation {
+		t.Fatal("retryable manager must allow stable controller names across process-lifetime rebuilds")
+	}
+}
+
 func TestControllerReadyRunnableGatesAuthorityUntilProviderDiscovery(t *testing.T) {
 	health := newControllerHealth(true)
 	authority := &managerAuthority{}

--- a/providers/databricks/portal/src/portalkit/dashboardtile.ts
+++ b/providers/databricks/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/edges/portal/src/portalkit/dashboardtile.ts
+++ b/providers/edges/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/infrastructure/portal/src/portalkit/dashboardtile.ts
+++ b/providers/infrastructure/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/kuery/portal/src/portalkit/dashboardtile.ts
+++ b/providers/kuery/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/quickstart/portal/src/portalkit/dashboardtile.ts
+++ b/providers/quickstart/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 

--- a/providers/vibe-studio/portal/src/portalkit/dashboardtile.ts
+++ b/providers/vibe-studio/portal/src/portalkit/dashboardtile.ts
@@ -71,6 +71,11 @@ export const tileClass = {
 export interface TileContext {
   token?: string | null
   tenant?: string | null
+  // Hub-proxy providers need the persisted tenant selection as well as the
+  // resolved kcp tenant path so their requests carry the same headers as the
+  // full provider surface.
+  orgUUID?: string | null
+  workspaceUUID?: string | null
   basePath?: string
 }
 


### PR DESCRIPTION
## Summary

- extend the canonical dashboard tile context with organization and workspace identifiers, then synchronize the portalkit copies
- give the Databricks connection reconciler an explicit stable controller name
- allow the retryable Databricks manager to reuse stable controller names across process-lifetime manager reconstruction
- add focused coverage for the retry manager controller configuration

## Root cause

The Databricks dashboard tile used `orgUUID` and `workspaceUUID` to build the required tenant-selection headers, but those fields were missing from the shared `TileContext` interface, so the portal typecheck failed and Tilt could not build the resource.

Separately, controller-runtime retains controller names in a process-global registry. When Databricks rebuilt its multicluster manager after readiness loss, the replacement manager attempted to register the same names and entered a permanent retry loop.

## Impact

The Databricks provider now builds successfully in Tilt, can recover its controller manager without name collisions, and reports real controller readiness after provider registration and APIExport initialization.

## Validation

- `npm test` in `providers/databricks/portal` (11 test programs passed)
- `make build-databricks-provider`
- `go test -count=1 ./...` in `providers/databricks`
- `go vet ./...` in `providers/databricks`
- `make verify-portalkit`
- `git diff --check`
- live Tilt resource: `updateStatus: ok`, `runtimeStatus: ok`
- live provider `/readyz`: HTTP 200 with `{"controller":"ready","status":"ready"}`
