### PR TITLE
Bump APIResourceSchema names when their content changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ codegen-edges-provider: $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) ## Codegen for the e
 		$(CURDIR)/$(CONTROLLER_GEN) object paths="./apis/..." && \
 		$(CURDIR)/$(CONTROLLER_GEN) crd paths="./apis/..." \
 			output:crd:artifacts:config=$(CURDIR)/providers/edges/config/crds
-	./$(KCP_APIGEN_GEN) --input-dir providers/edges/config/crds --output-dir providers/edges/config/kcp
+	./hack/apigen.sh --input-dir providers/edges/config/crds --output-dir providers/edges/config/kcp
 	@for r in kubernetesclusters linuxservers workloads placements services; do \
 		cp providers/edges/config/kcp/apiresourceschema-$$r.edges.faros.sh.yaml \
 		   providers/edges/deploy/chart/files/schemas/$$r.edges.faros.sh.yaml; \
@@ -275,7 +275,7 @@ codegen-code-provider: $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) ## Codegen for the co
 		$(CURDIR)/$(CONTROLLER_GEN) object paths="./apis/..." && \
 		$(CURDIR)/$(CONTROLLER_GEN) crd paths="./apis/..." \
 			output:crd:artifacts:config=$(CURDIR)/providers/code/config/crds
-	./$(KCP_APIGEN_GEN) --input-dir providers/code/config/crds --output-dir providers/code/config/kcp
+	./hack/apigen.sh --input-dir providers/code/config/crds --output-dir providers/code/config/kcp
 	@for r in connections repositories repositorycommits repositorycheckouts repositorybuildstatuses deploykeys collaborators packages; do \
 		cp providers/code/config/kcp/apiresourceschema-$$r.code.faros.sh.yaml \
 		   providers/code/deploy/chart/files/schemas/$$r.code.faros.sh.yaml; \
@@ -288,7 +288,7 @@ codegen-agents-provider: $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) ## Codegen for the 
 		$(CURDIR)/$(CONTROLLER_GEN) object paths="./apis/..." && \
 		$(CURDIR)/$(CONTROLLER_GEN) crd paths="./apis/..." \
 			output:crd:artifacts:config=$(CURDIR)/providers/agents/config/crds
-	./$(KCP_APIGEN_GEN) --input-dir providers/agents/config/crds --output-dir providers/agents/config/kcp
+	./hack/apigen.sh --input-dir providers/agents/config/crds --output-dir providers/agents/config/kcp
 	@for r in agents connections schedules triggers toolsets; do \
 		cp providers/agents/config/kcp/apiresourceschema-$$r.agents.faros.sh.yaml \
 		   providers/agents/deploy/chart/files/schemas/$$r.agents.faros.sh.yaml; \
@@ -301,7 +301,7 @@ codegen-app-studio-provider: $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) ## Codegen for 
 		$(CURDIR)/$(CONTROLLER_GEN) object paths="./apis/..." && \
 		$(CURDIR)/$(CONTROLLER_GEN) crd paths="./apis/..." \
 			output:crd:artifacts:config=$(CURDIR)/providers/app-studio/config/crds
-	./$(KCP_APIGEN_GEN) --input-dir providers/app-studio/config/crds --output-dir providers/app-studio/config/kcp
+	./hack/apigen.sh --input-dir providers/app-studio/config/crds --output-dir providers/app-studio/config/kcp
 	cp providers/app-studio/config/kcp/apiresourceschema-projects.ai.faros.sh.yaml \
 	   providers/app-studio/deploy/chart/files/schemas/projects.ai.faros.sh.yaml
 	cp providers/app-studio/config/kcp/apiresourceschema-sessions.ai.faros.sh.yaml \
@@ -316,7 +316,7 @@ codegen-databricks-provider: $(CONTROLLER_GEN) $(KCP_APIGEN_GEN) ## Codegen for 
 		$(CURDIR)/$(CONTROLLER_GEN) object paths="./apis/..." && \
 		$(CURDIR)/$(CONTROLLER_GEN) crd paths="./apis/..." \
 			output:crd:artifacts:config=$(CURDIR)/providers/databricks/config/crds
-	./$(KCP_APIGEN_GEN) --input-dir providers/databricks/config/crds --output-dir providers/databricks/config/kcp
+	./hack/apigen.sh --input-dir providers/databricks/config/crds --output-dir providers/databricks/config/kcp
 	@for r in connections warehouses tables; do \
 		cp providers/databricks/config/kcp/apiresourceschema-$$r.databricks.faros.sh.yaml \
 		   providers/databricks/deploy/chart/files/schemas/$$r.databricks.faros.sh.yaml; \

--- a/hack/apigen.sh
+++ b/hack/apigen.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Faros Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# apigen.sh wraps kcp's apigen so that a changed APIResourceSchema gets a NEW
+# name instead of being rewritten under the old one.
+#
+# Why this wrapper exists
+# -----------------------
+# APIResourceSchemas are IMMUTABLE in kcp. apigen on its own does not help you
+# here: pointed at an output directory that already contains a schema, it keeps
+# that schema's name and rewrites the content underneath it. The generated files
+# look fine and `git diff` looks innocent — but applying them to any cluster that
+# already has the old content fails with
+#
+#   apiresourceschemas.apis.kcp.io "v260615-841bea0.providers.admin.faros.sh"
+#     is forbidden: [spec: Invalid value: {...}: is immutable]
+#
+# and the hub's bootstrap (kcp's confighelpers.Bootstrap) retries that apply
+# forever without surfacing the error, so the hub simply never becomes ready.
+# A one-word doc-comment edit on an exported API type was enough to do it.
+#
+# What it does instead
+# --------------------
+#   1. Runs apigen into an empty temp dir, where it mints fresh names
+#      (v<yymmdd>-<HEAD-sha>) from the current CRDs.
+#   2. For each schema, compares the fresh output with what is already in the
+#      output dir, ignoring metadata.name:
+#        - identical  -> keeps the existing file, so the name does NOT churn on
+#                        every commit;
+#        - different  -> takes the fresh file, so the name bumps and kcp sees a
+#                        create instead of a forbidden update;
+#        - new        -> takes the fresh file.
+#   3. Runs apigen again against the output dir, which preserves the names
+#      chosen above and regenerates the APIExports to reference them.
+#
+# Usage: hack/apigen.sh --input-dir <crds> --output-dir <kcp>
+# Requires KCP_APIGEN_GEN (exported by the Makefile).
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -z "${KCP_APIGEN_GEN:-}" ]]; then
+    echo "KCP_APIGEN_GEN is not set. Invoke via make (e.g. 'make crds')." >&2
+    exit 1
+fi
+
+INPUT_DIR=""
+OUTPUT_DIR=""
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --input-dir)  INPUT_DIR="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        *)            EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+if [[ -z "${INPUT_DIR}" || -z "${OUTPUT_DIR}" ]]; then
+    echo "usage: $0 --input-dir <dir> --output-dir <dir> [apigen args...]" >&2
+    exit 1
+fi
+
+APIGEN="${KCP_APIGEN_GEN}"
+[[ -x "${APIGEN}" ]] || APIGEN="./${KCP_APIGEN_GEN}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${OUTPUT_DIR}"
+
+# Step 1: fresh generation into an empty dir — every schema gets today's name.
+"${APIGEN}" --input-dir "${INPUT_DIR}" --output-dir "${TMP_DIR}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} >/dev/null
+
+# strip_name drops the single versioned `metadata.name` line so two generations
+# can be compared on content alone. Both files come from the same apigen build,
+# so nothing else about the formatting can differ.
+strip_name() {
+    grep -v '^  name: v[0-9]' "$1"
+}
+
+shopt -s nullglob
+for fresh in "${TMP_DIR}"/apiresourceschema-*.yaml; do
+    base="$(basename "${fresh}")"
+    existing="${OUTPUT_DIR}/${base}"
+
+    if [[ ! -f "${existing}" ]]; then
+        echo "  + new schema ${base}"
+        cp "${fresh}" "${existing}"
+        continue
+    fi
+
+    if diff -q <(strip_name "${existing}") <(strip_name "${fresh}") >/dev/null; then
+        continue # content unchanged: keep the established name
+    fi
+
+    old_name="$(grep -m1 '^  name: v[0-9]' "${existing}" | awk '{print $2}')"
+    new_name="$(grep -m1 '^  name: v[0-9]' "${fresh}" | awk '{print $2}')"
+    if [[ "${old_name}" == "${new_name}" ]]; then
+        # apigen derives the name from HEAD, so a second schema-changing edit on
+        # the same commit reuses it. Renaming would be a no-op and the immutable
+        # update would come back, so say so loudly rather than generate a file
+        # that cannot be applied.
+        echo "  ! ${base}: content changed but the generated name is still ${new_name}." >&2
+        echo "    apigen derives names from HEAD; commit the API change and re-run" >&2
+        echo "    codegen so the schema gets a distinct name." >&2
+        exit 1
+    fi
+    echo "  ~ schema changed, bumping name: ${old_name} -> ${new_name}"
+    cp "${fresh}" "${existing}"
+done
+
+# Drop schemas whose CRD disappeared, so a removed API does not linger.
+for existing in "${OUTPUT_DIR}"/apiresourceschema-*.yaml; do
+    base="$(basename "${existing}")"
+    if [[ ! -f "${TMP_DIR}/${base}" ]]; then
+        echo "  - removing stale schema ${base}"
+        rm -f "${existing}"
+    fi
+done
+shopt -u nullglob
+
+# Step 2: regenerate in place. apigen preserves the names selected above and
+# writes the APIExports that reference them.
+"${APIGEN}" --input-dir "${INPUT_DIR}" --output-dir "${OUTPUT_DIR}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}

--- a/hack/update-codegen-crds.sh
+++ b/hack/update-codegen-crds.sh
@@ -47,11 +47,13 @@ rm -rf "${REPO_ROOT}/pkg/hub/bootstrap/crds"
 mkdir -p "${REPO_ROOT}/pkg/hub/bootstrap/crds"
 cp "${REPO_ROOT}"/config/crds/*.yaml "${REPO_ROOT}/pkg/hub/bootstrap/crds/"
 
-# Step 2: Generate kcp APIResourceSchemas and APIExport from CRDs using apigen.
+# Step 2: Generate kcp APIResourceSchemas and APIExport from CRDs. Goes through
+# hack/apigen.sh, not apigen directly: a changed schema must get a NEW name
+# because APIResourceSchemas are immutable in kcp (see that script's header).
 echo "Generating kcp APIResourceSchemas with apigen..."
 (
     cd "${REPO_ROOT}"
-    "./${KCP_APIGEN_GEN}" \
+    "${REPO_ROOT}/hack/apigen.sh" \
         --input-dir "${REPO_ROOT}/config/crds" \
         --output-dir "${REPO_ROOT}/config/kcp"
 )


### PR DESCRIPTION
## The problem

APIResourceSchemas are **immutable** in kcp. apigen doesn't help you here: pointed at an output directory that already contains a schema, it keeps that schema's name and rewrites the content underneath it. The generated files look fine and `git diff` looks innocent — then the apply fails:

```
apiresourceschemas.apis.kcp.io "v260615-841bea0.providers.admin.faros.sh"
  is forbidden: [spec: Invalid value: {...}: is immutable]
```

The hub's bootstrap runs that apply through kcp's `confighelpers.Bootstrap`, which retries forever and doesn't surface the error at our verbosity. So the hub stops here:

```
bootstrap.go:200 "Bootstrapping APIResourceSchemas and APIExports in system:controllers"
```

…and never becomes ready. Nothing logs an error. Every resource that depends on the hub just sits pending.

A one-word doc-comment edit on an exported API type in #519 was enough to trigger it. Because `config/kcp` is `go:embed`'d into the hub binary, a build carrying that regenerated schema would have hung **every existing cluster**, not just local dev.

## The fix

`hack/apigen.sh` wraps apigen:

1. Generates into an empty temp dir, where apigen mints fresh `v<yymmdd>-<HEAD-sha>` names from the current CRDs.
2. Compares each fresh schema against the checked-in copy, **ignoring `metadata.name`**:
   - identical → keep the established name, so names don't churn on every commit
   - different → take the freshly named file, so kcp sees a *create* rather than a forbidden update
   - new → take the fresh file
3. Runs apigen again in place, which preserves the chosen names and regenerates the APIExports to reference them.

Schemas whose CRD disappeared are pruned.

Wired into all six apigen call sites: the hub's `update-codegen-crds.sh` plus the edges / code / agents / app-studio / databricks provider targets.

## Verification

- **No-op when nothing changed**: `make crds` and a full `make codegen` (all six call sites) exit 0 with zero diff — no name churn.
- **Bump works**: editing a description on the Users CRD in a scratch copy produced
  ```
  ~ schema changed, bumping name: v260615-5246b68.users.tenants.faros.sh
                              -> v260815-c6acc7be.users.tenants.faros.sh
  ```
  Only that schema moved; the other seven kept their names. `apiexport-tenants.faros.sh.yaml` picked up the new name automatically and the new content landed in the bumped file.
- **Against a live kcp**, the bumped schema dry-run-applies as `created` and the APIExport as `configured` (APIExports are mutable), which is the path that was previously forbidden.
- `bash -n` clean.

## Known limitation

apigen derives names from HEAD, so two schema-changing edits on one commit would generate the same name twice. Rather than emit a file that can't be applied, the wrapper fails and exits 1:

```
! apiresourceschema-users.tenants.faros.sh.yaml: content changed but the generated
  name is still v260815-c6acc7be.users.tenants.faros.sh.
  apigen derives names from HEAD; commit the API change and re-run
  codegen so the schema gets a distinct name.
```

So the workflow is: change the API → commit → `make codegen` → commit the bump. Removing that dance entirely means deriving names from a content hash instead of HEAD, i.e. not using apigen's naming at all — a bigger change, worth doing only if this proves annoying in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)