### PR TITLE
Reset kro helm values on every operator upgrade

### DIFF
--- a/providers/infrastructure/operator/helm.go
+++ b/providers/infrastructure/operator/helm.go
@@ -128,10 +128,17 @@ func EnsureKroRelease(ctx context.Context, runtimeKubeconfigPath string, kro v1a
 		return err
 	}
 
+	// --reset-values: without it, an upgrade that passes no --set flags
+	// silently REUSES the previous release's values — which is how the
+	// retired fork's image pin (kro-multicluster:v0.0.1-mc.7) survived the
+	// chart switch to upstream and kept the fork binary running. The
+	// desired values are always exactly "chart defaults + the CR's
+	// overrides below", never whatever the last release happened to carry.
 	args := []string{
 		"upgrade", "--install", kro.ReleaseName, kro.Chart,
 		"--version", kro.Version,
 		"--namespace", kro.Namespace, "--create-namespace",
+		"--reset-values",
 	}
 	// Image overrides are opt-in: the upstream chart's own defaults
 	// (registry.k8s.io/kro/kro at the chart's appVersion) are correct.


### PR DESCRIPTION
Follow-up to #528, found debugging the faros-dev rollout: `helm upgrade` with no provided values silently **reuses the previous release's values**, so the retired fork's `image: kro-multicluster:v0.0.1-mc.7` pin survived the chart switch to upstream and kept the fork binary running (chart said `v0.9.3`, pod still ran the fork).

`--reset-values` makes every operator upgrade converge on chart defaults + the CR's explicit overrides, regardless of what the last release carried. faroshq/ops#21 is the immediate values-level unblock for faros-dev; this makes it structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)