### PR TITLE
Stop a stalled hub request from wedging the agent heartbeat

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -244,6 +244,32 @@ const (
 	AgentTypeServer AgentType = "server"
 )
 
+// hubClientTimeout bounds every request the agent makes to the hub.
+//
+// Without it rest.Config.Timeout is zero, which means http.Client.Timeout is
+// zero, which means no deadline at all. When a proxy in front of the hub drops
+// the TCP connection half-open — Cloudflare does this to long-lived
+// connections, and the agent only ever notices via a later RST — an in-flight
+// request never returns. The heartbeat loop in pkg/agent/status is synchronous,
+// so one wedged request stops heartbeats permanently: the hub then flips the
+// Edge to Disconnected on staleHeartbeatThreshold while the agent logs nothing
+// at all, because the call it is blocked in never produced an error to log.
+const hubClientTimeout = 30 * time.Second
+
+// applyHubClientDefaults stamps the settings every hub client must have,
+// regardless of how its config was built. Call it on every *rest.Config that
+// talks to the hub; the token-exchange path rebuilds the config from scratch,
+// so a timeout set only at construction would be silently dropped on refresh.
+func applyHubClientDefaults(cfg *rest.Config) *rest.Config {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = hubClientTimeout
+	}
+	return cfg
+}
+
 // resolveType normalises a raw --type flag value to a canonical AgentType.
 func resolveType(raw string) (AgentType, error) {
 	switch raw {
@@ -460,6 +486,8 @@ func New(opts *Options) (*Agent, error) {
 	} else {
 		return nil, fmt.Errorf("hub URL or hub kubeconfig is required")
 	}
+
+	applyHubClientDefaults(hubConfig)
 
 	hubTLSConfig, err := rest.TLSConfigFor(hubConfig)
 	if err != nil {
@@ -730,6 +758,8 @@ func (a *Agent) refreshHubClientFromSavedKubeconfig() (*farosclient.Client, erro
 		newCfg.CAData = nil
 		newCfg.CAFile = ""
 	}
+	applyHubClientDefaults(newCfg)
+
 	dynClient, err := dynamic.NewForConfig(newCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating dynamic client from saved kubeconfig: %w", err)

--- a/pkg/agent/hubclient_test.go
+++ b/pkg/agent/hubclient_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// TestApplyHubClientDefaults covers the invariant that every hub client gets a
+// request deadline. A zero rest.Config.Timeout means http.Client.Timeout is
+// zero, i.e. no deadline: an in-flight request against a half-open connection
+// then never returns and wedges its caller.
+func TestApplyHubClientDefaults(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *rest.Config
+		want time.Duration
+	}{
+		{
+			name: "zero timeout gets the default",
+			in:   &rest.Config{Host: "https://hub.example"},
+			want: hubClientTimeout,
+		},
+		{
+			name: "explicit timeout is preserved",
+			in:   &rest.Config{Host: "https://hub.example", Timeout: 5 * time.Second},
+			want: 5 * time.Second,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyHubClientDefaults(tc.in)
+			if got.Timeout != tc.want {
+				t.Errorf("Timeout = %v, want %v", got.Timeout, tc.want)
+			}
+		})
+	}
+
+	if applyHubClientDefaults(nil) != nil {
+		t.Error("applyHubClientDefaults(nil) should return nil rather than panic")
+	}
+}
+
+// TestHubClientTimeoutBoundsHeartbeats guards the relationship the wedge
+// depended on: the client deadline must be short enough that a stalled request
+// cannot outlive the hub's staleness threshold for an Edge (90s), otherwise the
+// Edge is marked Disconnected before the agent ever notices the request failed.
+func TestHubClientTimeoutBoundsHeartbeats(t *testing.T) {
+	const staleHeartbeatThreshold = 90 * time.Second
+	if hubClientTimeout >= staleHeartbeatThreshold {
+		t.Errorf("hubClientTimeout (%v) must be well under the hub staleness threshold (%v)",
+			hubClientTimeout, staleHeartbeatThreshold)
+	}
+}

--- a/pkg/agent/status/edge_reporter.go
+++ b/pkg/agent/status/edge_reporter.go
@@ -82,6 +82,19 @@ const (
 	HeartbeatInterval = 30 * time.Second
 )
 
+// heartbeatTimeout bounds a single heartbeat PATCH.
+//
+// Run() calls sendHeartbeat synchronously, so a request that never returns
+// wedges the whole reporter: heartbeats stop, tunnel-state transitions on the
+// channel stop being consumed, and the hub marks the Edge Disconnected while
+// the agent logs nothing. This deadline is defence in depth on top of the hub
+// client's own timeout — it keeps the loop alive even if a client is ever built
+// without one. It is deliberately shorter than HeartbeatInterval so a stalled
+// attempt cannot overlap the next tick.
+//
+// A var rather than a const so tests can shorten it.
+var heartbeatTimeout = 15 * time.Second
+
 // EdgeReporter sends heartbeats for an Edge resource.
 // It works for both EdgeTypeKubernetes and EdgeTypeServer.
 type EdgeReporter struct {
@@ -167,7 +180,10 @@ func (r *EdgeReporter) sendHeartbeat(ctx context.Context, logger klog.Logger) {
 		return
 	}
 
-	_, err = r.hubClient.Dynamic().Resource(r.gvr).Patch(ctx, r.edgeName,
+	patchCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
+	defer cancel()
+
+	_, err = r.hubClient.Dynamic().Resource(r.gvr).Patch(patchCtx, r.edgeName,
 		types.MergePatchType, patchBytes,
 		metav1.PatchOptions{}, "status")
 	if err != nil {

--- a/pkg/agent/status/edge_reporter_test.go
+++ b/pkg/agent/status/edge_reporter_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	farosclient "github.com/faroshq/faros/pkg/client"
+)
+
+var testGVR = schema.GroupVersionResource{
+	Group:    "edges.faros.sh",
+	Version:  "v1alpha1",
+	Resource: "linuxservers",
+}
+
+// TestSendHeartbeatUnblocksWhenHubHangs pins the failure that left agents stuck
+// in Disconnected: a hub that accepts the connection and then never answers.
+//
+// The reporter loop calls sendHeartbeat synchronously, so before the per-request
+// deadline existed this call blocked forever. Heartbeats stopped, the hub flipped
+// the Edge to Disconnected on staleness, and the agent logged nothing at all —
+// the request it was parked in never returned an error to log. Without the
+// deadline this test hangs until the go test timeout rather than failing fast.
+func TestSendHeartbeatUnblocksWhenHubHangs(t *testing.T) {
+	released := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-released // accept the request, then never respond
+	}))
+	// Release the handler before shutting the server down, otherwise Close
+	// blocks on the in-flight request we deliberately stalled.
+	defer srv.Close()
+	defer close(released)
+
+	prev := heartbeatTimeout
+	heartbeatTimeout = 500 * time.Millisecond
+	defer func() { heartbeatTimeout = prev }()
+
+	// No client-side timeout: this must be survivable on the strength of the
+	// per-request deadline alone.
+	dyn, err := dynamic.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("building dynamic client: %v", err)
+	}
+	r := NewEdgeReporter("edge", testGVR, farosclient.NewFromDynamic(dyn), nil, 0)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.sendHeartbeat(context.Background(), klog.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sendHeartbeat blocked on an unresponsive hub; the reporter loop would never heartbeat again")
+	}
+}
+
+// TestSendHeartbeatHonoursParentCancellation ensures shutdown is not delayed by
+// the per-request deadline: cancelling the reporter's context must return
+// immediately rather than waiting out heartbeatTimeout.
+func TestSendHeartbeatHonoursParentCancellation(t *testing.T) {
+	released := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-released
+	}))
+	defer srv.Close()
+	defer close(released)
+
+	prev := heartbeatTimeout
+	heartbeatTimeout = 30 * time.Second
+	defer func() { heartbeatTimeout = prev }()
+
+	dyn, err := dynamic.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("building dynamic client: %v", err)
+	}
+	r := NewEdgeReporter("edge", testGVR, farosclient.NewFromDynamic(dyn), nil, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.sendHeartbeat(ctx, klog.Background())
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sendHeartbeat ignored parent cancellation; agent shutdown would stall")
+	}
+}

--- a/pkg/agent/tunnel/tunneler.go
+++ b/pkg/agent/tunnel/tunneler.go
@@ -233,6 +233,17 @@ func initiateConnection(ctx context.Context, wsURL string, token string, tlsConf
 
 	wsConn, resp, err := dialer.DialContext(ctx, u.String(), header)
 	if err != nil {
+		// gorilla returns a non-nil resp when the upgrade was answered with
+		// something other than 101, and collapses every one of them into the
+		// same "bad handshake" error. Surface the status so a rejection by an
+		// intermediary (a proxy 403, a 502 with no origin behind it) is
+		// distinguishable from the hub genuinely refusing the agent's
+		// credentials — otherwise the only signal is an unattributable
+		// "websocket: bad handshake" in the journal.
+		if resp != nil {
+			return nil, nil, fmt.Errorf("WebSocket dial failed (hub returned HTTP %d %s): %w",
+				resp.StatusCode, http.StatusText(resp.StatusCode), err)
+		}
 		return nil, nil, fmt.Errorf("WebSocket dial failed: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

An agent whose tunnel is healthy can still sit in `Disconnected` indefinitely, with **nothing in its journal** to explain why.

Observed on `lenovo-server`:

```
status:
  connected: false
  phase: Disconnected
  lastHeartbeatTime: "2026-08-16T05:15:21Z"
```

while the agent's own log ends hours earlier, on a *success*:

```
Aug 16 02:07:37 revdial.Listener: read error (tunnel dead?):
    read tcp 192.168.1.201:41168->172.67.139.205:443: read: connection reset by peer
Aug 16 02:07:54 "Tunnel connection established"
   (nothing at 05:15:21, and nothing after)
```

## Cause

The hub client has **no request deadline**. `hubConfig` is built in three places and none sets `rest.Config.Timeout`, so `http.Client.Timeout` is zero — no deadline at all:

- `agent.go` kubeconfig branch
- `agent.go` HubURL branch
- `refreshHubClientFromSavedKubeconfig` — the token-exchange path, which rebuilds the config from scratch, so fixing only construction would regress on the next reconnect

(The `cfg.Timeout = 10 * time.Second` that already exists in `agent.go` is a startup preflight helper on a different config object; it never touches the long-lived hub client.)

That matters because `EdgeReporter.Run` calls `sendHeartbeat` **synchronously**. When a proxy in front of the hub drops the TCP connection half-open — observed against Cloudflare, which the agent only learns about via a much later RST — the heartbeat PATCH never returns. The reporter goroutine parks forever:

- heartbeats stop
- the `tunnelState` channel stops being drained, so later reconnects are never observed
- the hub flips the Edge to `Disconnected` once `lastHeartbeatTime` passes `staleHeartbeatThreshold` (90s)
- **nothing is logged**, because the call it is stuck in never produced an error to log

This is the same shape as the blocking channel send already documented in `tunneler.go:105-112`, in a different goroutine.

## Fix

Bound it at both levels:

1. **`applyHubClientDefaults`** — one helper applied to every hub `*rest.Config`, including the refresh path, so the timeout cannot be dropped by a config rebuild.
2. **Per-request deadline in `sendHeartbeat`** — defence in depth, keeping the loop alive even if a client is ever built without one. Shorter than `HeartbeatInterval` so a stalled attempt cannot overlap the next tick.

Also stops discarding the WebSocket handshake response. gorilla collapses every non-101 answer into `websocket: bad handshake`, which left reconnect failures unattributable — a proxy 403 and the hub rejecting the agent's credentials looked identical in the journal. The status code is now included in the error.

## Tests

`TestSendHeartbeatUnblocksWhenHubHangs` reproduces the wedge against a server that accepts the request and never answers. Verified it **fails without the fix**:

```
--- FAIL: TestSendHeartbeatUnblocksWhenHubHangs (10.00s)
    sendHeartbeat blocked on an unresponsive hub;
    the reporter loop would never heartbeat again
```

Also covers parent-context cancellation (shutdown must not wait out the deadline), the `applyHubClientDefaults` invariant, and that the client timeout stays well under the hub's 90s staleness threshold.

`go build ./...`, `go vet ./pkg/agent/...` and `go test ./pkg/agent/...` all pass.

## Note

This is **not** the cause of the separate `403` seen in the browser on `/auth/authorize` — that response carries Cloudflare's own edge-error header signature and never reached the origin. The two share a trigger (Cloudflare dropping connections to this zone) but not a mechanism. Fix 3 is what will tell us whether Cloudflare is also rejecting the agent's upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)