### PR TITLE
Restart app sign-in on stale state instead of dead-ending

### DIFF
--- a/providers/infrastructure/accessproxy/proxy.go
+++ b/providers/infrastructure/accessproxy/proxy.go
@@ -271,11 +271,20 @@ func (p *Proxy) redirectToAuthorize(w http.ResponseWriter, r *http.Request, path
 func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
 	partitioned := requestUsesPartitionedCookies(r)
 	state := r.URL.Query().Get("state")
-	returnPath, ok := p.consumeReturnState(w, r, state, partitioned)
-	if !ok {
+	outcome := p.consumeReturnState(w, r, state, partitioned)
+	if !outcome.OK {
+		// A stale sign-in is recoverable without involving the user: send the
+		// browser back through authorize with a fresh nonce and cookie. The
+		// restart is safe from looping because it is only offered when the
+		// browser demonstrably returned our cookie — see returnStateOutcome.
+		if outcome.Restart {
+			p.redirectToAuthorize(w, r, outcome.RestartPath)
+			return
+		}
 		http.Error(w, "invalid app access state", http.StatusBadRequest)
 		return
 	}
+	returnPath := outcome.Path
 	code := strings.TrimSpace(r.URL.Query().Get("code"))
 	if code == "" {
 		p.clearReturnCookie(w, partitioned)
@@ -380,39 +389,71 @@ func (p *Proxy) handleCallback(w http.ResponseWriter, r *http.Request) {
 // still be able to complete its own sign-in. Single use is enforced by the
 // usedStates cache below, which is a best-effort optimisation rather than the
 // authority — see markStateUsed.
-func (p *Proxy) consumeReturnState(w http.ResponseWriter, r *http.Request, state string, partitioned bool) (string, bool) {
+func (p *Proxy) consumeReturnState(w http.ResponseWriter, r *http.Request, state string, partitioned bool) returnStateOutcome {
 	cookie, err := r.Cookie(ReturnCookieName)
 	if err != nil {
+		// Deliberately NOT restartable. A restart would mint another cookie
+		// this browser also fails to send back, and the app would bounce
+		// between the gate and the hub for as long as the user waits.
 		p.logf("app access callback rejected: request carried no %s cookie (host=%s) — a copied callback URL, or the cookie was blocked", ReturnCookieName, p.config.host)
 		p.clearReturnCookie(w, partitioned)
-		return "", false
+		return returnStateOutcome{}
 	}
 	payload, ok := decodeReturnState(cookie.Value)
 	if !ok {
-		p.logf("app access callback rejected: %s cookie is malformed (host=%s)", ReturnCookieName, p.config.host)
-		p.clearReturnCookie(w, partitioned)
-		return "", false
+		// A cookie came back, so the browser does round-trip ours; it is just
+		// unreadable (truncated, or written by an older gate). Start over.
+		p.logf("app access callback recovering: %s cookie is malformed (host=%s) — restarting sign-in", ReturnCookieName, p.config.host)
+		return returnStateOutcome{Restart: true, RestartPath: "/"}
 	}
 	if state == "" || subtle.ConstantTimeCompare([]byte(payload.Nonce), []byte(state)) != 1 {
+		// Not restarted on purpose: the cookie may belong to a different
+		// sign-in this browser still has in flight, and overwriting it here
+		// would break that one to fix a callback that is probably forged or
+		// hand-copied.
 		p.logf("app access callback rejected: state parameter does not match the %s cookie (host=%s)", ReturnCookieName, p.config.host)
-		return "", false
+		return returnStateOutcome{}
 	}
 	if !p.now().Before(time.Unix(payload.ExpiresAt, 0)) {
-		p.logf("app access callback rejected: sign-in state expired (host=%s) — the round trip through the hub took longer than %s", p.config.host, stateTTL)
-		p.clearReturnCookie(w, partitioned)
-		return "", false
+		// The overwhelmingly common cause is a tab left open past stateTTL.
+		// The cookie proves the browser stores ours, so a fresh round trip
+		// will succeed — and the deep link survives it.
+		p.logf("app access callback recovering: sign-in state expired (host=%s) after %s — restarting sign-in", p.config.host, stateTTL)
+		return returnStateOutcome{Restart: true, RestartPath: cleanReturnPath(payload.Path)}
 	}
 	if !p.markStateUsed(payload.Nonce, time.Unix(payload.ExpiresAt, 0)) {
+		// Not restarted: a replay is an attack signal, and a successful
+		// sign-in already cleared the cookie, so the benign refresh case
+		// lands in the no-cookie branch above rather than here.
 		p.logf("app access callback rejected: sign-in state already used (host=%s) — replayed callback", p.config.host)
 		p.clearReturnCookie(w, partitioned)
-		return "", false
+		return returnStateOutcome{}
 	}
 	// Re-sanitise rather than trust: the path round-tripped through a cookie.
 	path := cleanReturnPath(payload.Path)
 	if path == "" {
 		path = "/"
 	}
-	return path, true
+	return returnStateOutcome{Path: path, OK: true}
+}
+
+// returnStateOutcome is the verdict on a callback's state/cookie pair.
+//
+// The distinction that matters is Restart: a stale sign-in is worth retrying
+// automatically, a blocked cookie is not. Both used to collapse into the same
+// opaque "invalid app access state" 400, which stranded users whose only fault
+// was leaving the tab open past stateTTL.
+type returnStateOutcome struct {
+	// Path is the sanitised return path. Meaningful only when OK.
+	Path string
+	OK   bool
+	// Restart reports that beginning a fresh sign-in can plausibly succeed.
+	// It is set ONLY when a cookie actually came back, because that is the
+	// evidence the browser round-trips ours — without it a restart loops.
+	Restart bool
+	// RestartPath is the deep link to preserve across a restart. Empty is
+	// fine; redirectToAuthorize substitutes "/".
+	RestartPath string
 }
 
 // newReturnState mints the nonce echoed to the hub and the cookie value that

--- a/providers/infrastructure/accessproxy/proxy_test.go
+++ b/providers/infrastructure/accessproxy/proxy_test.go
@@ -746,12 +746,16 @@ func TestReturnCookieWithTamperedPathRedirectsSameOrigin(t *testing.T) {
 	}
 }
 
-func TestExpiredReturnStateIsRejected(t *testing.T) {
+// An expired state is the tab-left-open case, not an attack. The gate restarts
+// the sign-in itself — the user never sees an error, and the deep link they
+// originally asked for survives the extra round trip. It previously dead-ended
+// on an opaque "invalid app access state" 400.
+func TestExpiredReturnStateRestartsSignIn(t *testing.T) {
 	upstream, _ := newUpstream(t, nil)
 	hub := newFakeHub("code-1")
 	p := newProxy(t, privateConfig(upstream.URL, hub))
 
-	first := doRequest(p, appRequest("/"))
+	first := doRequest(p, appRequest("/deep/link?q=1"))
 	returnCookie := cookieFromResponse(t, first, ReturnCookieName)
 	state := mustQuery(t, first.Header().Get("Location"), "state")
 
@@ -760,11 +764,71 @@ func TestExpiredReturnStateIsRejected(t *testing.T) {
 	p.now = func() time.Time { return base.Add(stateTTL + time.Second) }
 
 	rec := doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state, returnCookie))
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", rec.Code)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d body=%q, want 302 (restarted sign-in)", rec.Code, rec.Body.String())
 	}
+	if got := rec.Header().Get("Location"); !strings.HasPrefix(got, p.config.hubPublicURL+hubAuthorizePath) {
+		t.Fatalf("restart Location = %q, want the hub authorize endpoint", got)
+	}
+	// An expired state must never buy a hub exchange, restarted or not.
 	if hub.exchangeCount() != 0 {
 		t.Fatalf("expired state reached the hub exchange")
+	}
+	// The restart must carry a usable cookie, and keep the original deep link.
+	fresh := cookieFromResponse(t, rec, ReturnCookieName)
+	if fresh == nil || fresh.Value == "" {
+		t.Fatal("restart set no fresh return cookie")
+	}
+	payload, ok := decodeReturnState(fresh.Value)
+	if !ok {
+		t.Fatal("restart cookie is not decodable")
+	}
+	if payload.Path != "/deep/link?q=1" {
+		t.Fatalf("restart return path = %q, want the original deep link", payload.Path)
+	}
+	if payload.Nonce == state {
+		t.Fatal("restart reused the expired nonce")
+	}
+}
+
+// The loop guard. With no cookie at all there is no evidence the browser will
+// keep one, so restarting would bounce the app between the gate and the hub
+// indefinitely. This must terminate with an error instead.
+func TestMissingReturnCookieDoesNotRestartSignIn(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	p := newProxy(t, privateConfig(upstream.URL, hub))
+
+	first := doRequest(p, appRequest("/"))
+	state := mustQuery(t, first.Header().Get("Location"), "state")
+
+	// Same callback, but the browser never sends the cookie back.
+	rec := doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 — a restart here would loop", rec.Code)
+	}
+	if hub.exchangeCount() != 0 {
+		t.Fatalf("cookieless callback reached the hub exchange")
+	}
+}
+
+// A malformed cookie still proves the browser round-trips ours, so it is
+// recoverable: start over rather than stranding the user.
+func TestMalformedReturnCookieRestartsSignIn(t *testing.T) {
+	upstream, _ := newUpstream(t, nil)
+	hub := newFakeHub("code-1")
+	p := newProxy(t, privateConfig(upstream.URL, hub))
+
+	first := doRequest(p, appRequest("/"))
+	state := mustQuery(t, first.Header().Get("Location"), "state")
+
+	rec := doRequest(p, appRequest(CallbackPath+"?code="+hub.code+"&state="+state,
+		&http.Cookie{Name: ReturnCookieName, Value: "not-a-valid-payload"}))
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d body=%q, want 302 (restarted sign-in)", rec.Code, rec.Body.String())
+	}
+	if hub.exchangeCount() != 0 {
+		t.Fatalf("malformed cookie reached the hub exchange")
 	}
 }
 


### PR DESCRIPTION
## Problem

Leaving an app tab open past the 5 minute `stateTTL` strands the user on an opaque `400 invalid app access state`, with no way forward but to find the app's URL again by hand.

The sign-in round trip goes gate → hub → Dex → GitHub → back. On a slow environment that exceeds 5 minutes easily, so this is routine rather than exceptional. Hit repeatedly in local Tilt.

## Cause

`consumeReturnState` already distinguished five failure causes internally — and then collapsed every one of them into the same status:

```go
returnPath, ok := p.consumeReturnState(w, r, state, partitioned)
if !ok {
    http.Error(w, "invalid app access state", http.StatusBadRequest)
```

A stale sign-in and a blocked cookie are not the same problem, but they produced the same dead end.

## Fix

Return the cause, and restart the sign-in for the ones a fresh round trip actually fixes. The original deep link is carried across the restart, so the user lands where they asked to be.

| Cause | Before | After |
|---|---|---|
| Expired state (tab left open) | 400 | **302, restarts, deep link preserved** |
| Malformed / undecodable cookie | 400 | **302, restarts** |
| No cookie at all | 400 | 400 — *loop guard* |
| State ≠ cookie nonce | 400 | 400 — unchanged |
| Replayed state | 400 | 400 — unchanged |

### The loop guard

**A restart is only offered when a cookie came back.** That returned cookie is the evidence this browser round-trips ours, so a new nonce will come back too.

With no cookie at all — blocked, or a callback URL copied into a different browser — a restart would mint another cookie that gets dropped just the same, and the app would bounce between the gate and the hub for as long as the user waited. That case keeps terminating with an error. It's the same loop already documented in `pkg/hub/appauth`, which was observed minting ~8 sessions/second until a rate limiter stopped it.

A retry marker wouldn't help here regardless: the hub replaces `RawQuery` when it redirects to `redirect_uri`, so nothing survives the round trip except the cookie.

### Two causes deliberately keep their 400

- **State ≠ cookie nonce** — the cookie may belong to a *different* sign-in the browser still has in flight. Restarting would overwrite it, breaking a working login to fix a callback that is most likely forged or hand-copied. The existing code comments already call this out.
- **Replayed state** — an attack signal. The benign refresh-after-login case never reaches it, because a successful sign-in already cleared the cookie and so lands in the no-cookie branch.

Neither buys a hub exchange, restarted or not.

## Tests

`TestExpiredReturnStateIsRejected` asserted the old 400, so it's replaced by `TestExpiredReturnStateRestartsSignIn`, which verifies the 302 targets the hub authorize endpoint, a **fresh** nonce and cookie are issued, the original deep link survives, and the hub exchange is still never reached.

Added:
- `TestMissingReturnCookieDoesNotRestartSignIn` — pins the loop guard
- `TestMalformedReturnCookieRestartsSignIn`

Existing replay and mismatch tests pass unchanged. Full `providers/infrastructure` suite green; `go vet` and `gofmt` clean.

## Operability

Log lines now separate `recovering: … restarting sign-in` from `rejected: …`, so the two are distinguishable in the gate pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)