### PR TITLE
Demonstrate Config Connector with the infrastructure operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -954,10 +954,10 @@ e2e-tilt-cluster: ## Run Tilt-cluster provider e2e (requires `make tilt-cluster`
 	}
 	go test ./test/e2e/suites/tiltcluster/... -v -timeout $(E2E_TILT_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
 
-## Opt-in Config Connector composition steel-thread against the operator-managed
-## Tilt runtime. The test creates only a minimal StorageBucket CRD; it does not
-## install Config Connector or contact GCP. Override the runtime kubeconfig or
-## operator namespace when using a non-default Tilt stack.
+## Opt-in demonstration of using Config Connector CRDs with the infrastructure
+## operator's KRO runtime. The test creates only a minimal StorageBucket CRD; it
+## does not install Config Connector or contact GCP. Override the runtime
+## kubeconfig or operator namespace when using a non-default Tilt stack.
 .PHONY: e2e-tilt-cluster-config-connector
 e2e-tilt-cluster-config-connector: ## Run the opt-in Config Connector composition e2e
 	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { \
@@ -982,12 +982,12 @@ e2e-tilt-cluster-config-connector: ## Run the opt-in Config Connector compositio
 	FAROS_E2E_TILT_OPERATOR_NAMESPACE="$(E2E_TILT_OPERATOR_NAMESPACE)" \
 		go test ./test/e2e/suites/tiltcluster/... -run '^TestConfigConnectorComposition$$' -v -timeout $(E2E_TILT_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
 
-## Real-cloud extension of the composition steel thread. Installation imports
-## the caller-supplied service-account JSON into the runtime cluster, installs a
-## checksum-pinned Config Connector operator, and waits for the PubSubTopic API.
-## The run target then proves Pub/Sub creation and deletion independently via
-## Google's REST API. Both targets are deliberately separate from the fake-CRD
-## composition test above.
+## Real-cloud extension of the infrastructure-operator Config Connector
+## demonstration. Installation imports the caller-supplied service-account JSON
+## into the runtime cluster, installs a checksum-pinned Config Connector
+## operator, and waits for the PubSubTopic API. The run target then proves
+## Pub/Sub creation and deletion independently via Google's REST API. Both
+## targets are deliberately separate from the fake-CRD composition test above.
 .PHONY: e2e-tilt-cluster-config-connector-gcp-install e2e-tilt-cluster-config-connector-gcp-run e2e-tilt-cluster-config-connector-gcp
 e2e-tilt-cluster-config-connector-gcp-install: ## Install pinned Config Connector for the real Pub/Sub E2E
 	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { \

--- a/Makefile
+++ b/Makefile
@@ -933,6 +933,15 @@ E2E_TILT_KCP_KUBECONFIG ?= $(CURDIR)/tilt-frontproxy.kubeconfig
 E2E_TILT_RUNTIME_KUBECONFIG ?= $(CURDIR)/.faros-cluster.kubeconfig
 E2E_TILT_OPERATOR_NAMESPACE ?= faros-infrastructure-operator
 E2E_TILT_CONFIG_CONNECTOR_TIMEOUT ?= 30m
+KCC_INSTALL_SCRIPT ?= providers/infrastructure/contrib/config-connector/install.sh
+KCC_ENABLE_SCRIPT ?= providers/infrastructure/contrib/config-connector/enable.sh
+KCC_TEMPLATE_FILE ?= providers/infrastructure/contrib/config-connector/pubsub-template.yaml
+KCC_PROVIDER_WORKSPACE ?= root:faros:providers:infrastructure
+# Public dev configuration uses FAROS_CONFIG_CONNECTOR_GCP_*; keep the older
+# FAROS_E2E_GCP_* names as an explicit compatibility fallback for callers that
+# invoke these targets from an exported environment.
+KCC_GCP_PROJECT ?= $(or $(FAROS_CONFIG_CONNECTOR_GCP_PROJECT),$(FAROS_E2E_GCP_PROJECT))
+KCC_GCP_CREDENTIALS_FILE ?= $(or $(FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE),$(FAROS_E2E_GCP_CREDENTIALS_FILE))
 .PHONY: e2e-tilt-cluster
 e2e-tilt-cluster: ## Run Tilt-cluster provider e2e (requires `make tilt-cluster` running)
 	@curl -sk --max-time 5 -o /dev/null "$(E2E_TILT_HUB_URL)/healthz" || { \
@@ -985,9 +994,31 @@ e2e-tilt-cluster-config-connector-gcp-install: ## Install pinned Config Connecto
 		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
 		exit 1; \
 	}
-	@test -n "$$FAROS_E2E_GCP_CREDENTIALS_FILE" || { echo "FAROS_E2E_GCP_CREDENTIALS_FILE is required"; exit 1; }
+	@test -n "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (or legacy FAROS_E2E_GCP_CREDENTIALS_FILE) is required"; exit 1; }
+	@test -f "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "Config Connector credentials file does not exist"; exit 1; }
 	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
-		providers/infrastructure/test/e2e/config-connector/install.sh
+	FAROS_E2E_GCP_CREDENTIALS_FILE="$(KCC_GCP_CREDENTIALS_FILE)" \
+		$(KCC_INSTALL_SCRIPT)
+
+## Enable the checked-in Pub/Sub Template in the infrastructure provider
+## workspace. This does not install Config Connector and is intentionally a
+## separate manual action so ordinary Tilt startup remains cloud-neutral.
+.PHONY: e2e-tilt-cluster-config-connector-enable
+e2e-tilt-cluster-config-connector-enable: ## Apply and wait for the opt-in Pub/Sub Template/APIExport/KRO graph
+	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { \
+		echo "kcp front-proxy kubeconfig not found at $(E2E_TILT_KCP_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { \
+		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	FAROS_E2E_TILT_KUBECONFIG="$(E2E_TILT_KCP_KUBECONFIG)" \
+	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
+	FAROS_KCC_KCP_SERVER="$(KCC_KCP_SERVER)" \
+	FAROS_KCC_PROVIDER_WORKSPACE="$(KCC_PROVIDER_WORKSPACE)" \
+	FAROS_KCC_TEMPLATE_FILE="$(KCC_TEMPLATE_FILE)" \
+		$(KCC_ENABLE_SCRIPT)
 
 e2e-tilt-cluster-config-connector-gcp-run: ## Create then delete a real Pub/Sub topic through KRO and Config Connector
 	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { \
@@ -998,17 +1029,52 @@ e2e-tilt-cluster-config-connector-gcp-run: ## Create then delete a real Pub/Sub 
 		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
 		exit 1; \
 	}
-	@test -n "$$FAROS_E2E_GCP_PROJECT" || { echo "FAROS_E2E_GCP_PROJECT is required"; exit 1; }
-	@test -n "$$FAROS_E2E_GCP_CREDENTIALS_FILE" || { echo "FAROS_E2E_GCP_CREDENTIALS_FILE is required"; exit 1; }
+	@test -n "$(KCC_GCP_PROJECT)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_PROJECT (or legacy FAROS_E2E_GCP_PROJECT) is required"; exit 1; }
+	@test -n "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (or legacy FAROS_E2E_GCP_CREDENTIALS_FILE) is required"; exit 1; }
+	@test -f "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "Config Connector credentials file does not exist"; exit 1; }
 	FAROS_E2E_CONFIG_CONNECTOR_GCP=1 \
 	FAROS_E2E_TILT_KUBECONFIG="$(E2E_TILT_KCP_KUBECONFIG)" \
 	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
 	FAROS_E2E_TILT_OPERATOR_NAMESPACE="$(E2E_TILT_OPERATOR_NAMESPACE)" \
+	FAROS_E2E_GCP_PROJECT="$(KCC_GCP_PROJECT)" \
+	FAROS_E2E_GCP_CREDENTIALS_FILE="$(KCC_GCP_CREDENTIALS_FILE)" \
 		go test ./test/e2e/suites/tiltcluster/... -run '^TestConfigConnectorGCPPubSubLifecycle$$' -v -timeout $(E2E_TILT_CONFIG_CONNECTOR_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
 
+## Smoke only the already-enabled stable Pub/Sub Template. Installation and
+## Template enablement are separate manual actions; this target creates and
+## deletes only the test-owned cloud topic and its tenant/KRO objects.
+.PHONY: e2e-tilt-cluster-config-connector-smoke e2e-tilt-cluster-config-connector-gcp-smoke
+e2e-tilt-cluster-config-connector-smoke: ## Create then delete one real Pub/Sub topic using the enabled Template
+	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { \
+		echo "kcp front-proxy kubeconfig not found at $(E2E_TILT_KCP_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { \
+		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -n "$(KCC_GCP_PROJECT)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_PROJECT (or legacy FAROS_E2E_GCP_PROJECT) is required"; exit 1; }
+	@test -n "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (or legacy FAROS_E2E_GCP_CREDENTIALS_FILE) is required"; exit 1; }
+	@test -f "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "Config Connector credentials file does not exist"; exit 1; }
+	FAROS_E2E_CONFIG_CONNECTOR_GCP=1 \
+	FAROS_E2E_TILT_KUBECONFIG="$(E2E_TILT_KCP_KUBECONFIG)" \
+	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
+	FAROS_E2E_TILT_OPERATOR_NAMESPACE="$(E2E_TILT_OPERATOR_NAMESPACE)" \
+	FAROS_E2E_GCP_PROJECT="$(KCC_GCP_PROJECT)" \
+	FAROS_E2E_GCP_CREDENTIALS_FILE="$(KCC_GCP_CREDENTIALS_FILE)" \
+		go test ./test/e2e/suites/tiltcluster/... -run '^TestConfigConnectorGCPPubSubSmoke$$' -v -timeout $(E2E_TILT_CONFIG_CONNECTOR_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
+
+e2e-tilt-cluster-config-connector-gcp-smoke: e2e-tilt-cluster-config-connector-smoke
+
+.PHONY: config-connector-install config-connector-enable config-connector-smoke
+config-connector-install: e2e-tilt-cluster-config-connector-gcp-install
+config-connector-enable: e2e-tilt-cluster-config-connector-enable
+config-connector-smoke: e2e-tilt-cluster-config-connector-smoke
+
 e2e-tilt-cluster-config-connector-gcp: ## Install Config Connector and run the real Pub/Sub create/delete E2E
-	@test -n "$$FAROS_E2E_GCP_PROJECT" || { echo "FAROS_E2E_GCP_PROJECT is required before Config Connector is installed"; exit 1; }
-	@test -n "$$FAROS_E2E_GCP_CREDENTIALS_FILE" || { echo "FAROS_E2E_GCP_CREDENTIALS_FILE is required before Config Connector is installed"; exit 1; }
+	@test -n "$(KCC_GCP_PROJECT)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_PROJECT (or legacy FAROS_E2E_GCP_PROJECT) is required"; exit 1; }
+	@test -n "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (or legacy FAROS_E2E_GCP_CREDENTIALS_FILE) is required"; exit 1; }
+	@test -f "$(KCC_GCP_CREDENTIALS_FILE)" || { echo "Config Connector credentials file does not exist"; exit 1; }
 	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { echo "kcp front-proxy kubeconfig is required before Config Connector is installed"; exit 1; }
 	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { echo "runtime kubeconfig is required before Config Connector is installed"; exit 1; }
 	@curl -sk --max-time 5 -o /dev/null "$(E2E_TILT_HUB_URL)/healthz" || { echo "hub must be healthy before Config Connector is installed"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -929,6 +929,10 @@ e2e-edges-connectivity: build-hub build-edges-provider build-faros certs ## Run 
 E2E_TILT_TIMEOUT ?= 10m
 E2E_TILT_HUB_URL ?= https://localhost:9443
 E2E_TILT_INFRA_URL ?= http://localhost:8082
+E2E_TILT_KCP_KUBECONFIG ?= $(CURDIR)/tilt-frontproxy.kubeconfig
+E2E_TILT_RUNTIME_KUBECONFIG ?= $(CURDIR)/.faros-cluster.kubeconfig
+E2E_TILT_OPERATOR_NAMESPACE ?= faros-infrastructure-operator
+E2E_TILT_CONFIG_CONNECTOR_TIMEOUT ?= 30m
 .PHONY: e2e-tilt-cluster
 e2e-tilt-cluster: ## Run Tilt-cluster provider e2e (requires `make tilt-cluster` running)
 	@curl -sk --max-time 5 -o /dev/null "$(E2E_TILT_HUB_URL)/healthz" || { \
@@ -940,6 +944,77 @@ e2e-tilt-cluster: ## Run Tilt-cluster provider e2e (requires `make tilt-cluster`
 		exit 1; \
 	}
 	go test ./test/e2e/suites/tiltcluster/... -v -timeout $(E2E_TILT_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
+
+## Opt-in Config Connector composition steel-thread against the operator-managed
+## Tilt runtime. The test creates only a minimal StorageBucket CRD; it does not
+## install Config Connector or contact GCP. Override the runtime kubeconfig or
+## operator namespace when using a non-default Tilt stack.
+.PHONY: e2e-tilt-cluster-config-connector
+e2e-tilt-cluster-config-connector: ## Run the opt-in Config Connector composition e2e
+	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { \
+		echo "kcp front-proxy kubeconfig not found at $(E2E_TILT_KCP_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { \
+		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@curl -sk --max-time 5 -o /dev/null "$(E2E_TILT_HUB_URL)/healthz" || { \
+		echo "hub not reachable at $(E2E_TILT_HUB_URL); bring the stack up first in another terminal: make tilt-cluster"; \
+		exit 1; \
+	}
+	@curl -s --max-time 5 -o /dev/null "$(E2E_TILT_INFRA_URL)/healthz" || { \
+		echo "infrastructure provider not reachable at $(E2E_TILT_INFRA_URL); is 'make tilt-cluster' fully up?"; \
+		exit 1; \
+	}
+	FAROS_E2E_CONFIG_CONNECTOR_COMPOSITION=1 \
+	FAROS_E2E_TILT_KUBECONFIG="$(E2E_TILT_KCP_KUBECONFIG)" \
+	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
+	FAROS_E2E_TILT_OPERATOR_NAMESPACE="$(E2E_TILT_OPERATOR_NAMESPACE)" \
+		go test ./test/e2e/suites/tiltcluster/... -run '^TestConfigConnectorComposition$$' -v -timeout $(E2E_TILT_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
+
+## Real-cloud extension of the composition steel thread. Installation imports
+## the caller-supplied service-account JSON into the runtime cluster, installs a
+## checksum-pinned Config Connector operator, and waits for the PubSubTopic API.
+## The run target then proves Pub/Sub creation and deletion independently via
+## Google's REST API. Both targets are deliberately separate from the fake-CRD
+## composition test above.
+.PHONY: e2e-tilt-cluster-config-connector-gcp-install e2e-tilt-cluster-config-connector-gcp-run e2e-tilt-cluster-config-connector-gcp
+e2e-tilt-cluster-config-connector-gcp-install: ## Install pinned Config Connector for the real Pub/Sub E2E
+	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { \
+		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -n "$$FAROS_E2E_GCP_CREDENTIALS_FILE" || { echo "FAROS_E2E_GCP_CREDENTIALS_FILE is required"; exit 1; }
+	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
+		providers/infrastructure/test/e2e/config-connector/install.sh
+
+e2e-tilt-cluster-config-connector-gcp-run: ## Create then delete a real Pub/Sub topic through KRO and Config Connector
+	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { \
+		echo "kcp front-proxy kubeconfig not found at $(E2E_TILT_KCP_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { \
+		echo "runtime kubeconfig not found at $(E2E_TILT_RUNTIME_KUBECONFIG); bring the stack up first with: make tilt-cluster"; \
+		exit 1; \
+	}
+	@test -n "$$FAROS_E2E_GCP_PROJECT" || { echo "FAROS_E2E_GCP_PROJECT is required"; exit 1; }
+	@test -n "$$FAROS_E2E_GCP_CREDENTIALS_FILE" || { echo "FAROS_E2E_GCP_CREDENTIALS_FILE is required"; exit 1; }
+	FAROS_E2E_CONFIG_CONNECTOR_GCP=1 \
+	FAROS_E2E_TILT_KUBECONFIG="$(E2E_TILT_KCP_KUBECONFIG)" \
+	FAROS_E2E_TILT_RUNTIME_KUBECONFIG="$(E2E_TILT_RUNTIME_KUBECONFIG)" \
+	FAROS_E2E_TILT_OPERATOR_NAMESPACE="$(E2E_TILT_OPERATOR_NAMESPACE)" \
+		go test ./test/e2e/suites/tiltcluster/... -run '^TestConfigConnectorGCPPubSubLifecycle$$' -v -timeout $(E2E_TILT_CONFIG_CONNECTOR_TIMEOUT) $(if $(E2E_FLAGS),-args $(E2E_FLAGS))
+
+e2e-tilt-cluster-config-connector-gcp: ## Install Config Connector and run the real Pub/Sub create/delete E2E
+	@test -n "$$FAROS_E2E_GCP_PROJECT" || { echo "FAROS_E2E_GCP_PROJECT is required before Config Connector is installed"; exit 1; }
+	@test -n "$$FAROS_E2E_GCP_CREDENTIALS_FILE" || { echo "FAROS_E2E_GCP_CREDENTIALS_FILE is required before Config Connector is installed"; exit 1; }
+	@test -f "$(E2E_TILT_KCP_KUBECONFIG)" || { echo "kcp front-proxy kubeconfig is required before Config Connector is installed"; exit 1; }
+	@test -f "$(E2E_TILT_RUNTIME_KUBECONFIG)" || { echo "runtime kubeconfig is required before Config Connector is installed"; exit 1; }
+	@curl -sk --max-time 5 -o /dev/null "$(E2E_TILT_HUB_URL)/healthz" || { echo "hub must be healthy before Config Connector is installed"; exit 1; }
+	@curl -s --max-time 5 -o /dev/null "$(E2E_TILT_INFRA_URL)/healthz" || { echo "infrastructure provider must be healthy before Config Connector is installed"; exit 1; }
+	$(MAKE) e2e-tilt-cluster-config-connector-gcp-install
+	$(MAKE) e2e-tilt-cluster-config-connector-gcp-run
 
 ## Create quickstart's APIExport (+ endpoint slice + bind grant) inside its
 ## provider workspace, so tenants can Enable it. The Provider controller already

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1672,6 +1672,61 @@ local_resource(
     labels=['providers-kro'],
 )
 
+# --- optional Config Connector / GCP Pub/Sub steel thread ------------------
+# These three actions are deliberately manual and have no resource_deps. A
+# normal `make tilt-cluster` therefore never downloads a cloud controller,
+# imports a credential, enables a cloud-backed Template, or creates a billable
+# resource. Click them in order only when the local .env contains a disposable
+# FAROS_CONFIG_CONNECTOR_GCP_PROJECT and an absolute
+# FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (the legacy FAROS_E2E_GCP_*
+# names remain accepted by the Make targets).
+local_resource(
+    'config-connector-install',
+    cmd=('FAROS_E2E_TILT_RUNTIME_KUBECONFIG={runtime} ' +
+         'make config-connector-install').format(runtime=KIND_HOST_KUBECONFIG),
+    deps=[
+        '.env',
+        'providers/infrastructure/contrib/config-connector/install.sh',
+    ],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=['providers-kro'],
+)
+
+local_resource(
+    'config-connector-enable',
+    cmd=('FAROS_E2E_TILT_KUBECONFIG={admin} ' +
+         'FAROS_E2E_TILT_RUNTIME_KUBECONFIG={runtime} ' +
+         'FAROS_KCC_KCP_SERVER={server} ' +
+         'make config-connector-enable').format(
+             admin=KCP_ADMIN_KUBECONFIG, runtime=KIND_HOST_KUBECONFIG,
+             server=KCP_ADMIN_SERVER),
+    deps=[
+        '.env',
+        'providers/infrastructure/contrib/config-connector/enable.sh',
+        'providers/infrastructure/contrib/config-connector/pubsub-template.yaml',
+    ],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=['providers-kro'],
+)
+
+local_resource(
+    'config-connector-smoke',
+    cmd=('FAROS_E2E_TILT_KUBECONFIG={admin} ' +
+         'FAROS_E2E_TILT_RUNTIME_KUBECONFIG={runtime} ' +
+         'make config-connector-smoke').format(
+             admin=KCP_ADMIN_KUBECONFIG, runtime=KIND_HOST_KUBECONFIG),
+    deps=[
+        '.env',
+        'providers/infrastructure/contrib/config-connector/pubsub-template.yaml',
+        'test/e2e/suites/tiltcluster/config_connector_gcp_test.go',
+    ],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    labels=['providers-kro'],
+)
+
 # --- providers-code (git repository management) ---
 # Host binary on :8083, same shape as quickstart/infrastructure. register/init/
 # unregister override KROMC_KCP_KUBECONFIG / KROMC_KCP_SERVER to the in-cluster

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1672,11 +1672,13 @@ local_resource(
     labels=['providers-kro'],
 )
 
-# --- optional Config Connector / GCP Pub/Sub steel thread ------------------
+# --- optional infrastructure operator + Config Connector Pub/Sub demo ------
 # These three actions are deliberately manual and have no resource_deps. A
 # normal `make tilt-cluster` therefore never downloads a cloud controller,
 # imports a credential, enables a cloud-backed Template, or creates a billable
-# resource. Click them in order only when the local .env contains a disposable
+# resource. Together they demonstrate how an infrastructure Template uses KRO
+# to compose a Config Connector CR in the operator-managed runtime. Click them
+# in order only when the local .env contains a disposable
 # FAROS_CONFIG_CONNECTOR_GCP_PROJECT and an absolute
 # FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (the legacy FAROS_E2E_GCP_*
 # names remain accepted by the Make targets).

--- a/hack/dev/tenant-bootstrap.env.example
+++ b/hack/dev/tenant-bootstrap.env.example
@@ -35,6 +35,15 @@ FAROS_BOOTSTRAP_DATABRICKS_HOST=https://dbc-example.cloud.databricks.com
 FAROS_BOOTSTRAP_DATABRICKS_TOKEN=dapi_replace_me
 FAROS_BOOTSTRAP_DATABRICKS_CONNECTION_NAME=databricks
 
+# Opt-in Config Connector + GCP Pub/Sub smoke workflow. These values are
+# intentionally dev-neutral: use a disposable project and an absolute path to
+# a local service-account key. The key file is imported into the runtime
+# cluster by the manual Tilt action; never paste JSON into this file.
+FAROS_CONFIG_CONNECTOR_GCP_PROJECT=faros-dev-kcc
+FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE=/absolute/path/to/faros-kcc-service-account.json
+# Legacy FAROS_E2E_GCP_PROJECT / FAROS_E2E_GCP_CREDENTIALS_FILE variables are
+# still accepted when invoking the Make targets directly.
+
 # Before running this setup resource, register and initialize the Code and
 # Databricks providers, then enable both providers in the active tenant
 # workspace. The script waits for their APIBindings to reach Bound before it

--- a/providers/infrastructure/contrib/config-connector/enable.sh
+++ b/providers/infrastructure/contrib/config-connector/enable.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Faros Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Apply the checked-in Pub/Sub Template to the infrastructure provider
+# workspace, then wait until the provider APIExport, tenant-facing Template
+# cache, and runtime KRO graph expose it. This is a separate manual action from
+# installing Config Connector.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+: "${FAROS_E2E_TILT_KUBECONFIG:?FAROS_E2E_TILT_KUBECONFIG is required}"
+
+if [[ ! -f "${FAROS_E2E_TILT_KUBECONFIG}" ]]; then
+  echo "kcp kubeconfig does not exist: ${FAROS_E2E_TILT_KUBECONFIG}" >&2
+  exit 1
+fi
+
+for command in kubectl grep sed; do
+  command -v "${command}" >/dev/null || {
+    echo "${command} is required" >&2
+    exit 1
+  }
+done
+
+TEMPLATE_FILE="${FAROS_KCC_TEMPLATE_FILE:-providers/infrastructure/contrib/config-connector/pubsub-template.yaml}"
+WORKSPACE_PATH="${FAROS_KCC_PROVIDER_WORKSPACE:-root:faros:providers:infrastructure}"
+APIEXPORT_NAME="${FAROS_KCC_APIEXPORT_NAME:-infrastructure.providers.faros.sh}"
+INSTANCE_RESOURCE="${FAROS_KCC_INSTANCE_RESOURCE:-gcppubsubtopics}"
+INSTANCE_GROUP="${FAROS_KCC_INSTANCE_GROUP:-infrastructure.faros.sh}"
+CACHED_RESOURCE_NAME="${FAROS_KCC_CACHED_RESOURCE_NAME:-publish-templates}"
+RUNTIME_KUBECONFIG="${FAROS_E2E_TILT_RUNTIME_KUBECONFIG:-.faros-cluster.kubeconfig}"
+WAIT="${FAROS_KCC_WAIT:-15m}"
+WAIT_SECONDS="${FAROS_KCC_WAIT_SECONDS:-900}"
+POLL_SECONDS="${FAROS_KCC_POLL_SECONDS:-5}"
+
+if ! [[ "${WAIT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "FAROS_KCC_WAIT_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "${POLL_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "FAROS_KCC_POLL_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+
+if [[ ! -f "${TEMPLATE_FILE}" ]]; then
+  echo "Config Connector Template fixture does not exist: ${TEMPLATE_FILE}" >&2
+  exit 1
+fi
+if [[ ! -f "${RUNTIME_KUBECONFIG}" ]]; then
+  echo "runtime kubeconfig does not exist: ${RUNTIME_KUBECONFIG}" >&2
+  exit 1
+fi
+
+kcp_server="${FAROS_KCC_KCP_SERVER:-}"
+if [[ -z "${kcp_server}" ]]; then
+  kcp_server="$({ kubectl --kubeconfig "${FAROS_E2E_TILT_KUBECONFIG}" config view --minify -o jsonpath='{.clusters[0].cluster.server}'; printf '\n'; } | sed -E 's#/clusters/.*$##')"
+fi
+kcp_server="${kcp_server%/}"
+if [[ -z "${kcp_server}" ]]; then
+  echo "could not determine the kcp front-proxy server" >&2
+  exit 1
+fi
+
+kcp=(kubectl --kubeconfig "${FAROS_E2E_TILT_KUBECONFIG}" \
+  --server="${kcp_server}/clusters/${WORKSPACE_PATH}" --insecure-skip-tls-verify)
+runtime=(kubectl --kubeconfig "${RUNTIME_KUBECONFIG}")
+
+template_name="$("${kcp[@]}" apply --dry-run=client --validate=false -f "${TEMPLATE_FILE}" -o jsonpath='{.metadata.name}')"
+if [[ -z "${template_name}" ]]; then
+  echo "Config Connector Template fixture has no metadata.name" >&2
+  exit 1
+fi
+
+echo ">>> enabling Config Connector Template ${template_name} in ${WORKSPACE_PATH}"
+"${kcp[@]}" apply --validate=false -f "${TEMPLATE_FILE}"
+"${kcp[@]}" wait \
+  --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True \
+  "template/${template_name}" --timeout="${WAIT}"
+
+deadline=$((SECONDS + WAIT_SECONDS))
+echo ">>> waiting for ${APIEXPORT_NAME} to publish ${INSTANCE_GROUP}/${INSTANCE_RESOURCE}"
+while (( SECONDS < deadline )); do
+  resources="$("${kcp[@]}" get apiexport "${APIEXPORT_NAME}" \
+    -o jsonpath='{range .spec.resources[*]}{.group}/{.name}{"\n"}{end}' 2>/dev/null || true)"
+  if grep -Fxq "${INSTANCE_GROUP}/${INSTANCE_RESOURCE}" <<<"${resources}"; then
+    break
+  fi
+  sleep "${POLL_SECONDS}"
+done
+if ! grep -Fxq "${INSTANCE_GROUP}/${INSTANCE_RESOURCE}" <<<"${resources}"; then
+  echo "APIExport ${APIEXPORT_NAME} never published ${INSTANCE_GROUP}/${INSTANCE_RESOURCE}" >&2
+  exit 1
+fi
+
+deadline=$((SECONDS + WAIT_SECONDS))
+cache_phase=""
+local_count=""
+cached_count=""
+echo ">>> waiting for CachedResource ${CACHED_RESOURCE_NAME} to converge"
+while (( SECONDS < deadline )); do
+  cache_state="$("${kcp[@]}" get cachedresource "${CACHED_RESOURCE_NAME}" \
+    -o jsonpath='{.status.phase}|{.status.resourceCounts.local}|{.status.resourceCounts.cache}' \
+    2>/dev/null || true)"
+  IFS='|' read -r cache_phase local_count cached_count <<<"${cache_state}"
+  if [[ "${cache_phase}" == "Ready" && "${local_count}" =~ ^[0-9]+$ && \
+    "${cached_count}" =~ ^[0-9]+$ && "${local_count}" == "${cached_count}" ]]; then
+    break
+  fi
+  sleep "${POLL_SECONDS}"
+done
+if [[ "${cache_phase}" != "Ready" || ! "${local_count}" =~ ^[0-9]+$ || \
+  ! "${cached_count}" =~ ^[0-9]+$ || "${local_count}" != "${cached_count}" ]]; then
+  echo "CachedResource ${CACHED_RESOURCE_NAME} did not converge: phase=${cache_phase:-unknown} local=${local_count:-unknown} cache=${cached_count:-unknown}" >&2
+  echo "Inspect root-kcp logs for kcp-cached-resources-controller errors; a stopped shared informer requires KCP controller recovery." >&2
+  exit 1
+fi
+
+source_cluster="$("${kcp[@]}" get template "${template_name}" \
+  -o jsonpath='{.metadata.annotations.kcp\.io/cluster}')"
+replication_endpoint="$("${kcp[@]}" get cachedresourceendpointslice "${CACHED_RESOURCE_NAME}" \
+  -o jsonpath='{.status.endpoints[0].url}')"
+if [[ -z "${source_cluster}" || -z "${replication_endpoint}" ]]; then
+  echo "CachedResource ${CACHED_RESOURCE_NAME} is missing its source cluster or replication endpoint" >&2
+  exit 1
+fi
+
+replication=(kubectl --kubeconfig "${FAROS_E2E_TILT_KUBECONFIG}" \
+  --server="${replication_endpoint%/}/clusters/${source_cluster}" --insecure-skip-tls-verify)
+deadline=$((SECONDS + WAIT_SECONDS))
+cached_template_name=""
+echo ">>> verifying ${template_name} through the CachedResource replication endpoint"
+while (( SECONDS < deadline )); do
+  cached_template_name="$("${replication[@]}" get template "${template_name}" \
+    -o jsonpath='{.metadata.name}' 2>/dev/null || true)"
+  if [[ "${cached_template_name}" == "${template_name}" ]]; then
+    break
+  fi
+  sleep "${POLL_SECONDS}"
+done
+if [[ "${cached_template_name}" != "${template_name}" ]]; then
+  echo "Template ${template_name} is absent from CachedResource ${CACHED_RESOURCE_NAME} replication storage" >&2
+  echo "The provider object is Ready, but tenant catalogs cannot see it; inspect root-kcp cache-controller logs." >&2
+  exit 1
+fi
+
+echo ">>> waiting for runtime KRO ResourceGraphDefinition ${template_name}"
+"${runtime[@]}" wait \
+  --for=jsonpath='{.status.conditions[?(@.type=="GraphAccepted")].status}'=True \
+  "resourcegraphdefinition/${template_name}" --timeout="${WAIT}"
+
+echo ">>> Config Connector Template ${template_name} is enabled, cached, and GraphAccepted"

--- a/providers/infrastructure/contrib/config-connector/install.sh
+++ b/providers/infrastructure/contrib/config-connector/install.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Faros Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Install the opt-in, cluster-mode Config Connector runtime used by the
+# development Pub/Sub smoke test. This is intentionally outside the provider
+# bootstrap path: ordinary Tilt startup must not install a cloud controller or
+# import credentials into a cluster.
+
+set -euo pipefail
+
+readonly KCC_VERSION="1.153.0"
+readonly KCC_BUNDLE_URL="https://storage.googleapis.com/configconnector-operator/${KCC_VERSION}/release-bundle.tar.gz"
+readonly KCC_BUNDLE_SHA256="e2e46bb51638a39dbbf6e28f35260890d8bc32c4fccc455a02b34c947221e3f2"
+readonly KCC_NAMESPACE="cnrm-system"
+readonly KCC_SECRET="gsa-key"
+readonly KCC_NAME="configconnector.core.cnrm.cloud.google.com"
+readonly PUBSUB_CRD="pubsubtopics.pubsub.cnrm.cloud.google.com"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+# Make imports the repository .env for direct invocations as well as Make
+# recipes. The file is gitignored; only its path and the credential filename
+# are passed to kubectl, never the JSON contents.
+ENV_FILE="${FAROS_KCC_ENV_FILE:-.env}"
+dotenv_names=()
+command -v sed >/dev/null || {
+  echo "sed is required to load ${ENV_FILE}" >&2
+  exit 1
+}
+if [[ -f "${ENV_FILE}" ]]; then
+  while IFS= read -r env_name; do
+    [[ -n "${env_name}" ]] && dotenv_names+=("${env_name}")
+  done < <(sed -n -E 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*[:?+]?=.*/\2/p' "${ENV_FILE}")
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+fi
+
+# Make exports every assignment it finds in .env. Keep the values available to
+# this script, but explicitly remove their export attributes before invoking
+# curl/kubectl so unrelated credentials are never inherited by subprocesses.
+dotenv_names+=(
+  FAROS_CONFIG_CONNECTOR_GCP_PROJECT
+  FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE
+  FAROS_E2E_GCP_PROJECT
+  FAROS_E2E_GCP_CREDENTIALS_FILE
+)
+for env_name in "${dotenv_names[@]}"; do
+  export -n "${env_name}" 2>/dev/null || true
+done
+
+: "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG:?FAROS_E2E_TILT_RUNTIME_KUBECONFIG is required}"
+gcp_credentials_file="${FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE:-${FAROS_E2E_GCP_CREDENTIALS_FILE:-}}"
+: "${gcp_credentials_file:?FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE (or legacy FAROS_E2E_GCP_CREDENTIALS_FILE) is required}"
+
+if [[ ! -f "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}" ]]; then
+  echo "runtime kubeconfig does not exist: ${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}" >&2
+  exit 1
+fi
+if [[ ! -f "${gcp_credentials_file}" ]]; then
+  echo "GCP credentials file does not exist" >&2
+  exit 1
+fi
+
+for command in curl kubectl sha256sum tar mktemp; do
+  command -v "${command}" >/dev/null || {
+    echo "${command} is required" >&2
+    exit 1
+  }
+done
+
+task_tmp="$(mktemp -d)"
+trap 'rm -rf "${task_tmp}"' EXIT
+bundle="${task_tmp}/release-bundle.tar.gz"
+
+echo ">>> downloading checksum-pinned Config Connector ${KCC_VERSION} bundle"
+curl -fsSL "${KCC_BUNDLE_URL}" -o "${bundle}"
+echo "${KCC_BUNDLE_SHA256}  ${bundle}" | sha256sum -c -
+tar -xzf "${bundle}" -C "${task_tmp}"
+
+kc=(kubectl --kubeconfig "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}")
+
+echo ">>> applying Config Connector operator ${KCC_VERSION}"
+"${kc[@]}" apply -f "${task_tmp}/operator-system/configconnector-operator.yaml"
+"${kc[@]}" wait --for=condition=Established \
+  crd/configconnectors.core.cnrm.cloud.google.com --timeout=2m
+"${kc[@]}" -n configconnector-operator-system rollout status \
+  statefulset/configconnector-operator --timeout=5m
+
+echo ">>> importing the caller-supplied service-account key into ${KCC_NAMESPACE}/${KCC_SECRET}"
+"${kc[@]}" create namespace "${KCC_NAMESPACE}" --dry-run=client -o yaml | "${kc[@]}" apply -f -
+"${kc[@]}" -n "${KCC_NAMESPACE}" create secret generic "${KCC_SECRET}" \
+  --from-file="key.json=${gcp_credentials_file}" \
+  --dry-run=client -o yaml | "${kc[@]}" apply -f -
+
+echo ">>> configuring Config Connector cluster mode"
+"${kc[@]}" apply -f - <<EOF
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: ${KCC_NAME}
+spec:
+  mode: cluster
+  credentialSecretName: ${KCC_SECRET}
+  stateIntoSpec: Absent
+EOF
+
+"${kc[@]}" wait --for=jsonpath='{.status.healthy}'=true \
+  "configconnector/${KCC_NAME}" --timeout=10m
+
+echo ">>> waiting for Config Connector controllers and Pub/Sub CRD"
+"${kc[@]}" -n "${KCC_NAMESPACE}" wait --for=condition=Ready pod --all --timeout=10m
+"${kc[@]}" wait --for=condition=Established "crd/${PUBSUB_CRD}" --timeout=10m
+
+echo ">>> Config Connector ${KCC_VERSION} is healthy and PubSubTopic is Established"

--- a/providers/infrastructure/contrib/config-connector/pubsub-template.yaml
+++ b/providers/infrastructure/contrib/config-connector/pubsub-template.yaml
@@ -1,0 +1,52 @@
+# Copyright 2026 The Faros Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# This is an opt-in development fixture. It deliberately lives outside
+# install/templates so a normal provider bootstrap never enables a cloud
+# resource or advertises a GCP-specific catalog entry.
+apiVersion: infrastructure.faros.sh/v1alpha1
+kind: Template
+metadata:
+  name: gcp-pubsub-topic
+  labels:
+    faros.sh/config-connector: pubsub
+spec:
+  displayName: GCP Pub/Sub topic
+  description: Creates a Google Cloud Pub/Sub topic through Config Connector.
+  category: Cloud
+  version: 0.0.1
+  backend: kro
+  instanceCRD:
+    group: infrastructure.faros.sh
+    version: v1alpha1
+    resource: gcppubsubtopics
+    kind: GCPPubSubTopic
+  schema:
+    type: object
+    properties:
+      projectID:
+        type: string
+        description: Disposable Google Cloud project that owns the topic.
+      topicName:
+        type: string
+        description: Globally unique Pub/Sub topic name within the project.
+    required:
+      - projectID
+      - topicName
+  backendConfig:
+    resources:
+      - id: pubSubTopic
+        template:
+          apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+          kind: PubSubTopic
+          metadata:
+            name: "${schema.spec.topicName}"
+            namespace: default
+            annotations:
+              cnrm.cloud.google.com/project-id: "${schema.spec.projectID}"
+          spec: {}

--- a/providers/infrastructure/test/e2e/config-connector/install.sh
+++ b/providers/infrastructure/test/e2e/config-connector/install.sh
@@ -8,93 +8,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+# Compatibility entrypoint retained for callers of the original POC path.
+# The maintained installer lives under contrib so the opt-in runtime is kept
+# next to its checked-in Template fixture and Tilt workflow.
+
 set -euo pipefail
 
-readonly KCC_VERSION="1.153.0"
-readonly KCC_BUNDLE_URL="https://storage.googleapis.com/configconnector-operator/${KCC_VERSION}/release-bundle.tar.gz"
-readonly KCC_BUNDLE_SHA256="e2e46bb51638a39dbbf6e28f35260890d8bc32c4fccc455a02b34c947221e3f2"
-readonly KCC_NAMESPACE="cnrm-system"
-readonly KCC_SECRET="gsa-key"
-readonly KCC_NAME="configconnector.core.cnrm.cloud.google.com"
-readonly PUBSUB_CRD="pubsubtopics.pubsub.cnrm.cloud.google.com"
-
-: "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG:?FAROS_E2E_TILT_RUNTIME_KUBECONFIG is required}"
-: "${FAROS_E2E_GCP_CREDENTIALS_FILE:?FAROS_E2E_GCP_CREDENTIALS_FILE is required}"
-
-if [[ ! -f "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}" ]]; then
-  echo "runtime kubeconfig does not exist" >&2
-  exit 1
-fi
-if [[ ! -f "${FAROS_E2E_GCP_CREDENTIALS_FILE}" ]]; then
-  echo "GCP credentials file does not exist" >&2
-  exit 1
-fi
-
-for command in curl kubectl sha256sum tar; do
-  command -v "${command}" >/dev/null || {
-    echo "${command} is required" >&2
-    exit 1
-  }
-done
-
-task_tmp="$(mktemp -d)"
-trap 'rm -rf "${task_tmp}"' EXIT
-bundle="${task_tmp}/release-bundle.tar.gz"
-
-echo ">>> downloading pinned Config Connector ${KCC_VERSION} bundle"
-curl -fsSL "${KCC_BUNDLE_URL}" -o "${bundle}"
-echo "${KCC_BUNDLE_SHA256}  ${bundle}" | sha256sum -c -
-tar -xzf "${bundle}" -C "${task_tmp}"
-
-kc=(kubectl --kubeconfig "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}")
-
-echo ">>> applying Config Connector operator ${KCC_VERSION}"
-"${kc[@]}" apply -f "${task_tmp}/operator-system/configconnector-operator.yaml"
-"${kc[@]}" wait --for=condition=Established \
-  crd/configconnectors.core.cnrm.cloud.google.com --timeout=2m
-"${kc[@]}" -n configconnector-operator-system rollout status \
-  statefulset/configconnector-operator --timeout=5m
-
-echo ">>> importing the test service-account key into ${KCC_NAMESPACE}/${KCC_SECRET}"
-"${kc[@]}" create namespace "${KCC_NAMESPACE}" --dry-run=client -o yaml | "${kc[@]}" apply -f -
-"${kc[@]}" -n "${KCC_NAMESPACE}" create secret generic "${KCC_SECRET}" \
-  --from-file="key.json=${FAROS_E2E_GCP_CREDENTIALS_FILE}" \
-  --dry-run=client -o yaml | "${kc[@]}" apply -f -
-
-echo ">>> configuring Config Connector cluster mode"
-"${kc[@]}" apply -f - <<EOF
-apiVersion: core.cnrm.cloud.google.com/v1beta1
-kind: ConfigConnector
-metadata:
-  name: ${KCC_NAME}
-spec:
-  mode: cluster
-  credentialSecretName: ${KCC_SECRET}
-  stateIntoSpec: Absent
-EOF
-
-"${kc[@]}" wait --for=jsonpath='{.status.healthy}'=true \
-  "configconnector/${KCC_NAME}" --timeout=10m
-
-echo ">>> waiting for Config Connector controllers and PubSubTopic CRD"
-for _ in $(seq 1 120); do
-  if "${kc[@]}" -n "${KCC_NAMESPACE}" get pods -o name 2>/dev/null | grep -q .; then
-    break
-  fi
-  sleep 5
-done
-if ! "${kc[@]}" -n "${KCC_NAMESPACE}" get pods -o name 2>/dev/null | grep -q .; then
-  echo "Config Connector controller pods were not created" >&2
-  exit 1
-fi
-"${kc[@]}" -n "${KCC_NAMESPACE}" wait --for=condition=Ready pod --all --timeout=10m
-
-for _ in $(seq 1 120); do
-  if "${kc[@]}" get "crd/${PUBSUB_CRD}" >/dev/null 2>&1; then
-    break
-  fi
-  sleep 5
-done
-"${kc[@]}" wait --for=condition=Established "crd/${PUBSUB_CRD}" --timeout=2m
-
-echo ">>> Config Connector ${KCC_VERSION} is ready for the Pub/Sub E2E"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+exec "${ROOT_DIR}/providers/infrastructure/contrib/config-connector/install.sh" "$@"

--- a/providers/infrastructure/test/e2e/config-connector/install.sh
+++ b/providers/infrastructure/test/e2e/config-connector/install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Faros Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+set -euo pipefail
+
+readonly KCC_VERSION="1.153.0"
+readonly KCC_BUNDLE_URL="https://storage.googleapis.com/configconnector-operator/${KCC_VERSION}/release-bundle.tar.gz"
+readonly KCC_BUNDLE_SHA256="e2e46bb51638a39dbbf6e28f35260890d8bc32c4fccc455a02b34c947221e3f2"
+readonly KCC_NAMESPACE="cnrm-system"
+readonly KCC_SECRET="gsa-key"
+readonly KCC_NAME="configconnector.core.cnrm.cloud.google.com"
+readonly PUBSUB_CRD="pubsubtopics.pubsub.cnrm.cloud.google.com"
+
+: "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG:?FAROS_E2E_TILT_RUNTIME_KUBECONFIG is required}"
+: "${FAROS_E2E_GCP_CREDENTIALS_FILE:?FAROS_E2E_GCP_CREDENTIALS_FILE is required}"
+
+if [[ ! -f "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}" ]]; then
+  echo "runtime kubeconfig does not exist" >&2
+  exit 1
+fi
+if [[ ! -f "${FAROS_E2E_GCP_CREDENTIALS_FILE}" ]]; then
+  echo "GCP credentials file does not exist" >&2
+  exit 1
+fi
+
+for command in curl kubectl sha256sum tar; do
+  command -v "${command}" >/dev/null || {
+    echo "${command} is required" >&2
+    exit 1
+  }
+done
+
+task_tmp="$(mktemp -d)"
+trap 'rm -rf "${task_tmp}"' EXIT
+bundle="${task_tmp}/release-bundle.tar.gz"
+
+echo ">>> downloading pinned Config Connector ${KCC_VERSION} bundle"
+curl -fsSL "${KCC_BUNDLE_URL}" -o "${bundle}"
+echo "${KCC_BUNDLE_SHA256}  ${bundle}" | sha256sum -c -
+tar -xzf "${bundle}" -C "${task_tmp}"
+
+kc=(kubectl --kubeconfig "${FAROS_E2E_TILT_RUNTIME_KUBECONFIG}")
+
+echo ">>> applying Config Connector operator ${KCC_VERSION}"
+"${kc[@]}" apply -f "${task_tmp}/operator-system/configconnector-operator.yaml"
+"${kc[@]}" wait --for=condition=Established \
+  crd/configconnectors.core.cnrm.cloud.google.com --timeout=2m
+"${kc[@]}" -n configconnector-operator-system rollout status \
+  statefulset/configconnector-operator --timeout=5m
+
+echo ">>> importing the test service-account key into ${KCC_NAMESPACE}/${KCC_SECRET}"
+"${kc[@]}" create namespace "${KCC_NAMESPACE}" --dry-run=client -o yaml | "${kc[@]}" apply -f -
+"${kc[@]}" -n "${KCC_NAMESPACE}" create secret generic "${KCC_SECRET}" \
+  --from-file="key.json=${FAROS_E2E_GCP_CREDENTIALS_FILE}" \
+  --dry-run=client -o yaml | "${kc[@]}" apply -f -
+
+echo ">>> configuring Config Connector cluster mode"
+"${kc[@]}" apply -f - <<EOF
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: ${KCC_NAME}
+spec:
+  mode: cluster
+  credentialSecretName: ${KCC_SECRET}
+  stateIntoSpec: Absent
+EOF
+
+"${kc[@]}" wait --for=jsonpath='{.status.healthy}'=true \
+  "configconnector/${KCC_NAME}" --timeout=10m
+
+echo ">>> waiting for Config Connector controllers and PubSubTopic CRD"
+for _ in $(seq 1 120); do
+  if "${kc[@]}" -n "${KCC_NAMESPACE}" get pods -o name 2>/dev/null | grep -q .; then
+    break
+  fi
+  sleep 5
+done
+if ! "${kc[@]}" -n "${KCC_NAMESPACE}" get pods -o name 2>/dev/null | grep -q .; then
+  echo "Config Connector controller pods were not created" >&2
+  exit 1
+fi
+"${kc[@]}" -n "${KCC_NAMESPACE}" wait --for=condition=Ready pod --all --timeout=10m
+
+for _ in $(seq 1 120); do
+  if "${kc[@]}" get "crd/${PUBSUB_CRD}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+"${kc[@]}" wait --for=condition=Established "crd/${PUBSUB_CRD}" --timeout=2m
+
+echo ">>> Config Connector ${KCC_VERSION} is ready for the Pub/Sub E2E"

--- a/test/e2e/suites/tiltcluster/README.md
+++ b/test/e2e/suites/tiltcluster/README.md
@@ -53,7 +53,12 @@ already excludes `test/e2e`.)
   with no caller identity (no `X-Faros-Tenant`, no bearer token) is refused
   rather than silently acting cross-tenant.
 
-## Config Connector composition steel-thread (opt-in)
+## Using Config Connector with the infrastructure operator (opt-in)
+
+This example demonstrates how an infrastructure provider `Template` can use
+the operator-managed KRO runtime to compose Google Config Connector resources.
+It has a credential-free composition check for the infrastructure operator
+contract and a manual real-cloud workflow that creates and deletes Pub/Sub.
 
 Run the focused composition test only after the operator-managed runtime is up:
 
@@ -67,7 +72,8 @@ make e2e-tilt-cluster-config-connector
 `storage.cnrm.cloud.google.com/v1beta1` `StorageBucket` CRD, and creates a
 test-only `Template` whose `GCSBucket` instance composes to a KRO-labeled
 runtime `StorageBucket` child. The assertion checks the child's `location` and
-`uniformBucketLevelAccess` values.
+`uniformBucketLevelAccess` values. This is the same composition boundary used
+when a real Config Connector controller reconciles that child into GCP.
 
 This is deliberately a composition-only check. It does not install or fake a
 Config Connector controller, configure `ConfigConnectorContext` or cloud IAM,
@@ -76,7 +82,7 @@ StorageBucket CRD is already installed, the test skips rather than replacing
 it. Direct package execution also skips cleanly when the Tilt stack or runtime
 kubeconfig is absent.
 
-### Real Pub/Sub create/delete extension (manual Tilt workflow)
+### Real Pub/Sub create/delete demonstration (manual Tilt workflow)
 
 Config Connector is not part of ordinary `make tilt-cluster`. The Tiltfile
 surfaces three manual resources, all default-off and independent of the

--- a/test/e2e/suites/tiltcluster/README.md
+++ b/test/e2e/suites/tiltcluster/README.md
@@ -35,6 +35,8 @@ already excludes `test/e2e`.)
 | hub REST + MCP | `https://localhost:9443` | `FAROS_E2E_HUB_URL` |
 | infrastructure `/mcp` | `http://localhost:8082` | `FAROS_E2E_INFRA_URL` |
 | hub static token | `dev-token` | `FAROS_E2E_STATIC_TOKEN` |
+| operator/KRO runtime kubeconfig | `.faros-cluster.kubeconfig` | `FAROS_E2E_TILT_RUNTIME_KUBECONFIG` |
+| operator namespace | `faros-infrastructure-operator` | `FAROS_E2E_TILT_OPERATOR_NAMESPACE` |
 
 ## What it asserts
 
@@ -50,6 +52,62 @@ already excludes `test/e2e`.)
 - **Tenant isolation** (`TestTenantIsolationRequiresIdentity`) — a tool call
   with no caller identity (no `X-Faros-Tenant`, no bearer token) is refused
   rather than silently acting cross-tenant.
+
+## Config Connector composition steel-thread (opt-in)
+
+Run the focused composition test only after the operator-managed runtime is up:
+
+```sh
+make e2e-tilt-cluster-config-connector
+```
+
+`TestConfigConnectorComposition` verifies the operator's
+`InfrastructureProvider` lifecycle (`Bootstrapped`, `KroReleased`,
+`ProviderDeployed`, and `Registered`), applies a test-owned minimal
+`storage.cnrm.cloud.google.com/v1beta1` `StorageBucket` CRD, and creates a
+test-only `Template` whose `GCSBucket` instance composes to a KRO-labeled
+runtime `StorageBucket` child. The assertion checks the child's `location` and
+`uniformBucketLevelAccess` values.
+
+This is deliberately a composition-only check. It does not install or fake a
+Config Connector controller, configure `ConfigConnectorContext` or cloud IAM,
+contact GCP, or prove that a real bucket is reconciled. If a non-test-owned
+StorageBucket CRD is already installed, the test skips rather than replacing
+it. Direct package execution also skips cleanly when the Tilt stack or runtime
+kubeconfig is absent.
+
+### Real Pub/Sub create/delete extension
+
+The explicitly opted-in real-cloud target installs the checksum-pinned Config
+Connector 1.153.0 operator in cluster mode, runs the same infrastructure
+operator and multicluster KRO path with a native `PubSubTopic` child, and then
+deletes the Faros parent:
+
+```sh
+export FAROS_E2E_GCP_PROJECT='disposable-test-project'
+export FAROS_E2E_GCP_CREDENTIALS_FILE='/absolute/path/to/service-account.json'
+make e2e-tilt-cluster-config-connector-gcp
+```
+
+The service account must be able to mint OAuth tokens and create, get, and
+delete Pub/Sub topics in the selected disposable project; the Pub/Sub API must
+already be enabled. The credential file is read locally, imported only into the
+runtime cluster's `cnrm-system/gsa-key` Secret, and never copied into the
+repository. The installer is idempotent. It intentionally leaves Config
+Connector installed after the test, but the test removes every test-owned
+Template, RGD, tenant workspace/binding, parent instance, child CR, and cloud
+topic.
+
+`TestConfigConnectorGCPPubSubLifecycle` requires the child to report
+`Ready=True` at its current generation. A direct authenticated Pub/Sub REST GET
+must then return HTTP 200. After deleting the Faros parent, both Kubernetes
+objects must be NotFound and the same REST GET must return HTTP 404. Failure
+cleanup can directly delete only the exact `faros-kcc-e2e-<hex>` topic and must
+also prove HTTP 404; it never removes finalizers.
+
+To rerun without reinstalling the operator, use
+`make e2e-tilt-cluster-config-connector-gcp-run`. Setting the real-cloud opt-in
+without both required environment variables is a failure, not a skip.
 
 ## Possible follow-ups
 

--- a/test/e2e/suites/tiltcluster/README.md
+++ b/test/e2e/suites/tiltcluster/README.md
@@ -76,27 +76,57 @@ StorageBucket CRD is already installed, the test skips rather than replacing
 it. Direct package execution also skips cleanly when the Tilt stack or runtime
 kubeconfig is absent.
 
-### Real Pub/Sub create/delete extension
+### Real Pub/Sub create/delete extension (manual Tilt workflow)
 
-The explicitly opted-in real-cloud target installs the checksum-pinned Config
-Connector 1.153.0 operator in cluster mode, runs the same infrastructure
-operator and multicluster KRO path with a native `PubSubTopic` child, and then
-deletes the Faros parent:
+Config Connector is not part of ordinary `make tilt-cluster`. The Tiltfile
+surfaces three manual resources, all default-off and independent of the
+automatic resource graph:
+
+1. `config-connector-install` downloads the checksum-pinned Config Connector
+   1.153.0 operator, imports the service-account file into
+   `cnrm-system/gsa-key`, configures cluster mode, and waits for healthy
+   controllers plus the `PubSubTopic` CRD.
+2. `config-connector-enable` applies the checked-in
+   `providers/infrastructure/contrib/config-connector/pubsub-template.yaml`
+   to the infrastructure provider workspace and waits for the Template,
+   infrastructure APIExport, tenant-facing `publish-templates` cache, and
+   runtime KRO ResourceGraphDefinition. It fails if the cache does not converge
+   or the exact Template is absent from the replication endpoint, so provider
+   readiness alone cannot falsely report console availability.
+3. `config-connector-smoke` creates and deletes one uniquely named cloud topic
+   through that already-enabled Template. It does not install Config Connector
+   or re-apply the Template.
+
+The equivalent Make targets are `config-connector-install`,
+`config-connector-enable`, and `config-connector-smoke`. Set the disposable
+GCP inputs in the gitignored repository-root `.env` (the tracked example uses
+dev-neutral placeholders). The public names are
+`FAROS_CONFIG_CONNECTOR_GCP_PROJECT` and
+`FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE`; the older
+`FAROS_E2E_GCP_*` names remain accepted for compatibility:
 
 ```sh
-export FAROS_E2E_GCP_PROJECT='disposable-test-project'
-export FAROS_E2E_GCP_CREDENTIALS_FILE='/absolute/path/to/service-account.json'
-make e2e-tilt-cluster-config-connector-gcp
+export FAROS_CONFIG_CONNECTOR_GCP_PROJECT='disposable-test-project'
+export FAROS_CONFIG_CONNECTOR_GCP_CREDENTIALS_FILE='/absolute/path/to/service-account.json'
+make config-connector-install
+make config-connector-enable
+make config-connector-smoke
 ```
 
 The service account must be able to mint OAuth tokens and create, get, and
 delete Pub/Sub topics in the selected disposable project; the Pub/Sub API must
 already be enabled. The credential file is read locally, imported only into the
 runtime cluster's `cnrm-system/gsa-key` Secret, and never copied into the
-repository. The installer is idempotent. It intentionally leaves Config
-Connector installed after the test, but the test removes every test-owned
-Template, RGD, tenant workspace/binding, parent instance, child CR, and cloud
-topic.
+repository or rendered inline in YAML. The installer is idempotent. It
+intentionally leaves Config Connector installed after the smoke, but the test
+removes every test-owned tenant workspace/binding, parent instance, child CR,
+and cloud topic. The stable enabled Template is left in place for the next
+manual smoke; delete it explicitly when you want to disable the offering.
+
+For backwards compatibility, `make e2e-tilt-cluster-config-connector-gcp`
+still performs installation and runs the isolated lifecycle test. The
+lifecycle test loads the same checked-in YAML and renames it before creating a
+test-owned Template, so it cannot mutate the stable enabled fixture.
 
 `TestConfigConnectorGCPPubSubLifecycle` requires the child to report
 `Ready=True` at its current generation. A direct authenticated Pub/Sub REST GET
@@ -105,9 +135,10 @@ objects must be NotFound and the same REST GET must return HTTP 404. Failure
 cleanup can directly delete only the exact `faros-kcc-e2e-<hex>` topic and must
 also prove HTTP 404; it never removes finalizers.
 
-To rerun without reinstalling the operator, use
+To rerun the isolated lifecycle without reinstalling the operator, use
 `make e2e-tilt-cluster-config-connector-gcp-run`. Setting the real-cloud opt-in
-without both required environment variables is a failure, not a skip.
+without both required environment variables is a failure, not a skip. The
+manual smoke also requires the install and enable actions to have completed.
 
 ## Possible follow-ups
 

--- a/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
+++ b/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -58,6 +59,7 @@ const (
 	configConnectorName                 = "configconnector.core.cnrm.cloud.google.com"
 	configConnectorPubSubCRDName        = "pubsubtopics.pubsub.cnrm.cloud.google.com"
 	configConnectorPubSubTemplatePrefix = "gcp-pubsub-steel-thread-"
+	configConnectorPubSubTemplateName   = "gcp-pubsub-topic"
 	configConnectorPubSubWorkspacePref  = "e2e-pubsub-"
 	configConnectorPubSubNode           = "pubSubTopic"
 	configConnectorPubSubResource       = "gcppubsubtopics"
@@ -74,12 +76,42 @@ var (
 	configConnectorTopicPattern   = regexp.MustCompile(`^faros-kcc-e2e-[0-9a-f]{8}$`)
 )
 
-// TestConfigConnectorGCPPubSubLifecycle is the explicit real-cloud extension
+// TestConfigConnectorGCPPubSubLifecycle is the isolated real-cloud extension
 // of TestConfigConnectorComposition. It is selected only by its dedicated Make
 // target because it installs no fake CRD and creates a billable cloud resource.
 func TestConfigConnectorGCPPubSubLifecycle(t *testing.T) {
+	runConfigConnectorGCPPubSubLifecycle(t, false)
+}
+
+// TestConfigConnectorGCPPubSubSmoke uses the stable Template enabled by the
+// manual Tilt action. It deliberately does not create or update that Template;
+// the only cloud object it owns is the generated Pub/Sub topic.
+func TestConfigConnectorGCPPubSubSmoke(t *testing.T) {
+	runConfigConnectorGCPPubSubLifecycle(t, true)
+}
+
+// TestConfigConnectorPubSubTemplateFixture is a read-only guard that runs
+// without a Tilt stack. The real-cloud tests must consume this exact YAML
+// rather than carrying a second, drift-prone Go representation.
+func TestConfigConnectorPubSubTemplateFixture(t *testing.T) {
+	template := configConnectorPubSubTemplate(t, configConnectorPubSubTemplateName)
+	resource, found, err := unstructured.NestedString(template.Object, "spec", "instanceCRD", "resource")
+	if err != nil || !found || resource != configConnectorPubSubResource {
+		t.Fatalf("fixture instanceCRD.resource = %q (found=%t err=%v), want %q", resource, found, err, configConnectorPubSubResource)
+	}
+	resources, found, err := unstructured.NestedSlice(template.Object, "spec", "backendConfig", "resources")
+	if err != nil || !found || len(resources) != 1 {
+		t.Fatalf("fixture backendConfig.resources = %#v (found=%t err=%v), want one resource", resources, found, err)
+	}
+	resourceObject, ok := resources[0].(map[string]any)
+	if !ok || resourceObject["id"] != configConnectorPubSubNode {
+		t.Fatalf("fixture backendConfig resource = %#v, want id %q", resources[0], configConnectorPubSubNode)
+	}
+}
+
+func runConfigConnectorGCPPubSubLifecycle(t *testing.T, useEnabledTemplate bool) {
 	if os.Getenv(configConnectorGCPOptIn) != "1" {
-		t.Skip("run only through make e2e-tilt-cluster-config-connector-gcp")
+		t.Skip("run only through an explicit Config Connector Make target")
 	}
 
 	projectID := os.Getenv(configConnectorGCPProjectEnv)
@@ -121,6 +153,9 @@ func TestConfigConnectorGCPPubSubLifecycle(t *testing.T) {
 		t.Fatalf("refusing topic name %q because the preflight REST GET returned HTTP %d instead of 404", topicName, initialStatus)
 	}
 	templateName := configConnectorPubSubTemplatePrefix + shortNonce()
+	if useEnabledTemplate {
+		templateName = configConnectorPubSubTemplateName
+	}
 	workspaceName := configConnectorPubSubWorkspacePref + shortNonce()
 
 	var (
@@ -208,10 +243,12 @@ func TestConfigConnectorGCPPubSubLifecycle(t *testing.T) {
 		}
 	})
 
-	if _, err := providerClient.Resource(configConnectorTemplateGVR).Create(context.Background(), configConnectorPubSubTemplate(templateName), metav1.CreateOptions{}); err != nil {
-		t.Fatalf("create test Template %q: %v", templateName, err)
+	if !useEnabledTemplate {
+		if _, err := providerClient.Resource(configConnectorTemplateGVR).Create(context.Background(), configConnectorPubSubTemplate(t, templateName), metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create test Template %q: %v", templateName, err)
+		}
+		templateCreated = true
 	}
-	templateCreated = true
 	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
 		got, err := providerClient.Resource(configConnectorTemplateGVR).Get(context.Background(), templateName, metav1.GetOptions{})
 		if err != nil {
@@ -386,50 +423,26 @@ func requiredConfigConnectorRuntimeClient(t *testing.T) dynamic.Interface {
 	return client
 }
 
-func configConnectorPubSubTemplate(name string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": infraGroup + "/v1alpha1",
-		"kind":       "Template",
-		"metadata": map[string]any{
-			"name":   name,
-			"labels": map[string]any{configConnectorTestLabel: configConnectorTestLabelValue},
-		},
-		"spec": map[string]any{
-			"displayName": "GCP Pub/Sub Config Connector steel thread",
-			"description": "Test-only KRO composition of a real Config Connector PubSubTopic.",
-			"category":    "Test",
-			"version":     "0.0.1",
-			"backend":     "kro",
-			"instanceCRD": map[string]any{
-				"group": infraGroup, "version": "v1alpha1", "resource": configConnectorPubSubResource, "kind": "GCPPubSubTopic",
-			},
-			"schema": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"projectID": map[string]any{"type": "string"},
-					"topicName": map[string]any{"type": "string"},
-				},
-				"required": []any{"projectID", "topicName"},
-			},
-			"backendConfig": map[string]any{
-				"resources": []any{map[string]any{
-					"id": configConnectorPubSubNode,
-					"template": map[string]any{
-						"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
-						"kind":       "PubSubTopic",
-						"metadata": map[string]any{
-							"name":      "${schema.spec.topicName}",
-							"namespace": "default",
-							"annotations": map[string]any{
-								"cnrm.cloud.google.com/project-id": "${schema.spec.projectID}",
-							},
-						},
-						"spec": map[string]any{},
-					},
-				}},
-			},
-		},
-	}}
+func configConnectorPubSubTemplate(t *testing.T, name string) *unstructured.Unstructured {
+	t.Helper()
+	path := filepath.Join(repoRoot, "providers/infrastructure/contrib/config-connector/pubsub-template.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Config Connector Pub/Sub Template fixture %q: %v", path, err)
+	}
+	var object map[string]any
+	if err := yaml.Unmarshal(raw, &object); err != nil {
+		t.Fatalf("decode Config Connector Pub/Sub Template fixture %q: %v", path, err)
+	}
+	template := &unstructured.Unstructured{Object: object}
+	if template.GetAPIVersion() != infraGroup+"/v1alpha1" || template.GetKind() != "Template" {
+		t.Fatalf("Config Connector Pub/Sub Template fixture has type %s/%s", template.GetAPIVersion(), template.GetKind())
+	}
+	if template.GetName() != configConnectorPubSubTemplateName {
+		t.Fatalf("Config Connector Pub/Sub Template fixture name = %q, want %q", template.GetName(), configConnectorPubSubTemplateName)
+	}
+	template.SetName(name)
+	return template
 }
 
 func waitConfigConnectorChildReady(t *testing.T, runtimeClient dynamic.Interface, namespace, name string) {

--- a/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
+++ b/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
@@ -1,0 +1,639 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package tiltcluster
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	configConnectorGVR = schema.GroupVersionResource{
+		Group: "core.cnrm.cloud.google.com", Version: "v1beta1", Resource: "configconnectors",
+	}
+	configConnectorPubSubTopicGVR = schema.GroupVersionResource{
+		Group: "pubsub.cnrm.cloud.google.com", Version: "v1beta1", Resource: "pubsubtopics",
+	}
+	configConnectorPubSubInstanceGVR = schema.GroupVersionResource{
+		Group: infraGroup, Version: "v1alpha1", Resource: "gcppubsubtopics",
+	}
+)
+
+const (
+	configConnectorGCPOptIn             = "FAROS_E2E_CONFIG_CONNECTOR_GCP"
+	configConnectorGCPProjectEnv        = "FAROS_E2E_GCP_PROJECT"
+	configConnectorGCPCredentialsEnv    = "FAROS_E2E_GCP_CREDENTIALS_FILE"
+	configConnectorName                 = "configconnector.core.cnrm.cloud.google.com"
+	configConnectorPubSubCRDName        = "pubsubtopics.pubsub.cnrm.cloud.google.com"
+	configConnectorPubSubTemplatePrefix = "gcp-pubsub-steel-thread-"
+	configConnectorPubSubWorkspacePref  = "e2e-pubsub-"
+	configConnectorPubSubNode           = "pubSubTopic"
+	configConnectorPubSubResource       = "gcppubsubtopics"
+	configConnectorGCPTokenURI          = "https://oauth2.googleapis.com/token"
+	configConnectorGCPPubSubScope       = "https://www.googleapis.com/auth/pubsub"
+
+	configConnectorGCPWait        = 12 * time.Minute
+	configConnectorGCPCleanupWait = 2 * time.Minute
+	configConnectorGCPPoll        = 5 * time.Second
+)
+
+var (
+	configConnectorProjectPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
+	configConnectorTopicPattern   = regexp.MustCompile(`^faros-kcc-e2e-[0-9a-f]{8}$`)
+)
+
+// TestConfigConnectorGCPPubSubLifecycle is the explicit real-cloud extension
+// of TestConfigConnectorComposition. It is selected only by its dedicated Make
+// target because it installs no fake CRD and creates a billable cloud resource.
+func TestConfigConnectorGCPPubSubLifecycle(t *testing.T) {
+	if os.Getenv(configConnectorGCPOptIn) != "1" {
+		t.Skip("run only through make e2e-tilt-cluster-config-connector-gcp")
+	}
+
+	projectID := os.Getenv(configConnectorGCPProjectEnv)
+	credentialsFile := os.Getenv(configConnectorGCPCredentialsEnv)
+	if projectID == "" || credentialsFile == "" {
+		t.Fatalf("%s and %s are required when %s=1", configConnectorGCPProjectEnv, configConnectorGCPCredentialsEnv, configConnectorGCPOptIn)
+	}
+	if !configConnectorProjectPattern.MatchString(projectID) {
+		t.Fatalf("%s is not a conservative Google Cloud project ID", configConnectorGCPProjectEnv)
+	}
+
+	credentialJSON, err := os.ReadFile(credentialsFile)
+	if err != nil {
+		// Do not include err: os.PathError contains the credential path.
+		t.Fatalf("%s could not be read", configConnectorGCPCredentialsEnv)
+	}
+	defer clear(credentialJSON)
+	accessToken := mintConfigConnectorGCPAccessToken(t, credentialJSON)
+
+	if !stackReady {
+		t.Fatal("tilt-cluster stack is required when the real-cloud Config Connector E2E is enabled")
+	}
+	runtimeClient := requiredConfigConnectorRuntimeClient(t)
+	waitInfrastructureProviderReady(t, runtimeClient)
+	requireHealthyConfigConnector(t, runtimeClient)
+
+	providerClient := kcpAdminDynamic(t, providerWorkspace)
+	parentClient := kcpAdminDynamic(t, "root:faros")
+	topicName := "faros-kcc-e2e-" + configConnectorGCPNonce()
+	if !configConnectorTopicPattern.MatchString(topicName) {
+		t.Fatalf("generated topic %q is outside the E2E ownership boundary", topicName)
+	}
+	topicResource := fmt.Sprintf("projects/%s/topics/%s", projectID, topicName)
+	initialStatus, err := getConfigConnectorPubSubTopic(accessToken, topicResource)
+	if err != nil {
+		t.Fatalf("preflight Pub/Sub topic ownership check failed: %v", err)
+	}
+	if initialStatus != http.StatusNotFound {
+		t.Fatalf("refusing topic name %q because the preflight REST GET returned HTTP %d instead of 404", topicName, initialStatus)
+	}
+	templateName := configConnectorPubSubTemplatePrefix + shortNonce()
+	workspaceName := configConnectorPubSubWorkspacePref + shortNonce()
+
+	var (
+		templateCreated  bool
+		workspaceCreated bool
+		bindingCreated   bool
+		instanceCreated  bool
+		instanceDeleted  bool
+		parentGone       bool
+		cloudCleanupOK   bool
+		cloudAbsent      bool
+		workspacePath    string
+		instanceUID      string
+		childName        string
+		childNamespace   string
+		tenantClient     dynamic.Interface
+	)
+
+	t.Cleanup(func() {
+		parentGone = instanceDeleted
+		if instanceCreated && !instanceDeleted && workspacePath != "" {
+			if err := tenantClient.Resource(configConnectorPubSubInstanceGVR).Delete(context.Background(), topicName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup GCPPubSubTopic %q: %v", topicName, err)
+			}
+			parentGone = waitTilt(t, configConnectorGCPCleanupWait, func() (bool, string) {
+				_, err := tenantClient.Resource(configConnectorPubSubInstanceGVR).Get(context.Background(), topicName, metav1.GetOptions{})
+				return apierrors.IsNotFound(err), fmt.Sprintf("get cleanup parent: %v", err)
+			})
+			if !parentGone {
+				t.Errorf("cleanup did not observe GCPPubSubTopic parent %q gone", topicName)
+			}
+		}
+
+		childrenGone := waitConfigConnectorChildrenGone(t, runtimeClient, instanceUID, configConnectorGCPCleanupWait)
+		if !childrenGone {
+			childrenGone = waitConfigConnectorChildrenGone(t, runtimeClient, instanceUID, configConnectorGCPCleanupWait)
+		}
+		safeCloudCleanup := cloudCleanupOK && ((instanceUID != "" && childrenGone) || (instanceUID == "" && parentGone))
+		if safeCloudCleanup && !cloudAbsent {
+			if !waitConfigConnectorPubSubState(t, accessToken, topicResource, false, configConnectorGCPCleanupWait) {
+				if err := deleteConfigConnectorPubSubTopic(accessToken, topicResource); err != nil {
+					t.Errorf("emergency cleanup of test-owned Pub/Sub topic %q: %v", topicName, err)
+				} else if !waitConfigConnectorPubSubState(t, accessToken, topicResource, false, configConnectorGCPCleanupWait) {
+					t.Errorf("emergency cleanup did not prove Pub/Sub topic %q absent", topicName)
+				}
+			}
+		} else if cloudCleanupOK && !cloudAbsent {
+			t.Errorf("refusing emergency Pub/Sub deletion because the controller child cleanup boundary was not proven")
+		}
+
+		if !childrenGone {
+			t.Errorf("cleanup did not observe PubSubTopic children for instance %q gone", instanceUID)
+		} else if instanceUID == "" && childName != "" {
+			waitTiltResourceGone(t, runtimeClient.Resource(configConnectorPubSubTopicGVR).Namespace(childNamespace), childName, configConnectorGCPCleanupWait)
+		}
+		if bindingCreated && workspacePath != "" {
+			if err := tenantClient.Resource(configConnectorAPIBindingGVR).Delete(context.Background(), "infrastructure", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup infrastructure APIBinding in %s: %v", workspacePath, err)
+			}
+		}
+		if workspaceCreated {
+			if err := parentClient.Resource(configConnectorWorkspaceGVR).Delete(context.Background(), workspaceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup workspace %q: %v", workspaceName, err)
+			}
+			waitTiltResourceGone(t, parentClient.Resource(configConnectorWorkspaceGVR), workspaceName, configConnectorGCPCleanupWait)
+		}
+		if templateCreated {
+			if err := providerClient.Resource(configConnectorTemplateGVR).Delete(context.Background(), templateName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup Template %q: %v", templateName, err)
+			}
+			waitTiltResourceGone(t, providerClient.Resource(configConnectorTemplateGVR), templateName, configConnectorGCPCleanupWait)
+			if err := runtimeClient.Resource(configConnectorRGDGVR).Delete(context.Background(), templateName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup ResourceGraphDefinition %q: %v", templateName, err)
+			}
+			waitTiltResourceGone(t, runtimeClient.Resource(configConnectorRGDGVR), templateName, configConnectorGCPCleanupWait)
+			if !waitTilt(t, configConnectorGCPCleanupWait, func() (bool, string) {
+				export, err := providerClient.Resource(apiExportGVR).Get(context.Background(), infraAPIExportName, metav1.GetOptions{})
+				if err != nil {
+					return false, err.Error()
+				}
+				return !apiExportHasResource(export.Object, configConnectorPubSubResource, infraGroup), "APIExport still lists gcppubsubtopics"
+			}) {
+				t.Errorf("cleanup did not observe gcppubsubtopics removed from the infrastructure APIExport")
+			}
+		}
+	})
+
+	if _, err := providerClient.Resource(configConnectorTemplateGVR).Create(context.Background(), configConnectorPubSubTemplate(templateName), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create test Template %q: %v", templateName, err)
+	}
+	templateCreated = true
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		got, err := providerClient.Resource(configConnectorTemplateGVR).Get(context.Background(), templateName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		status, reason, message := conditionState(got.Object, "Ready")
+		return status == "True", fmt.Sprintf("Ready=%s reason=%s message=%s", status, reason, message)
+	}) {
+		t.Fatalf("test Template %q never became Ready", templateName)
+	}
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		export, err := providerClient.Resource(apiExportGVR).Get(context.Background(), infraAPIExportName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		return apiExportHasResource(export.Object, configConnectorPubSubResource, infraGroup), "APIExport does not list gcppubsubtopics"
+	}) {
+		t.Fatal("infrastructure APIExport never listed gcppubsubtopics")
+	}
+	if status, message := waitRGDGraphAccepted(t, runtimeClient, templateName); status != "True" {
+		t.Fatalf("test Template RGD %q was not GraphAccepted: status=%s message=%s", templateName, status, message)
+	}
+
+	workspacePath = createConfigConnectorWorkspace(t, parentClient, workspaceName)
+	workspaceCreated = true
+	tenantClient = kcpAdminDynamic(t, workspacePath)
+	if _, err := tenantClient.Resource(configConnectorAPIBindingGVR).Create(context.Background(), configConnectorAPIBinding(), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create infrastructure APIBinding in %s: %v", workspacePath, err)
+	}
+	bindingCreated = true
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		got, err := tenantClient.Resource(configConnectorAPIBindingGVR).Get(context.Background(), "infrastructure", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		phase, _, _ := unstructured.NestedString(got.Object, "status", "phase")
+		return phase == "Bound", "phase=" + phase
+	}) {
+		t.Fatalf("infrastructure APIBinding in %s never reached Bound", workspacePath)
+	}
+
+	instance := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": infraGroup + "/v1alpha1",
+		"kind":       "GCPPubSubTopic",
+		"metadata":   map[string]any{"name": topicName},
+		"spec": map[string]any{
+			"projectID": projectID,
+			"topicName": topicName,
+		},
+	}}
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		created, err := tenantClient.Resource(configConnectorPubSubInstanceGVR).Create(context.Background(), instance.DeepCopy(), metav1.CreateOptions{})
+		if err == nil {
+			instanceUID = string(created.GetUID())
+			return true, ""
+		}
+		if apierrors.IsAlreadyExists(err) {
+			created, getErr := tenantClient.Resource(configConnectorPubSubInstanceGVR).Get(context.Background(), topicName, metav1.GetOptions{})
+			if getErr == nil {
+				instanceUID = string(created.GetUID())
+				return true, "already exists after an uncertain create response"
+			}
+			return false, getErr.Error()
+		}
+		return false, err.Error()
+	}) {
+		t.Fatalf("create GCPPubSubTopic %q in %s", topicName, workspacePath)
+	}
+	instanceCreated = true
+	cloudCleanupOK = true
+	if instanceUID == "" && !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		got, err := tenantClient.Resource(configConnectorPubSubInstanceGVR).Get(context.Background(), topicName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		instanceUID = string(got.GetUID())
+		return instanceUID != "", "instance UID not assigned"
+	}) {
+		t.Fatalf("GCPPubSubTopic %q never received a UID", topicName)
+	}
+
+	selector := fmt.Sprintf("%s=%s,%s=%s", kroInstanceIDLabel, instanceUID, kroNodeIDLabel, configConnectorPubSubNode)
+	var child *unstructured.Unstructured
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		items, err := runtimeClient.Resource(configConnectorPubSubTopicGVR).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(items.Items) != 1 {
+			return false, fmt.Sprintf("found %d KRO-labeled PubSubTopic children", len(items.Items))
+		}
+		child = items.Items[0].DeepCopy()
+		return true, ""
+	}) {
+		t.Fatalf("KRO never created one PubSubTopic child for %q", topicName)
+	}
+	childName, childNamespace = child.GetName(), child.GetNamespace()
+	if childNamespace == "" {
+		t.Fatalf("runtime PubSubTopic child %q has no namespace", childName)
+	}
+	if childName != topicName {
+		t.Fatalf("runtime PubSubTopic child name = %q, want %q", childName, topicName)
+	}
+	if got := child.GetAnnotations()["cnrm.cloud.google.com/project-id"]; got != projectID {
+		t.Fatalf("runtime PubSubTopic project annotation = %q, want %q", got, projectID)
+	}
+	childSpec, found, err := unstructured.NestedMap(child.Object, "spec")
+	if err != nil || !found || len(childSpec) != 0 {
+		t.Fatalf("runtime PubSubTopic spec = %v (found=%t err=%v), want an explicit empty spec", childSpec, found, err)
+	}
+	waitConfigConnectorChildReady(t, runtimeClient, childNamespace, childName)
+	if !waitConfigConnectorPubSubState(t, accessToken, topicResource, true, configConnectorGCPWait) {
+		t.Fatalf("Pub/Sub REST API never proved topic %q exists", topicResource)
+	}
+
+	if err := tenantClient.Resource(configConnectorPubSubInstanceGVR).Delete(context.Background(), topicName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete GCPPubSubTopic %q: %v", topicName, err)
+	}
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		_, err := tenantClient.Resource(configConnectorPubSubInstanceGVR).Get(context.Background(), topicName, metav1.GetOptions{})
+		return apierrors.IsNotFound(err), fmt.Sprintf("get parent: %v", err)
+	}) {
+		t.Fatalf("GCPPubSubTopic parent %q was not deleted", topicName)
+	}
+	instanceDeleted = true
+	if !waitTilt(t, configConnectorGCPWait, func() (bool, string) {
+		_, err := runtimeClient.Resource(configConnectorPubSubTopicGVR).Namespace(childNamespace).Get(context.Background(), childName, metav1.GetOptions{})
+		return apierrors.IsNotFound(err), fmt.Sprintf("get child: %v", err)
+	}) {
+		t.Fatalf("PubSubTopic child %s/%s was not deleted", childNamespace, childName)
+	}
+	if !waitConfigConnectorPubSubState(t, accessToken, topicResource, false, configConnectorGCPWait) {
+		t.Fatalf("Pub/Sub REST API never proved topic %q absent", topicResource)
+	}
+	cloudAbsent = true
+	t.Logf("KRO and Config Connector created Pub/Sub topic %q, direct REST proved it existed, and deleting the Faros parent removed both child and cloud topic", topicResource)
+}
+
+func requireHealthyConfigConnector(t *testing.T, runtimeClient dynamic.Interface) {
+	t.Helper()
+	crd, err := runtimeClient.Resource(configConnectorCRDGVR).Get(context.Background(), configConnectorPubSubCRDName, metav1.GetOptions{})
+	if err != nil || !crdEstablished(crd) {
+		t.Fatalf("real Config Connector PubSubTopic CRD is not Established; run make e2e-tilt-cluster-config-connector-gcp-install first: %v", err)
+	}
+	connector, err := runtimeClient.Resource(configConnectorGVR).Get(context.Background(), configConnectorName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigConnector %q: %v", configConnectorName, err)
+	}
+	healthy, _, _ := unstructured.NestedBool(connector.Object, "status", "healthy")
+	observed, _, _ := unstructured.NestedInt64(connector.Object, "status", "observedGeneration")
+	if !healthy || observed != connector.GetGeneration() {
+		errors, _, _ := unstructured.NestedStringSlice(connector.Object, "status", "errors")
+		phase, _, _ := unstructured.NestedString(connector.Object, "status", "phase")
+		t.Fatalf("ConfigConnector is not current and healthy: healthy=%t observedGeneration=%d generation=%d phase=%s errors=%v", healthy, observed, connector.GetGeneration(), phase, errors)
+	}
+}
+
+func requiredConfigConnectorRuntimeClient(t *testing.T) dynamic.Interface {
+	t.Helper()
+	path := envOr("FAROS_E2E_TILT_RUNTIME_KUBECONFIG", filepath.Join(repoRoot, ".faros-cluster.kubeconfig"))
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		t.Fatalf("runtime kubeconfig is required at %q when the real-cloud E2E is enabled", path)
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Fatalf("runtime kubeconfig %q is not usable: %v", path, err)
+	}
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("runtime client from %q is unavailable: %v", path, err)
+	}
+	return client
+}
+
+func configConnectorPubSubTemplate(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": infraGroup + "/v1alpha1",
+		"kind":       "Template",
+		"metadata": map[string]any{
+			"name":   name,
+			"labels": map[string]any{configConnectorTestLabel: configConnectorTestLabelValue},
+		},
+		"spec": map[string]any{
+			"displayName": "GCP Pub/Sub Config Connector steel thread",
+			"description": "Test-only KRO composition of a real Config Connector PubSubTopic.",
+			"category":    "Test",
+			"version":     "0.0.1",
+			"backend":     "kro",
+			"instanceCRD": map[string]any{
+				"group": infraGroup, "version": "v1alpha1", "resource": configConnectorPubSubResource, "kind": "GCPPubSubTopic",
+			},
+			"schema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"projectID": map[string]any{"type": "string"},
+					"topicName": map[string]any{"type": "string"},
+				},
+				"required": []any{"projectID", "topicName"},
+			},
+			"backendConfig": map[string]any{
+				"resources": []any{map[string]any{
+					"id": configConnectorPubSubNode,
+					"template": map[string]any{
+						"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
+						"kind":       "PubSubTopic",
+						"metadata": map[string]any{
+							"name":      "${schema.spec.topicName}",
+							"namespace": "default",
+							"annotations": map[string]any{
+								"cnrm.cloud.google.com/project-id": "${schema.spec.projectID}",
+							},
+						},
+						"spec": map[string]any{},
+					},
+				}},
+			},
+		},
+	}}
+}
+
+func waitConfigConnectorChildReady(t *testing.T, runtimeClient dynamic.Interface, namespace, name string) {
+	t.Helper()
+	deadline := time.Now().Add(configConnectorGCPWait)
+	for {
+		child, err := runtimeClient.Resource(configConnectorPubSubTopicGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err == nil {
+			status, reason, message := conditionState(child.Object, "Ready")
+			observed, _, _ := unstructured.NestedInt64(child.Object, "status", "observedGeneration")
+			if status == "False" {
+				t.Fatalf("Config Connector PubSubTopic %s/%s reported Ready=False: reason=%s message=%s", namespace, name, reason, message)
+			}
+			if status == "True" && observed == child.GetGeneration() {
+				return
+			}
+			t.Logf("waiting for Config Connector PubSubTopic %s/%s: Ready=%s observedGeneration=%d generation=%d reason=%s message=%s", namespace, name, status, observed, child.GetGeneration(), reason, message)
+		} else if !apierrors.IsNotFound(err) {
+			t.Logf("waiting for Config Connector PubSubTopic %s/%s: %v", namespace, name, err)
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("Config Connector PubSubTopic %s/%s did not become Ready at its current generation", namespace, name)
+		}
+		time.Sleep(configConnectorGCPPoll)
+	}
+}
+
+func waitConfigConnectorChildrenGone(t *testing.T, runtimeClient dynamic.Interface, instanceUID string, timeout time.Duration) bool {
+	t.Helper()
+	if instanceUID == "" {
+		return true
+	}
+	selector := fmt.Sprintf("%s=%s,%s=%s", kroInstanceIDLabel, instanceUID, kroNodeIDLabel, configConnectorPubSubNode)
+	return waitTilt(t, timeout, func() (bool, string) {
+		items, err := runtimeClient.Resource(configConnectorPubSubTopicGVR).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+		if apierrors.IsNotFound(err) {
+			return true, "PubSubTopic CRD is absent"
+		}
+		if err != nil {
+			return false, err.Error()
+		}
+		return len(items.Items) == 0, fmt.Sprintf("%d PubSubTopic child(ren) remain", len(items.Items))
+	})
+}
+
+type configConnectorServiceAccountCredentials struct {
+	Type         string `json:"type"`
+	ClientEmail  string `json:"client_email"`
+	PrivateKey   string `json:"private_key"`
+	PrivateKeyID string `json:"private_key_id"`
+	TokenURI     string `json:"token_uri"`
+}
+
+type configConnectorTokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+func mintConfigConnectorGCPAccessToken(t *testing.T, credentialJSON []byte) string {
+	t.Helper()
+	var credentials configConnectorServiceAccountCredentials
+	if err := json.Unmarshal(credentialJSON, &credentials); err != nil {
+		t.Fatal("GCP credentials are not valid JSON")
+	}
+	if credentials.Type != "service_account" || credentials.ClientEmail == "" || credentials.PrivateKey == "" {
+		t.Fatal("GCP credentials must be a service_account JSON key")
+	}
+	if credentials.TokenURI != configConnectorGCPTokenURI {
+		t.Fatalf("GCP service-account token URI must be %s", configConnectorGCPTokenURI)
+	}
+	block, _ := pem.Decode([]byte(credentials.PrivateKey))
+	if block == nil {
+		t.Fatal("GCP service-account private key is not PEM encoded")
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	clear(block.Bytes)
+	if err != nil {
+		t.Fatal("GCP service-account private key is not valid PKCS8")
+	}
+	privateKey, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatal("GCP service-account private key is not RSA")
+	}
+
+	now := time.Now().Unix()
+	header, _ := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT", "kid": credentials.PrivateKeyID})
+	claims, _ := json.Marshal(map[string]any{
+		"iss": credentials.ClientEmail, "scope": configConnectorGCPPubSubScope,
+		"aud": configConnectorGCPTokenURI, "iat": now, "exp": now + 3600,
+	})
+	unsigned := base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(claims)
+	digest := sha256.Sum256([]byte(unsigned))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatal("sign GCP service-account assertion")
+	}
+	assertion := unsigned + "." + base64.RawURLEncoding.EncodeToString(signature)
+	clear(signature)
+
+	form := url.Values{
+		"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+		"assertion":  {assertion},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, configConnectorGCPTokenURI, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal("build GCP token request")
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("GCP token exchange failed")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GCP token exchange returned HTTP %d", resp.StatusCode)
+	}
+	var token configConnectorTokenResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&token); err != nil || token.AccessToken == "" {
+		t.Fatal("GCP token exchange returned no access token")
+	}
+	return token.AccessToken
+}
+
+func waitConfigConnectorPubSubState(t *testing.T, accessToken, resource string, wantExists bool, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := ""
+	for {
+		status, err := getConfigConnectorPubSubTopic(accessToken, resource)
+		if err == nil {
+			switch status {
+			case http.StatusOK:
+				if wantExists {
+					return true
+				}
+				last = "HTTP 200: topic still exists"
+			case http.StatusNotFound:
+				if !wantExists {
+					return true
+				}
+				last = "HTTP 404: topic not created yet"
+			case http.StatusUnauthorized, http.StatusForbidden:
+				t.Logf("Pub/Sub REST authorization failed with HTTP %d", status)
+				return false
+			default:
+				last = fmt.Sprintf("HTTP %d", status)
+			}
+		} else {
+			last = err.Error()
+		}
+		if !time.Now().Before(deadline) {
+			t.Logf("Pub/Sub REST state wait timed out after %s: %s", timeout, last)
+			return false
+		}
+		time.Sleep(configConnectorGCPPoll)
+	}
+}
+
+func getConfigConnectorPubSubTopic(accessToken, resource string) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://pubsub.googleapis.com/v1/"+resource, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	return resp.StatusCode, nil
+}
+
+func deleteConfigConnectorPubSubTopic(accessToken, resource string) error {
+	parts := strings.Split(resource, "/")
+	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "topics" {
+		return fmt.Errorf("refusing malformed Pub/Sub resource %q", resource)
+	}
+	topicName := parts[3]
+	if !configConnectorTopicPattern.MatchString(topicName) {
+		return fmt.Errorf("refusing to delete non-test-owned topic %q", topicName)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, "https://pubsub.googleapis.com/v1/"+resource, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("Pub/Sub delete returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func configConnectorGCPNonce() string {
+	return fmt.Sprintf("%08x", uint32(time.Now().UnixNano()))
+}

--- a/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
+++ b/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
@@ -58,7 +58,7 @@ const (
 	configConnectorGCPCredentialsEnv    = "FAROS_E2E_GCP_CREDENTIALS_FILE"
 	configConnectorName                 = "configconnector.core.cnrm.cloud.google.com"
 	configConnectorPubSubCRDName        = "pubsubtopics.pubsub.cnrm.cloud.google.com"
-	configConnectorPubSubTemplatePrefix = "gcp-pubsub-steel-thread-"
+	configConnectorPubSubTemplatePrefix = "gcp-pubsub-kcc-demo-"
 	configConnectorPubSubTemplateName   = "gcp-pubsub-topic"
 	configConnectorPubSubWorkspacePref  = "e2e-pubsub-"
 	configConnectorPubSubNode           = "pubSubTopic"

--- a/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
+++ b/test/e2e/suites/tiltcluster/config_connector_gcp_test.go
@@ -556,7 +556,7 @@ func mintConfigConnectorGCPAccessToken(t *testing.T, credentialJSON []byte) stri
 	if err != nil {
 		t.Fatal("GCP token exchange failed")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GCP token exchange returned HTTP %d", resp.StatusCode)
 	}
@@ -614,7 +614,7 @@ func getConfigConnectorPubSubTopic(accessToken, resource string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
 	return resp.StatusCode, nil
 }
@@ -639,7 +639,7 @@ func deleteConfigConnectorPubSubTopic(accessToken, resource string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
 		return fmt.Errorf("Pub/Sub delete returned HTTP %d", resp.StatusCode)

--- a/test/e2e/suites/tiltcluster/config_connector_test.go
+++ b/test/e2e/suites/tiltcluster/config_connector_test.go
@@ -54,11 +54,11 @@ var (
 const (
 	configConnectorOperatorNamespace = "faros-infrastructure-operator"
 	configConnectorOperatorName      = "infrastructure"
-	configConnectorTemplatePrefix    = "gcs-bucket-steel-thread-"
+	configConnectorTemplatePrefix    = "gcs-bucket-kcc-demo-"
 	configConnectorWorkspacePrefix   = "e2e-gcs-"
 	configConnectorStorageBucketNode = "storageBucket"
 	configConnectorTestLabel         = "faros.sh/e2e-config-connector"
-	configConnectorTestLabelValue    = "steel-thread"
+	configConnectorTestLabelValue    = "infra-operator-kcc-demo"
 
 	configConnectorWait = 3 * time.Minute
 	configConnectorPoll = 2 * time.Second
@@ -69,8 +69,9 @@ const (
 	kroNodeIDLabel     = "kro.run/node-id"
 )
 
-// TestConfigConnectorComposition proves the opt-in Config Connector steel
-// thread against the operator-managed Tilt runtime:
+// TestConfigConnectorComposition demonstrates how the infrastructure operator
+// can publish a Template whose KRO graph creates a Config Connector CR in the
+// operator-managed Tilt runtime:
 //
 //	InfrastructureProvider Ready -> test-owned StorageBucket CRD -> Template
 //	Ready -> KRO GraphAccepted -> isolated tenant/APIExport binding ->
@@ -419,8 +420,8 @@ func configConnectorTemplate(name string) *unstructured.Unstructured {
 			},
 		},
 		"spec": map[string]any{
-			"displayName": "GCS bucket composition steel-thread",
-			"description": "Test-only composition from a tenant GCSBucket to a StorageBucket CR.",
+			"displayName": "GCS bucket Config Connector composition demo",
+			"description": "Test-only infrastructure operator composition from a tenant GCSBucket to a Config Connector StorageBucket CR.",
 			"category":    "Test",
 			"version":     "0.0.1",
 			"backend":     "kro",

--- a/test/e2e/suites/tiltcluster/config_connector_test.go
+++ b/test/e2e/suites/tiltcluster/config_connector_test.go
@@ -1,0 +1,603 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package tiltcluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	configConnectorInfrastructureProviderGVR = schema.GroupVersionResource{
+		Group: "infrastructure.faros.sh", Version: "v1alpha1", Resource: "infrastructureproviders",
+	}
+	configConnectorWorkspaceGVR = schema.GroupVersionResource{
+		Group: "tenancy.kcp.io", Version: "v1alpha1", Resource: "workspaces",
+	}
+	configConnectorAPIBindingGVR = schema.GroupVersionResource{
+		Group: "apis.kcp.io", Version: "v1alpha2", Resource: "apibindings",
+	}
+	configConnectorCRDGVR = schema.GroupVersionResource{
+		Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions",
+	}
+	configConnectorRGDGVR = schema.GroupVersionResource{
+		Group: "kro.run", Version: "v1alpha1", Resource: "resourcegraphdefinitions",
+	}
+	configConnectorStorageBucketGVR = schema.GroupVersionResource{
+		Group: "storage.cnrm.cloud.google.com", Version: "v1beta1", Resource: "storagebuckets",
+	}
+	configConnectorTemplateGVR = schema.GroupVersionResource{
+		Group: infraGroup, Version: "v1alpha1", Resource: "templates",
+	}
+)
+
+const (
+	configConnectorOperatorNamespace = "faros-infrastructure-operator"
+	configConnectorOperatorName      = "infrastructure"
+	configConnectorTemplatePrefix    = "gcs-bucket-steel-thread-"
+	configConnectorWorkspacePrefix   = "e2e-gcs-"
+	configConnectorStorageBucketNode = "storageBucket"
+	configConnectorTestLabel         = "faros.sh/e2e-config-connector"
+	configConnectorTestLabelValue    = "steel-thread"
+
+	configConnectorWait = 3 * time.Minute
+	configConnectorPoll = 2 * time.Second
+)
+
+const (
+	kroInstanceIDLabel = "kro.run/instance-id"
+	kroNodeIDLabel     = "kro.run/node-id"
+)
+
+// TestConfigConnectorComposition proves the opt-in Config Connector steel
+// thread against the operator-managed Tilt runtime:
+//
+//	InfrastructureProvider Ready -> test-owned StorageBucket CRD -> Template
+//	Ready -> KRO GraphAccepted -> isolated tenant/APIExport binding ->
+//	GCSBucket instance -> KRO-labeled StorageBucket child.
+//
+// The StorageBucket CRD is deliberately minimal and no Config Connector
+// controller is installed. This proves only that KRO composes the expected CR
+// with the expected fields; it does not contact GCP or reconcile a bucket.
+func TestConfigConnectorComposition(t *testing.T) {
+	if os.Getenv("FAROS_E2E_CONFIG_CONNECTOR_COMPOSITION") != "1" {
+		t.Skip("run only through make e2e-tilt-cluster-config-connector")
+	}
+	requireStack(t)
+	runtimeClient := configConnectorRuntimeClient(t)
+	waitInfrastructureProviderReady(t, runtimeClient)
+
+	crdOwned := ensureStorageBucketCRD(t, runtimeClient)
+	if crdOwned {
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if err := runtimeClient.Resource(configConnectorCRDGVR).Delete(ctx, "storagebuckets.storage.cnrm.cloud.google.com", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup StorageBucket CRD: %v", err)
+			}
+			cancel()
+			waitTiltResourceGone(t, runtimeClient.Resource(configConnectorCRDGVR), "storagebuckets.storage.cnrm.cloud.google.com", 30*time.Second)
+		})
+	}
+
+	templateName := configConnectorTemplatePrefix + shortNonce()
+	providerClient := kcpAdminDynamic(t, providerWorkspace)
+	tmpl := configConnectorTemplate(templateName)
+	if _, err := providerClient.Resource(configConnectorTemplateGVR).Create(context.Background(), tmpl, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create test Template %q: %v", templateName, err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := providerClient.Resource(configConnectorTemplateGVR).Delete(ctx, templateName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Errorf("cleanup Template %q: %v", templateName, err)
+		}
+		cancel()
+		waitTiltResourceGone(t, providerClient.Resource(configConnectorTemplateGVR), templateName, 60*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		if err := runtimeClient.Resource(configConnectorRGDGVR).Delete(ctx, templateName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Errorf("cleanup ResourceGraphDefinition %q: %v", templateName, err)
+		}
+		cancel()
+		waitTiltResourceGone(t, runtimeClient.Resource(configConnectorRGDGVR), templateName, 60*time.Second)
+	})
+
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		got, err := providerClient.Resource(configConnectorTemplateGVR).Get(context.Background(), templateName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		status, reason, message := conditionState(got.Object, "Ready")
+		return status == "True", fmt.Sprintf("Ready=%s reason=%s message=%s", status, reason, message)
+	}) {
+		t.Fatalf("test Template %q never became Ready", templateName)
+	}
+
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		export, err := providerClient.Resource(apiExportGVR).Get(context.Background(), infraAPIExportName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if apiExportHasResource(export.Object, "gcsbuckets", infraGroup) {
+			return true, ""
+		}
+		return false, "APIExport does not list gcsbuckets yet"
+	}) {
+		t.Fatalf("infrastructure APIExport never listed test resource gcsbuckets")
+	}
+
+	if status, message := waitRGDGraphAccepted(t, runtimeClient, templateName); status != "True" {
+		t.Fatalf("test Template RGD %q was not GraphAccepted: status=%s message=%s", templateName, status, message)
+	}
+
+	workspaceName := configConnectorWorkspacePrefix + shortNonce()
+	parentClient := kcpAdminDynamic(t, "root:faros")
+	workspacePath := createConfigConnectorWorkspace(t, parentClient, workspaceName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := parentClient.Resource(configConnectorWorkspaceGVR).Delete(ctx, workspaceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Errorf("cleanup workspace %q: %v", workspaceName, err)
+		}
+		waitTiltResourceGone(t, parentClient.Resource(configConnectorWorkspaceGVR), workspaceName, 60*time.Second)
+	})
+
+	tenantClient := kcpAdminDynamic(t, workspacePath)
+	binding := configConnectorAPIBinding()
+	if _, err := tenantClient.Resource(configConnectorAPIBindingGVR).Create(context.Background(), binding, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create infrastructure APIBinding in %s: %v", workspacePath, err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := tenantClient.Resource(configConnectorAPIBindingGVR).Delete(ctx, "infrastructure", metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Errorf("cleanup infrastructure APIBinding in %s: %v", workspacePath, err)
+		}
+		waitTiltResourceGone(t, tenantClient.Resource(configConnectorAPIBindingGVR), "infrastructure", 30*time.Second)
+	})
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		got, err := tenantClient.Resource(configConnectorAPIBindingGVR).Get(context.Background(), "infrastructure", metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		phase, _, _ := unstructured.NestedString(got.Object, "status", "phase")
+		return phase == "Bound", "phase=" + phase
+	}) {
+		t.Fatalf("infrastructure APIBinding in %s never reached Bound", workspacePath)
+	}
+
+	instanceName := "gcs-bucket-" + shortNonce()
+	instanceGVR := schema.GroupVersionResource{Group: infraGroup, Version: "v1alpha1", Resource: "gcsbuckets"}
+	instance := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": infraGroup + "/v1alpha1",
+		"kind":       "GCSBucket",
+		"metadata":   map[string]any{"name": instanceName},
+		"spec": map[string]any{
+			"name":                     instanceName,
+			"location":                 "US",
+			"uniformBucketLevelAccess": true,
+		},
+	}}
+	var createdInstance *unstructured.Unstructured
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		created, err := tenantClient.Resource(instanceGVR).Create(context.Background(), instance.DeepCopy(), metav1.CreateOptions{})
+		if err == nil {
+			createdInstance = created
+			return true, ""
+		}
+		if apierrors.IsAlreadyExists(err) {
+			created, getErr := tenantClient.Resource(instanceGVR).Get(context.Background(), instanceName, metav1.GetOptions{})
+			if getErr == nil {
+				createdInstance = created
+				return true, "already exists"
+			}
+			return false, getErr.Error()
+		}
+		return false, err.Error()
+	}) {
+		t.Fatalf("create GCSBucket %q in %s: API not served after binding", instanceName, workspacePath)
+	}
+
+	var instanceUID string
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := tenantClient.Resource(instanceGVR).Delete(ctx, instanceName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Errorf("cleanup GCSBucket %q: %v", instanceName, err)
+		}
+		if instanceUID != "" {
+			deleteRuntimeStorageBucketChildren(t, runtimeClient, instanceUID)
+		}
+	})
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		got, err := tenantClient.Resource(instanceGVR).Get(context.Background(), instanceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		instanceUID = string(got.GetUID())
+		if instanceUID == "" {
+			return false, "GCSBucket UID not assigned yet"
+		}
+		return true, ""
+	}) {
+		t.Fatalf("GCSBucket %q never received a UID (create response=%v)", instanceName, createdInstance)
+	}
+
+	var child *unstructured.Unstructured
+	selector := fmt.Sprintf("%s=%s,%s=%s", kroInstanceIDLabel, instanceUID, kroNodeIDLabel, configConnectorStorageBucketNode)
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		items, err := runtimeClient.Resource(configConnectorStorageBucketGVR).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(items.Items) == 0 {
+			return false, "no KRO-labeled StorageBucket child yet"
+		}
+		child = items.Items[0].DeepCopy()
+		return true, fmt.Sprintf("found %s/%s", child.GetNamespace(), child.GetName())
+	}) {
+		t.Fatalf("KRO never created a StorageBucket child for GCSBucket %q", instanceName)
+	}
+
+	if got := child.GetKind(); got != "StorageBucket" {
+		t.Fatalf("runtime child kind = %q, want StorageBucket", got)
+	}
+	if got := child.GetLabels()[kroInstanceIDLabel]; got != instanceUID {
+		t.Fatalf("runtime child %s instance-id label = %q, want %q", child.GetName(), got, instanceUID)
+	}
+	if got := child.GetLabels()[kroNodeIDLabel]; got != configConnectorStorageBucketNode {
+		t.Fatalf("runtime child %s node-id label = %q, want %q", child.GetName(), got, configConnectorStorageBucketNode)
+	}
+	if got, found, err := unstructured.NestedString(child.Object, "spec", "location"); err != nil || !found || got != "US" {
+		t.Fatalf("runtime StorageBucket %s spec.location = %q (found=%t err=%v), want US", child.GetName(), got, found, err)
+	}
+	if got, found, err := unstructured.NestedBool(child.Object, "spec", "uniformBucketLevelAccess"); err != nil || !found || !got {
+		t.Fatalf("runtime StorageBucket %s spec.uniformBucketLevelAccess = %t (found=%t err=%v), want true", child.GetName(), got, found, err)
+	}
+	t.Logf("KRO composed StorageBucket %s/%s from tenant GCSBucket %q; no Config Connector/GCP reconciliation was exercised", child.GetNamespace(), child.GetName(), instanceName)
+}
+
+func configConnectorRuntimeClient(t *testing.T) dynamic.Interface {
+	t.Helper()
+	path := envOr("FAROS_E2E_TILT_RUNTIME_KUBECONFIG", filepath.Join(repoRoot, ".faros-cluster.kubeconfig"))
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		t.Skipf("runtime kubeconfig %q is absent; start `make tilt-cluster` first", path)
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		t.Skipf("runtime kubeconfig %q is not usable: %v", path, err)
+	}
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Skipf("runtime client from %q is unavailable: %v", path, err)
+	}
+	return client
+}
+
+func waitInfrastructureProviderReady(t *testing.T, runtimeClient dynamic.Interface) {
+	t.Helper()
+	namespace := envOr("FAROS_E2E_TILT_OPERATOR_NAMESPACE", configConnectorOperatorNamespace)
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		provider, err := runtimeClient.Resource(configConnectorInfrastructureProviderGVR).Namespace(namespace).Get(context.Background(), configConnectorOperatorName, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		phase, _, _ := unstructured.NestedString(provider.Object, "status", "phase")
+		for _, condition := range []string{"Bootstrapped", "KroReleased", "ProviderDeployed", "Registered"} {
+			status, reason, message := conditionState(provider.Object, condition)
+			if status != "True" {
+				return false, fmt.Sprintf("phase=%s %s=%s reason=%s message=%s", phase, condition, status, reason, message)
+			}
+		}
+		return phase == "Ready", "phase=" + phase
+	}) {
+		t.Fatalf("InfrastructureProvider %s/%s never reached Ready with lifecycle conditions true", namespace, configConnectorOperatorName)
+	}
+	t.Logf("InfrastructureProvider %s/%s lifecycle ready", namespace, configConnectorOperatorName)
+}
+
+// ensureStorageBucketCRD creates only the minimal API surface KRO needs to
+// apply its child. A real Config Connector CRD is intentionally not modified;
+// the test skips in that case so it cannot accidentally invoke cloud behavior.
+func ensureStorageBucketCRD(t *testing.T, runtimeClient dynamic.Interface) bool {
+	t.Helper()
+	const name = "storagebuckets.storage.cnrm.cloud.google.com"
+	existing, err := runtimeClient.Resource(configConnectorCRDGVR).Get(context.Background(), name, metav1.GetOptions{})
+	if err == nil {
+		if existing.GetLabels()[configConnectorTestLabel] != configConnectorTestLabelValue {
+			t.Skipf("StorageBucket CRD %q already exists; refusing to replace a non-test-owned Config Connector surface", name)
+		}
+		if !waitTilt(t, configConnectorWait, func() (bool, string) {
+			got, getErr := runtimeClient.Resource(configConnectorCRDGVR).Get(context.Background(), name, metav1.GetOptions{})
+			return crdEstablished(got), fmt.Sprintf("get=%v", getErr)
+		}) {
+			t.Fatalf("test-owned StorageBucket CRD %q is not Established", name)
+		}
+		return true
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("get StorageBucket CRD %q: %v", name, err)
+	}
+
+	crd := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata": map[string]any{
+			"name": name,
+			"labels": map[string]any{
+				configConnectorTestLabel: configConnectorTestLabelValue,
+			},
+		},
+		"spec": map[string]any{
+			"group": "storage.cnrm.cloud.google.com",
+			"names": map[string]any{
+				"kind":       "StorageBucket",
+				"listKind":   "StorageBucketList",
+				"plural":     "storagebuckets",
+				"singular":   "storagebucket",
+				"shortNames": []any{"gcpstoragebucket"},
+			},
+			"scope": "Namespaced",
+			"versions": []any{map[string]any{
+				"name":    "v1beta1",
+				"served":  true,
+				"storage": true,
+				"schema": map[string]any{
+					"openAPIV3Schema": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"spec": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"location":                 map[string]any{"type": "string"},
+									"uniformBucketLevelAccess": map[string]any{"type": "boolean"},
+								},
+							},
+							"status": map[string]any{
+								"type":                                 "object",
+								"x-kubernetes-preserve-unknown-fields": true,
+							},
+						},
+					},
+				},
+				"subresources": map[string]any{"status": map[string]any{}},
+			}},
+		},
+	}}
+	if _, err := runtimeClient.Resource(configConnectorCRDGVR).Create(context.Background(), crd, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create test-owned StorageBucket CRD: %v", err)
+	}
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		got, getErr := runtimeClient.Resource(configConnectorCRDGVR).Get(context.Background(), name, metav1.GetOptions{})
+		if getErr != nil {
+			return false, getErr.Error()
+		}
+		if crdEstablished(got) {
+			return true, ""
+		}
+		return false, "Established condition is not True"
+	}) {
+		t.Fatalf("test-owned StorageBucket CRD %q never became Established", name)
+	}
+	return true
+}
+
+func crdEstablished(crd *unstructured.Unstructured) bool {
+	if crd == nil {
+		return false
+	}
+	status, _, _ := conditionState(crd.Object, "Established")
+	return status == "True"
+}
+
+func configConnectorTemplate(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": infraGroup + "/v1alpha1",
+		"kind":       "Template",
+		"metadata": map[string]any{
+			"name": name,
+			"labels": map[string]any{
+				configConnectorTestLabel: configConnectorTestLabelValue,
+			},
+		},
+		"spec": map[string]any{
+			"displayName": "GCS bucket composition steel-thread",
+			"description": "Test-only composition from a tenant GCSBucket to a StorageBucket CR.",
+			"category":    "Test",
+			"version":     "0.0.1",
+			"backend":     "kro",
+			"instanceCRD": map[string]any{
+				"group":    infraGroup,
+				"version":  "v1alpha1",
+				"resource": "gcsbuckets",
+				"kind":     "GCSBucket",
+			},
+			"schema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":                     map[string]any{"type": "string"},
+					"location":                 map[string]any{"type": "string"},
+					"uniformBucketLevelAccess": map[string]any{"type": "boolean"},
+				},
+				"required": []any{"name", "location", "uniformBucketLevelAccess"},
+			},
+			"backendConfig": map[string]any{
+				"resources": []any{map[string]any{
+					"id": configConnectorStorageBucketNode,
+					"template": map[string]any{
+						"apiVersion": "storage.cnrm.cloud.google.com/v1beta1",
+						"kind":       "StorageBucket",
+						"metadata": map[string]any{
+							"name":      "${schema.spec.name}",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"location":                 "${schema.spec.location}",
+							"uniformBucketLevelAccess": "${schema.spec.uniformBucketLevelAccess}",
+						},
+					},
+				}},
+			},
+		},
+	}}
+}
+
+func configConnectorAPIBinding() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apis.kcp.io/v1alpha2",
+		"kind":       "APIBinding",
+		"metadata":   map[string]any{"name": "infrastructure"},
+		"spec": map[string]any{
+			"reference": map[string]any{
+				"export": map[string]any{
+					"path": providerWorkspace,
+					"name": infraAPIExportName,
+				},
+			},
+		},
+	}}
+}
+
+func createConfigConnectorWorkspace(t *testing.T, parent dynamic.Interface, name string) string {
+	t.Helper()
+	workspace := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "tenancy.kcp.io/v1alpha1",
+		"kind":       "Workspace",
+		"metadata": map[string]any{
+			"name": name,
+			"labels": map[string]any{
+				configConnectorTestLabel: configConnectorTestLabelValue,
+			},
+		},
+	}}
+	if _, err := parent.Resource(configConnectorWorkspaceGVR).Create(context.Background(), workspace, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create isolated workspace %q: %v", name, err)
+	}
+	var path string
+	if !waitTilt(t, configConnectorWait, func() (bool, string) {
+		got, err := parent.Resource(configConnectorWorkspaceGVR).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		phase, _, _ := unstructured.NestedString(got.Object, "status", "phase")
+		path, _, _ = unstructured.NestedString(got.Object, "spec", "cluster")
+		return phase == "Ready" && path != "", fmt.Sprintf("phase=%s cluster=%s", phase, path)
+	}) {
+		t.Fatalf("isolated workspace %q never became Ready", name)
+	}
+	return path
+}
+
+func waitRGDGraphAccepted(t *testing.T, runtimeClient dynamic.Interface, name string) (string, string) {
+	t.Helper()
+	var status, message string
+	waitTilt(t, configConnectorWait, func() (bool, string) {
+		got, err := runtimeClient.Resource(configConnectorRGDGVR).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		status, _, message = conditionState(got.Object, "GraphAccepted")
+		if status == "True" || status == "False" {
+			return true, message
+		}
+		return false, "GraphAccepted condition not reported yet"
+	})
+	return status, message
+}
+
+func conditionState(obj map[string]any, want string) (status, reason, message string) {
+	conditions, _, _ := unstructured.NestedSlice(obj, "status", "conditions")
+	for _, raw := range conditions {
+		condition, ok := raw.(map[string]any)
+		if !ok || condition["type"] != want {
+			continue
+		}
+		status, _, _ = unstructured.NestedString(condition, "status")
+		reason, _, _ = unstructured.NestedString(condition, "reason")
+		message, _, _ = unstructured.NestedString(condition, "message")
+		return status, reason, message
+	}
+	return "", "", ""
+}
+
+func waitTilt(t *testing.T, timeout time.Duration, condition func() (bool, string)) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for {
+		ok, message := condition()
+		if ok {
+			return true
+		}
+		last = message
+		if !time.Now().Before(deadline) {
+			t.Logf("wait timeout after %s: %s", timeout, last)
+			return false
+		}
+		time.Sleep(configConnectorPoll)
+	}
+}
+
+func waitTiltResourceGone(t *testing.T, resource dynamic.ResourceInterface, name string, timeout time.Duration) {
+	t.Helper()
+	if !waitTilt(t, timeout, func() (bool, string) {
+		_, err := resource.Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, ""
+		}
+		if err != nil {
+			return false, err.Error()
+		}
+		return false, "resource still exists"
+	}) {
+		t.Errorf("cleanup did not observe %q gone", name)
+	}
+}
+
+func deleteRuntimeStorageBucketChildren(t *testing.T, runtimeClient dynamic.Interface, instanceUID string) {
+	t.Helper()
+	selector := fmt.Sprintf("%s=%s", kroInstanceIDLabel, instanceUID)
+	if !waitTilt(t, 30*time.Second, func() (bool, string) {
+		items, err := runtimeClient.Resource(configConnectorStorageBucketGVR).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, "CRD gone"
+			}
+			return false, err.Error()
+		}
+		if len(items.Items) == 0 {
+			return true, ""
+		}
+		for _, item := range items.Items {
+			resource := runtimeClient.Resource(configConnectorStorageBucketGVR).Namespace(item.GetNamespace())
+			if err := resource.Delete(context.Background(), item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup runtime StorageBucket %s/%s: %v", item.GetNamespace(), item.GetName(), err)
+			}
+		}
+		return false, fmt.Sprintf("%d runtime StorageBucket child(ren) remain", len(items.Items))
+	}) {
+		t.Errorf("cleanup did not observe runtime StorageBucket children for instance %q gone", instanceUID)
+	}
+}
+
+func shortNonce() string {
+	return strings.ToLower(fmt.Sprintf("%x", time.Now().UnixNano()&0xffffffff))
+}


### PR DESCRIPTION
## Summary

- demonstrate how an infrastructure provider `Template` uses the operator-managed KRO runtime to compose Google Config Connector resources
- add a credential-free composition test for the infrastructure operator contract
- add a real Google Cloud Pub/Sub create/delete E2E with independent REST verification
- add manual Tilt jobs for Config Connector installation, Template enablement, and smoke testing
- pin Config Connector 1.153.0 with checksum verification and import credentials from a caller-supplied file
- keep ordinary Tilt startup and local development cloud-neutral

## What this demonstrates

The infrastructure operator owns the provider lifecycle, publishes the infrastructure `Template`, and makes the KRO runtime available. A tenant creates the Template's Faros instance CR; multicluster KRO composes that instance into a native Config Connector `PubSubTopic` in the operator-managed runtime; Config Connector then reconciles the child into Google Cloud.

The implementation keeps the runtime-administration boundary explicit: Config Connector installation and cloud credentials are opt-in prerequisites, while the infrastructure operator and Template define how tenant intent becomes a KCC resource.

## Developer impact

The workflow is manual and default-off. Developers opt in through the `config-connector-install`, `config-connector-enable`, and `config-connector-smoke` Tilt jobs or their Make aliases. A disposable GCP project and service-account credential file are required only for the live-cloud path.

## Validation

- `go test -count=1 ./test/e2e/suites/tiltcluster/... -run 'TestConfigConnector'`
- Make dry-runs for composition, install, enable, and smoke targets
- repository search confirms the superseded terminology is absent from affected files
- `git diff --check`
- pinned golangci-lint reports zero issues for the changed E2E package

The focused tests safely skipped credential-gated live cluster/cloud paths during clean-branch verification; no cloud mutation was performed by that verification run.
