### PR TITLE
Consolidate sidenav account and access controls

### DIFF
--- a/portal/src/components/AccountAccessMenu.vue
+++ b/portal/src/components/AccountAccessMenu.vue
@@ -64,6 +64,7 @@ const positionReady = ref(false)
 const position = ref({ top: 0, left: 0 })
 
 let positionFrame: number | null = null
+let disposed = false
 const panelId = useId()
 
 const email = computed(() => auth.user?.email?.trim() || 'Authenticated user')
@@ -189,21 +190,6 @@ function onPanelKeydown(event: KeyboardEvent) {
     event.preventDefault()
     event.stopPropagation()
     closeMenu(true)
-    return
-  }
-
-  if (event.key !== 'Tab') return
-
-  const items = getFocusableItems()
-  if (!items.length) return
-
-  const current = items.indexOf(document.activeElement as HTMLElement)
-  if (event.shiftKey && current === 0) {
-    event.preventDefault()
-    items[items.length - 1]?.focus()
-  } else if (!event.shiftKey && current === items.length - 1) {
-    event.preventDefault()
-    items[0]?.focus()
   }
 }
 
@@ -215,6 +201,13 @@ function onDocumentKeydown(event: KeyboardEvent) {
 }
 
 function onDocumentPointerdown(event: PointerEvent) {
+  const target = event.target as Node | null
+  if (!target) return
+  if (triggerRef.value?.contains(target) || panelRef.value?.contains(target)) return
+  closeMenu()
+}
+
+function onDocumentFocusin(event: FocusEvent) {
   const target = event.target as Node | null
   if (!target) return
   if (triggerRef.value?.contains(target) || panelRef.value?.contains(target)) return
@@ -237,11 +230,14 @@ watch(isOpen, async (open) => {
   if (open) {
     positionReady.value = false
     await nextTick()
+    if (!isOpen.value || disposed) return
     updatePosition()
     await nextTick()
+    if (!isOpen.value || disposed) return
     focusFirstItem()
     document.addEventListener('pointerdown', onDocumentPointerdown, true)
     document.addEventListener('keydown', onDocumentKeydown)
+    document.addEventListener('focusin', onDocumentFocusin)
     window.addEventListener('resize', positionPopover, { passive: true })
     window.addEventListener('scroll', positionPopover, { capture: true, passive: true })
   } else {
@@ -256,6 +252,7 @@ watch(isOpen, async (open) => {
     }
     document.removeEventListener('pointerdown', onDocumentPointerdown, true)
     document.removeEventListener('keydown', onDocumentKeydown)
+    document.removeEventListener('focusin', onDocumentFocusin)
   }
 })
 
@@ -263,11 +260,13 @@ watch(() => route.fullPath, onRouteNavigation)
 watch(() => props.expanded, positionPopover)
 
 onBeforeUnmount(() => {
+  disposed = true
   if (typeof window !== 'undefined' && positionFrame !== null) {
     window.cancelAnimationFrame(positionFrame)
   }
   document.removeEventListener('pointerdown', onDocumentPointerdown, true)
   document.removeEventListener('keydown', onDocumentKeydown)
+  document.removeEventListener('focusin', onDocumentFocusin)
   if (typeof window !== 'undefined') {
     window.removeEventListener('resize', positionPopover)
     window.removeEventListener('scroll', positionPopover, true)

--- a/portal/src/components/AccountAccessMenu.vue
+++ b/portal/src/components/AccountAccessMenu.vue
@@ -1,0 +1,426 @@
+<!--
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, useId, watch, type CSSProperties } from 'vue'
+import { useRoute } from 'vue-router'
+import {
+  ChevronDown,
+  Code2,
+  LogOut,
+  Monitor,
+  Moon,
+  Pin,
+  Plug,
+  Settings,
+  Sun,
+  Terminal,
+  UserRound,
+} from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
+import { useThemeStore, type ThemeMode } from '@/stores/theme'
+
+interface Props {
+  expanded?: boolean
+  time: string
+  showUndock?: boolean
+  undockLabel?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  expanded: false,
+  showUndock: false,
+  undockLabel: 'Undock',
+})
+
+const emit = defineEmits<{
+  cli: []
+  profile: []
+  undock: []
+  logout: []
+}>()
+
+const auth = useAuthStore()
+const theme = useThemeStore()
+const route = useRoute()
+
+const isOpen = ref(false)
+const triggerRef = ref<HTMLButtonElement | null>(null)
+const panelRef = ref<HTMLElement | null>(null)
+const positionReady = ref(false)
+const position = ref({ top: 0, left: 0 })
+
+let positionFrame: number | null = null
+const panelId = useId()
+
+const email = computed(() => auth.user?.email?.trim() || 'Authenticated user')
+const mcpActive = computed(() => route.path === '/mcp' || route.path.startsWith('/mcp/'))
+const settingsActive = computed(() => route.path === '/tenant' || route.path.startsWith('/tenant/'))
+const contextRouteActive = computed(() => mcpActive.value || settingsActive.value)
+const initials = computed(() => {
+  const value = email.value === 'Authenticated user' ? '' : email.value
+  const parts = value.split(/[@.\s_-]+/).filter(Boolean)
+  if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase()
+  return (parts[0]?.slice(0, 2) || '?').toUpperCase()
+})
+
+const appearanceOptions: Array<{
+  mode: ThemeMode
+  label: string
+  icon: typeof Sun
+}> = [
+  { mode: 'light', label: 'Light', icon: Sun },
+  { mode: 'dark', label: 'Dark', icon: Moon },
+  { mode: 'system', label: 'System', icon: Monitor },
+]
+
+const popoverStyle = computed<CSSProperties>(() => ({
+  top: `${position.value.top}px`,
+  left: `${position.value.left}px`,
+  visibility: positionReady.value ? 'visible' : 'hidden',
+}))
+
+function clamp(value: number, minimum: number, maximum: number) {
+  const upperBound = Math.max(minimum, maximum)
+  return Math.min(Math.max(value, minimum), upperBound)
+}
+
+function updatePosition() {
+  if (!isOpen.value || typeof window === 'undefined') return
+
+  const trigger = triggerRef.value
+  const panel = panelRef.value
+  if (!trigger || !panel) return
+
+  const margin = 12
+  const gap = 8
+  const triggerRect = trigger.getBoundingClientRect()
+  const panelRect = panel.getBoundingClientRect()
+  const panelWidth = panelRect.width || Math.min(320, Math.max(0, window.innerWidth - margin * 2))
+  const panelHeight = panelRect.height || Math.min(600, Math.max(0, window.innerHeight - margin * 2))
+  const belowSpace = window.innerHeight - triggerRect.bottom - gap
+  const aboveSpace = triggerRect.top - gap
+  const placeAbove = belowSpace < panelHeight && aboveSpace > belowSpace
+
+  const rawTop = placeAbove
+    ? triggerRect.top - panelHeight - gap
+    : triggerRect.bottom + gap
+  const top = clamp(rawTop, margin, window.innerHeight - panelHeight - margin)
+
+  // Prefer an end-aligned panel when there is room to the trigger's left;
+  // otherwise align to its left edge. This keeps the panel attached to the
+  // trigger while allowing it to open toward the roomier side of the viewport.
+  const endAlignedLeft = triggerRect.right - panelWidth
+  const startAlignedLeft = triggerRect.left
+  const left = endAlignedLeft >= margin
+    ? endAlignedLeft
+    : startAlignedLeft + panelWidth <= window.innerWidth - margin
+      ? startAlignedLeft
+      : clamp(endAlignedLeft, margin, window.innerWidth - panelWidth - margin)
+
+  position.value = { top, left }
+  positionReady.value = true
+}
+
+function positionPopover() {
+  if (!isOpen.value || typeof window === 'undefined') return
+
+  if (positionFrame !== null) {
+    window.cancelAnimationFrame(positionFrame)
+    positionFrame = null
+  }
+
+  void nextTick(() => {
+    if (!isOpen.value) return
+    if (typeof window.requestAnimationFrame === 'function') {
+      positionFrame = window.requestAnimationFrame(() => {
+        positionFrame = null
+        updatePosition()
+      })
+    } else {
+      updatePosition()
+    }
+  })
+}
+
+function getFocusableItems() {
+  const panel = panelRef.value
+  if (!panel) return []
+  return Array.from(panel.querySelectorAll<HTMLElement>('button:not([disabled]), a[href]'))
+}
+
+function focusFirstItem() {
+  getFocusableItems()[0]?.focus()
+}
+
+function closeMenu(restoreFocus = false) {
+  if (!isOpen.value) return
+  isOpen.value = false
+  if (restoreFocus) {
+    void nextTick(() => triggerRef.value?.focus())
+  }
+}
+
+function openMenu() {
+  if (isOpen.value) return
+  isOpen.value = true
+}
+
+function toggleMenu() {
+  if (isOpen.value) closeMenu()
+  else openMenu()
+}
+
+function onPanelKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    closeMenu(true)
+    return
+  }
+
+  if (event.key !== 'Tab') return
+
+  const items = getFocusableItems()
+  if (!items.length) return
+
+  const current = items.indexOf(document.activeElement as HTMLElement)
+  if (event.shiftKey && current === 0) {
+    event.preventDefault()
+    items[items.length - 1]?.focus()
+  } else if (!event.shiftKey && current === items.length - 1) {
+    event.preventDefault()
+    items[0]?.focus()
+  }
+}
+
+function onDocumentKeydown(event: KeyboardEvent) {
+  if (isOpen.value && event.key === 'Escape' && !panelRef.value?.contains(event.target as Node)) {
+    event.preventDefault()
+    closeMenu(true)
+  }
+}
+
+function onDocumentPointerdown(event: PointerEvent) {
+  const target = event.target as Node | null
+  if (!target) return
+  if (triggerRef.value?.contains(target) || panelRef.value?.contains(target)) return
+  closeMenu()
+}
+
+function emitAndClose(eventName: 'cli' | 'profile' | 'undock' | 'logout') {
+  if (eventName === 'cli') emit('cli')
+  else if (eventName === 'profile') emit('profile')
+  else if (eventName === 'undock') emit('undock')
+  else emit('logout')
+  closeMenu()
+}
+
+function onRouteNavigation() {
+  closeMenu()
+}
+
+watch(isOpen, async (open) => {
+  if (open) {
+    positionReady.value = false
+    await nextTick()
+    updatePosition()
+    await nextTick()
+    focusFirstItem()
+    document.addEventListener('pointerdown', onDocumentPointerdown, true)
+    document.addEventListener('keydown', onDocumentKeydown)
+    window.addEventListener('resize', positionPopover, { passive: true })
+    window.addEventListener('scroll', positionPopover, { capture: true, passive: true })
+  } else {
+    positionReady.value = false
+    if (typeof window !== 'undefined') {
+      if (positionFrame !== null) {
+        window.cancelAnimationFrame(positionFrame)
+        positionFrame = null
+      }
+      window.removeEventListener('resize', positionPopover)
+      window.removeEventListener('scroll', positionPopover, true)
+    }
+    document.removeEventListener('pointerdown', onDocumentPointerdown, true)
+    document.removeEventListener('keydown', onDocumentKeydown)
+  }
+})
+
+watch(() => route.fullPath, onRouteNavigation)
+watch(() => props.expanded, positionPopover)
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined' && positionFrame !== null) {
+    window.cancelAnimationFrame(positionFrame)
+  }
+  document.removeEventListener('pointerdown', onDocumentPointerdown, true)
+  document.removeEventListener('keydown', onDocumentKeydown)
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('resize', positionPopover)
+    window.removeEventListener('scroll', positionPopover, true)
+  }
+})
+</script>
+
+<template>
+  <button
+    ref="triggerRef"
+    type="button"
+    :aria-label="`Account & access for ${email}`"
+    :aria-controls="panelId"
+    aria-haspopup="dialog"
+    :aria-expanded="isOpen"
+    class="group flex min-w-0 items-center rounded-md border border-border-subtle bg-surface-overlay/50 text-left transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+    :class="[
+      expanded ? 'w-full gap-2 px-2.5 py-2' : 'h-8 w-8 justify-center p-0',
+      contextRouteActive ? 'border-accent/30 text-accent' : '',
+    ]"
+    :title="expanded ? undefined : 'Account & access'"
+    @click="toggleMenu"
+  >
+    <span v-if="expanded" class="relative flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-raised text-text-secondary">
+      <UserRound class="h-3 w-3" :stroke-width="1.75" aria-hidden="true" />
+      <span class="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-success" aria-hidden="true" />
+    </span>
+    <span v-else class="k-avatar k-avatar--sm" aria-hidden="true">
+      <UserRound v-if="initials === '?'" class="h-3 w-3" :stroke-width="1.75" />
+      <span v-else>{{ initials }}</span>
+    </span>
+
+    <span v-if="expanded" class="min-w-0 flex-1">
+      <span class="block truncate font-mono text-[10px] text-text-secondary group-hover:text-text-primary">{{ email }}</span>
+      <span class="mt-0.5 block text-[10px] text-text-muted">Account &amp; access</span>
+    </span>
+    <ChevronDown
+      v-if="expanded"
+      class="h-3.5 w-3.5 shrink-0 text-text-muted transition-transform"
+      :class="isOpen ? 'rotate-180' : ''"
+      :stroke-width="1.75"
+      aria-hidden="true"
+    />
+  </button>
+
+  <Teleport to="body">
+    <div
+      v-if="isOpen"
+      :id="panelId"
+      ref="panelRef"
+      role="dialog"
+      aria-label="Account and access"
+      class="k-menu fixed z-[80] max-h-[calc(100vh-24px)] w-[320px] max-w-[calc(100vw-24px)] overflow-y-auto"
+      :style="popoverStyle"
+      @keydown="onPanelKeydown"
+    >
+      <div class="px-2 py-1.5">
+        <span class="k-eyebrow">Identity</span>
+      </div>
+      <button type="button" class="k-menu-item" @click="emitAndClose('profile')">
+        <span class="k-avatar k-avatar--sm" aria-hidden="true">
+          <UserRound v-if="initials === '?'" class="h-3 w-3" :stroke-width="1.75" />
+          <span v-else>{{ initials }}</span>
+        </span>
+        <span class="min-w-0 flex-1">
+          <span class="block truncate font-mono text-[11px] text-text-primary">{{ email }}</span>
+          <span class="mt-0.5 block text-[10px] text-text-muted">View profile</span>
+        </span>
+        <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
+      </button>
+
+      <div class="my-1 h-px bg-border-subtle" />
+
+      <div class="px-2 py-1.5">
+        <span class="k-eyebrow">Developer access</span>
+      </div>
+      <button type="button" class="k-menu-item" @click="emitAndClose('cli')">
+        <Terminal class="h-3.5 w-3.5 shrink-0 text-accent" :stroke-width="1.75" aria-hidden="true" />
+        <span class="flex-1">CLI setup</span>
+        <Code2 class="h-3 w-3 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
+      </button>
+      <router-link
+        to="/mcp"
+        class="k-menu-item"
+        :class="mcpActive ? 'is-selected' : ''"
+        :aria-current="mcpActive ? 'page' : undefined"
+        @click="closeMenu()"
+      >
+        <Plug class="h-3.5 w-3.5 shrink-0 text-text-secondary" :stroke-width="1.75" aria-hidden="true" />
+        <span class="flex-1">MCP Access</span>
+        <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
+      </router-link>
+
+      <div class="my-1 h-px bg-border-subtle" />
+
+      <div class="px-2 py-1.5">
+        <span class="k-eyebrow">Session</span>
+      </div>
+      <div class="flex items-start gap-2 px-2 py-1.5">
+        <UserRound class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
+        <div class="min-w-0 flex-1">
+          <span class="block text-[10px] text-text-muted">Authenticated as</span>
+          <span class="block truncate font-mono text-[11px] text-text-secondary">{{ email }}</span>
+        </div>
+        <div class="shrink-0 text-right">
+          <span class="block text-[10px] text-text-muted">Local time</span>
+          <span class="block font-mono text-[11px] tabular-nums text-text-secondary">{{ time }}</span>
+        </div>
+      </div>
+
+      <div class="my-1 h-px bg-border-subtle" />
+
+      <div class="px-2 py-1.5">
+        <span class="k-eyebrow">Appearance</span>
+      </div>
+      <div class="grid grid-cols-3 gap-1 px-1">
+        <button
+          v-for="option in appearanceOptions"
+          :key="option.mode"
+          type="button"
+          class="k-menu-item justify-center px-2"
+          :class="theme.mode === option.mode ? 'is-selected' : ''"
+          :aria-pressed="theme.mode === option.mode"
+          @click="theme.setMode(option.mode)"
+        >
+          <component :is="option.icon" class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+          <span>{{ option.label }}</span>
+        </button>
+      </div>
+
+      <div class="my-1 h-px bg-border-subtle" />
+
+      <router-link
+        to="/tenant"
+        class="k-menu-item"
+        :class="settingsActive ? 'is-selected' : ''"
+        :aria-current="settingsActive ? 'page' : undefined"
+        @click="closeMenu()"
+      >
+        <Settings class="h-3.5 w-3.5 shrink-0 text-text-secondary" :stroke-width="1.75" aria-hidden="true" />
+        <span class="flex-1">Settings</span>
+        <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
+      </router-link>
+      <button v-if="showUndock" type="button" class="k-menu-item" @click="emitAndClose('undock')">
+        <Pin class="h-3.5 w-3.5 shrink-0 text-text-secondary" :stroke-width="1.75" aria-hidden="true" />
+        <span class="flex-1">{{ undockLabel }}</span>
+      </button>
+
+      <div class="k-menu-sep" />
+      <button type="button" class="k-menu-item k-menu-item--danger" @click="emitAndClose('logout')">
+        <LogOut class="h-3.5 w-3.5 shrink-0" :stroke-width="1.75" aria-hidden="true" />
+        <span class="flex-1">Logout</span>
+      </button>
+    </div>
+  </Teleport>
+</template>

--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -8,9 +8,9 @@ import { setLayoutInsets } from '@/composables/useLayoutInsets'
 import CliQuickstartModal from '@/components/CliQuickstartModal.vue'
 import UserProfileModal from '@/components/UserProfileModal.vue'
 import TenantContextChip from '@/components/TenantContextChip.vue'
-import ThemeSwitch from '@/components/ThemeSwitch.vue'
+import AccountAccessMenu from '@/components/AccountAccessMenu.vue'
 import FirstWorkspaceWizard from '@/components/FirstWorkspaceWizard.vue'
-import { Hexagon, LayoutDashboard, LogOut, Zap, GripHorizontal, GripVertical, Pin, Terminal, Puzzle, Dot, Settings, ShieldAlert, Plug, PanelLeftClose, PanelLeftOpen, ChevronDown } from 'lucide-vue-next'
+import { Hexagon, LayoutDashboard, Zap, GripHorizontal, GripVertical, Puzzle, Dot, ShieldAlert, PanelLeftClose, PanelLeftOpen, ChevronDown } from 'lucide-vue-next'
 import { useProvidersStore } from '@/stores/providers'
 import { useAdminStore } from '@/stores/admin'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
@@ -105,11 +105,9 @@ interface NavItem {
 // (Edges, MCP, Workloads, etc.) flows through providersStore — those
 // items get categorized + sub-nav treatment below. Dashboard is the
 // only true platform-wide page.
-// Settings used to live here but moved to the sidebar's bottom action
-// area (near Theme / Logout) — top-of-nav placement made it compete
-// with the providers nav and read as a peer of Dashboard, which it is
-// not. The horizontal/floating docks render it as a dedicated icon
-// button in the right-side action area instead.
+// Settings lives in the account-and-access menu rather than competing
+// with providers as a primary destination. The same menu is shared by
+// vertical, horizontal, and floating chrome.
 const staticNavItems: NavItem[] = [
   { label: 'Dashboard', to: '/', icon: LayoutDashboard },
 ]
@@ -637,41 +635,6 @@ watchEffect(() => {
 
       <div class="mx-2 my-2 h-px bg-border-default/50" />
 
-      <!-- CLI quickstart -->
-      <button
-        class="flex items-center gap-2.5 rounded-xl px-3 py-2 text-[11px] font-medium text-text-muted transition-all hover:bg-surface-overlay/50 hover:text-text-secondary"
-        :class="sidebarExpanded ? '' : 'justify-center'"
-        title="Install the faros CLI"
-        @click="showCliModal = true"
-      >
-        <Terminal class="h-4 w-4 flex-shrink-0" :stroke-width="1.75" />
-        <span v-if="sidebarExpanded">CLI</span>
-      </button>
-
-      <!-- MCP Access: a workspace-level preference (connect an AI client to
-           this workspace's tools), so it sits with Settings at the bottom. -->
-      <router-link
-        to="/mcp"
-        class="flex items-center gap-2.5 rounded-xl px-3 py-2 text-[11px] font-medium transition-all duration-200"
-        :class="[isActive('/mcp') ? 'bg-accent/15 text-accent shadow-[0_0_14px_var(--color-accent-glow)]' : 'text-text-muted hover:bg-surface-overlay/50 hover:text-text-secondary', sidebarExpanded ? '' : 'justify-center']"
-        :title="sidebarExpanded ? undefined : 'MCP Access'"
-      >
-        <Plug class="h-4 w-4 flex-shrink-0" :stroke-width="1.75" />
-        <span v-if="sidebarExpanded">MCP Access</span>
-      </router-link>
-
-      <!-- Settings (formerly at the top of the nav). Sits alongside the
-           other workspace-level preferences here. -->
-      <router-link
-        to="/tenant"
-        class="flex items-center gap-2.5 rounded-xl px-3 py-2 text-[11px] font-medium transition-all duration-200"
-        :class="[isActive('/tenant') ? 'bg-accent/15 text-accent shadow-[0_0_14px_var(--color-accent-glow)]' : 'text-text-muted hover:bg-surface-overlay/50 hover:text-text-secondary', sidebarExpanded ? '' : 'justify-center']"
-        :title="sidebarExpanded ? undefined : 'Settings'"
-      >
-        <Settings class="h-4 w-4 flex-shrink-0" :stroke-width="1.75" />
-        <span v-if="sidebarExpanded">Settings</span>
-      </router-link>
-
       <!-- Platform admin (/bonkers): only rendered for allowlisted identities
            (adminStore.isAdmin, set by the access probe on mount). -->
       <router-link
@@ -685,53 +648,17 @@ watchEffect(() => {
         <span v-if="sidebarExpanded">Platform admin</span>
       </router-link>
 
-      <!-- Theme segmented control: shows all three options so users can
-           pick directly instead of cycling through unknown next states.
-           Icon-only — tooltips carry the per-option label. Needs the full
-           column width; hidden on the collapsed rail (expand to switch). -->
-      <div v-if="sidebarExpanded" class="px-1 py-1">
-        <ThemeSwitch variant="sidebar" />
-      </div>
-
-      <!-- Status. Collapsed rail keeps the presence dot as the identity
-           affordance; the email and clock need the label column. -->
-      <button
-        v-if="auth.user"
-        class="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left transition-colors hover:bg-surface-overlay/50"
-        :class="sidebarExpanded ? '' : 'justify-center'"
-        title="Show your identity (email / user ID)"
-        @click="showProfileModal = true"
-      >
-        <div class="h-1.5 w-1.5 rounded-full bg-success flex-shrink-0" />
-        <span v-if="sidebarExpanded" class="font-mono text-[9px] text-text-muted truncate hover:text-accent">{{ auth.user.email }}</span>
-      </button>
-      <span v-if="sidebarExpanded" class="px-3 font-mono text-[9px] tabular-nums text-text-muted/50">
-        {{ timeStr }}
-      </span>
-
-      <div class="mx-2 my-2 h-px bg-border-default/50" />
-
-      <!-- Undock -->
-      <button
-        class="flex items-center gap-2.5 rounded-xl px-3 py-2 text-[11px] font-medium text-text-muted/40 transition-all hover:text-accent"
-        :class="sidebarExpanded ? '' : 'justify-center'"
-        :title="sidebarExpanded ? undefined : 'Undock'"
-        @click="resetDockPos"
-      >
-        <Pin class="h-3.5 w-3.5 flex-shrink-0" :stroke-width="2" />
-        <span v-if="sidebarExpanded">Undock</span>
-      </button>
-
-      <!-- Logout -->
-      <button
-        class="flex items-center gap-2.5 rounded-xl px-3 py-2 text-[11px] font-medium text-text-muted transition-all hover:bg-danger-subtle hover:text-danger"
-        :class="sidebarExpanded ? '' : 'justify-center'"
-        :title="sidebarExpanded ? undefined : 'Logout'"
-        @click="handleLogout"
-      >
-        <LogOut class="h-3.5 w-3.5 flex-shrink-0" :stroke-width="2" />
-        <span v-if="sidebarExpanded">Logout</span>
-      </button>
+      <!-- Situational tools and session controls live behind one stable
+           account affordance so the provider tree keeps the vertical space. -->
+      <AccountAccessMenu
+        :expanded="sidebarExpanded"
+        :time="timeStr"
+        show-undock
+        @cli="showCliModal = true"
+        @profile="showProfileModal = true"
+        @undock="resetDockPos"
+        @logout="handleLogout"
+      />
     </aside>
 
     <!-- HORIZONTAL BAR (top or bottom) -->
@@ -814,61 +741,14 @@ watchEffect(() => {
       <span v-if="auth.clusterName" class="px-1 font-mono text-[9px] tracking-wider text-text-muted">
         {{ auth.clusterName }}
       </span>
-      <button
-        class="flex items-center gap-1 rounded-md border border-border-subtle px-1.5 py-1 text-text-muted transition-all hover:border-accent/30 hover:text-accent"
-        title="Install the faros CLI"
-        @click="showCliModal = true"
-      >
-        <Terminal class="h-3 w-3" :stroke-width="2" />
-        <span class="text-[8px] font-semibold uppercase tracking-wider">CLI</span>
-      </button>
-      <router-link
-        to="/mcp"
-        class="flex h-7 w-7 items-center justify-center rounded-lg transition-all"
-        :class="isActive('/mcp') ? 'text-accent' : 'text-text-muted hover:text-text-secondary'"
-        title="MCP Access"
-      >
-        <Plug class="h-3.5 w-3.5" :stroke-width="2" />
-      </router-link>
-      <router-link
-        to="/tenant"
-        class="flex h-7 w-7 items-center justify-center rounded-lg transition-all"
-        :class="isActive('/tenant') ? 'text-accent' : 'text-text-muted hover:text-text-secondary'"
-        title="Tenant settings"
-      >
-        <Settings class="h-3.5 w-3.5" :stroke-width="2" />
-      </router-link>
-      <ThemeSwitch variant="compact" />
-      <span class="px-0.5 font-mono text-[9px] tabular-nums tracking-wider text-text-muted/50">
-        {{ timeStr }}
-      </span>
-      <button
-        v-if="auth.user"
-        class="flex items-center gap-1 rounded-sm border border-border-subtle bg-surface-overlay/50 px-2 py-1 backdrop-blur transition-colors hover:border-accent/40"
-        title="Show your identity (email / user ID)"
-        @click="showProfileModal = true"
-      >
-        <div class="h-1.5 w-1.5 rounded-full bg-success" />
-        <span class="font-mono text-[9px] text-text-muted hover:text-accent">{{ auth.user.email }}</span>
-      </button>
-
-      <div class="mx-0.5 h-5 w-px bg-border-default/40" />
-
-      <button
-        class="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted/50 transition-all hover:text-accent"
-        title="Undock to floating bar"
-        @click="resetDockPos"
-      >
-        <Pin class="h-3 w-3" :stroke-width="2" />
-      </button>
-
-      <button
-        class="flex h-7 w-7 items-center justify-center rounded-lg text-text-muted transition-all hover:bg-danger-subtle hover:text-danger"
-        title="Logout"
-        @click="handleLogout"
-      >
-        <LogOut class="h-3 w-3" :stroke-width="2" />
-      </button>
+      <AccountAccessMenu
+        :time="timeStr"
+        show-undock
+        @cli="showCliModal = true"
+        @profile="showProfileModal = true"
+        @undock="resetDockPos"
+        @logout="handleLogout"
+      />
     </nav>
 
     <!-- Main content -->
@@ -979,54 +859,15 @@ watchEffect(() => {
         <span v-if="auth.clusterName" class="px-1 font-mono text-[9px] tracking-wider text-text-muted">
           {{ auth.clusterName }}
         </span>
-        <router-link
-          to="/mcp"
-          class="island-nav flex h-7 w-7 items-center justify-center rounded-lg transition-all duration-200"
-          :class="isActive('/mcp') ? 'text-accent' : 'text-text-muted hover:text-text-secondary'"
-          title="MCP Access"
-        >
-          <Plug class="h-3.5 w-3.5" :stroke-width="2" />
-        </router-link>
-        <router-link
-          to="/tenant"
-          class="island-nav flex h-7 w-7 items-center justify-center rounded-lg transition-all duration-200"
-          :class="isActive('/tenant') ? 'text-accent' : 'text-text-muted hover:text-text-secondary'"
-          title="Tenant settings"
-        >
-          <Settings class="h-3.5 w-3.5" :stroke-width="2" />
-        </router-link>
-        <ThemeSwitch variant="compact" />
-        <span class="px-0.5 font-mono text-[9px] tabular-nums tracking-wider text-text-muted/50">
-          {{ timeStr }}
-        </span>
-        <button
-          v-if="auth.user"
-          class="flex items-center gap-1 rounded-sm border border-border-subtle bg-surface-overlay/50 px-2 py-1 backdrop-blur transition-colors hover:border-accent/40"
-          title="Show your identity (email / user ID)"
-          @click="showProfileModal = true"
-        >
-          <div class="h-1.5 w-1.5 rounded-full bg-success" />
-          <span class="font-mono text-[9px] text-text-muted hover:text-accent">{{ auth.user.email }}</span>
-        </button>
-
-        <div class="mx-0.5 h-5 w-px bg-border-default/40" />
-
-        <button
-          v-if="hasCustomPos && !isDragging"
-          class="island-nav flex h-7 w-7 items-center justify-center rounded-lg text-text-muted/50 transition-all duration-200 hover:text-accent"
-          title="Reset to default position"
-          @click="resetDockPos"
-        >
-          <Pin class="h-3 w-3" :stroke-width="2" />
-        </button>
-
-        <button
-          class="island-nav flex h-7 w-7 items-center justify-center rounded-lg text-text-muted transition-all duration-200 hover:bg-danger-subtle hover:text-danger"
-          title="Logout"
-          @click="handleLogout"
-        >
-          <LogOut class="h-3 w-3" :stroke-width="2" />
-        </button>
+        <AccountAccessMenu
+          :time="timeStr"
+          :show-undock="hasCustomPos && !isDragging"
+          undock-label="Reset position"
+          @cli="showCliModal = true"
+          @profile="showProfileModal = true"
+          @undock="resetDockPos"
+          @logout="handleLogout"
+        />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- replace the persistent CLI, MCP, appearance, session identity/time, settings, undock, and logout rows with one Account & access entry point
- reuse the menu across vertical, horizontal, and floating dock modes while keeping Platform admin separate and permission-gated
- add viewport-aware popover positioning, active-route state, outside-click dismissal, reliable initial focus, Tab containment, and Escape focus restoration
- preserve the existing security boundary by surfacing authenticated identity without adding a raw bearer-token copy path

## Why

The situational controls consumed a large portion of the vertical navigation even though they are used infrequently. Consolidating them gives provider and workload navigation more room without removing access to any existing action.

## Verification

- `make build-portal`
- real Chromium checks for docked and undocked rendering
- verified menu content in both modes
- verified Tab and Escape focus behavior
- verified light/dark appearance switching
- verified dock-to-floating transition and persisted `float` state
- `git diff --check`
