### PR TITLE
Scale every provider: leader election, claims, tunnel routing, and an in-cluster dev loop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,11 @@ providers/*/portal/node_modules
 # bundles in case `COPY .` runs before the dist overwrite.
 portal/dist
 providers/*/portal/dist
+
+# Never ship VCS history, local kcp state, dev kubeconfigs, or host build
+# output into image build contexts (provider images build from the repo root:
+# docker build -f providers/<name>/Dockerfile .).
+.git
+.kcp
+bin
+*.kubeconfig

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -106,12 +106,17 @@ jobs:
           # provider-release.yaml on the infrastructure provider's tag.
           - name: infrastructure/dev-agent
             image: ${{ github.repository_owner }}/faros-dev-agent
+            # Self-contained Dockerfile with module-local paths — keeps its
+            # own context (no provider-sdk dependency).
+            context: ./providers/infrastructure/dev-agent
           # Second infrastructure companion: the access gate every publishable
           # template renders in front of its app. Non-default Dockerfile in the
           # provider module root, hence the explicit context/dockerfile.
           - name: access-proxy
             image: ${{ github.repository_owner }}/faros-access-proxy
-            context: ./providers/infrastructure
+            # Shares the infrastructure go.mod, which resolves provider-sdk
+            # in-tree — repo-root context like every provider image.
+            context: .
             dockerfile: ./providers/infrastructure/Dockerfile.access-proxy
     steps:
       - name: Checkout repository
@@ -137,7 +142,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context || format('./providers/{0}', matrix.name) }}
+          # Repo-root context by default: provider modules resolve the
+          # in-tree provider-sdk via a go.mod replace and their Dockerfiles
+          # copy it into the build (docker build -f providers/<n>/Dockerfile .).
+          context: ${{ matrix.context || '.' }}
           file: ${{ matrix.dockerfile || format('./providers/{0}/Dockerfile', matrix.name) }}
           # Multi-arch on release; single-arch build-only on PRs (no QEMU emulation cost).
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -109,7 +109,10 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: ./providers/${{ needs.meta.outputs.provider }}
+          # Repo-root context: provider modules resolve the in-tree
+          # provider-sdk via a go.mod replace, and the Dockerfiles copy it
+          # into the build (docker build -f providers/<name>/Dockerfile .).
+          context: .
           file: ./providers/${{ needs.meta.outputs.provider }}/Dockerfile
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ needs.meta.outputs.provider }}-${{ steps.prep.outputs.arch }}

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -215,7 +215,7 @@ jobs:
         if: needs.meta.outputs.provider == 'infrastructure'
         uses: docker/build-push-action@v6
         with:
-          context: ./providers/infrastructure
+          context: .
           file: ./providers/infrastructure/Dockerfile.access-proxy
           platforms: linux/amd64,linux/arm64
           push: true

--- a/Makefile
+++ b/Makefile
@@ -2139,7 +2139,7 @@ helm-deploy-provider-infrastructure: ## (experimental) Build+load image, helm in
 	@command -v kind >/dev/null || { echo "kind not found; brew install kind"; exit 1; }
 	@test -f $(KRO_KIND_KUBECONFIG) || { echo "faros-kro cluster missing; run 'make dev-kro-up' first"; exit 1; }
 	@echo ">>> building $(INFRASTRUCTURE_IMAGE)"
-	docker build -t $(INFRASTRUCTURE_IMAGE) providers/infrastructure
+	docker build -t $(INFRASTRUCTURE_IMAGE) -f providers/infrastructure/Dockerfile .
 	@echo ">>> loading image into kind cluster $(KRO_KIND_NAME)"
 	kind load docker-image $(INFRASTRUCTURE_IMAGE) --name $(KRO_KIND_NAME)
 	@echo ">>> ensuring namespace + heartbeat token Secret in $(INFRASTRUCTURE_NAMESPACE)"

--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,17 @@ init-provider-edges: build-edges-provider ## Bootstrap edges APIExport + write d
 	EDGES_WORKSPACE_PATH=$(EDGES_WORKSPACE_PATH) \
 		$(BINDIR)/edges-provider init
 
+# Replica identity for the tunnel-routing registry (multi-replica dev): every
+# instance needs a distinct POD_NAME/EDGES_INTERNAL_PORT; POD_IP is loopback
+# for host binaries. A second instance: make run-provider-edges
+# EDGES_PORT=18088 EDGES_INTERNAL_PORT=18090 POD_NAME=edges-local-2
+EDGES_INTERNAL_PORT ?= 8090
 run-provider-edges: build-edges-provider ## Run the edges provider (needs: hub + install + init)
-	@echo "Starting edges provider on :$(EDGES_PORT) (SINGLE-REPLICA)"
+	@echo "Starting edges provider on :$(EDGES_PORT) (replica $${POD_NAME:-edges-local-1}, relay :$(EDGES_INTERNAL_PORT))"
 	PORT=$(EDGES_PORT) \
+	POD_NAME=$${POD_NAME:-edges-local-1} \
+	POD_IP=$${POD_IP:-127.0.0.1} \
+	EDGES_INTERNAL_PORT=$(EDGES_INTERNAL_PORT) \
 	FAROS_HUB_URL=$(EDGES_HUB_URL) \
 	FAROS_HUB_EXTERNAL_URL=$(EDGES_HUB_EXTERNAL_URL) \
 	FAROS_HUB_TOKEN=$(EDGES_TOKEN) \
@@ -2146,7 +2154,7 @@ helm-deploy-provider-infrastructure: ## (experimental) Build+load image, helm in
 		--set image.repository=faros-infrastructure-provider \
 		--set image.tag=dev \
 		--set image.pullPolicy=Never \
-		--set replicaCount=1 \
+		--set replicaCount=2 \
 		--set bootstrap.enabled=true \
 		--set hub.url=$(HUB_INTERNAL_URL) \
 		--set hub.insecure=true \

--- a/Tiltfile
+++ b/Tiltfile
@@ -669,7 +669,9 @@ local_resource(
 #     faros-provider-kubeconfig (HostSecretWriter, enabled by the hub's
 #     --kubeconfig + --hub-internal-url flags above), the init container
 #     bootstraps the workspace with it, then serve runs — all inside the
-#     faros-kro kind cluster.
+#     faros-kro kind cluster. Deploys TWO replicas (the only Tilt resource
+#     with real kube replicas + Service round-robin): exercises the
+#     leader-elected Template/Instance controllers and bootstrap loop.
 #
 #     Manual (click ▶). Order: kro-mgmt-up → infrastructure-register →
 #     infrastructure-pod. Stop the host-binary `infrastructure` resource
@@ -695,9 +697,11 @@ local_resource(
 # edges — the standalone edges provider (KubernetesCluster + LinuxServer under
 # one group edges.faros.sh) PLUS the dev agents that connect to it.
 #
-# The provider is SINGLE-REPLICA (revdial dialer map is process-global). It
-# terminates the agent reverse tunnels and serves kubectl/ssh/mcp; the agents
-# below dial it through the hub backend proxy at /services/providers/edges/*.
+# The provider terminates the agent reverse tunnels and serves
+# kubectl/ssh/mcp; the agents below dial it through the hub backend proxy at
+# /services/providers/edges/*. Multi-replica capable: tunnels are claimed in
+# a Lease registry and peer replicas relay to the owner (see the `edges-2`
+# standby under the `replicas` label).
 #
 # Workflow:
 #   1. `edges` serves automatically; click ▶ on `edges-register` then
@@ -850,4 +854,61 @@ local_resource(
     resource_deps=['ha-kube-deploy'],
     links=[link('http://localhost:8123', 'Home Assistant')],
     labels=['edges'],
+)
+
+# ---------------------------------------------------------------------------
+# replicas — second instances of the scalable providers (manual, click ▶)
+#
+# The hub proxies each provider through ONE fixed URL (localhost:{port}), so
+# these standbys receive no request traffic; what they exercise is the durable
+# coordination the scaling work added: leader election (code), per-edge claim
+# sharding (kuery), and the tunnel-ownership registry + relay (edges — both
+# instances run with replica routing enabled, POD_IP=127.0.0.1, so the standby
+# sees instance 1's tunnels through the Lease registry instead of flapping
+# their status). Real replicas WITH load-balanced traffic: `infrastructure-pod`
+# (helm, replicaCount=2 in the faros-kro kind cluster).
+#
+# Not here on purpose:
+#   - hub: Tilt runs it with --embedded-kcp; HA requires external kcp.
+#   - app-studio: dev uses the in-memory message store, which is per-process —
+#     replica claims need the shared Postgres store to mean anything.
+# ---------------------------------------------------------------------------
+
+local_resource(
+    'code-2',
+    serve_cmd='make run-provider-code CODE_PORT=18083',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['code'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=18083, path='/healthz'),
+    ),
+    labels=['replicas'],
+)
+
+local_resource(
+    'kuery-2',
+    serve_cmd='make run-provider-kuery KUERY_PORT=18084',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['kuery'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=18084, path='/healthz'),
+    ),
+    labels=['replicas'],
+)
+
+local_resource(
+    'edges-2',
+    serve_cmd='POD_NAME=edges-local-2 make run-provider-edges EDGES_PORT=18088 EDGES_INTERNAL_PORT=18090',
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+    resource_deps=['edges'],
+    readiness_probe=probe(
+        period_secs=5,
+        http_get=http_get_action(port=18088, path='/healthz'),
+    ),
+    labels=['replicas'],
 )

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1120,7 +1120,11 @@ spec:
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "faros"]
+            # First boot runs initdb + a temporary "rejecting connections"
+            # server before the real one starts; don't paint that window red.
+            initialDelaySeconds: 10
             periodSeconds: 5
+            failureThreshold: 12
       volumes:
         - name: init
           configMap:

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -863,6 +863,12 @@ k8s_yaml(helm(
     namespace=hub_namespace,
     set=[
         'image.hub.tag=dev',
+        # TWO hub replicas — external kcp is exactly the configuration the
+        # hub's HA work targets: singleton controllers gate on the
+        # faros-hub-controllers Lease, browser sessions and published-app auth
+        # codes live in kcp-backed Secrets, so sign-in survives either pod and
+        # the Service round-robins requests across both.
+        'replicaCount=2',
         'kcp.embedded.enabled=false',
         'kcp.external.enabled=true',
         'kcp.external.existingSecret=kcp-frontproxy-admin',
@@ -896,6 +902,12 @@ k8s_yaml(helm(
 
 k8s_resource(
     'faros-hub',
+    # NB with replicaCount=2: a Tilt port-forward attaches to ONE pod, so
+    # browser traffic through :9443 pins to a single replica (and drops while
+    # Tilt re-attaches if that pod dies). In-cluster traffic — providers and
+    # minted kubeconfigs via hub.internalURL — goes through the Service and
+    # round-robins across both replicas. To exercise failover from the
+    # browser, kill the pod Tilt is forwarding to and let it re-attach.
     port_forwards=['9443:9443'],
     resource_deps=['hub-compile', 'hub-kcp-secrets', 'hub-rbac', 'hub-tls', 'dex'],
     labels=['hub'],

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1584,6 +1584,34 @@ local_resource(
 # answers queries/edge listings from the shared store. Engagement needs
 # ▶ kuery-register then ▶ kuery-init (mints the runtime kubeconfig the
 # secrets sync delivers).
+#
+# The kubernetesclusters permission claim needs the EDGES APIExport's
+# identityHash (kcp hard-rejects hash-less claims on non-built-in types) —
+# same discovery-file pattern as app-studio's hashes below.
+kuery_hash_file = '.kcp/kuery-edges-identity-hash.env'
+local_resource(
+    'kuery-edges-identity-hash',
+    cmd='''
+set -eu
+hash="$(kubectl --kubeconfig=%s --server=%s/clusters/root:faros:providers:edges \
+  --insecure-skip-tls-verify get apiexport edges.providers.faros.sh \
+  -o jsonpath='{.status.identityHash}' 2>/dev/null || true)"
+if [ -z "$hash" ]; then
+  echo "edges identityHash not discoverable yet - re-trigger after edges-init"
+  exit 0
+fi
+printf 'edges=%%s\\n' "$hash" > %s
+echo "wrote %s"
+'''.strip() % (KCP_ADMIN_KUBECONFIG, KCP_ADMIN_SERVER, kuery_hash_file, kuery_hash_file),
+    deps=['.kcp/edges-runtime.kubeconfig', 'tilt-frontproxy.kubeconfig'],
+    allow_parallel=True,
+    labels=['providers-kuery'],
+)
+kuery_edges_hash = ''
+for _line in str(read_file(kuery_hash_file, '')).splitlines():
+    if _line.startswith('edges='):
+        kuery_edges_hash = _line[len('edges='):].strip()
+
 provider_kubeconfig_sync('kuery', '.kcp/kuery-runtime.kubeconfig', ['providers-kuery'])
 provider_pod(
     'kuery', 8084,
@@ -1591,6 +1619,7 @@ provider_pod(
         'replicaCount=2',
         'store.driver=postgres',
         'store.dsn=%s' % providers_db_url('kuery'),
+        'apiExport.edgesIdentityHash=%s' % kuery_edges_hash,
     ],
     resource_deps=['kuery-secrets', 'providers-db'],
 )

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1014,7 +1014,11 @@ def rewrite_manifest_cmd(src, name, port):
                                     svc=provider_svc_url(name, port)), out
 
 QUICKSTART_REWRITE_CMD, QUICKSTART_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/quickstart/manifest.yaml', 'quickstart', 8081)
-INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/infrastructure/manifest.yaml', 'infrastructure', 8082)
+# infrastructure's serve Service is stamped by its operator into the
+# faros-infrastructure-provider namespace (and the operator self-registers
+# the CatalogEntry with that URL anyway) — rewrite to match, not to
+# faros-providers.
+INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = ("sed 's|http://localhost:8082|http://infrastructure.faros-infrastructure-provider.svc.cluster.local:8082|g' providers/infrastructure/manifest.yaml > /tmp/faros-providers_infrastructure_manifest.yaml", '/tmp/faros-providers_infrastructure_manifest.yaml')
 APP_STUDIO_REWRITE_CMD, APP_STUDIO_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/app-studio/manifest.yaml', 'app-studio', 8085)
 CODE_REWRITE_CMD, CODE_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/code/manifest.yaml', 'code', 8083)
 KUERY_REWRITE_CMD, KUERY_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/kuery/manifest.yaml', 'kuery', 8084)
@@ -1164,7 +1168,7 @@ kubectl --context {ctx} -n {ns} create secret generic faros-{name}-kubeconfig \
 # One helper per podified provider: Tilt-built image (auto kind-load +
 # rebuild-on-change), the provider's production chart, and a port-forward on
 # the historical host port so portals/curl keep working.
-def provider_pod(name, port, chart_extra=[], resource_deps=[], labels=None, image_only_deps=None, port_forwards=None):
+def provider_pod(name, port, chart_extra=[], resource_deps=[], labels=None, image_only_deps=None, port_forwards=None, container_port=None):
     labels = labels or ['providers-' + name]
     image_ref = 'faros-%s-provider' % name
     # Repo-root context: the Dockerfiles copy the in-tree provider-sdk (go.mod
@@ -1193,7 +1197,10 @@ def provider_pod(name, port, chart_extra=[], resource_deps=[], labels=None, imag
     ))
     k8s_resource(
         name,
-        port_forwards=port_forwards or ['%d:%d' % (port, port)],
+        # No host port-forwards: the portal and every API path go hub →
+        # in-cluster Service (CatalogEntry URLs). Debug directly with
+        # kubectl -n faros-providers port-forward svc/<name> <port>.
+        port_forwards=port_forwards or [],
         resource_deps=['faros-hub', 'kcp-dns'] + resource_deps,
         labels=labels,
     )
@@ -1523,6 +1530,7 @@ for _line in str(read_file(app_studio_hash_file, '')).splitlines():
 provider_kubeconfig_sync('app-studio', '.kcp/app-studio-provider.kubeconfig', ['providers-app-studio'])
 provider_pod(
     'app-studio', 8085,
+    container_port=8081,
     chart_extra=[
         'replicaCount=2',
         'store.databaseURL=%s' % providers_db_url('appstudio'),
@@ -1615,6 +1623,7 @@ for _line in str(read_file(kuery_hash_file, '')).splitlines():
 provider_kubeconfig_sync('kuery', '.kcp/kuery-runtime.kubeconfig', ['providers-kuery'])
 provider_pod(
     'kuery', 8084,
+    container_port=8081,
     chart_extra=[
         'replicaCount=2',
         'store.driver=postgres',
@@ -1926,12 +1935,30 @@ local_resource(
 # derives the runtime kubeconfig from that admin kubeconfig, so it reuses the
 # front-proxy credential in cluster mode without a separate token.
 # Two replicas: the controller lease keeps one active reconciler set while
-# both serve REST/MCP.
+# both serve REST/MCP. GitHub OAuth app credentials ride providers/code/.env
+# → the code-env Secret, exactly like agents.
+local_resource(
+    'code-env',
+    cmd='''
+set -eu
+if [ -f providers/code/.env ]; then
+  kubectl --context %s -n %s create secret generic code-env \
+    --from-env-file=providers/code/.env --dry-run=client -o yaml | \
+    kubectl --context %s -n %s apply -f -
+else
+  kubectl --context %s -n %s create secret generic code-env \
+    --dry-run=client -o yaml | kubectl --context %s -n %s apply -f -
+fi
+'''.strip() % (k8s_context(), providers_namespace, k8s_context(), providers_namespace,
+               k8s_context(), providers_namespace, k8s_context(), providers_namespace),
+    deps=['providers/code/.env'],
+    labels=['providers-code'],
+)
 provider_kubeconfig_sync('code', '.kcp/code-runtime.kubeconfig', ['providers-code'])
 provider_pod(
     'code', 8083,
-    chart_extra=['replicaCount=2'],
-    resource_deps=['code-secrets'],
+    chart_extra=['replicaCount=2', 'envFromSecret=code-env'],
+    resource_deps=['code-secrets', 'code-env'],
 )
 
 local_resource(

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -959,35 +959,28 @@ kubectl create secret generic kcp-static-tokens -n default \
 )
 
 # ---------------------------------------------------------------------------
-# providers — external (Helm-style) provider binaries that register with
-# the hub via a CatalogEntry and serve their UI + HTTP API on a host port.
-# Same shape as the embedded-kcp ./Tiltfile (lines ~66-222). Resource_deps
-# point at `faros-hub` here (vs `hub` in that file) since this Tiltfile's
-# hub workload is named faros-hub.
+# providers — run as PODS in this kind cluster: Tilt-built images + each
+# provider's production chart, in the `faros-providers` namespace. Dev
+# exercises the real in-cluster behavior: 2 replicas, leader election,
+# claims, tunnel routing, Service round-robin, chart probes.
 #
-#   providers-quickstart   — reference example (port :8081)
-#   providers-app-studio   — AI workspace provider (port :8085) +
-#                            host URL rewritten for the in-cluster hub
-#   providers-kro          — infrastructure broker (port :8082) +
-#                            management kind cluster that kro runs in
-#   providers-code         — git repository manager (port :8083)
-#   providers-kuery        — fleet query engine (port :8084)
-#   providers-agents       — long-running personal AI agents (port :8087)
+#   quickstart :8081 · infrastructure :8082 (operator mode) · code :8083
+#   kuery :8084 · app-studio :8085 · databricks :8086 · agents :8087
+#   edges :8088 — each port-forwarded to its historical host port.
 #
-# Each provider has three resources:
-#   <name>            build + serve; auto-restarts on src change
-#   <name>-register   manual ▶ to kubectl apply the CatalogEntry
-#   <name>-unregister manual ▶ to kubectl delete it
+# Each provider keeps its aux resources:
+#   <name>-register   manual ▶ apply Provider + CatalogEntry into kcp
+#                     (URLs rewritten to the in-cluster Service)
+#   <name>-init       manual ▶ seed the workspace + write the runtime
+#                     kubeconfig under .kcp/
+#   <name>-secrets    auto: syncs that kubeconfig into the pod's Secret —
+#                     until init runs, the pod waits on the missing mount
+#   <name>-unregister manual ▶ delete the kcp objects
 #
-# The kro group adds two more for the backing infrastructure:
-#   kro-mgmt-up    builds the kind cluster + helm-installs kro + applies
-#                  seed RGDs (see providers/infrastructure/examples/rgds/).
-#                  Auto-runs at `tilt up`.
-#   kro-mgmt-down  manual ▶ to tear down (kind delete cluster).
-#
-# The make targets the providers call (install-provider-*, run-provider-*)
-# hit the hub at hub_external_url with the `dev-token` static token,
-# which the watchdog above keeps wired up to kcp.
+# Pods reach kcp with the SAME kubeconfigs the host flow mints: the kcp-dns
+# resource points (kcp|*.kcp).localhost at the Envoy gateway via CoreDNS,
+# cluster-wide — the pod equivalent of the hub's hostAliases. The stateful
+# providers share the in-cluster providers-db Postgres.
 #
 # CatalogEntry install/uninstall talks DIRECTLY to kcp (not via the hub) — it
 # needs cluster-admin to write into root:faros:providers. The embedded-kcp
@@ -1000,46 +993,209 @@ kubectl create secret generic kcp-static-tokens -n default \
 KCP_ADMIN_KUBECONFIG = os.path.abspath('tilt-frontproxy.kubeconfig')
 KCP_ADMIN_SERVER = 'https://kcp.localhost:8443'
 
-# Provider binaries run on the HOST (via `make run-provider-*`); the hub runs
-# IN-CLUSTER, so the CatalogEntry's ui.url / backend.url can't be localhost —
-# that resolves to the hub pod's own loopback. host.docker.internal resolves
-# to the host's network from inside kind/Docker Desktop/OrbStack pods.
+# Providers run as PODS in the kind cluster (their production charts +
+# Tilt-built images), so in-cluster behavior — replicas, leader election,
+# claims, tunnel routing, Service round-robin — is what dev exercises. The
+# CatalogEntry's ui.url / backend.url therefore point at each provider's
+# in-cluster Service.
 #
 # Manifest files commit to localhost so the embedded-kcp Tiltfile (everything
 # on the host) works out-of-the-box. We rewrite at install time here instead
 # of templating the manifest, so neither flow needs the other's URLs.
-def rewrite_manifest_cmd(src):
-    out = '/tmp/faros-{}.yaml'.format(src.replace('/', '_'))
-    return ("sed 's|http://localhost:|http://host.docker.internal:|g' " +
-            "{src} > {out}").format(src=src, out=out), out
+providers_namespace = 'faros-providers'
 
-QUICKSTART_REWRITE_CMD, QUICKSTART_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/quickstart/manifest.yaml')
-INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/infrastructure/manifest.yaml')
-APP_STUDIO_REWRITE_CMD, APP_STUDIO_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/app-studio/manifest.yaml')
-CODE_REWRITE_CMD, CODE_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/code/manifest.yaml')
-KUERY_REWRITE_CMD, KUERY_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/kuery/manifest.yaml')
-DATABRICKS_REWRITE_CMD, DATABRICKS_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/databricks/manifest.yaml')
-AGENTS_REWRITE_CMD, AGENTS_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/agents/manifest.yaml')
-EDGES_REWRITE_CMD, EDGES_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/edges/manifest.yaml')
+def provider_svc_url(name, port):
+    return 'http://%s.%s.svc.cluster.local:%d' % (name, providers_namespace, port)
+
+def rewrite_manifest_cmd(src, name, port):
+    out = '/tmp/faros-{}.yaml'.format(src.replace('/', '_'))
+    return ("sed 's|http://localhost:{port}|{svc}|g' " +
+            "{src} > {out}").format(src=src, out=out, port=port,
+                                    svc=provider_svc_url(name, port)), out
+
+QUICKSTART_REWRITE_CMD, QUICKSTART_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/quickstart/manifest.yaml', 'quickstart', 8081)
+INFRA_REWRITE_CMD, INFRA_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/infrastructure/manifest.yaml', 'infrastructure', 8082)
+APP_STUDIO_REWRITE_CMD, APP_STUDIO_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/app-studio/manifest.yaml', 'app-studio', 8085)
+CODE_REWRITE_CMD, CODE_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/code/manifest.yaml', 'code', 8083)
+KUERY_REWRITE_CMD, KUERY_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/kuery/manifest.yaml', 'kuery', 8084)
+DATABRICKS_REWRITE_CMD, DATABRICKS_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/databricks/manifest.yaml', 'databricks', 8086)
+AGENTS_REWRITE_CMD, AGENTS_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/agents/manifest.yaml', 'agents', 8087)
+EDGES_REWRITE_CMD, EDGES_MANIFEST_REWRITTEN = rewrite_manifest_cmd('providers/edges/manifest.yaml', 'edges', 8088)
+
+# ---------------------------------------------------------------------------
+# shared pod plumbing: namespace, kcp DNS, hub token, provider Postgres
+# ---------------------------------------------------------------------------
+k8s_yaml(blob('''
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+''' % providers_namespace))
+
+# Provider pods reach kcp with the operator-issued kubeconfigs UNCHANGED:
+# CoreDNS answers (kcp|*.kcp).localhost with the Envoy gateway ClusterIP —
+# the cluster-wide equivalent of the hostAliases the hub pod gets.
+local_resource(
+    'kcp-dns',
+    cmd='true',
+    serve_cmd='''
+set -eu
+cleanup() { hack/scripts/configure-tilt-kcp-dns.sh --cleanup %s %s || true; }
+trap cleanup 0
+trap 'exit 0' 2 15
+hack/scripts/configure-tilt-kcp-dns.sh %s %s
+while :; do sleep 86400; done
+'''.strip() % (k8s_context(), gateway_ip, k8s_context(), gateway_ip),
+    deps=['hack/scripts/configure-tilt-kcp-dns.sh'],
+    labels=['providers-shared'],
+)
+
+# Every provider heartbeats with the dev static token; the charts read it from
+# a Secret via hub.tokenSecretRef.
+k8s_yaml(blob('''
+apiVersion: v1
+kind: Secret
+metadata:
+  name: faros-provider-hub-token
+  namespace: %s
+stringData:
+  token: dev-token
+''' % providers_namespace))
+
+# One Postgres for the stateful providers (kuery / app-studio / agents), each
+# with its own database — the in-cluster replacement for the host `make
+# *-db-up` docker containers. Dev-only credentials.
+k8s_yaml(blob('''
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: providers-db-init
+  namespace: %s
+data:
+  init.sql: |
+    CREATE DATABASE kuery;
+    CREATE DATABASE appstudio;
+    CREATE DATABASE agents;
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: providers-db
+  namespace: %s
+spec:
+  selector:
+    app: providers-db
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: providers-db
+  namespace: %s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: providers-db
+  template:
+    metadata:
+      labels:
+        app: providers-db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_USER
+              value: faros
+            - name: POSTGRES_PASSWORD
+              value: faros-dev
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: init
+              mountPath: /docker-entrypoint-initdb.d
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "faros"]
+            periodSeconds: 5
+      volumes:
+        - name: init
+          configMap:
+            name: providers-db-init
+''' % (providers_namespace, providers_namespace, providers_namespace)))
+k8s_resource(
+    'providers-db',
+    objects=['providers-db-init:configmap'],
+    labels=['providers-shared'],
+)
+
+def providers_db_url(db):
+    return 'postgres://faros:faros-dev@providers-db.%s.svc.cluster.local:5432/%s?sslmode=disable' % (providers_namespace, db)
+
+# Syncs a host kubeconfig file (written by the manual <name>-init resource)
+# into the provider's kubeconfig Secret. Runs automatically once the file
+# exists; until then the pod waits on the missing Secret mount — the visible
+# "run register + init first" state.
+def provider_kubeconfig_sync(name, kubeconfig_file, labels):
+    local_resource(
+        name + '-secrets',
+        cmd='''
+set -eu
+if [ ! -f {file} ]; then
+  echo "{file} not found - trigger {name}-register then {name}-init first"
+  exit 0
+fi
+kubectl --context {ctx} -n {ns} create secret generic faros-{name}-kubeconfig \
+  --from-file=kubeconfig={file} --dry-run=client -o yaml | \
+  kubectl --context {ctx} -n {ns} apply -f -
+'''.format(file=kubeconfig_file, name=name, ns=providers_namespace, ctx=k8s_context()).strip(),
+        deps=[kubeconfig_file],
+        allow_parallel=True,
+        labels=labels,
+    )
+
+# One helper per podified provider: Tilt-built image (auto kind-load +
+# rebuild-on-change), the provider's production chart, and a port-forward on
+# the historical host port so portals/curl keep working.
+def provider_pod(name, port, chart_extra=[], resource_deps=[], labels=None, image_only_deps=None, port_forwards=None):
+    labels = labels or ['providers-' + name]
+    image_ref = 'faros-%s-provider' % name
+    docker_build(image_ref, 'providers/' + name, only=image_only_deps)
+    k8s_yaml(helm(
+        'providers/%s/deploy/chart' % name,
+        name=name,
+        namespace=providers_namespace,
+        set=[
+            'fullnameOverride=%s' % name,
+            'image.repository=%s' % image_ref,
+            'image.pullPolicy=IfNotPresent',
+            'service.port=%d' % port,
+            'hub.url=https://faros-hub.%s.svc.cluster.local:9443' % hub_namespace,
+            'hub.insecure=true',
+            'hub.tokenSecretRef.name=faros-provider-hub-token',
+            'hub.tokenSecretRef.key=token',
+            'providerKubeconfig.secretName=faros-%s-kubeconfig' % name,
+            # CatalogEntry registration stays with the host-side
+            # <name>-register resource (admin kubeconfig into kcp).
+            'catalogEntry.enabled=false',
+        ] + chart_extra,
+    ))
+    k8s_resource(
+        name,
+        port_forwards=port_forwards or ['%d:%d' % (port, port)],
+        resource_deps=['faros-hub', 'kcp-dns'] + resource_deps,
+        labels=labels,
+    )
 
 # --- providers-quickstart ---
-local_resource(
-    'quickstart',
-    cmd='make build-quickstart-provider',
-    serve_cmd='make run-provider-quickstart',
-    deps=[
-        'providers/quickstart/main.go',
-        'providers/quickstart/assets.go',
-        'providers/quickstart/portal/src',
-        'providers/quickstart/portal/package.json',
-        'providers/quickstart/go.mod',
-    ],
-    resource_deps=['faros-hub'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8081, path='/healthz'),
-    ),
-    labels=['providers-quickstart'],
+provider_kubeconfig_sync('quickstart', '.kcp/quickstart-runtime.kubeconfig', ['providers-quickstart'])
+provider_pod(
+    'quickstart', 8081,
+    chart_extra=['replicaCount=2'],
+    resource_deps=['quickstart-secrets'],
 )
 
 local_resource(
@@ -1080,30 +1236,21 @@ local_resource(
 )
 
 # --- edges (KubernetesCluster + LinuxServer, one group edges.faros.sh) ---
-# Single, self-contained, SINGLE-REPLICA provider: terminates agent reverse
-# tunnels (revdial) and serves kubectl/ssh/mcp. Runs on the host like the other
-# providers here; agents dial it through the hub backend proxy.
-local_resource(
-    'edges',
-    cmd='make build-edges-provider',
-    serve_cmd='make run-provider-edges',
-    deps=[
-        'providers/edges/main.go',
-        'providers/edges/controller_manager.go',
-        'providers/edges/init_cmd.go',
-        'providers/edges/heartbeat.go',
-        'providers/edges/apis',
-        'providers/edges/internal',
-        'providers/edges/scheme',
-        'providers/edges/portal/src',
-        'providers/edges/portal/package.json',
-        'providers/edges/go.mod',
+# Two replicas: agents dial ONE replica through the hub; the tunnel-ownership
+# Lease registry + pod-to-pod relay route pickups and data-plane requests to
+# whichever replica holds each tunnel (POD_IP/POD_NAME come from the chart's
+# downward API wiring).
+provider_kubeconfig_sync('edges', '.kcp/edges-runtime.kubeconfig', ['edges'])
+provider_pod(
+    'edges', 8088,
+    chart_extra=[
+        'replicaCount=2',
+        'staticTokens=dev-token',
+        'devMode=true',
+        'hub.externalURL=%s' % hub_external_url,
+        'hub.internalURL=https://faros-hub.%s.svc.cluster.local:9443' % hub_namespace,
     ],
-    resource_deps=['faros-hub'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8088, path='/healthz'),
-    ),
+    resource_deps=['edges-secrets'],
     labels=['edges'],
 )
 
@@ -1146,48 +1293,35 @@ local_resource(
 
 # --- providers-agents ---
 # Long-running personal AI agents (chat, scheduled runs, tools, durable memory).
-# Standalone: only hard deps are the hub and the durable store (local Postgres
-# container via agents-db). No app-studio/infrastructure dependency.
+# Standalone: only hard deps are the hub and the shared providers-db Postgres.
+# LLM/channel credentials come from providers/agents/.env, synced into an
+# envFrom-able Secret so the pod sees the same keys the host binary did.
 local_resource(
-    'agents-db',
-    cmd='make agents-db-up',
-    deps=[
-        'providers/agents/.env',
-    ],
+    'agents-env',
+    cmd='''
+set -eu
+if [ -f providers/agents/.env ]; then
+  kubectl --context %s -n %s create secret generic agents-env \
+    --from-env-file=providers/agents/.env --dry-run=client -o yaml | \
+    kubectl --context %s -n %s apply -f -
+else
+  kubectl --context %s -n %s create secret generic agents-env \
+    --dry-run=client -o yaml | kubectl --context %s -n %s apply -f -
+fi
+'''.strip() % (k8s_context(), providers_namespace, k8s_context(), providers_namespace,
+               k8s_context(), providers_namespace, k8s_context(), providers_namespace),
+    deps=['providers/agents/.env'],
     labels=['providers-agents'],
 )
 
-local_resource(
-    'agents',
-    cmd='make build-agents-provider',
-    serve_cmd='make run-provider-agents',
-    deps=[
-        'providers/agents/main.go',
-        'providers/agents/heartbeat.go',
-        'providers/agents/assets.go',
-        'providers/agents/init_cmd.go',
-        'providers/agents/api',
-        'providers/agents/channels',
-        'providers/agents/apis',
-        'providers/agents/client',
-        'providers/agents/engine',
-        'providers/agents/executor',
-        'providers/agents/tools',
-        'providers/agents/llm',
-        'providers/agents/store',
-        'providers/agents/tenant',
-        'providers/agents/go.mod',
-        'providers/agents/portal/src',
-        'providers/agents/portal/package.json',
-        'providers/agents/portal/vite.config.ts',
-        'providers/agents/.env',
+provider_kubeconfig_sync('agents', '.kcp/agents-provider.kubeconfig', ['providers-agents'])
+provider_pod(
+    'agents', 8087,
+    chart_extra=[
+        'store.databaseURL=%s' % providers_db_url('agents'),
+        'envFromSecret=agents-env',
     ],
-    resource_deps=['faros-hub', 'agents-db'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8087, path='/healthz'),
-    ),
-    labels=['providers-agents'],
+    resource_deps=['agents-secrets', 'agents-env', 'providers-db'],
 )
 
 local_resource(
@@ -1227,13 +1361,6 @@ local_resource(
     labels=['providers-agents'],
 )
 
-local_resource(
-    'agents-db-down',
-    cmd='make agents-db-down',
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    auto_init=False,
-    labels=['providers-agents'],
-)
 
 # --- providers-app-studio ---
 local_resource(
@@ -1246,17 +1373,9 @@ local_resource(
     labels=['providers-app-studio'],
 )
 
-local_resource(
-    'app-studio-db',
-    cmd='make app-studio-db-up',
-    deps=[
-        'Makefile',
-        'providers/app-studio/.env',
-        'providers/app-studio/.env.example',
-    ],
-    resource_deps=['faros-hub'],
-    labels=['providers-app-studio'],
-)
+# App Studio's durable store is the shared in-cluster providers-db Postgres
+# (database "appstudio") — the same store replica claims and project pins live
+# in, so multi-replica behavior is real in dev.
 
 # Generated apps and their coordinator call the hub through its in-cluster
 # Service, not the host-only 9443 port-forward. Preserve TLS verification by
@@ -1326,64 +1445,55 @@ local_resource(
 )
 
 
+# The exported hub CA file becomes a ConfigMap the app-studio chart mounts
+# (hub.actionsCABundleConfigMap) so action-enabled development runtimes keep
+# verified TLS to the in-cluster hub Service.
 local_resource(
-    'app-studio',
-    cmd='make build-app-studio-provider',
-    # The controller manager watches the APIExportEndpointSlice in the
-    # PROVIDER workspace, so the serve kubeconfig must be the
-    # workspace-scoped one init writes (.kcp/app-studio-provider.kubeconfig —
-    # the Makefile pins it, same as vibe-studio). Pointing this at the admin
-    # /clusters/root kubeconfig makes the reconcilers watch an empty
-    # workspace and silently never engage. Development previews are the
-    # template instance's own public URL — no preview-gateway env.
-    serve_cmd=(app_studio_actions_ca_cmd +
-               'FAROS_ACTIONS_EXTERNAL_URL=https://faros-hub.%s.svc:9443 ' +
-               'FAROS_ACTIONS_CA_BUNDLE_FILE=%s ' +
-               'make run-provider-app-studio') % (
-                   hub_namespace,
-                   app_studio_actions_ca_file),
-    deps=[
-        'providers/app-studio/main.go',
-        'providers/app-studio/heartbeat.go',
-        'providers/app-studio/assets.go',
-        'providers/app-studio/api',
-        'providers/app-studio/apis',
-        'providers/app-studio/scaffold',
-        'providers/app-studio/client',
-        'providers/app-studio/store',
-        'providers/app-studio/tenant',
-        'providers/app-studio/go.mod',
-        'providers/app-studio/go.sum',
-        'providers/app-studio/portal/src',
-        'providers/app-studio/portal/package.json',
-        'providers/app-studio/portal/vite.config.ts',
-        'providers/app-studio/manifest.yaml',
-        'providers/app-studio/.env',
-        # The provider loads this public CA once at process start. Restart it
-        # when the hub identity rotates so existing project bindings reconcile
-        # from the new authoritative bundle instead of retaining stale trust.
-        app_studio_actions_ca_file,
-    ],
-    resource_deps=[
-        'faros-hub',
-        'app-studio-db',
-        'app-studio-actions-ca',
-        'dev-agent-image',
-        'app-studio-preview-console-key',
-    ],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8085, path='/healthz'),
-    ),
+    'app-studio-actions-ca-cm',
+    cmd='''
+set -eu
+kubectl --context %s -n %s create configmap app-studio-actions-ca \
+  --from-file=ca-bundle.pem=%s --dry-run=client -o yaml | \
+  kubectl --context %s -n %s apply -f -
+'''.strip() % (k8s_context(), providers_namespace, app_studio_actions_ca_file,
+               k8s_context(), providers_namespace),
+    deps=[app_studio_actions_ca_file],
+    resource_deps=['app-studio-actions-ca'],
     labels=['providers-app-studio'],
 )
 
-local_resource(
-    'app-studio-db-down',
-    cmd='make app-studio-db-down',
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    auto_init=False,
-    labels=['providers-app-studio'],
+# Two replicas: durable run claims + project affinity live in the shared
+# providers-db Postgres, workspaces are emptyDir caches rebuilt from git on
+# adoption (docs/app-studio-replica-awareness.md).
+#
+# The controller manager watches the APIExportEndpointSlice in the PROVIDER
+# workspace, so the synced kubeconfig must be the workspace-scoped one init
+# writes (.kcp/app-studio-provider.kubeconfig). previewConsole is disabled in
+# pod mode for now: the dev signing-key flow generates the key id at runtime,
+# which chart values can't consume at render time — App Studio serves without
+# console instrumentation (its documented degraded mode).
+provider_kubeconfig_sync('app-studio', '.kcp/app-studio-provider.kubeconfig', ['providers-app-studio'])
+provider_pod(
+    'app-studio', 8085,
+    chart_extra=[
+        'replicaCount=2',
+        'store.databaseURL=%s' % providers_db_url('appstudio'),
+        'hub.actionsExternalURL=https://faros-hub.%s.svc:9443' % hub_namespace,
+        'hub.actionsCABundleConfigMap.name=app-studio-actions-ca',
+        'hub.actionsCABundleConfigMap.key=ca-bundle.pem',
+        'previewConsole.enabled=false',
+        # identityHashes of the infrastructure/code APIExports — required for
+        # the Project reconciler's first-party claims. Set them once known:
+        #   tilt args -- --app-studio-infra-identity-hash=... --app-studio-code-identity-hash=...
+        'apiExport.infraIdentityHash=%s' % cfg.get('app-studio-infra-identity-hash', ''),
+        'apiExport.codeIdentityHash=%s' % cfg.get('app-studio-code-identity-hash', ''),
+    ],
+    resource_deps=[
+        'app-studio-secrets',
+        'providers-db',
+        'app-studio-actions-ca-cm',
+        'dev-agent-image',
+    ],
 )
 
 local_resource(
@@ -1424,50 +1534,20 @@ local_resource(
 )
 
 # --- providers-kuery (fleet query engine, port :8084) ---
-# Local Postgres for the kuery store. Dev always runs the same SQL backend
-# as production — SQLite hid real Postgres-only query bugs, so it is not an
-# option here. make run-provider-kuery depends on this too.
-local_resource(
-    'kuery-db',
-    cmd='make kuery-db-up',
-    deps=['Makefile'],
-    resource_deps=['faros-hub'],
-    labels=['providers-kuery'],
-)
-
-# Same shape as the embedded Tiltfile: serve immediately; engagement
-# needs ▶ kuery-register then ▶ kuery-init (mints the runtime kubeconfig
-# from the provider SA token + ensures the APIExportEndpointSlice).
-local_resource(
-    'kuery',
-    cmd='make build-kuery-provider',
-    serve_cmd='make run-provider-kuery',
-    deps=[
-        'providers/kuery/main.go',
-        'providers/kuery/assets.go',
-        'providers/kuery/core',
-        'providers/kuery/engagement',
-        'providers/kuery/queryapi',
-        'providers/kuery/mcpserver',
-        'providers/kuery/portal/src',
-        'providers/kuery/portal/package.json',
-        'providers/kuery/go.mod',
-        '.kcp/kuery-runtime.kubeconfig',
+# Two replicas over the shared providers-db Postgres (the chart refuses >1
+# with SQLite): per-edge Lease claims shard engagement, and every replica
+# answers queries/edge listings from the shared store. Engagement needs
+# ▶ kuery-register then ▶ kuery-init (mints the runtime kubeconfig the
+# secrets sync delivers).
+provider_kubeconfig_sync('kuery', '.kcp/kuery-runtime.kubeconfig', ['providers-kuery'])
+provider_pod(
+    'kuery', 8084,
+    chart_extra=[
+        'replicaCount=2',
+        'store.driver=postgres',
+        'store.dsn=%s' % providers_db_url('kuery'),
     ],
-    resource_deps=['faros-hub', 'kuery-db'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8084, path='/healthz'),
-    ),
-    labels=['providers-kuery'],
-)
-
-local_resource(
-    'kuery-db-down',
-    cmd='make kuery-db-down',
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    auto_init=False,
-    labels=['providers-kuery'],
+    resource_deps=['kuery-secrets', 'providers-db'],
 )
 
 local_resource(
@@ -1537,65 +1617,55 @@ local_resource(
     labels=['providers-kro'],
 )
 
-local_resource(
-    'infrastructure',
-    cmd='make build-infrastructure-provider',
-    # Serve (host binary). The operator does bootstrap + kro; serve just runs
-    # with the admin kubeconfig retargeted to the provider workspace
-    # (INFRASTRUCTURE_WORKSPACE_PATH), so no init-minted kubeconfig is needed.
-    # KRO_KUBECONFIG points at the kind cluster's host kubeconfig (where kro is).
-    serve_cmd=('KRO_KUBECONFIG={kro} INFRASTRUCTURE_KUBECONFIG={kc} ' +
-               'INFRASTRUCTURE_WORKSPACE_PATH=root:faros:providers:infrastructure ' +
-               'FAROS_APP_BASE_DOMAIN={apps_domain} ' +
-               # PublishedApp proxies run in the runtime kind cluster and
-               # therefore call the in-cluster hub Service rather than the
-               # host port-forward. The proxy has no mounted dev CA, so this
-               # explicit dev-only switch is required for its hub call.
-               'FAROS_ACCESS_PROXY_IMAGE={proxy_image} ' +
-               'FAROS_ACCESS_HUB_URL=https://faros-hub.faros-system.svc:9443 ' +
-               'FAROS_ACCESS_HUB_PUBLIC_URL=%s ' % hub_external_url +
-               'FAROS_ACCESS_HUB_INSECURE=true ' +
-               'FAROS_ACCESS_PUBLIC_SCHEME=https ' +
-               # The ONE platform Gateway all template HTTPRoutes attach to —
-               # locally the envoy Gateway above, in prod cfgate's
-               # cloudflare-tunnel (the in-binary default).
-               'FAROS_GATEWAY_NAME={gateway} ' +
-               'FAROS_GATEWAY_NAMESPACE=envoy-gateway-system ' +
-               # Locally the Gateway is only reachable via the envoy
-               # port-forward — templates append this to status.url
-               # (${faros.appPublicPort}); prod leaves it unset (443).
-               'FAROS_APP_PUBLIC_PORT={port} ' +
-               'make run-provider-infrastructure').format(
-                   kro=KIND_HOST_KUBECONFIG, kc=KCP_ADMIN_KUBECONFIG,
-                   apps_domain=app_base_domain,
-                   proxy_image=access_proxy_image,
-                   gateway=app_studio_preview_parent_gateway_name,
-                   port=app_studio_preview_public_port),
-    deps=[
-        'providers/infrastructure/main.go',
-        'providers/infrastructure/heartbeat.go',
-        'providers/infrastructure/assets.go',
-        'providers/infrastructure/server',
-        'providers/infrastructure/kro',
-        'providers/infrastructure/tenant',
-        'providers/infrastructure/mcpserver',
-        # The Template controller + kro backend author the RGDs the catalog
-        # reads; without watching these, a change to RGD authoring (e.g. the
-        # catalog labels) silently won't hot-reload.
-        'providers/infrastructure/backend',
-        'providers/infrastructure/controller',
-        'providers/infrastructure/portal/src',
-        'providers/infrastructure/portal/package.json',
-        'providers/infrastructure/go.mod',
-        'providers/infrastructure/go.sum',
+# Infrastructure runs FULLY in-cluster via the chart's CRD-driven operator
+# mode: the chart installs the operator (2 replicas of it are unnecessary —
+# it is leader-elected in-cluster via controller-runtime), the operator
+# bootstraps the provider kcp workspace with the synced admin kubeconfig,
+# helm-installs kro into THIS cluster (in-cluster runtime, pod SA), deploys
+# the serve Deployment (2 replicas — leader-elected Template/Instance
+# controllers + bootstrap-loop leases), and self-registers the CatalogEntry
+# with its serve Service URL.
+provider_kubeconfig_sync('infrastructure', 'tilt-frontproxy.kubeconfig', ['providers-kro'])
+docker_build('faros-infrastructure-provider', 'providers/infrastructure')
+k8s_yaml(helm(
+    'providers/infrastructure/deploy/chart',
+    name='infrastructure',
+    namespace=providers_namespace,
+    set=[
+        'fullnameOverride=infrastructure',
+        'image.repository=faros-infrastructure-provider',
+        'image.pullPolicy=IfNotPresent',
+        'hub.url=https://faros-hub.%s.svc.cluster.local:9443' % hub_namespace,
+        'hub.insecure=true',
+        'hub.tokenSecretRef.name=faros-provider-hub-token',
+        'hub.tokenSecretRef.key=token',
+        'operator.enabled=true',
+        'operator.clusterAdmin=true',
+        'operator.providerWorkspace=root:faros:providers:infrastructure',
+        'operator.providerKubeconfigSecret.name=faros-infrastructure-kubeconfig',
+        'operator.providerKubeconfigSecret.key=kubeconfig',
+        'operator.provider.replicas=2',
+        'operator.provider.port=8082',
+        # Application-template exposure + platform access gate, mapped from
+        # the old host-serve env: the local envoy Gateway, the sslip.io apps
+        # zone, and the in-cluster hub for the access-proxy protocol.
+        'operator.application.baseDomain=%s' % app_base_domain,
+        'operator.application.gateway.name=%s' % app_studio_preview_parent_gateway_name,
+        'operator.application.gateway.namespace=envoy-gateway-system',
+        'operator.publishing.baseDomain=%s' % app_base_domain,
+        'operator.publishing.accessProxyImage=%s' % access_proxy_image,
+        'operator.publishing.hubURL=https://faros-hub.%s.svc:9443' % hub_namespace,
+        'operator.publishing.hubPublicURL=%s' % hub_external_url,
+        'operator.publishing.insecure=true',
+        'operator.publishing.publicScheme=https',
+        'operator.publishing.publicPort=%s' % app_studio_preview_public_port,
+        'operator.publishing.gateway.name=%s' % app_studio_preview_parent_gateway_name,
+        'operator.publishing.gateway.namespace=envoy-gateway-system',
     ],
-    # faros-hub for the CatalogEntry registration target; infrastructure-operator
-    # for the workspace bootstrap + kro install the serve process depends on.
-    resource_deps=['faros-hub', 'infrastructure-operator', 'app-studio-preview-console-key', 'access-proxy-image-load'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8082, path='/healthz'),
-    ),
+))
+k8s_resource(
+    'infrastructure-operator',
+    resource_deps=['faros-hub', 'kcp-dns', 'infrastructure-secrets', 'access-proxy-image-load'],
     labels=['providers-kro'],
 )
 
@@ -1646,43 +1716,11 @@ local_resource(
     labels=['providers-kro'],
 )
 
-# --- infrastructure-operator (CRD-driven) ---
-# One controller that REPLACES kro-mgmt-up + infrastructure-init: it applies the
-# InfrastructureProvider CRD/Secrets/CR into the kind cluster, then reconciles —
-# bootstrapping the provider workspace, helm-installing kro (with the kind
-# hostAliases + self-cluster patches), and seeding kro's kcp-kubeconfig. Serve
-# still runs as the host-binary `infrastructure` resource (skip-serve) for fast
-# iteration. Order: infrastructure-operator → infrastructure (serve).
-#
-# NOT resource_deps on infrastructure-register: that resource is manual
-# (auto_init=False), and Tilt treats a never-built dep as unsatisfied, so
-# depending on it deadlocks this chain on every `tilt up` until someone
-# triggers register by hand — with the hub then answering 503
-# "provider not ready: infrastructure" for preview/data-plane routes. The
-# operator bootstraps the workspace itself, and register is an idempotent
-# CatalogEntry apply that survives cluster restarts, so the gate bought
-# nothing. Trigger infrastructure-register manually when the CatalogEntry
-# or Provider manifest actually changes.
-local_resource(
-    'infrastructure-operator',
-    cmd='make build-infrastructure-provider',
-    serve_cmd=('INFRA_OPERATOR_PROVIDER_KC={kc} INFRA_OPERATOR_RUNTIME_KC={kro} ' +
-               'INFRA_OPERATOR_KIND_NAME={name} ' +
-               'make run-provider-infrastructure-controller').format(
-                   kc=KCP_ADMIN_KUBECONFIG, kro=KIND_HOST_KUBECONFIG, name=cluster_name),
-    deps=[
-        'providers/infrastructure/main.go',
-        'providers/infrastructure/operator.go',
-        'providers/infrastructure/operator',
-        'providers/infrastructure/apis',
-        'providers/infrastructure/init_cmd.go',
-        'providers/infrastructure/install',
-        'providers/infrastructure/go.mod',
-        'providers/infrastructure/go.sum',
-    ],
-    resource_deps=['faros-hub', 'app-studio-preview-console-key'],
-    labels=['providers-kro'],
-)
+# The CRD-driven operator now runs IN-CLUSTER via the chart (see the helm
+# install above): it applies the InfrastructureProvider CRD/Secrets/CR and
+# reconciles — bootstrapping the provider workspace, helm-installing kro into
+# this cluster, and owning the serve Deployment. The old host-binary
+# controller + skip-serve split is gone with the rest of the host providers.
 
 # --- optional infrastructure operator + Config Connector Pub/Sub demo ------
 # These three actions are deliberately manual and have no resource_deps. A
@@ -1798,37 +1836,13 @@ local_resource(
 # kcp front-proxy (the embedded-kcp defaults are localhost). init-provider-code
 # derives the runtime kubeconfig from that admin kubeconfig, so it reuses the
 # front-proxy credential in cluster mode without a separate token.
-local_resource(
-    'code',
-    cmd='make build-code-provider',
-    serve_cmd='make run-provider-code',
-    deps=[
-        'providers/code/main.go',
-        'providers/code/heartbeat.go',
-        'providers/code/assets.go',
-        'providers/code/controller_manager.go',
-        'providers/code/init_cmd.go',
-        'providers/code/server',
-        'providers/code/tenant',
-        'providers/code/mcpserver',
-        'providers/code/controller',
-        'providers/code/backend',
-        'providers/code/commitbundle',
-        'providers/code/apis',
-        'providers/code/install',
-        'providers/code/scheme',
-        'providers/code/portal/src',
-        'providers/code/portal/package.json',
-        'providers/code/go.mod',
-        'providers/code/go.sum',
-        '.kcp/code-runtime.kubeconfig',
-    ],
-    resource_deps=['faros-hub'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8083, path='/healthz'),
-    ),
-    labels=['providers-code'],
+# Two replicas: the controller lease keeps one active reconciler set while
+# both serve REST/MCP.
+provider_kubeconfig_sync('code', '.kcp/code-runtime.kubeconfig', ['providers-code'])
+provider_pod(
+    'code', 8083,
+    chart_extra=['replicaCount=2'],
+    resource_deps=['code-secrets'],
 )
 
 local_resource(
@@ -1872,33 +1886,13 @@ local_resource(
 )
 
 # --- providers-databricks (Databricks table access) ---
-local_resource(
-    'databricks',
-    cmd='make build-databricks-provider',
-    serve_cmd='make run-provider-databricks',
-    deps=[
-        'providers/databricks/main.go',
-        'providers/databricks/assets.go',
-        'providers/databricks/backend',
-        'providers/databricks/init_cmd.go',
-        'providers/databricks/mcpserver',
-        'providers/databricks/queryapi',
-        'providers/databricks/tenant',
-        'providers/databricks/apis',
-        'providers/databricks/portal/src',
-        'providers/databricks/portal/public',
-        'providers/databricks/portal/package.json',
-        'providers/databricks/portal/vite.config.ts',
-        'providers/databricks/go.mod',
-        'providers/databricks/go.sum',
-        '.kcp/databricks-runtime.kubeconfig',
-    ],
-    resource_deps=['faros-hub'],
-    readiness_probe=probe(
-        period_secs=5,
-        http_get=http_get_action(port=8086, path='/healthz'),
-    ),
-    labels=['providers-databricks'],
+# Two replicas: serving resolves tenant clusters through the slice-backed
+# authority on every replica; the controllers are leader-elected.
+provider_kubeconfig_sync('databricks', '.kcp/databricks-runtime.kubeconfig', ['providers-databricks'])
+provider_pod(
+    'databricks', 8086,
+    chart_extra=['replicaCount=2'],
+    resource_deps=['databricks-secrets'],
 )
 
 local_resource(

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1959,6 +1959,13 @@ provider_pod(
     'code', 8083,
     chart_extra=['replicaCount=2', 'envFromSecret=code-env'],
     resource_deps=['code-secrets', 'code-env'],
+    # THE one legitimate host forward: the GitHub OAuth flow is
+    # browser → provider DIRECT (deliberately not through the hub's
+    # authenticated proxy), and the OAuth App's registered callback is
+    # http://localhost:8083/oauth/github/callback (GITHUB_OAUTH_REDIRECT_URL
+    # in providers/code/.env). The container listens on 8083, so the pod
+    # forward matches.
+    port_forwards=['8083:8083'],
 )
 
 local_resource(

--- a/Tiltfile.cluster
+++ b/Tiltfile.cluster
@@ -1167,7 +1167,11 @@ kubectl --context {ctx} -n {ns} create secret generic faros-{name}-kubeconfig \
 def provider_pod(name, port, chart_extra=[], resource_deps=[], labels=None, image_only_deps=None, port_forwards=None):
     labels = labels or ['providers-' + name]
     image_ref = 'faros-%s-provider' % name
-    docker_build(image_ref, 'providers/' + name, only=image_only_deps)
+    # Repo-root context: the Dockerfiles copy the in-tree provider-sdk (go.mod
+    # replace) — same invocation as CI: docker build -f providers/<n>/Dockerfile .
+    docker_build(image_ref, '.',
+                 dockerfile='providers/%s/Dockerfile' % name,
+                 only=image_only_deps or ['providers/' + name, 'provider-sdk'])
     k8s_yaml(helm(
         'providers/%s/deploy/chart' % name,
         name=name,
@@ -1466,6 +1470,46 @@ kubectl --context %s -n %s create configmap app-studio-actions-ca \
     labels=['providers-app-studio'],
 )
 
+# The app-studio init container applies its APIExport with first-party
+# permission claims on the infrastructure/code APIExports — kcp REQUIRES
+# their identityHashes (empty hash = hard apply failure). The host init
+# target auto-discovered them; here a resource does the same lookups and
+# writes them to a file that read_file() below watches: the moment discovery
+# succeeds (after infrastructure/code exist), Tilt re-renders the chart with
+# the hashes and the pods restart with valid claims.
+app_studio_hash_file = '.kcp/app-studio-identity-hashes.env'
+local_resource(
+    'app-studio-identity-hashes',
+    cmd='''
+set -eu
+lookup() {
+  kubectl --kubeconfig=%s --server=%s/clusters/root:faros:providers:$1 \
+    --insecure-skip-tls-verify get apiexport $2 \
+    -o jsonpath='{.status.identityHash}' 2>/dev/null || true
+}
+infra="$(lookup infrastructure infrastructure.providers.faros.sh)"
+code="$(lookup code code.providers.faros.sh)"
+if [ -z "$infra" ] || [ -z "$code" ]; then
+  echo "identityHashes not discoverable yet (infra='$infra' code='$code')"
+  echo "re-trigger after the infrastructure operator has bootstrapped and code-init has run"
+  exit 0
+fi
+printf 'infra=%%s\\ncode=%%s\\n' "$infra" "$code" > %s
+echo "wrote %s"
+'''.strip() % (KCP_ADMIN_KUBECONFIG, KCP_ADMIN_SERVER, app_studio_hash_file, app_studio_hash_file),
+    deps=['.kcp/code-runtime.kubeconfig', 'tilt-frontproxy.kubeconfig'],
+    allow_parallel=True,
+    labels=['providers-app-studio'],
+)
+
+app_studio_infra_hash = cfg.get('app-studio-infra-identity-hash', '')
+app_studio_code_hash = cfg.get('app-studio-code-identity-hash', '')
+for _line in str(read_file(app_studio_hash_file, '')).splitlines():
+    if _line.startswith('infra=') and not app_studio_infra_hash:
+        app_studio_infra_hash = _line[len('infra='):].strip()
+    if _line.startswith('code=') and not app_studio_code_hash:
+        app_studio_code_hash = _line[len('code='):].strip()
+
 # Two replicas: durable run claims + project affinity live in the shared
 # providers-db Postgres, workspaces are emptyDir caches rebuilt from git on
 # adoption (docs/app-studio-replica-awareness.md).
@@ -1486,11 +1530,8 @@ provider_pod(
         'hub.actionsCABundleConfigMap.name=app-studio-actions-ca',
         'hub.actionsCABundleConfigMap.key=ca-bundle.pem',
         'previewConsole.enabled=false',
-        # identityHashes of the infrastructure/code APIExports — required for
-        # the Project reconciler's first-party claims. Set them once known:
-        #   tilt args -- --app-studio-infra-identity-hash=... --app-studio-code-identity-hash=...
-        'apiExport.infraIdentityHash=%s' % cfg.get('app-studio-infra-identity-hash', ''),
-        'apiExport.codeIdentityHash=%s' % cfg.get('app-studio-code-identity-hash', ''),
+        'apiExport.infraIdentityHash=%s' % app_studio_infra_hash,
+        'apiExport.codeIdentityHash=%s' % app_studio_code_hash,
     ],
     resource_deps=[
         'app-studio-secrets',
@@ -1630,7 +1671,20 @@ local_resource(
 # controllers + bootstrap-loop leases), and self-registers the CatalogEntry
 # with its serve Service URL.
 provider_kubeconfig_sync('infrastructure', 'tilt-frontproxy.kubeconfig', ['providers-kro'])
-docker_build('faros-infrastructure-provider', 'providers/infrastructure')
+# custom_build instead of docker_build: the OPERATOR deployment gets Tilt's
+# content-hashed tag as usual, but the SERVE deployment is stamped by the
+# operator from the CR's spec.provider.image — a split repo/tag field Tilt
+# cannot inject into. Build once, tag it :dev additionally, and kind-load
+# that tag so the CR-spawned pods resolve it locally.
+# NB a rebuild does not restart the operator-owned serve pods (same :dev
+# tag): kubectl -n faros-infrastructure-provider rollout restart deploy/infrastructure
+custom_build(
+    'faros-infrastructure-provider',
+    ('docker build -f providers/infrastructure/Dockerfile -t $EXPECTED_REF . && ' +
+     'docker tag $EXPECTED_REF faros-infrastructure-provider:dev && ' +
+     'kind load docker-image faros-infrastructure-provider:dev --name %s') % cluster_name,
+    deps=['providers/infrastructure', 'provider-sdk'],
+)
 k8s_yaml(helm(
     'providers/infrastructure/deploy/chart',
     name='infrastructure',
@@ -1648,6 +1702,8 @@ k8s_yaml(helm(
         'operator.providerWorkspace=root:faros:providers:infrastructure',
         'operator.providerKubeconfigSecret.name=faros-infrastructure-kubeconfig',
         'operator.providerKubeconfigSecret.key=kubeconfig',
+        'operator.provider.image.repository=faros-infrastructure-provider',
+        'operator.provider.image.tag=dev',
         'operator.provider.replicas=2',
         'operator.provider.port=8082',
         # Application-template exposure + platform access gate, mapped from

--- a/docs/app-studio-replica-awareness.md
+++ b/docs/app-studio-replica-awareness.md
@@ -1,0 +1,151 @@
+# App Studio replica awareness — design
+
+Status: **proposed** · Date: 2026-08-17 · Author: design note
+Related: [`provider-horizontal-scaling.md`](./provider-horizontal-scaling.md)
+(the cross-provider plan this details), the kuery per-edge claims
+(`providers/kuery/engagement/claims.go`) and the edges replica routing
+(`providers/edges/internal/tunnel/{registry,remote}.go`) — the two primitives
+this design reuses.
+
+## Where app-studio actually stands
+
+The audit (2026-08-17) split the provider's state cleanly in two:
+
+**Already multi-replica-clean.** Everything conversational lives in Postgres
+with real concurrency control: revision-CAS on run snapshots, sequence-CAS on
+thread events, `SELECT … FOR UPDATE`, advisory-locked schema bootstrap
+(`store/store.go:203,215`, `store/postgres.go:38,996`). The client-facing SSE
+stream is a pure store poll (`api/assistant_threads.go:823-856`) — it would
+serve correctly from any replica today. Project/Session/Studio state is kcp
+CRs; committed source of truth is git via the code provider.
+
+**Pod-local.** Two clusters of state, and they are different problems:
+
+1. **Run ownership** — the supervisor's `runs`/`reservations` maps, the Busy
+   gate, steering channels, thread mirrors (`api/assistant_supervisor.go:55-56`,
+   `api/assistant_busy.go:22-44`). Worst consequence: the orphan-run
+   reconciler (`api/assistant_supervisor_http.go:1171-1220`) force-interrupts
+   any `running` run **not found in the local supervisor** — with two
+   replicas, the first poll that lands on the wrong one kills a live run.
+2. **The workspace tree** — the assistant's working files plus the
+   dirty/revision/settlement ledgers on a pod-local RWO volume
+   (`workspace/store.go`, `source_state.go`). A second replica sees an empty
+   tree, which silently reads as "project clean" and can push an **empty
+   file list** to the dev sandbox (audit F3).
+
+The chart hard-fails `replicaCount != 1` today
+(`deploy/chart/templates/deployment.yaml:3-5`).
+
+## Design verdict
+
+No hub changes, no shared filesystem. Two provider-side mechanisms:
+
+- **Durable run claims in Postgres** make run lifecycle correct fleet-wide.
+- **Project pinning + peer forwarding** keep all workspace-touching work on
+  one replica per project, with git re-hydration as the failover story.
+
+The hub keeps its "no request pinned to a pod" model: the Service still
+round-robins, and the *provider* forwards internally exactly like edges does
+for tunnels — one intra-cluster hop, invisible to the hub and the browser.
+
+## Mechanism 1 — run claims (Postgres)
+
+A `run_claims` table (or owner columns on `assistant_runs`): `run_key`,
+`owner_replica`, `owner_addr`, `heartbeat_at`. Semantics copied from kuery's
+per-edge claims, SQL-backed because the store is already there:
+
+- `supervisor.Attach` inserts the claim (`ON CONFLICT` guarded by a staleness
+  check); the worker goroutine renews it (~15s); completion clears it.
+- **Busy / reservations become cluster-wide**: `Busy(scope)` is "local map OR
+  live claim in Postgres"; the external-operation lock (hydrate, template
+  switch, delete) claims through the same table, so two replicas can no
+  longer run a turn and a hydrate concurrently (audit F5).
+- **The orphan-interrupt reconciler fires only on claim-EXPIRED runs**
+  (heartbeat older than ~60s), never on "not in my local map". This deletes
+  failure mode F1 outright, and is a strict improvement even at one replica
+  (today a provider restart mid-run relies on the same local-map heuristic).
+- Thread mirrors and any other per-run singletons gate on holding the claim
+  (F8).
+- Interrupt/steer/approve on a non-owner replica: resolve `owner_addr` from
+  the claim and forward (mechanism 2's listener), instead of today's 409
+  `"assistant turn is not active on this provider"`.
+
+## Mechanism 2 — project pinning + peer forwarding
+
+The workspace tree cannot be shared cheaply, so it isn't: each project is
+**owned by one replica at a time**, and workspace-touching requests execute
+on the owner.
+
+- **Claim**: `project_claims` row (same table shape) keyed by project UID,
+  holding `owner_addr` (`podIP:internalPort` — the edges pattern; POD_IP via
+  downward API). Acquired lazily by the first workspace-touching request for
+  an unclaimed project; renewed while runs/dev-sync are active; expires after
+  ~10 minutes idle so projects rebalance across the fleet over time.
+- **Forwarding**: an internal HTTP listener (plain `httputil.ReverseProxy`,
+  shared-bearer auth, loop-guard header — no raw relay needed since
+  app-studio is HTTP-only). A middleware on project-scoped routes checks the
+  claim: owner → serve; foreign owner → forward; no owner → claim and serve.
+- **Route split** (from the audit's flow map):
+  - *Forwarded (workspace/run-touching)*: turn start, steer, interrupt,
+    approvals/resume, hydrate-workspace, template switch, scaffold reseed,
+    dev-sync, file browser, promote gate, preview-console, preview
+    interaction (browser lock).
+  - *Served anywhere (store/CR-backed)*: SSE event streams, thread/message
+    listing, project listing, health, portal assets, MCP surfaces that only
+    read the store.
+- **Workspace lifecycle becomes claim-driven**: on claiming a project whose
+  tree is absent locally, re-hydrate from git (the existing
+  `hydrate-workspace` flow) before serving. This turns the volume into a
+  **cache**: the chart's RWO PVC can become `emptyDir`, pods become cattle,
+  and the migration-marker/monotonic-growth issues go with it. The
+  `source-revision.json` fence must be seeded from the durable side (a
+  revision column on the project claim) rather than restarting at 1, so the
+  dev-sandbox staleness check survives a move (audit F3).
+
+**Failover semantics (the deliberate trade)**: a replica crash loses the
+uncommitted workspace edits of the projects it owned; the next request
+re-claims elsewhere and re-hydrates from the last commit. For a dev sandbox
+whose durable truth is git, that matches user expectations — and commit
+cadence is assistant-driven and frequent. Hardening later, if wanted:
+periodic WIP snapshot pushes to a scratch branch shrink the loss window
+without changing the design.
+
+## Mechanism 3 — reconciler sharding (no leader election)
+
+The multicluster manager stays on every replica (pod readiness requires it —
+`controller_manager.go:266-292` — and it is not serving-entangled). Instead
+of a global lease, the **Project reconciler's commit-convergence path runs
+only on the project's owner** (claim check at the top; foreign projects
+requeue). The CR-only parts (instance ensure, status mirroring) are
+idempotent and may stay active-active initially; folding them under the same
+claim check is a later cleanup. This is claims-sharding, same shape as
+kuery's engagement — leader election is the wrong tool here because the
+work is inherently partitioned by project, not singleton.
+
+## What this deletes
+
+- The orphan-interrupt cross-kill (F1) and the non-mutual Busy gate (F5).
+- The chart's `replicaCount != 1` hard fail and the RWO PVC.
+- The empty-workspace dev-sync wipe (F3) — non-owners never touch workspaces.
+- Preview-console session breakage (F6) — console routes ride the pin.
+
+## Phasing
+
+| Phase | Work | Safe at 1 replica? |
+|---|---|---|
+| A | Run claims table + Busy/reservation/orphan-interrupt on claims | Yes — strictly better restart semantics |
+| B | Internal listener + project claims + forwarding middleware; revision fence to durable side | Yes — forwarding is a no-op single-replica |
+| C | Claim-driven hydration, `emptyDir` default, reconciler owner-gating, drop the chart fail | Unlocks N replicas |
+| D (optional) | WIP snapshot-to-git; preview-console to sharedstore if forwarding proves noisy | Hardening |
+
+## Open decisions
+
+1. **`emptyDir` + re-hydration vs keeping per-pod PVCs** (StatefulSet +
+   volumeClaimTemplates). Recommendation: `emptyDir` — a PVC that survives
+   pod moves but not claim moves buys little once hydration is claim-driven.
+2. **Crash-loss tolerance**: is losing uncommitted edits on replica crash
+   acceptable v1 behavior, or is Phase D's WIP snapshotting a launch
+   requirement?
+3. **Forward-all vs selective**: start with the selective route split above,
+   or forward every project-scoped route and carve out reads later? The
+   selective split is more work to get right but keeps SSE latency flat.

--- a/docs/app-studio-replica-awareness.md
+++ b/docs/app-studio-replica-awareness.md
@@ -1,6 +1,9 @@
 # App Studio replica awareness — design
 
-Status: **proposed** · Date: 2026-08-17 · Author: design note
+Status: **phases A–C implemented** (run claims; project affinity + peer
+forwarding; git re-hydration on adoption, emptyDir workspaces, owner-gated
+commit convergence — phase D snapshotting remains optional hardening) ·
+Date: 2026-08-17 · Author: design note
 Related: [`provider-horizontal-scaling.md`](./provider-horizontal-scaling.md)
 (the cross-provider plan this details), the kuery per-edge claims
 (`providers/kuery/engagement/claims.go`) and the edges replica routing

--- a/docs/provider-horizontal-scaling.md
+++ b/docs/provider-horizontal-scaling.md
@@ -1,0 +1,279 @@
+# Provider horizontal scaling — beyond leader election
+
+Status: **proposed** · Date: 2026-08-17 · Author: design note
+Related: [`provider-connectivity-contract.md`](./provider-connectivity-contract.md),
+[`platform-internal-networking.md`](./platform-internal-networking.md) (tunnel-HA
+prior art), [`cross-provider-simplification.md`](./cross-provider-simplification.md)
+(kuery's dead sync path), [`helm.md`](./helm.md) §HA (the hub's own scaling
+model), `provider-sdk/leaderelection` (the first HA primitive).
+
+## The problem
+
+Leader election (`provider-sdk/leaderelection`) made **code**, **vibe-studio**,
+and **infrastructure** safe to scale: their multicluster managers host only
+write loops, so gating the manager on a Lease leaves non-leaders serving
+REST/MCP/portal untouched.
+
+Four providers could not take that fix, each for a different structural
+reason, and today they pin `replicaCount: 1`:
+
+| Provider | Why the manager can't just be gated |
+|---|---|
+| **databricks** | The HTTP action path resolves tenant clusters *through the running manager* (`managerAuthority`, `providers/databricks/controller_manager.go:209-219`); readiness and heartbeat require it too (`main.go:171-181`). |
+| **kuery** | Engagement is per-replica serving state: each replica syncs edges into its own store and answers `/api/edges` from an in-memory map (`providers/kuery/engagement/controller.go:103-104,197-208`). |
+| **edges** | revdial registers tunnel dialers in a **process-global map closed over the accepted socket** (`provider-sdk/revdial/revdial.go:89-91`); pickup dials and every consumer request must reach the process holding the fd (`providers/edges/internal/tunnel/connman.go:24-26`). |
+| **app-studio** | Assistant runs are owned by in-process supervisors, the workspace source tree is a pod-local RWO volume, and an orphan-run reconciler on any *other* replica force-interrupts a live run (`providers/app-studio/api/assistant_supervisor_http.go:1171-1220`); the chart hard-fails `replicaCount != 1` (`deploy/chart/templates/deployment.yaml:3-5`). |
+
+This doc answers: what does each provider actually need to scale out, whether
+the hub should grow a session/affinity layer, and in what order to do the work.
+
+## Evidence summary (what the audit found)
+
+Full per-provider audits were done against the tree on 2026-08-17; the
+load-bearing findings:
+
+**The hub deliberately has no affinity, and nothing can address a specific
+provider pod.** Every request to a provider goes hub backend proxy →
+`CatalogEntry.spec.backend.url` → a plain ClusterIP Service
+(`pkg/hub/providers/proxy.go:293-326`, `docs/helm.md:190-192`: "no request is
+pinned to a pod"). There is no headless Service, no `sessionAffinity`, no
+pod-DNS use anywhere in the platform charts. Any per-pod routing scheme is
+greenfield.
+
+**databricks' coupling is shallow.** The authority consumer takes exactly one
+thing from the manager: `cluster.GetClient()` (`tenant/client.go:191-213`). The
+client it gets is just the provider SA config with
+`Host = {VW-shard-URL}/clusters/{cluster}` plus an informer cache
+(`multicluster-provider/pkg/cache/cluster.go:41-61`). The **agents provider
+already builds exactly these clients with no manager at all** — reading
+`APIExportEndpointSlice.status.endpoints[].url` directly, with per-shard
+probing and a learned cluster→shard cache
+(`providers/agents/api/background.go:163-241,303-337`). Databricks even reads
+the same slice today and throws the URL away
+(`controller_manager.go:656-672`).
+
+**kuery's engagement path is dead code, and its store is a derived cache.**
+The reconciler watches the retired `faros.sh/v1alpha1 Edge` kind and dials the
+removed `/services/edges-proxy` hub mount (`engagement/controller.go:66,371-374`;
+tracked in `cross-provider-simplification.md:110-118`). All synced data lives
+in one SQL store (SQLite file on an RWO PVC by default, Postgres supported and
+used in dev), keyed by cluster name, fully re-buildable from live discovery +
+informer relist — deterministic row IDs, idempotent upserts
+(`kuery/pkg/sync/handler.go:20,82-84`). Queries are answered **from SQL, never
+from the engagement runtime** (`kuery/pkg/engine/engine.go:35-91`) — so with a
+shared Postgres, *any* replica can answer *any* query; only engagement (the
+sync work) needs partitioning. The current schema has no ownership column and
+disengage/GC are global, so naive 2-replica operation wipes tenant labels and
+purges live data (audit items #5-#7).
+
+**edges has exactly two structural blockers, and the industry has exactly two
+answers.** (1) Connection affinity: revdial's dialer *is* the accepted socket;
+(2) the manager doubles as the serving path's tenant-config resolver — but
+that dependency is shallow too: consumers only need
+`rest.Config{Host: {VW-URL}/clusters/{cluster}}`, constructible from the slice
+the provider already ensures (`controller_manager.go:89`). On tunnel HA the
+platform doc already surveyed the field
+(`platform-internal-networking.md:456-480`): either **the agent opens one
+tunnel per replica** (Konnectivity `--server-count`, kcp per-shard tunneler)
+or **the ingress does connection-aware routing** to the owning replica
+(Gardener SNI). There is no third option; revdial cannot escape this.
+
+**app-studio is two problems wearing one trench coat.** Everything
+conversational is already multi-process-safe in Postgres: revision/sequence
+CAS on every mutation, advisory-locked schema bootstrap, and an SSE stream
+that is a pure store poll usable from any replica
+(`store/store.go:203,215`, `api/assistant_threads.go:823-856`). What is
+pod-local is (a) **run ownership** — supervisor maps, Busy/reservation gates,
+steering channels, and the orphan-interrupt logic that trusts them
+(`api/assistant_supervisor.go:55-56`, `api/assistant_busy.go:22-44`), and (b)
+**the workspace file tree** plus its dirty/revision/settlement ledgers on a
+pod-local volume (`workspace/store.go:159-180`, `source_state.go:32-36`).
+Git (the code provider) is already the durable source of truth for committed
+work; the workspace is uncommitted working state.
+
+**The hub's sharedstore is portable but not reusable in place.** It is ~250
+lines of Secrets-as-KV with TTL and single-use `Take`
+(`pkg/hub/sharedstore/sharedstore.go`), but it lives in the monorepo module and
+writes to a hub-internal workspace providers can't reach. The port target is
+`provider-sdk`, storing in the provider's **own** workspace — the same move
+already made for `leaderelection`.
+
+## The verdict on hub-level session management
+
+**Don't build it.** The audits show three of the four providers scale without
+any hub routing change, and the fourth (app-studio) is better served by
+ownership state + peer forwarding *inside the provider*:
+
+- The hub's own HA design principle — every replica serves the full surface,
+  no request pinned to a pod (`docs/helm.md:190-192`) — is worth preserving.
+  A hub-side affinity table keyed by provider-internal concepts (run IDs,
+  edge names, project UIDs) would leak every provider's domain model into the
+  hub and make the hub a party to each provider's failover story.
+- Per-pod addressing from the hub is greenfield (no headless Services, no
+  replica identity in CatalogEntry/heartbeats) and was already rejected once
+  as a cross-provider pattern (`platform-internal-networking.md:137-140`).
+- Affinity routing solves *request placement* but not *state placement*: even
+  with perfect stickiness, a replica crash still loses the workspace tree or
+  the tunnel unless the state problem is solved anyway. Solve state, and
+  stickiness becomes an optimization, not a correctness requirement.
+
+What the platform *should* grow instead are three small, provider-side
+primitives in `provider-sdk` (Phase 0 below).
+
+## Shared primitives (provider-sdk)
+
+**P1 — `sharedstore` port.** The hub's Secrets-backed KV (TTL, GC, single-use
+`Take`), parameterized on the provider's own workspace + a namespace. Backing
+for: app-studio preview-console sessions, small cross-replica memos. (~250
+lines + tests, mechanical port.)
+
+**P2 — `ownership` claims registry.** A tiny claim/renew/release API for
+*sharded* singletons — "replica R owns item X until TTL" — with the item set
+defined by the provider (edge names, cluster names, run keys). Two backends:
+kcp Leases in the provider workspace (no new deps; same RBAC the
+leader-election work already granted) for small cardinality, and a SQL table
+for providers that already run one (kuery, app-studio). This is
+leader-election generalized from one lease to N.
+
+**P3 — peer addressing + forwarding.** A headless Service per provider chart
+(`clusterIP: None`, pod DNS) plus a small HTTP helper: "not my item → 307/
+proxy to the owner replica recorded in P2". Contained entirely inside each
+provider; the hub keeps dialing the one ClusterIP Service. Charts gain a
+`replicaId` (pod name) env via the downward API.
+
+## Per-provider plans
+
+### databricks — small; no new primitives needed
+
+1. **Slice-backed authority.** Implement `ClusterAuthority` reading
+   `APIExportEndpointSlice.status.endpoints[].url` directly (copy the agents
+   pattern: multi-shard URL extraction, shard probe + learned cache,
+   `background.go:217-241,303-337`). Keep the credential-preserving provider
+   config for it (today `SetBaseConfig` deliberately drops credentials —
+   `tenant/client.go:114-148` — so add a second path). Reads become live GETs
+   instead of informer-cached; acceptable for the action-path volume, and it
+   removes the engagement warm-up wait.
+2. **Decouple readiness/heartbeat from the manager** — ready when the slice
+   yields ≥1 endpoint URL, not when the manager engages.
+3. **Leader-elect the controller manager** exactly like code/vibe-studio
+   (fresh per term, `SkipNameValidation`), now that serving no longer needs it.
+4. Chart: `replicaCount` becomes freely scalable.
+
+Behavioral deltas to accept: a tenant without a Ready APIBinding gets a kcp
+403/404 instead of "cluster unavailable"; wrong-shard reads must fail loudly
+(probe list, don't guess).
+
+### kuery — medium; blocked on fixing the dead sync path first
+
+1. **Revive the data path** (already-tracked defect): watch
+   `edges.faros.sh/{KubernetesCluster,LinuxServer}`, dial the edges provider's
+   `edgeproxy` URL from `status.URL` instead of the removed hub mount.
+2. **Postgres required for >1 replica** (chart gate: refuse `replicaCount > 1`
+   with the SQLite/RWO-PVC store). The store is a derived cache — migration is
+   "point at Postgres, let it re-sync", no data migration.
+3. **Partition engagement with P2 (SQL backend).** Add an `owner_replica` +
+   `owner_heartbeat` to the `clusters` table (or a sibling claims table).
+   Reconcile becomes: claim edge → engage locally; lost claim → disengage
+   *without* touching shared rows. Fix the two global-write hazards the audit
+   found: disengage/pod-shutdown must not `markStale`/wipe labels on rows it
+   doesn't own, and GC must run only on claim-expired clusters.
+4. **Serve `/api/edges` and `/api/status` from SQL**, not the in-memory map —
+   then any replica answers any query and any listing; no affinity needed
+   anywhere.
+
+### edges — large; adopt tunnel-per-replica (industry option 1)
+
+Recommendation: **the agent dials every replica** (Konnectivity
+`--server-count` model), not connection-aware routing — it eliminates the
+forwarding hop on the hot data path, keeps the hub untouched, and matches
+what kcp itself does per-shard.
+
+1. **Replica discovery for agents.** The provider advertises its replica set
+   (count + per-replica pickup identity) on the connect handshake; the agent
+   maintains one control WS per replica (re-list on change). Pickup dials go
+   to the *replica-specific* path — P3's headless Service gives each replica
+   an addressable identity to embed in the pickup URL, so the revdial global
+   map is only ever consulted by the process that owns the dialer.
+2. **Serving path drops the manager dependency**: construct tenant configs
+   from the slice URL directly (same shallow dependency as databricks;
+   the two caveats in the audit apply — fail-closed semantics move to kcp).
+   With tunnels on every replica, `ConnManager.Load` succeeds locally and the
+   502 class disappears.
+3. **Event store → shared backend** (the in-code plan: Redis `LPUSH/LTRIM`
+   per key, `internal/events/store.go:59-60`), and event *subscribers* gated
+   by P2 claims (one UniFi WS per service across the fleet, not per replica).
+4. **Controllers**: with every replica able to dial every edge, the
+   tunnel-liveness cross-check is no longer replica-local — controllers can
+   be leader-elected with the standard pattern. Status writes stop flapping.
+5. Interim guardrail (cheap, do first): a runtime assertion that refuses to
+   start with >1 endpoints in its own Service while the above is unbuilt —
+   today nothing but a values comment prevents the flap storm.
+
+Cost note: N replicas ⇒ N control connections per agent. That is the accepted
+trade everywhere in the industry survey; agents are few (per site), replicas
+are 2-3.
+
+### app-studio — large; durable run ownership + a workspace decision
+
+The conversational plane is already multi-replica-clean (Postgres CAS + SSE
+store-polling). Two work streams:
+
+1. **Run ownership in Postgres (P2, SQL backend).** A `run_owner` claim
+   (replica ID + heartbeat) written at `supervisor.Attach`, renewed by the
+   worker, cleared on completion:
+   - `Busy`/`reserved` consult claims, not local maps — the commit-convergence
+     gate and external-operation lock become cluster-wide correct.
+   - The orphan-interrupt reconciler fires only on *claim-expired* runs —
+     fixing the F1 cross-kill without any routing change.
+   - Interrupt/steer/approve on a non-owner replica forward to the owner via
+     P3 (single internal hop) instead of returning 409.
+2. **The workspace tree.** Two viable endpoints, decide by ops preference:
+   - **(a) Shared RWX volume** (NFS/Filestore/EFS): smallest code delta —
+     the `mutationMu` process mutex must become a claim-based per-project
+     lock (P2), and `fsGroup`/locking semantics need validation on the chosen
+     filesystem. Ops burden: an RWX storage class everywhere faros deploys.
+   - **(b) Replica-pinned projects** (P2 claim per project + P3 forwarding
+     for all workspace-touching routes): no storage dependency; a replica
+     crash loses uncommitted workspace state for its projects (recovered by
+     re-hydrating from git — the flow that already exists for
+     `hydrate-workspace`), which is arguably acceptable for *uncommitted*
+     assistant work. Leans into git-as-source-of-truth.
+   Recommendation: **(b)** first — it needs no new infra, reuses hydrate, and
+   its failure mode (lose uncommitted edits on pod crash) matches user
+   expectations of a dev sandbox; (a) remains open as a later hardening.
+3. Preview-console sessions move to P1 (sharedstore) or ride the project pin.
+4. Only then: leader-elect/claim-gate the Project reconciler per project
+   (owner replica reconciles its own projects — reconcile-side sharding via
+   the same claims), and lift the chart's `replicaCount != 1` fail.
+
+## Phasing and order
+
+| Phase | Work | Size | Unlocks |
+|---|---|---|---|
+| 0 | provider-sdk: P1 sharedstore port, P2 ownership claims (Lease + SQL backends), P3 headless-Service + forwarding helper; per-replica heartbeat field (optional, additive) | S-M | everything below |
+| 1 | databricks slice-backed authority + leader-elected controllers | S | databricks → N replicas |
+| 2 | kuery: revive sync path → Postgres gate → claims-partitioned engagement → SQL-backed listings | M | kuery → N replicas |
+| 3 | edges: replica-set handshake + per-replica pickups, manager-free serving configs, shared event store, leader-elected controllers | L | edges → 2-3 replicas |
+| 4 | app-studio: run-ownership claims → peer forwarding → project pinning (workspace option b) → per-project reconcile sharding | L | app-studio → N replicas |
+
+Phases 1-4 are independent of each other (order chosen by value/effort);
+each ends with the provider's chart guard removed and a failover test
+(kill the owner replica mid-operation, assert convergence).
+
+## Open questions
+
+1. **P2 backend split** — is one interface over two backends (Lease vs SQL)
+   worth it, or should kuery/app-studio just use their DBs directly and only
+   edges use Leases? (Leases in kcp have write-rate limits worth respecting
+   at high claim cardinality.)
+2. **Edges replica-set handshake compatibility** — old agents that dial once
+   must keep working against a scaled provider (they'd reach one replica;
+   data-plane requests to other replicas would need P3 forwarding as a
+   compatibility shim, or agents upgrade first).
+3. **app-studio option (b) crash semantics** — is losing uncommitted
+   workspace edits on replica crash acceptable product behavior, or does that
+   force option (a)/periodic snapshot-to-git?
+4. **Per-replica heartbeats** — the registry is name-keyed and CatalogEntry
+   status is single-writer-averse; per-replica liveness may be better served
+   by each provider's own claims table than by widening the hub heartbeat
+   protocol. Revisit only if a concrete consumer appears.

--- a/hack/scripts/configure-tilt-kcp-dns.sh
+++ b/hack/scripts/configure-tilt-kcp-dns.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Configure the local kind cluster's CoreDNS to resolve kcp.localhost (and the
+# per-shard *.kcp.localhost names) to the in-cluster Envoy gateway, so PROVIDER
+# PODS can use the operator-issued kubeconfigs unchanged — the same trick the
+# hub pod gets via hostAliases, done once cluster-wide instead of per chart.
+# Host-side resolution is untouched (kcp.localhost resolves to loopback for the
+# kcp-frontproxy-forward port-forward).
+#
+# Sibling of configure-tilt-preview-dns.sh with its own managed block.
+
+set -euo pipefail
+
+cleanup=false
+if [[ "${1:-}" == "--cleanup" ]]; then
+  cleanup=true
+  shift
+fi
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 [--cleanup] <kubectl-context> <gateway-ip>" >&2
+  exit 2
+fi
+
+context="$1"
+gateway_ip="$2"
+marker_start="# faros-kcp-dns"
+marker_end="# faros-kcp-dns-end"
+
+if [[ ! "$gateway_ip" =~ ^[0-9.]+$ ]]; then
+  echo "invalid gateway IP: $gateway_ip" >&2
+  exit 2
+fi
+
+if [[ "$cleanup" == true ]]; then
+  corefile="$(kubectl --context "$context" -n kube-system get configmap coredns -o jsonpath='{.data.Corefile}' 2>/dev/null || true)"
+else
+  for _ in $(seq 1 60); do
+    corefile="$(kubectl --context "$context" -n kube-system get configmap coredns -o jsonpath='{.data.Corefile}' 2>/dev/null || true)"
+    if [[ -n "$corefile" ]]; then
+      break
+    fi
+    sleep 1
+  done
+fi
+if [[ "$cleanup" == true && -z "${corefile:-}" ]]; then
+  exit 0
+fi
+if [[ -z "${corefile:-}" ]]; then
+  echo "CoreDNS ConfigMap did not become available" >&2
+  exit 1
+fi
+
+without_managed="$(printf '%s\n' "$corefile" | awk -v start="$marker_start" -v end="$marker_end" '
+  $0 == start { skipping = 1; next }
+  skipping && $0 == end { skipping = 0; next }
+  !skipping { print }
+')"
+
+if [[ "$cleanup" == true ]]; then
+  if [[ "$without_managed" == "$corefile" ]]; then
+    exit 0
+  fi
+  patch_json="$(jq -cn --arg corefile "$without_managed" '{data:{Corefile:$corefile}}')"
+  kubectl --context "$context" -n kube-system patch configmap coredns --type merge -p "$patch_json" >/dev/null 2>&1 || exit 0
+  kubectl --context "$context" -n kube-system delete pods -l k8s-app=kube-dns --ignore-not-found >/dev/null 2>&1 || true
+  exit 0
+fi
+
+# Apex + one shard label: kcp.localhost, root.kcp.localhost, theseus.kcp.localhost.
+block_file="$(mktemp)"
+trap 'rm -f "$block_file"' EXIT
+cat >"$block_file" <<EOF
+${marker_start}
+    template IN A {
+        match ^([^.]+\\.)?kcp\\.localhost\\.$
+        answer "{{ .Name }} 60 IN A ${gateway_ip}"
+        fallthrough
+    }
+${marker_end}
+EOF
+
+patched="$(awk -v block_file="$block_file" '
+  BEGIN {
+    while ((getline line < block_file) > 0) block = block line "\n"
+    close(block_file)
+  }
+  {
+    print
+    if (!inserted && $0 ~ /^[[:space:]]*errors[[:space:]]*$/) {
+      printf "%s", block
+      inserted = 1
+    }
+  }
+  END {
+    if (!inserted) exit 42
+  }
+' <<<"$without_managed")" || {
+  echo "CoreDNS Corefile has no errors plugin insertion point" >&2
+  exit 1
+}
+patch_json="$(jq -cn --arg corefile "$patched" '{data:{Corefile:$corefile}}')"
+if [[ "$patched" != "$corefile" ]]; then
+  kubectl --context "$context" -n kube-system patch configmap coredns --type merge -p "$patch_json" >/dev/null
+  kubectl --context "$context" -n kube-system delete pods -l k8s-app=kube-dns --ignore-not-found >/dev/null
+fi

--- a/provider-sdk/go.mod
+++ b/provider-sdk/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/provider-sdk/leaderelection/leaderelection.go
+++ b/provider-sdk/leaderelection/leaderelection.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leaderelection gates a provider's singleton controllers so a
+// provider scaled to multiple replicas still reconciles each object exactly
+// once. It is the provider-side twin of the hub's pkg/hub/leaderelection.
+//
+// The lock is a coordination.k8s.io/v1 Lease held in the provider's own kcp
+// workspace (kcp serves Leases inside every logical cluster), so no
+// host-cluster ServiceAccount or RBAC is required — the provider kubeconfig
+// the hub mints is the only credential involved.
+//
+// Only *write* loops belong behind this gate. Machinery the request path
+// reads — a multicluster manager that doubles as the HTTP layer's tenant
+// client resolver, per-replica engagement state, and the like — must keep
+// running on every replica, or a non-leader would serve requests against
+// nothing.
+//
+// Because a stopped controller-runtime manager cannot be restarted, the
+// elected callback must build its manager fresh each term (and set
+// Controller.SkipNameValidation — controller names register process-globally,
+// which a second term would otherwise trip over).
+package leaderelection
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog/v2"
+)
+
+// DefaultNamespace is where the Lease lives inside the provider workspace.
+// kcp creates the "default" namespace in every logical cluster, so it is
+// always present without any bootstrap step.
+const DefaultNamespace = "default"
+
+// Default lease timings. They match controller-runtime's defaults, which are
+// tuned for a control plane that may briefly stall (kcp shard restart, front
+// proxy failover) without triggering a spurious failover.
+const (
+	DefaultLeaseDuration = 15 * time.Second
+	DefaultRenewDeadline = 10 * time.Second
+	DefaultRetryPeriod   = 2 * time.Second
+)
+
+// Options configures a single election.
+type Options struct {
+	// Config must already target the workspace holding the Lease (i.e. its
+	// Host carries the /clusters/<path> segment).
+	Config *rest.Config
+	// Namespace and Name identify the Lease object.
+	Namespace string
+	Name      string
+	// Identity distinguishes this replica. Defaults to the pod hostname plus
+	// the process ID, which stays unique if two replicas ever share a host.
+	Identity string
+
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+}
+
+func (o *Options) defaults() error {
+	if o.Config == nil {
+		return fmt.Errorf("leaderelection: Config is required")
+	}
+	return o.defaultsWithoutConfig()
+}
+
+func (o *Options) defaultsWithoutConfig() error {
+	if o.Namespace == "" || o.Name == "" {
+		return fmt.Errorf("leaderelection: Namespace and Name are required")
+	}
+	if o.Identity == "" {
+		host, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("leaderelection: resolving hostname for identity: %w", err)
+		}
+		o.Identity = fmt.Sprintf("%s_%d", host, os.Getpid())
+	}
+	if o.LeaseDuration <= 0 {
+		o.LeaseDuration = DefaultLeaseDuration
+	}
+	if o.RenewDeadline <= 0 {
+		o.RenewDeadline = DefaultRenewDeadline
+	}
+	if o.RetryPeriod <= 0 {
+		o.RetryPeriod = DefaultRetryPeriod
+	}
+	return nil
+}
+
+// Run campaigns for the lease and calls run every time this replica is elected,
+// with a context that is cancelled the moment leadership is lost. It blocks
+// until ctx is done, re-entering the election after each loss, so a transient
+// kcp hiccup costs the provider a controller pause rather than a process
+// restart — the same replica keeps serving REST/MCP/portal traffic throughout.
+//
+// run must return promptly once its context is cancelled: the next leader may
+// already be reconciling.
+func Run(ctx context.Context, opts Options, run func(context.Context)) error {
+	if err := (&opts).defaults(); err != nil {
+		return err
+	}
+	client, err := kubernetes.NewForConfig(opts.Config)
+	if err != nil {
+		return fmt.Errorf("leaderelection: building client: %w", err)
+	}
+	return runWithClient(ctx, opts, client, run)
+}
+
+// runWithClient is Run with the client injected, so tests can drive the whole
+// election loop against a fake API.
+func runWithClient(ctx context.Context, opts Options, client kubernetes.Interface, run func(context.Context)) error {
+	if err := (&opts).defaultsWithoutConfig(); err != nil {
+		return err
+	}
+	logger := klog.FromContext(ctx).WithName("leaderelection").
+		WithValues("lease", opts.Namespace+"/"+opts.Name, "identity", opts.Identity)
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  metav1.ObjectMeta{Namespace: opts.Namespace, Name: opts.Name},
+		Client:     client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{Identity: opts.Identity},
+	}
+
+	// The election callback only hands the term's context back; run itself is
+	// invoked on this goroutine below. client-go launches OnStartedLeading in a
+	// goroutine it never joins, so calling run from there would let a new term
+	// begin while the previous term's controllers are still draining.
+	terms := make(chan context.Context, 1)
+
+	config := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: opts.LeaseDuration,
+		RenewDeadline: opts.RenewDeadline,
+		RetryPeriod:   opts.RetryPeriod,
+		// Hand the lease back on a clean shutdown so a rolling update promotes
+		// the next replica immediately instead of after LeaseDuration.
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(termCtx context.Context) { terms <- termCtx },
+			OnStoppedLeading: func() {
+				logger.Info("Lost leadership; controllers stopping, will campaign again")
+			},
+			OnNewLeader: func(identity string) {
+				if identity != opts.Identity {
+					logger.V(2).Info("Observed new leader", "leader", identity)
+				}
+			},
+		},
+	}
+
+	for {
+		elector, err := leaderelection.NewLeaderElector(config)
+		if err != nil {
+			return fmt.Errorf("leaderelection: creating elector: %w", err)
+		}
+		logger.V(2).Info("Campaigning for leadership")
+
+		// Scoped to this term so we can step down deliberately: if run returns
+		// while the lease is still held — a controller failed to start, say —
+		// holding the lease would stall the platform, because no other replica
+		// can take over work this one is no longer doing. Cancelling here
+		// releases the lease and lets a peer win the next round.
+		electionCtx, endTerm := context.WithCancel(ctx)
+		electorDone := make(chan struct{})
+		go func() {
+			defer close(electorDone)
+			elector.Run(electionCtx)
+		}()
+
+		select {
+		case termCtx := <-terms:
+			logger.Info("Acquired leadership")
+			run(termCtx)
+			if termCtx.Err() == nil {
+				logger.Info("Controllers stopped while still leader; releasing the lease")
+			}
+			endTerm()
+			<-electorDone
+		case <-electorDone:
+			// Never won this round, or ctx was cancelled while campaigning.
+		}
+		endTerm()
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(opts.RetryPeriod):
+		}
+	}
+}

--- a/provider-sdk/leaderelection/leaderelection_test.go
+++ b/provider-sdk/leaderelection/leaderelection_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNamespace = "default"
+	testLease     = "test-provider-controllers"
+)
+
+// fastOptions keeps the election responsive enough for a unit test while
+// preserving the real ordering constraints.
+func fastOptions(identity string) Options {
+	return Options{
+		Namespace:     testNamespace,
+		Name:          testLease,
+		Identity:      identity,
+		LeaseDuration: time.Second,
+		RenewDeadline: 500 * time.Millisecond,
+		RetryPeriod:   50 * time.Millisecond,
+	}
+}
+
+func TestRunInvokesCallbackWhenElected(t *testing.T) {
+	client := kubefake.NewClientset()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	elected := make(chan struct{})
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		_ = runWithClient(ctx, fastOptions("replica-a"), client, func(termCtx context.Context) {
+			close(elected)
+			<-termCtx.Done()
+		})
+	}()
+
+	select {
+	case <-elected:
+	case <-ctx.Done():
+		t.Fatal("never elected")
+	}
+
+	cancel()
+	select {
+	case <-released:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+// Exactly one replica may run the singleton controllers at a time — that is the
+// whole point of the lease.
+func TestOnlyOneReplicaLeadsAtATime(t *testing.T) {
+	client := kubefake.NewClientset()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		running int
+		maxSeen int
+	)
+	leading := make(chan string, 2)
+
+	var wg sync.WaitGroup
+	for _, identity := range []string{"replica-a", "replica-b"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = runWithClient(ctx, fastOptions(identity), client, func(termCtx context.Context) {
+				mu.Lock()
+				running++
+				if running > maxSeen {
+					maxSeen = running
+				}
+				mu.Unlock()
+				leading <- identity
+				<-termCtx.Done()
+				mu.Lock()
+				running--
+				mu.Unlock()
+			})
+		}()
+	}
+
+	select {
+	case <-leading:
+	case <-ctx.Done():
+		t.Fatal("neither replica was elected")
+	}
+	// Give the loser ample opportunity to wrongly acquire as well.
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	got := maxSeen
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("concurrent leaders = %d, want 1", got)
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+// A leader whose controllers fail to start must not sit on the lease: no peer
+// could take over the work it is no longer doing.
+func TestLeaderStepsDownWhenCallbackReturnsEarly(t *testing.T) {
+	client := kubefake.NewClientset()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	terms := make(chan struct{}, 8)
+	go func() {
+		_ = runWithClient(ctx, fastOptions("replica-a"), client, func(context.Context) {
+			// Simulates a controller that failed to start: return immediately
+			// while the lease is still held.
+			terms <- struct{}{}
+		})
+	}()
+
+	// Stepping down and re-campaigning must produce repeated terms rather than
+	// one term that holds the lease forever.
+	for i := range 2 {
+		select {
+		case <-terms:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d term(s) observed; leader kept the lease after failing", i)
+		}
+	}
+}
+
+func TestRunRequiresLeaseCoordinates(t *testing.T) {
+	client := kubefake.NewClientset()
+	err := runWithClient(context.Background(), Options{Identity: "replica-a"}, client, func(context.Context) {})
+	if err == nil {
+		t.Fatal("expected an error when Namespace and Name are unset")
+	}
+}

--- a/providers/agents/Dockerfile
+++ b/providers/agents/Dockerfile
@@ -3,27 +3,31 @@
 # 1. Build the portal micro-frontend (Vite + TS → portal/dist).
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/agents/portal/package.json providers/agents/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/agents/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. assets.go //go:embeds portal/dist.
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/agents/go.mod providers/agents/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/agents/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY main.go heartbeat.go assets.go init_cmd.go ./
-COPY apis ./apis
-COPY api ./api
-COPY channels ./channels
-COPY client ./client
-COPY engine ./engine
-COPY executor ./executor
-COPY llm ./llm
-COPY store ./store
-COPY tenant ./tenant
-COPY tools ./tools
+COPY providers/agents/main.go providers/agents/heartbeat.go providers/agents/assets.go providers/agents/init_cmd.go ./
+COPY providers/agents/apis ./apis
+COPY providers/agents/api ./api
+COPY providers/agents/channels ./channels
+COPY providers/agents/client ./client
+COPY providers/agents/engine ./engine
+COPY providers/agents/executor ./executor
+COPY providers/agents/llm ./llm
+COPY providers/agents/store ./store
+COPY providers/agents/tenant ./tenant
+COPY providers/agents/tools ./tools
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/agents-provider .
 
@@ -31,7 +35,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    baked at /etc/faros/schemas (FAROS_SCHEMAS_DIR).
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/agents-provider /agents-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/agents/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8087
 ENV PORT=8087
 USER nonroot:nonroot

--- a/providers/agents/deploy/chart/templates/deployment.yaml
+++ b/providers/agents/deploy/chart/templates/deployment.yaml
@@ -68,6 +68,14 @@ spec:
           readinessProbe:
             httpGet: { path: /healthz, port: http }
             periodSeconds: 5
+          {{- if .Values.envFromSecret }}
+          # Bulk environment injection (LLM/channel credentials). The Secret's
+          # keys become env vars verbatim — the containerized equivalent of the
+          # host binary sourcing a .env file.
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
           env:
             - name: PORT
               value: "8087"

--- a/providers/agents/deploy/chart/values.yaml
+++ b/providers/agents/deploy/chart/values.yaml
@@ -52,6 +52,10 @@ hub:
     name: ""
     key: token
 
+# Optional Secret whose keys are injected wholesale as environment variables
+# (LLM/channel credentials) — the containerized equivalent of sourcing .env.
+envFromSecret: ""
+
 podLabels: {}
 podAnnotations: {}
 podSecurityContext:

--- a/providers/agents/go.mod
+++ b/providers/agents/go.mod
@@ -108,3 +108,8 @@ replace (
 	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20260602065202-e006560fc76a
 	k8s.io/kms => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kms v0.0.0-20260602065202-e006560fc76a
 )
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/agents/go.sum
+++ b/providers/agents/go.sum
@@ -38,8 +38,6 @@ github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bF
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=

--- a/providers/app-studio/Dockerfile
+++ b/providers/app-studio/Dockerfile
@@ -10,9 +10,9 @@
 #    are needed.
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/app-studio/portal/package.json providers/app-studio/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/app-studio/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. assets.go //go:embeds portal/dist, overlaid from the
@@ -21,9 +21,13 @@ RUN npm run build
 #    proxy in a standalone build context.
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/app-studio/go.mod providers/app-studio/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/app-studio/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY . ./
+COPY providers/app-studio/ ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/app-studio-provider .
 
@@ -32,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    /etc/faros/schemas (FAROS_SCHEMAS_DIR).
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/app-studio-provider /app-studio-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/app-studio/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8081
 ENV PORT=8081
 USER nonroot:nonroot

--- a/providers/app-studio/api/assistant_busy.go
+++ b/providers/app-studio/api/assistant_busy.go
@@ -11,14 +11,21 @@ You may obtain a copy of the License at
 package api
 
 import (
+	"context"
+	"time"
+
+	"k8s.io/klog/v2"
+
 	"github.com/faroshq/provider-app-studio/store"
 	"github.com/faroshq/provider-app-studio/workspace"
 )
 
 // AssistantBusy reports whether an assistant turn or a reserved external
-// operation currently owns the project's workspace. The Project reconciler's
-// commit convergence gates on this: committing mid-turn would capture a
-// half-written app.
+// operation currently owns the project's workspace — on ANY replica, not just
+// this one. The Project reconciler's commit convergence gates on this:
+// committing mid-turn would capture a half-written app. The local maps answer
+// for this replica's activity; the durable activity claim answers for the
+// fleet, and an unreadable store fails busy (never commit on uncertainty).
 func (s *Server) AssistantBusy(scope workspace.Scope) bool {
 	if s == nil {
 		return false
@@ -29,16 +36,28 @@ func (s *Server) AssistantBusy(scope workspace.Scope) bool {
 		ProjectName:   scope.ProjectName,
 		ProjectUID:    scope.ProjectUID,
 	}
-	if s.assistantRunManager != nil && s.assistantRunManager.busy(key) {
-		return true
-	}
-	if s.assistantSupervisor != nil && s.assistantSupervisor.reserved(store.Scope{
+	storeScope := store.Scope{
 		OrgUUID:       scope.OrgUUID,
 		WorkspaceUUID: scope.WorkspaceUUID,
 		ProjectName:   scope.ProjectName,
 		ProjectUID:    scope.ProjectUID,
-	}) {
+	}
+	if s.assistantRunManager != nil && s.assistantRunManager.busy(key) {
 		return true
 	}
-	return false
+	if s.assistantSupervisor != nil && s.assistantSupervisor.reserved(storeScope) {
+		return true
+	}
+	if s.store == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	claim, ok, err := s.store.GetReplicaClaim(ctx, store.ActivityClaimKey(storeScope))
+	if err != nil {
+		klog.Background().Error(err, "reading assistant activity claim; treating project as busy",
+			"org", scope.OrgUUID, "workspace", scope.WorkspaceUUID, "project", scope.ProjectName)
+		return true
+	}
+	return ok && claim.Live(time.Now().UTC(), assistantActivityClaimTTL)
 }

--- a/providers/app-studio/api/assistant_supervisor.go
+++ b/providers/app-studio/api/assistant_supervisor.go
@@ -278,16 +278,19 @@ func (s *projectAssistantSupervisor) renewActivityClaims() {
 		for _, scope := range scopes {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			held, err := s.store.RenewReplicaClaim(ctx, store.ActivityClaimKey(scope), replicaID)
-			cancel()
 			if err != nil {
 				klog.Background().Error(err, "renewing assistant activity claim",
 					"org", scope.OrgUUID, "workspace", scope.WorkspaceUUID, "project", scope.ProjectName)
-				continue
-			}
-			if !held {
+			} else if !held {
 				klog.Background().Info("assistant activity claim lost to another replica",
 					"org", scope.OrgUUID, "workspace", scope.WorkspaceUUID, "project", scope.ProjectName)
 			}
+			// A long turn can outlive the request-path renewals of the project
+			// PIN (the run writes the workspace without further HTTP traffic);
+			// renew it alongside so the project cannot be adopted mid-turn.
+			// Owner-checked: a pin legitimately held elsewhere is untouched.
+			_, _ = s.store.RenewReplicaClaim(ctx, projectClaimKey(scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName), replicaID)
+			cancel()
 		}
 	}
 }

--- a/providers/app-studio/api/assistant_supervisor.go
+++ b/providers/app-studio/api/assistant_supervisor.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,15 @@ import (
 
 const projectAssistantTextSnapshotInterval = 250 * time.Millisecond
 const projectAssistantSteeringQueueCapacity = 64
+
+// Activity-claim timings: the durable, fleet-wide twin of the local
+// runs/reservations maps (store.ReplicaClaimKindActivity). A claim not
+// renewed within the TTL is dead — its replica crashed — and only then may
+// the orphan reconciler interrupt the run or a peer take the project over.
+const (
+	assistantActivityClaimTTL           = 60 * time.Second
+	assistantActivityClaimRenewInterval = 15 * time.Second
+)
 
 const projectAssistantSteeringRequestMetadata = "assistantSteeringRequestID"
 const projectAssistantSteeringRunMetadata = "assistantSteeringRunID"
@@ -51,9 +61,16 @@ type projectAssistantSupervisor struct {
 	cancel       context.CancelFunc
 	lifecycleLog func(string, store.Scope, store.AssistantRun)
 
+	// replicaID identifies this process in durable activity claims;
+	// replicaAddr (podIP:internalPort, may be empty) lets peers forward to
+	// it. Set via SetReplicaIdentity before serving; the default identity is
+	// process-unique so claims from a crashed predecessor age out.
+	replicaID   string
+	replicaAddr string
+
 	mu           sync.Mutex
 	runs         map[projectAssistantRunKey]*projectAssistantSupervisedRun
-	reservations map[projectAssistantRunKey]struct{}
+	reservations map[projectAssistantRunKey]store.Scope
 }
 
 type projectAssistantSupervisedRun struct {
@@ -150,7 +167,8 @@ func newProjectAssistantSupervisor(parent context.Context, msgStore store.Store)
 	// the server-owned work "interrupted".
 	ctx, cancel := context.WithCancel(context.Background())
 	supervisor := &projectAssistantSupervisor{
-		store: msgStore, ctx: ctx, cancel: cancel, lifecycleLog: logProjectAssistantLifecycle, runs: map[projectAssistantRunKey]*projectAssistantSupervisedRun{}, reservations: map[projectAssistantRunKey]struct{}{},
+		store: msgStore, ctx: ctx, cancel: cancel, lifecycleLog: logProjectAssistantLifecycle, runs: map[projectAssistantRunKey]*projectAssistantSupervisedRun{}, reservations: map[projectAssistantRunKey]store.Scope{},
+		replicaID: defaultReplicaIdentity(),
 	}
 	go func() {
 		select {
@@ -159,7 +177,119 @@ func newProjectAssistantSupervisor(parent context.Context, msgStore store.Store)
 		case <-ctx.Done():
 		}
 	}()
+	go supervisor.renewActivityClaims()
 	return supervisor
+}
+
+// defaultReplicaIdentity is process-unique (hostname + pid) so a crashed
+// predecessor's claims age out instead of being mistaken for our own.
+func defaultReplicaIdentity() string {
+	host, err := os.Hostname()
+	if err != nil {
+		host = "replica"
+	}
+	return fmt.Sprintf("%s_%d", host, os.Getpid())
+}
+
+// SetReplicaIdentity overrides the claim identity and records the address
+// peers can forward to. Call before serving.
+func (s *projectAssistantSupervisor) SetReplicaIdentity(replicaID, replicaAddr string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if replicaID != "" {
+		s.replicaID = replicaID
+	}
+	s.replicaAddr = replicaAddr
+}
+
+// claimActivity records this replica as the owner of the project's assistant
+// activity. A fresh foreign claim means another replica is mid-run or
+// mid-operation → ErrAssistantRunConflict, same signal the local maps give.
+// Store failures also conflict: exclusivity cannot be verified, so fail
+// closed rather than risk two writers.
+func (s *projectAssistantSupervisor) claimActivity(scope store.Scope, detail string) error {
+	if s == nil || s.store == nil {
+		return errors.New("assistant supervisor store not configured")
+	}
+	s.mu.Lock()
+	replicaID, replicaAddr := s.replicaID, s.replicaAddr
+	s.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, held, err := s.store.TryClaimReplica(ctx, store.ReplicaClaim{
+		Key:          store.ActivityClaimKey(scope),
+		Kind:         store.ReplicaClaimKindActivity,
+		ScopeKey:     store.ReplicaClaimScopeKey(scope),
+		OwnerReplica: replicaID,
+		OwnerAddr:    replicaAddr,
+		Detail:       detail,
+	}, assistantActivityClaimTTL)
+	if err != nil {
+		return fmt.Errorf("assistant activity claim: %w", err)
+	}
+	if !held {
+		return store.ErrAssistantRunConflict
+	}
+	return nil
+}
+
+// releaseActivity drops the durable claim (owner-checked in the store).
+func (s *projectAssistantSupervisor) releaseActivity(scope store.Scope) {
+	if s == nil || s.store == nil {
+		return
+	}
+	s.mu.Lock()
+	replicaID := s.replicaID
+	s.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.store.ReleaseReplicaClaim(ctx, store.ActivityClaimKey(scope), replicaID); err != nil {
+		klog.Background().Error(err, "releasing assistant activity claim",
+			"org", scope.OrgUUID, "workspace", scope.WorkspaceUUID, "project", scope.ProjectName)
+	}
+}
+
+// renewActivityClaims heartbeats the durable claim for every live local run
+// and reservation until the supervisor shuts down. A lost renewal (a peer
+// took the claim over after this replica stalled past the TTL) is logged —
+// the peer's orphan reconciliation owns the durable outcome.
+func (s *projectAssistantSupervisor) renewActivityClaims() {
+	ticker := time.NewTicker(assistantActivityClaimRenewInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		s.mu.Lock()
+		replicaID := s.replicaID
+		scopes := make([]store.Scope, 0, len(s.runs)+len(s.reservations))
+		for _, active := range s.runs {
+			scopes = append(scopes, active.scope)
+		}
+		for _, scope := range s.reservations {
+			scopes = append(scopes, scope)
+		}
+		s.mu.Unlock()
+		for _, scope := range scopes {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			held, err := s.store.RenewReplicaClaim(ctx, store.ActivityClaimKey(scope), replicaID)
+			cancel()
+			if err != nil {
+				klog.Background().Error(err, "renewing assistant activity claim",
+					"org", scope.OrgUUID, "workspace", scope.WorkspaceUUID, "project", scope.ProjectName)
+				continue
+			}
+			if !held {
+				klog.Background().Info("assistant activity claim lost to another replica",
+					"org", scope.OrgUUID, "workspace", scope.WorkspaceUUID, "project", scope.ProjectName)
+			}
+		}
+	}
 }
 
 func (s *projectAssistantSupervisor) log(event string, scope store.Scope, run store.AssistantRun) {
@@ -186,20 +316,37 @@ func (s *projectAssistantSupervisor) Reserve(scope store.Scope) (func(), error) 
 		return nil, store.ErrAssistantRunConflict
 	}
 	if s.reservations == nil {
-		s.reservations = map[projectAssistantRunKey]struct{}{}
+		s.reservations = map[projectAssistantRunKey]store.Scope{}
 	}
 	if _, exists := s.reservations[key]; exists {
 		s.mu.Unlock()
 		return nil, store.ErrAssistantRunConflict
 	}
-	s.reservations[key] = struct{}{}
+	s.reservations[key] = scope
 	s.mu.Unlock()
+	// The durable twin: peers observe the reservation through the activity
+	// claim, so an external operation here and a turn on another replica
+	// cannot interleave. A fresh foreign claim (or an unverifiable store)
+	// conflicts, mirroring the local semantics.
+	if err := s.claimActivity(scope, "operation"); err != nil {
+		s.mu.Lock()
+		delete(s.reservations, key)
+		s.mu.Unlock()
+		return nil, err
+	}
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			s.mu.Lock()
 			delete(s.reservations, key)
+			// A run attached during the reservation now owns the claim
+			// (Attach re-claimed it with the run ID); releasing here would
+			// drop the live run's claim.
+			runOwnsClaim := s.runs[key] != nil
 			s.mu.Unlock()
+			if !runOwnsClaim {
+				s.releaseActivity(scope)
+			}
 		})
 	}, nil
 }
@@ -244,6 +391,17 @@ func (s *projectAssistantSupervisor) Shutdown(ctx context.Context) {
 			_ = appendProjectAssistantInterruptedBoundary(ctx, s.store, interrupted.scope, interrupted.run)
 		}
 	}
+	// Hand back any reservation claims so a peer can take the projects over
+	// immediately rather than after the claim TTL.
+	s.mu.Lock()
+	reservationScopes := make([]store.Scope, 0, len(s.reservations))
+	for _, scope := range s.reservations {
+		reservationScopes = append(reservationScopes, scope)
+	}
+	s.mu.Unlock()
+	for _, scope := range reservationScopes {
+		s.releaseActivity(scope)
+	}
 	if s.cancel != nil {
 		s.cancel()
 	}
@@ -260,8 +418,8 @@ func (s *projectAssistantSupervisor) Attach(scope store.Scope, run store.Assista
 	run.ProjectName = scope.ProjectName
 	message.ProjectName = scope.ProjectName
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if existing := s.runs[key]; existing != nil {
+		s.mu.Unlock()
 		if existing.run.ID == run.ID {
 			return &projectAssistantSnapshotAccumulator{supervisor: s, key: key, runID: run.ID}, nil
 		}
@@ -269,7 +427,7 @@ func (s *projectAssistantSupervisor) Attach(scope store.Scope, run store.Assista
 	}
 	delete(s.reservations, key)
 	_, cancel := context.WithCancelCause(s.ctx)
-	s.runs[key] = &projectAssistantSupervisedRun{
+	inserted := &projectAssistantSupervisedRun{
 		scope:            scope,
 		run:              run,
 		message:          message,
@@ -279,6 +437,18 @@ func (s *projectAssistantSupervisor) Attach(scope store.Scope, run store.Assista
 		subscribers:      map[uint64]chan projectAssistantRunSnapshot{},
 		steering:         make(chan projectAssistantSteeringInput, projectAssistantSteeringQueueCapacity),
 		steeringReceipts: map[string]store.Message{},
+	}
+	s.runs[key] = inserted
+	s.mu.Unlock()
+	// Durable ownership: record this replica as the run's owner (upgrading a
+	// reservation's claim in place — same owner). A fresh foreign claim means
+	// another replica is mid-run on this project; back the local attach out
+	// and surface the same conflict the local map would have.
+	if err := s.claimActivity(scope, run.ID); err != nil {
+		s.mu.Lock()
+		s.removeRunLocked(key, inserted)
+		s.mu.Unlock()
+		return nil, err
 	}
 	return &projectAssistantSnapshotAccumulator{supervisor: s, key: key, runID: run.ID}, nil
 }
@@ -736,6 +906,9 @@ func (s *projectAssistantSupervisor) removeRunLocked(key projectAssistantRunKey,
 		close(subscriber)
 	}
 	active.subscribers = nil
+	// Release the durable activity claim off the lock; owner-checked, so a
+	// replacement owner's claim survives a late release.
+	go s.releaseActivity(active.scope)
 }
 
 func assistantRunTerminal(status store.AssistantRunStatus) bool {

--- a/providers/app-studio/api/assistant_supervisor_http.go
+++ b/providers/app-studio/api/assistant_supervisor_http.go
@@ -1194,8 +1194,25 @@ func (s *Server) reconcileOrphanedProjectAssistantRun(ctx context.Context, scope
 	}
 	supervisor.mu.Lock()
 	active := supervisor.runs[key]
+	selfReplica := supervisor.replicaID
 	supervisor.mu.Unlock()
 	if active != nil && active.run.ID == run.ID {
+		return nil
+	}
+	// The run is not on THIS replica — but that no longer means orphaned:
+	// with multiple replicas the worker is usually elsewhere. Only a run
+	// whose durable activity claim is missing, expired (its replica died
+	// without a clean shutdown), or owned by THIS replica (Attach registers
+	// locally before claiming, so a self-owned claim without a local run is
+	// a detach leftover whose async release hasn't landed) is truly
+	// orphaned; a fresh FOREIGN claim naming this run means a worker is
+	// heartbeating it on a peer.
+	claim, ok, err := s.store.GetReplicaClaim(ctx, store.ActivityClaimKey(scope))
+	if err != nil {
+		return err
+	}
+	if ok && claim.Detail == run.ID && claim.OwnerReplica != selfReplica &&
+		claim.Live(time.Now().UTC(), assistantActivityClaimTTL) {
 		return nil
 	}
 	run.Status = store.AssistantRunStatusInterrupted

--- a/providers/app-studio/api/development_sync.go
+++ b/providers/app-studio/api/development_sync.go
@@ -267,6 +267,11 @@ func (s *Server) syncProjectDevelopmentTarget(ctx context.Context, c *asclient.C
 	if err != nil {
 		return nil, err
 	}
+	// Mirror the monotonic source-revision fence onto the durable project
+	// claim so it survives the project moving between replicas — the sandbox
+	// rejects stale revisions, and a fence restarting at 1 on a new owner
+	// would break that check (Phase C seeds it back on hydration).
+	s.recordProjectClaimRevision(id, p.Name, snapshot.SourceRevision)
 	files := snapshot.Files
 	// Validate the instance exists in the workspace first (clear 404 vs proxy err).
 	if err := s.validateDevelopmentInstance(ctx, c, target); err != nil {

--- a/providers/app-studio/api/replica_affinity.go
+++ b/providers/app-studio/api/replica_affinity.go
@@ -1,0 +1,271 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// Project affinity: the workspace file tree is pod-local, so every
+// workspace-touching request for a project must execute on the ONE replica
+// that owns it (docs/app-studio-replica-awareness.md). Ownership is a durable
+// project claim carrying the owner's pod address; the middleware here claims
+// unowned projects lazily, serves owned ones, and forwards the rest to the
+// owner over the internal listener — one intra-cluster hop, invisible to the
+// hub and the browser. Store/CR-backed reads (SSE streams, listings) are
+// served by any replica without touching claims.
+//
+// Single-replica deployments run this unchanged: every claim resolves to the
+// local replica and forwarding never triggers.
+
+import (
+	"context"
+	"crypto/subtle"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/faroshq/provider-app-studio/store"
+)
+
+const (
+	// replicaForwardedHeader marks a request already forwarded by a peer —
+	// the loop guard. Only the internal listener may set it; the public
+	// listener strips it.
+	replicaForwardedHeader = "X-Faros-AppStudio-Forwarded"
+	// replicaInternalTokenHeader authenticates peer-forwarded requests on the
+	// internal listener. Deliberately not Authorization: that header carries
+	// the caller's bearer and is forwarded untouched.
+	replicaInternalTokenHeader = "X-Faros-AppStudio-Internal-Token"
+
+	// projectClaimTTL is how stale a project pin may go before any replica
+	// may take the project over (workspace re-hydration is Phase C; until
+	// then a takeover simply moves future requests). Idle projects unpin on
+	// this cadence so the fleet rebalances.
+	projectClaimTTL = 10 * time.Minute
+	// projectClaimRefreshInterval bounds claim writes: a locally-owned
+	// project renews its claim at most this often on the request path.
+	projectClaimRefreshInterval = 10 * time.Second
+)
+
+// projectClaimKey pins by org/workspace/project NAME — the identity the
+// request path carries; the UID-carrying scopes join in the handlers.
+func projectClaimKey(orgUUID, workspaceUUID, projectName string) string {
+	return store.ReplicaClaimKindProject + "/" + orgUUID + "/" + workspaceUUID + "/" + projectName
+}
+
+type replicaRouting struct {
+	id    string
+	addr  string
+	token string
+
+	mu       sync.Mutex
+	owned    map[string]time.Time // claim key → last successful claim/renew
+	misroute map[string]time.Time // claim key → last "owner has no addr" log
+}
+
+// SetReplicaRouting wires the replica identity for project affinity and run
+// claims. addr is this replica's internal-listener address (podIP:port, empty
+// disables forwarding); token authenticates peer-forwarded requests. Call
+// before serving.
+func (s *Server) SetReplicaRouting(replicaID, addr, token string) {
+	if s == nil {
+		return
+	}
+	s.replicaRouting = &replicaRouting{id: replicaID, addr: addr, token: token, owned: map[string]time.Time{}, misroute: map[string]time.Time{}}
+	if s.assistantSupervisor != nil {
+		s.assistantSupervisor.SetReplicaIdentity(replicaID, addr)
+	}
+}
+
+// StripReplicaHeaders removes the spoofable affinity headers from PUBLIC
+// traffic — the loop guard and internal token are only meaningful on the
+// internal listener, which re-injects them after authenticating the peer.
+func (s *Server) StripReplicaHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Del(replicaForwardedHeader)
+		r.Header.Del(replicaInternalTokenHeader)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// InternalReplicaHandler is the internal listener's wrapper: authenticate the
+// peer, then mark the request forwarded so affinity serves it locally.
+func (s *Server) InternalReplicaHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routing := s.routing()
+		if routing == nil || routing.token == "" ||
+			subtle.ConstantTimeCompare([]byte(r.Header.Get(replicaInternalTokenHeader)), []byte(routing.token)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		r.Header.Set(replicaForwardedHeader, "1")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) routing() *replicaRouting {
+	if s == nil {
+		return nil
+	}
+	return s.replicaRouting
+}
+
+// ReplicaAffinity routes project-scoped requests to the project's owning
+// replica. Wrap the full handler with it on every listener; requests outside
+// /api/projects/{project}, store-backed reads, and forwarded requests pass
+// straight through.
+func (s *Server) ReplicaAffinity(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routing := s.routing()
+		if routing == nil || r.Header.Get(replicaForwardedHeader) != "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		project, rest, scoped := splitProjectPath(r.URL.Path)
+		if !scoped || localSafeProjectRead(r.Method, rest) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		id, ok := identityFromRequest(w, r)
+		if !ok {
+			return
+		}
+		key := projectClaimKey(id.orgUUID, id.workspaceUUID, project)
+
+		// Fast path: recently confirmed local ownership.
+		routing.mu.Lock()
+		last, owned := routing.owned[key]
+		routing.mu.Unlock()
+		if owned && time.Since(last) < projectClaimRefreshInterval {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		claim, held, err := s.store.TryClaimReplica(ctx, store.ReplicaClaim{
+			Key:          key,
+			Kind:         store.ReplicaClaimKindProject,
+			ScopeKey:     key,
+			OwnerReplica: routing.id,
+			OwnerAddr:    routing.addr,
+		}, projectClaimTTL)
+		cancel()
+		if err != nil {
+			klog.Background().Error(err, "project affinity claim failed", "project", project)
+			http.Error(w, "project ownership unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if held {
+			routing.mu.Lock()
+			routing.owned[key] = time.Now()
+			routing.mu.Unlock()
+			next.ServeHTTP(w, r)
+			return
+		}
+		routing.mu.Lock()
+		delete(routing.owned, key)
+		routing.mu.Unlock()
+		if claim.OwnerAddr == "" || claim.OwnerAddr == routing.addr {
+			// An owner without a forwardable address (routing disabled on it,
+			// or a stale self entry): serve locally rather than fail — the
+			// workspace divergence risk only exists once multi-replica routing
+			// is fully configured, in which case every owner has an address.
+			routing.mu.Lock()
+			if time.Since(routing.misroute[key]) > time.Minute {
+				routing.misroute[key] = time.Now()
+				klog.Background().Info("project owner has no forwardable address; serving locally",
+					"project", project, "owner", claim.OwnerReplica)
+			}
+			routing.mu.Unlock()
+			next.ServeHTTP(w, r)
+			return
+		}
+		s.forwardToOwner(w, r, routing, claim.OwnerAddr)
+	})
+}
+
+// forwardToOwner proxies the request — path, query, caller Authorization and
+// identity headers untouched — to the owning replica's internal listener.
+func (s *Server) forwardToOwner(w http.ResponseWriter, r *http.Request, routing *replicaRouting, addr string) {
+	target := &url.URL{Scheme: "http", Host: addr}
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(target)
+			pr.Out.URL.Path = r.URL.Path
+			pr.Out.URL.RawQuery = r.URL.RawQuery
+			pr.Out.Header.Set(replicaInternalTokenHeader, routing.token)
+		},
+		// SSE and long polls must stream through unbuffered.
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			klog.Background().Error(err, "forwarding to project owner failed", "owner", addr, "path", r.URL.Path)
+			http.Error(w, "project owner unreachable", http.StatusBadGateway)
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// splitProjectPath extracts the {project} segment and the remainder from
+// /api/projects/{project}[/rest]. Literal collection endpoints that happen to
+// sit under /api/projects/ are not project-scoped.
+func splitProjectPath(path string) (project, rest string, ok bool) {
+	const prefix = "/api/projects/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", "", false
+	}
+	tail := strings.TrimPrefix(path, prefix)
+	project, rest, _ = strings.Cut(tail, "/")
+	if rest != "" {
+		rest = "/" + rest
+	}
+	switch project {
+	case "", "stream", "create-readiness", "plan", "development-templates", "import-repositories", "llm-settings":
+		return "", "", false
+	}
+	return project, rest, true
+}
+
+// localSafeProjectRead reports whether a project-scoped request is safe on
+// any replica: read-only AND backed by the store/CRs/data-plane rather than
+// the pod-local workspace. Workspace-reading GETs (files, skills) must go to
+// the owner; everything mutating always does. Defaulting unknown routes to
+// "forward" keeps a forgotten route correct at the cost of one hop.
+func localSafeProjectRead(method, rest string) bool {
+	if method != http.MethodGet && method != http.MethodHead {
+		return false
+	}
+	if strings.HasPrefix(rest, "/files") || strings.HasPrefix(rest, "/assistant/skills") {
+		return false
+	}
+	return true
+}
+
+// recordProjectClaimRevision raises the durable revision floor on the
+// project's claim, so the workspace source-revision fence survives the
+// project moving between replicas (seeded back on hydration — Phase C).
+func (s *Server) recordProjectClaimRevision(id identity, projectName string, revision uint64) {
+	routing := s.routing()
+	if routing == nil || s.store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	key := projectClaimKey(id.orgUUID, id.workspaceUUID, projectName)
+	if err := s.store.BumpReplicaClaimRevision(ctx, key, routing.id, int64(revision)); err != nil {
+		klog.Background().Error(err, "recording project claim revision", "project", projectName)
+	}
+}

--- a/providers/app-studio/api/replica_affinity.go
+++ b/providers/app-studio/api/replica_affinity.go
@@ -29,6 +29,7 @@ package api
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -36,9 +37,11 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/faroshq/provider-app-studio/store"
+	"github.com/faroshq/provider-app-studio/workspace"
 )
 
 const (
@@ -155,7 +158,18 @@ func (s *Server) ReplicaAffinity(next http.Handler) http.Handler {
 			return
 		}
 
+		// The prior claim decides whether an acquisition is an ADOPTION (the
+		// project last lived on another replica — or nowhere — and this
+		// replica's workspace tree must be rebuilt from git) or a plain
+		// renewal.
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		prev, prevOK, err := s.store.GetReplicaClaim(ctx, key)
+		if err != nil {
+			cancel()
+			klog.Background().Error(err, "project affinity claim read failed", "project", project)
+			http.Error(w, "project ownership unavailable", http.StatusServiceUnavailable)
+			return
+		}
 		claim, held, err := s.store.TryClaimReplica(ctx, store.ReplicaClaim{
 			Key:          key,
 			Kind:         store.ReplicaClaimKindProject,
@@ -173,6 +187,9 @@ func (s *Server) ReplicaAffinity(next http.Handler) http.Handler {
 			routing.mu.Lock()
 			routing.owned[key] = time.Now()
 			routing.mu.Unlock()
+			if !prevOK || prev.OwnerReplica != routing.id {
+				s.adoptProject(r, id, project, prev, prevOK, claim)
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -252,6 +269,83 @@ func localSafeProjectRead(method, rest string) bool {
 		return false
 	}
 	return true
+}
+
+// adoptProject prepares this replica's workspace after it takes over a
+// project (Phase C of docs/app-studio-replica-awareness.md): seed the
+// source-revision fence from the claim's durable floor, then rebuild the tree
+// from git unless the previous owner was THIS pod (same forwarding address —
+// a process restart on a persistent volume, where the local tree is newer
+// than the last commit). Hydration failures are logged and the request served
+// anyway: a project without a repository has nothing to hydrate, and failing
+// closed would brick every project whenever the code provider is down.
+func (s *Server) adoptProject(r *http.Request, id identity, projectName string, prev store.ReplicaClaim, prevOK bool, claim store.ReplicaClaim) {
+	routing := s.routing()
+	if routing == nil || s.workspaces == nil {
+		return
+	}
+	ctx := r.Context()
+	logger := klog.Background().WithValues("project", projectName, "previousOwner", prev.OwnerReplica)
+	c, err := s.clientFor(id)
+	if err != nil {
+		logger.Error(err, "project adoption: building tenant client; serving with the local tree as-is")
+		return
+	}
+	p, err := c.Projects().Get(ctx, projectName, metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "project adoption: reading Project; serving with the local tree as-is")
+		return
+	}
+	scope := projectWorkspaceScope(id, p)
+	if claim.Revision > 0 {
+		if err := s.workspaces.EnsureSourceRevisionFloor(ctx, scope, uint64(claim.Revision)); err != nil {
+			logger.Error(err, "project adoption: seeding source-revision floor")
+		}
+	}
+	if prevOK && prev.OwnerAddr != "" && prev.OwnerAddr == routing.addr {
+		// Same pod, new process: the local volume outlived the restart and may
+		// hold uncommitted work newer than the last commit — keep it.
+		return
+	}
+	hydrated, err := s.hydrateWorkspaceFromRepository(ctx, id, p, r, "")
+	if err != nil {
+		var validationErr *ValidationError
+		if errors.As(err, &validationErr) {
+			// No repository yet (fresh project) — nothing to rebuild.
+			logger.V(4).Info("project adoption: nothing to hydrate", "reason", err.Error())
+			return
+		}
+		logger.Error(err, "project adoption: hydrating workspace from git failed; the local tree may be stale until a manual hydrate")
+		return
+	}
+	logger.Info("project adopted: workspace rebuilt from git",
+		"commit", hydrated.CommitSHA, "files", len(hydrated.Written), "revisionFloor", claim.Revision)
+}
+
+// OwnsProject reports whether the project's workspace commit convergence may
+// run on this replica: yes when it holds the live project claim, or when no
+// live claim exists (a crashed owner's leftover dirty tree must still
+// converge — replicas without local files no-op naturally). An unreadable
+// store refuses: never commit on uncertainty.
+func (s *Server) OwnsProject(scope workspace.Scope) bool {
+	routing := s.routing()
+	if routing == nil {
+		return true
+	}
+	if s.store == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	claim, ok, err := s.store.GetReplicaClaim(ctx, projectClaimKey(scope.OrgUUID, scope.WorkspaceUUID, scope.ProjectName))
+	if err != nil {
+		klog.Background().Error(err, "reading project claim; refusing commit convergence", "project", scope.ProjectName)
+		return false
+	}
+	if !ok || !claim.Live(time.Now().UTC(), projectClaimTTL) {
+		return true
+	}
+	return claim.OwnerReplica == routing.id
 }
 
 // recordProjectClaimRevision raises the durable revision floor on the

--- a/providers/app-studio/api/replica_affinity_test.go
+++ b/providers/app-studio/api/replica_affinity_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/faroshq/provider-app-studio/store"
+	"github.com/faroshq/provider-app-studio/workspace"
+)
+
+func affinityTestServer(t *testing.T, replicaID, addr string) (*Server, store.Store) {
+	t.Helper()
+	msgStore := store.NewMemoryStore()
+	s := &Server{store: msgStore}
+	s.SetReplicaRouting(replicaID, addr, "internal-token")
+	return s, msgStore
+}
+
+func projectRequest(path string, method string) *http.Request {
+	r := httptest.NewRequest(method, path, nil)
+	r.Header.Set("X-Faros-Tenant", "root:faros:tenants:org-1:ws-1")
+	return r
+}
+
+func TestReplicaAffinityClaimsUnownedProjectsAndServesLocally(t *testing.T) {
+	s, msgStore := affinityTestServer(t, "replica-a", "10.0.0.1:8091")
+	served := 0
+	h := s.ReplicaAffinity(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, projectRequest("/api/projects/shop/hydrate-workspace", http.MethodPost))
+	if served != 1 || rec.Code != http.StatusNoContent {
+		t.Fatalf("unowned project not served locally: served=%d code=%d", served, rec.Code)
+	}
+	claim, ok, err := msgStore.GetReplicaClaim(context.Background(), projectClaimKey("org-1", "ws-1", "shop"))
+	if err != nil || !ok || claim.OwnerReplica != "replica-a" || claim.OwnerAddr != "10.0.0.1:8091" {
+		t.Fatalf("claim after local serve = %+v/%v/%v, want owned by replica-a", claim, ok, err)
+	}
+}
+
+func TestReplicaAffinityForwardsForeignProjects(t *testing.T) {
+	// The "owner" replica: an internal listener requiring the shared token.
+	ownerHits := 0
+	owner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(replicaInternalTokenHeader) != "internal-token" {
+			t.Errorf("forwarded request missing internal token")
+		}
+		if r.URL.Path != "/api/projects/shop/sync-development" {
+			t.Errorf("forwarded path = %q", r.URL.Path)
+		}
+		ownerHits++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer owner.Close()
+	ownerAddr := strings.TrimPrefix(owner.URL, "http://")
+
+	s, msgStore := affinityTestServer(t, "replica-b", "10.0.0.2:8091")
+	// Seed a fresh claim held by the owner replica.
+	if _, held, err := msgStore.TryClaimReplica(context.Background(), store.ReplicaClaim{
+		Key:          projectClaimKey("org-1", "ws-1", "shop"),
+		Kind:         store.ReplicaClaimKindProject,
+		ScopeKey:     projectClaimKey("org-1", "ws-1", "shop"),
+		OwnerReplica: "replica-a",
+		OwnerAddr:    ownerAddr,
+	}, projectClaimTTL); err != nil || !held {
+		t.Fatalf("seeding owner claim: %v/%v", held, err)
+	}
+
+	local := 0
+	h := s.ReplicaAffinity(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { local++ }))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, projectRequest("/api/projects/shop/sync-development", http.MethodPost))
+	if local != 0 || ownerHits != 1 || rec.Code != http.StatusAccepted {
+		t.Fatalf("foreign project not forwarded: local=%d owner=%d code=%d", local, ownerHits, rec.Code)
+	}
+}
+
+func TestReplicaAffinityServesStoreBackedReadsAnywhere(t *testing.T) {
+	s, msgStore := affinityTestServer(t, "replica-b", "10.0.0.2:8091")
+	// Fresh foreign claim exists, but store-backed reads never consult it.
+	if _, held, err := msgStore.TryClaimReplica(context.Background(), store.ReplicaClaim{
+		Key:          projectClaimKey("org-1", "ws-1", "shop"),
+		Kind:         store.ReplicaClaimKindProject,
+		ScopeKey:     projectClaimKey("org-1", "ws-1", "shop"),
+		OwnerReplica: "replica-a",
+		OwnerAddr:    "10.255.255.1:1", // unreachable — a forward would fail loudly
+	}, projectClaimTTL); err != nil || !held {
+		t.Fatalf("seeding owner claim: %v/%v", held, err)
+	}
+	served := 0
+	h := s.ReplicaAffinity(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { served++ }))
+
+	for _, path := range []string{
+		"/api/projects/shop/assistant/threads/th-1/events", // SSE stream
+		"/api/projects/shop/assistant/threads",
+		"/api/projects/shop",
+	} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, projectRequest(path, http.MethodGet))
+		if rec.Code == http.StatusBadGateway {
+			t.Fatalf("store-backed read %s was forwarded", path)
+		}
+	}
+	if served != 3 {
+		t.Fatalf("store-backed reads served locally = %d, want 3", served)
+	}
+
+	// Workspace-reading GETs are NOT local-safe.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, projectRequest("/api/projects/shop/files", http.MethodGet))
+	if served != 3 {
+		t.Fatal("workspace-reading GET bypassed affinity")
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("workspace GET for a foreign project = %d, want forwarded (and here, 502 to the unreachable owner)", rec.Code)
+	}
+}
+
+func TestReplicaAffinityLoopGuardAndCollectionRoutes(t *testing.T) {
+	s, _ := affinityTestServer(t, "replica-b", "10.0.0.2:8091")
+	served := 0
+	h := s.ReplicaAffinity(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { served++ }))
+
+	// A forwarded request must serve locally regardless of claims.
+	r := projectRequest("/api/projects/shop/sync-development", http.MethodPost)
+	r.Header.Set(replicaForwardedHeader, "1")
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	// Collection endpoints under /api/projects/ are not project-scoped.
+	for _, path := range []string{"/api/projects", "/api/projects/plan", "/api/projects/llm-settings"} {
+		h.ServeHTTP(httptest.NewRecorder(), projectRequest(path, http.MethodPost))
+	}
+	if served != 4 {
+		t.Fatalf("loop-guard/collection dispatch served = %d, want 4 local", served)
+	}
+}
+
+func TestInternalReplicaHandlerRequiresToken(t *testing.T) {
+	s, _ := affinityTestServer(t, "replica-a", "10.0.0.1:8091")
+	inner := 0
+	h := s.InternalReplicaHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(replicaForwardedHeader) == "" {
+			t.Error("internal handler did not mark the request forwarded")
+		}
+		inner++
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/projects/shop/sync-development", nil))
+	if rec.Code != http.StatusUnauthorized || inner != 0 {
+		t.Fatalf("tokenless internal request = %d/%d, want 401", rec.Code, inner)
+	}
+	r := httptest.NewRequest(http.MethodPost, "/api/projects/shop/sync-development", nil)
+	r.Header.Set(replicaInternalTokenHeader, "internal-token")
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	if inner != 1 {
+		t.Fatal("authenticated internal request rejected")
+	}
+}
+
+func TestAssistantBusySeesForeignActivityClaims(t *testing.T) {
+	s, msgStore := affinityTestServer(t, "replica-b", "")
+	scope := store.Scope{OrgUUID: "org-1", WorkspaceUUID: "ws-1", ProjectName: "shop", ProjectUID: "uid-1"}
+	if _, held, err := msgStore.TryClaimReplica(context.Background(), store.ReplicaClaim{
+		Key:          store.ActivityClaimKey(scope),
+		Kind:         store.ReplicaClaimKindActivity,
+		ScopeKey:     store.ReplicaClaimScopeKey(scope),
+		OwnerReplica: "replica-a",
+		Detail:       "run-1",
+	}, assistantActivityClaimTTL); err != nil || !held {
+		t.Fatalf("seeding activity claim: %v/%v", held, err)
+	}
+	wsScope := workspace.Scope{OrgUUID: scope.OrgUUID, WorkspaceUUID: scope.WorkspaceUUID, ProjectName: scope.ProjectName, ProjectUID: scope.ProjectUID}
+	if !s.AssistantBusy(wsScope) {
+		t.Fatal("AssistantBusy ignored a fresh foreign activity claim")
+	}
+	// Released claim → not busy.
+	if err := msgStore.ReleaseReplicaClaim(context.Background(), store.ActivityClaimKey(scope), "replica-a"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if s.AssistantBusy(wsScope) {
+		t.Fatal("AssistantBusy stuck after the claim was released")
+	}
+}

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -76,6 +76,10 @@ type Server struct {
 	projectClientFor             func(identity) (*asclient.Client, error)
 	assistantRunManager          *projectAssistantRunManager
 	assistantSupervisor          *projectAssistantSupervisor
+	// replicaRouting carries this replica's identity/address/token for
+	// project affinity and durable run claims (replica_affinity.go). Nil
+	// until SetReplicaRouting; affinity is a no-op without it.
+	replicaRouting *replicaRouting
 	assistantProjectionLocks     map[string]*assistantThreadProjectionLockEntry
 	assistantThreadMirrors       map[string]struct{}
 	developmentSyncLocks         map[string]*sync.Mutex

--- a/providers/app-studio/controller/project/commit.go
+++ b/providers/app-studio/controller/project/commit.go
@@ -99,6 +99,12 @@ func (r *Reconciler) commitWorkspace(ctx context.Context, c client.Client, p *ai
 	if !repositoryReady(repo) {
 		return true, nil // repository still provisioning; poll
 	}
+	if r.Owns != nil && !r.Owns(scope) {
+		// Another replica owns this project's workspace; whatever this
+		// replica's tree holds is a leftover from a previous ownership term
+		// and must not be committed over the live owner's work.
+		return false, nil
+	}
 	if r.Busy != nil && r.Busy(scope) {
 		return true, nil // an assistant turn owns the workspace; poll
 	}

--- a/providers/app-studio/controller/project/controller.go
+++ b/providers/app-studio/controller/project/controller.go
@@ -93,6 +93,12 @@ type Reconciler struct {
 	// Busy reports whether an assistant turn currently owns the project's
 	// workspace — commits wait for idle.
 	Busy func(workspace.Scope) bool
+	// Owns reports whether THIS replica owns the project's workspace (the
+	// durable project claim). Every replica runs this reconciler; only the
+	// owner's local tree is authoritative, and a stale tree left behind on a
+	// previous owner must never be committed over the live one. Nil means
+	// single-replica: always owner.
+	Owns func(workspace.Scope) bool
 	// HubBase / HubInsecure address the hub for MCP commit calls.
 	HubBase     string
 	HubInsecure bool

--- a/providers/app-studio/controller_manager.go
+++ b/providers/app-studio/controller_manager.go
@@ -203,6 +203,7 @@ type controllerDeps struct {
 	Actions     bindings.ActionsRuntimeConfig
 	Workspace   *workspace.FileStore
 	Busy        func(workspace.Scope) bool
+	Owns        func(workspace.Scope) bool
 	Store       store.Store
 	HubBase     string
 	HubInsecure bool
@@ -251,6 +252,7 @@ func startControllerManager(ctx context.Context, config *rest.Config, deps contr
 		Actions:     deps.Actions,
 		Workspace:   deps.Workspace,
 		Busy:        deps.Busy,
+		Owns:        deps.Owns,
 		HubBase:     deps.HubBase,
 		HubInsecure: deps.HubInsecure,
 	}).SetupWithManager(mgr); err != nil {

--- a/providers/app-studio/controller_manager.go
+++ b/providers/app-studio/controller_manager.go
@@ -212,7 +212,15 @@ type controllerDeps struct {
 // reconciler, and blocks until the manager exits. A nil config means "skip the
 // manager, run REST-only". Keeping Start synchronous is important: callers can
 // observe both setup errors and post-start exits and re-enter the bounded retry
-// loop instead of hiding the manager in a detached goroutine. When a health
+// loop instead of hiding the manager in a detached goroutine.
+//
+// Deliberately NOT leader-elected (unlike code/vibe-studio/infrastructure):
+// the Project reconciler converges commits from the pod-local workspace
+// FileStore the HTTP assistant writes to, and pod readiness requires the
+// manager to be running (controllerReadyRunnable below) — a lease would both
+// strand sessions whose files live on a non-leader and wedge rollouts on a
+// never-ready standby. The provider is single-replica by design (chart pins
+// replicaCount: 1); scaling it needs shared workspace storage first. When a health
 // dependency is supplied, a controller-runtime RunnableFunc is registered
 // before Start. That runnable marks health ready only when the manager starts
 // launching runnables and then blocks for manager cancellation; any error

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -84,6 +84,11 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
+            # Peer-forwarded project requests (replica affinity). Reached by
+            # pod IP from peer replicas; deliberately NOT on the Service.
+            - name: internal
+              containerPort: {{ .Values.internalPort }}
+              protocol: TCP
           livenessProbe:
             httpGet: { path: /healthz, port: http }
             initialDelaySeconds: 5
@@ -94,6 +99,18 @@ spec:
           env:
             - name: PORT
               value: "8081"
+            # Replica identity + forwarding address for durable run claims and
+            # project affinity (docs/app-studio-replica-awareness.md).
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: APP_STUDIO_INTERNAL_PORT
+              value: {{ .Values.internalPort | quote }}
             - name: FAROS_HUB_URL
               value: {{ .Values.hub.url | quote }}
             {{- if .Values.hub.actionsExternalURL }}

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $catalogEntryConfigMap := and .Values.catalogEntry.enabled .Values.catalogEntry.renderAsConfigMap -}}
 {{- $actionsCABundleConfigMap := .Values.hub.actionsCABundleConfigMap.name -}}
-{{- if ne (int .Values.replicaCount) 1 -}}
-{{- fail "app-studio replicaCount must be 1 because assistant project mutations require a single active writer" -}}
+{{- if and (ne (int .Values.replicaCount) 1) (not .Values.workspace.emptyDir) (not .Values.workspace.existingClaim) -}}
+{{- fail "app-studio replicaCount > 1 requires workspace.emptyDir=true: a single ReadWriteOnce PVC cannot back multiple replicas (workspaces are rebuilt from git on adoption)" -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -11,8 +11,20 @@ metadata:
     {{- include "appstudio.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  # Replica awareness (durable run claims + project affinity with git
+  # re-hydration on adoption) lets replicas coexist; rolling updates keep
+  # capacity and only move the replaced pod's projects.
   strategy:
+    {{- if .Values.workspace.emptyDir }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    {{- else }}
+    # A single RWO workspace volume can only be mounted by one pod: replace,
+    # never overlap.
     type: Recreate
+    {{- end }}
   selector:
     matchLabels:
       {{- include "appstudio.selectorLabels" . | nindent 6 }}

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -4,7 +4,14 @@ fullnameOverride: ""
 # App Studio assistant project mutations use a single active writer. The chart
 # rejects other values and uses a Recreate deployment strategy to prevent
 # cross-pod overlap during upgrades.
+# Phase A+B of docs/app-studio-replica-awareness.md are in place (durable run
+# claims, project affinity + peer forwarding); replicaCount stays pinned to 1
+# until Phase C lands claim-driven workspace re-hydration.
 replicaCount: 1
+
+# internalPort carries peer-forwarded project requests between replicas.
+# Deliberately not part of the Service.
+internalPort: 8091
 
 image:
   repository: ghcr.io/faroshq/faros/app-studio-provider

--- a/providers/app-studio/deploy/chart/values.yaml
+++ b/providers/app-studio/deploy/chart/values.yaml
@@ -4,9 +4,13 @@ fullnameOverride: ""
 # App Studio assistant project mutations use a single active writer. The chart
 # rejects other values and uses a Recreate deployment strategy to prevent
 # cross-pod overlap during upgrades.
-# Phase A+B of docs/app-studio-replica-awareness.md are in place (durable run
-# claims, project affinity + peer forwarding); replicaCount stays pinned to 1
-# until Phase C lands claim-driven workspace re-hydration.
+# Safe to scale with the default emptyDir workspace: runs and external
+# operations are guarded by durable claims, projects pin to one replica with
+# peer forwarding, and an adopting replica rebuilds the workspace from git
+# (docs/app-studio-replica-awareness.md). A replica crash loses only that
+# replica's uncommitted workspace edits — the durable truth is git.
+# With a PVC-backed workspace (workspace.emptyDir=false) the template refuses
+# replicaCount > 1: one ReadWriteOnce volume cannot back multiple replicas.
 replicaCount: 1
 
 # internalPort carries peer-forwarded project requests between replicas.
@@ -110,10 +114,17 @@ store:
 
 # App Studio project workspaces. The provider stores checked-out/generated
 # project files here so the agent can list, read, search, and later mutate them.
+#
+# The workspace is a CACHE of git plus in-flight edits: a replica that adopts
+# a project rebuilds the tree from the last commit, so the default is an
+# ephemeral emptyDir — pods are cattle and replicas can scale. Committed work
+# is always safe in git; a pod crash loses only edits since the last commit.
+# Set emptyDir=false (PVC) to keep the old durable-volume behavior, at the
+# cost of being pinned to one replica and Recreate rollouts.
 workspace:
   path: /var/lib/faros-app-studio/workspaces
   existingClaim: ""
-  emptyDir: false
+  emptyDir: true
   persistence:
     enabled: true
     size: 1Gi

--- a/providers/app-studio/go.mod
+++ b/providers/app-studio/go.mod
@@ -143,3 +143,8 @@ replace (
 )
 
 replace github.com/kcp-dev/apimachinery/v2 => github.com/kcp-dev/apimachinery/v2 v2.32.0
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/app-studio/go.sum
+++ b/providers/app-studio/go.sum
@@ -71,8 +71,6 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=

--- a/providers/app-studio/main.go
+++ b/providers/app-studio/main.go
@@ -48,6 +48,21 @@ import (
 	"github.com/faroshq/provider-app-studio/workspace"
 )
 
+// replicaIdentityFromEnv is the durable-claim identity: the pod name (chart
+// downward API) plus the pid, so a container restart inside the same pod gets
+// a fresh identity and its predecessor's claims age out.
+func replicaIdentityFromEnv() string {
+	host := os.Getenv("POD_NAME")
+	if host == "" {
+		if h, err := os.Hostname(); err == nil {
+			host = h
+		} else {
+			host = "replica"
+		}
+	}
+	return fmt.Sprintf("%s_%d", host, os.Getpid())
+}
+
 func envOr(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -193,9 +208,34 @@ func runServe() {
 		log.Fatalf("portal embed: %v", err)
 	}
 
+	// Replica awareness (docs/app-studio-replica-awareness.md): durable run
+	// claims + project affinity. The routing identity is always set (claims
+	// work single-replica and fix restart semantics); the forwarding address
+	// and the internal listener need POD_IP + a provider bearer and degrade
+	// to local-only serving without them.
+	replicaID := replicaIdentityFromEnv()
+	internalPort := envOr("APP_STUDIO_INTERNAL_PORT", "8091")
+	replicaAddr := ""
+	if podIP := os.Getenv("POD_IP"); podIP != "" {
+		replicaAddr = podIP + ":" + internalPort
+	}
+	internalToken := ""
+	if cfg, cfgErr := loadProviderConfig(); cfgErr == nil && cfg != nil {
+		internalToken = cfg.BearerToken
+	}
+	if replicaAddr != "" && internalToken == "" {
+		log.Printf("replica forwarding disabled (provider credential has no bearer token); serving project requests locally")
+		replicaAddr = ""
+	}
+	apiServer.SetReplicaRouting(replicaID, replicaAddr, internalToken)
+
+	// Project affinity wraps the full handler; the public listener strips the
+	// spoofable routing headers, the internal listener authenticates peers
+	// and marks their requests forwarded (the loop guard).
+	core := apiServer.ReplicaAffinity(handler)
 	srv := &http.Server{
 		Addr:              ":" + port,
-		Handler:           logMiddleware(handler),
+		Handler:           logMiddleware(apiServer.StripReplicaHeaders(core)),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -205,6 +245,26 @@ func runServe() {
 			log.Fatalf("server: %v", err)
 		}
 	}()
+
+	if replicaAddr != "" {
+		internalSrv := &http.Server{
+			Addr:              ":" + internalPort,
+			Handler:           logMiddleware(apiServer.InternalReplicaHandler(core)),
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			log.Printf("app-studio internal listener (peer-forwarded project requests) on :%s replica=%s", internalPort, replicaID)
+			if err := internalSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Printf("internal listener failed; peers cannot forward to this replica: %v", err)
+			}
+		}()
+		go func() {
+			<-ctx.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = internalSrv.Shutdown(shutdownCtx)
+		}()
+	}
 
 	go runHeartbeat(ctx, controllerHealth)
 

--- a/providers/app-studio/main.go
+++ b/providers/app-studio/main.go
@@ -281,6 +281,7 @@ func runServe() {
 			Actions:     apiServer.ActionsRuntimeConfig(),
 			Workspace:   workspaces,
 			Busy:        apiServer.AssistantBusy,
+			Owns:        apiServer.OwnsProject,
 			Store:       msgStore,
 			HubBase:     strings.TrimRight(os.Getenv("FAROS_HUB_URL"), "/"),
 			HubInsecure: os.Getenv("FAROS_HUB_INSECURE") == "true",

--- a/providers/app-studio/store/claims.go
+++ b/providers/app-studio/store/claims.go
@@ -1,0 +1,301 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+// Replica claims are the fleet-wide ownership map that makes App Studio
+// replica-aware (docs/app-studio-replica-awareness.md): which replica owns a
+// project's assistant activity (a run or a reserved external operation), and
+// which replica a project's workspace is pinned to. They ride the same store
+// the runs do, so ownership and run state share one durability domain.
+//
+// Semantics mirror the kuery/edges Lease claims: try-acquire takes a free or
+// stale claim and renews an owned one; a fresh foreign claim is declined;
+// releases are owner-checked so a slow cleanup cannot erase a newer claim.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Replica claim kinds.
+const (
+	// ReplicaClaimKindActivity marks a project's assistant activity — an
+	// attached run or a reserved external operation (hydrate, template
+	// switch, delete). One per project scope; Detail carries the run ID or
+	// "operation".
+	ReplicaClaimKindActivity = "activity"
+	// ReplicaClaimKindProject pins a project's workspace to a replica; the
+	// affinity middleware forwards workspace-touching requests to OwnerAddr.
+	// Revision carries the durable floor of the workspace source-revision
+	// fence so it survives the project moving between replicas.
+	ReplicaClaimKindProject = "project"
+)
+
+// ReplicaClaim is one fleet-wide ownership record.
+type ReplicaClaim struct {
+	Key          string
+	Kind         string
+	ScopeKey     string
+	OwnerReplica string
+	OwnerAddr    string
+	Detail       string
+	Revision     int64
+	HeartbeatAt  time.Time
+}
+
+// Live reports whether the claim was renewed within staleAfter of now.
+func (c ReplicaClaim) Live(now time.Time, staleAfter time.Duration) bool {
+	return !c.HeartbeatAt.IsZero() && now.Sub(c.HeartbeatAt) <= staleAfter
+}
+
+// ReplicaClaimScopeKey renders the canonical per-project scope key.
+func ReplicaClaimScopeKey(scope Scope) string {
+	return scope.OrgUUID + "/" + scope.WorkspaceUUID + "/" + scope.ProjectName + "/" + scope.ProjectUID
+}
+
+// ActivityClaimKey is the claim key for a project's assistant activity.
+func ActivityClaimKey(scope Scope) string {
+	return ReplicaClaimKindActivity + "/" + ReplicaClaimScopeKey(scope)
+}
+
+// ---- Postgres ----
+
+const replicaClaimSchemaVersion = "replica-claims-v1"
+
+func replicaClaimSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS app_studio_replica_claims (
+			claim_key text PRIMARY KEY,
+			kind text NOT NULL,
+			scope_key text NOT NULL,
+			owner_replica text NOT NULL,
+			owner_addr text NOT NULL DEFAULT '',
+			detail text NOT NULL DEFAULT '',
+			revision bigint NOT NULL DEFAULT 0,
+			heartbeat_at timestamptz NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS app_studio_replica_claims_scope
+			ON app_studio_replica_claims (scope_key, kind)`,
+	}
+}
+
+// TryClaimReplica acquires (or renews) the claim in one atomic upsert: a
+// missing claim is created, an owned or stale claim is overwritten, a fresh
+// foreign claim is left untouched. It returns the claim as currently held and
+// whether this owner holds it. Revision is preserved across takeovers.
+func (s *PostgresStore) TryClaimReplica(ctx context.Context, claim ReplicaClaim, staleAfter time.Duration) (ReplicaClaim, bool, error) {
+	now := time.Now().UTC()
+	cutoff := now.Add(-staleAfter)
+	row := s.db.QueryRowContext(ctx, `
+		INSERT INTO app_studio_replica_claims (claim_key, kind, scope_key, owner_replica, owner_addr, detail, revision, heartbeat_at)
+		VALUES ($1, $2, $3, $4, $5, $6, 0, $7)
+		ON CONFLICT (claim_key) DO UPDATE SET
+			owner_replica = EXCLUDED.owner_replica,
+			owner_addr = EXCLUDED.owner_addr,
+			detail = EXCLUDED.detail,
+			heartbeat_at = EXCLUDED.heartbeat_at
+		WHERE app_studio_replica_claims.owner_replica = EXCLUDED.owner_replica
+			OR app_studio_replica_claims.heartbeat_at < $8
+		RETURNING owner_replica, owner_addr, detail, revision, heartbeat_at`,
+		claim.Key, claim.Kind, claim.ScopeKey, claim.OwnerReplica, claim.OwnerAddr, claim.Detail, now, cutoff)
+	held := claim
+	if err := row.Scan(&held.OwnerReplica, &held.OwnerAddr, &held.Detail, &held.Revision, &held.HeartbeatAt); err == nil {
+		return held, true, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return ReplicaClaim{}, false, fmt.Errorf("claim %s: %w", claim.Key, err)
+	}
+	// Fresh foreign claim: report the current holder.
+	current, ok, err := s.GetReplicaClaim(ctx, claim.Key)
+	if err != nil {
+		return ReplicaClaim{}, false, err
+	}
+	if !ok {
+		// Deleted between the upsert and the read; the caller's next attempt
+		// will take it.
+		return ReplicaClaim{}, false, nil
+	}
+	return current, false, nil
+}
+
+// RenewReplicaClaim refreshes the heartbeat when this owner still holds the
+// claim, reporting whether it did.
+func (s *PostgresStore) RenewReplicaClaim(ctx context.Context, claimKey, ownerReplica string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE app_studio_replica_claims SET heartbeat_at = $1 WHERE claim_key = $2 AND owner_replica = $3`,
+		time.Now().UTC(), claimKey, ownerReplica)
+	if err != nil {
+		return false, fmt.Errorf("renew claim %s: %w", claimKey, err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// ReleaseReplicaClaim drops the claim if this owner still holds it.
+func (s *PostgresStore) ReleaseReplicaClaim(ctx context.Context, claimKey, ownerReplica string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM app_studio_replica_claims WHERE claim_key = $1 AND owner_replica = $2`,
+		claimKey, ownerReplica)
+	if err != nil {
+		return fmt.Errorf("release claim %s: %w", claimKey, err)
+	}
+	return nil
+}
+
+// GetReplicaClaim reads one claim; ok=false when absent.
+func (s *PostgresStore) GetReplicaClaim(ctx context.Context, claimKey string) (ReplicaClaim, bool, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT claim_key, kind, scope_key, owner_replica, owner_addr, detail, revision, heartbeat_at
+		FROM app_studio_replica_claims WHERE claim_key = $1`, claimKey)
+	var c ReplicaClaim
+	if err := row.Scan(&c.Key, &c.Kind, &c.ScopeKey, &c.OwnerReplica, &c.OwnerAddr, &c.Detail, &c.Revision, &c.HeartbeatAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ReplicaClaim{}, false, nil
+		}
+		return ReplicaClaim{}, false, fmt.Errorf("get claim %s: %w", claimKey, err)
+	}
+	return c, true, nil
+}
+
+// LiveReplicaClaims lists the claims for a scope renewed within staleAfter.
+func (s *PostgresStore) LiveReplicaClaims(ctx context.Context, scopeKey string, staleAfter time.Duration) ([]ReplicaClaim, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT claim_key, kind, scope_key, owner_replica, owner_addr, detail, revision, heartbeat_at
+		FROM app_studio_replica_claims WHERE scope_key = $1 AND heartbeat_at >= $2`,
+		scopeKey, time.Now().UTC().Add(-staleAfter))
+	if err != nil {
+		return nil, fmt.Errorf("live claims %s: %w", scopeKey, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ReplicaClaim
+	for rows.Next() {
+		var c ReplicaClaim
+		if err := rows.Scan(&c.Key, &c.Kind, &c.ScopeKey, &c.OwnerReplica, &c.OwnerAddr, &c.Detail, &c.Revision, &c.HeartbeatAt); err != nil {
+			return nil, fmt.Errorf("live claims %s: %w", scopeKey, err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// BumpReplicaClaimRevision raises the claim's revision floor (never lowers)
+// while this owner holds it.
+func (s *PostgresStore) BumpReplicaClaimRevision(ctx context.Context, claimKey, ownerReplica string, revision int64) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE app_studio_replica_claims SET revision = GREATEST(revision, $1) WHERE claim_key = $2 AND owner_replica = $3`,
+		revision, claimKey, ownerReplica)
+	if err != nil {
+		return fmt.Errorf("bump claim %s: %w", claimKey, err)
+	}
+	return nil
+}
+
+// ---- Memory ----
+
+func (m *MemoryStore) TryClaimReplica(_ context.Context, claim ReplicaClaim, staleAfter time.Duration) (ReplicaClaim, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.replicaClaims == nil {
+		m.replicaClaims = map[string]ReplicaClaim{}
+	}
+	now := time.Now().UTC()
+	current, exists := m.replicaClaims[claim.Key]
+	if exists && current.OwnerReplica != claim.OwnerReplica && current.Live(now, staleAfter) {
+		return current, false, nil
+	}
+	claim.Revision = current.Revision // preserved across takeovers
+	claim.HeartbeatAt = now
+	m.replicaClaims[claim.Key] = claim
+	return claim, true, nil
+}
+
+func (m *MemoryStore) RenewReplicaClaim(_ context.Context, claimKey, ownerReplica string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, exists := m.replicaClaims[claimKey]
+	if !exists || current.OwnerReplica != ownerReplica {
+		return false, nil
+	}
+	current.HeartbeatAt = time.Now().UTC()
+	m.replicaClaims[claimKey] = current
+	return true, nil
+}
+
+func (m *MemoryStore) ReleaseReplicaClaim(_ context.Context, claimKey, ownerReplica string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if current, exists := m.replicaClaims[claimKey]; exists && current.OwnerReplica == ownerReplica {
+		delete(m.replicaClaims, claimKey)
+	}
+	return nil
+}
+
+func (m *MemoryStore) GetReplicaClaim(_ context.Context, claimKey string) (ReplicaClaim, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	c, ok := m.replicaClaims[claimKey]
+	return c, ok, nil
+}
+
+func (m *MemoryStore) LiveReplicaClaims(_ context.Context, scopeKey string, staleAfter time.Duration) ([]ReplicaClaim, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	now := time.Now().UTC()
+	var out []ReplicaClaim
+	for _, c := range m.replicaClaims {
+		if c.ScopeKey == scopeKey && c.Live(now, staleAfter) {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (m *MemoryStore) BumpReplicaClaimRevision(_ context.Context, claimKey, ownerReplica string, revision int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if current, exists := m.replicaClaims[claimKey]; exists && current.OwnerReplica == ownerReplica && revision > current.Revision {
+		current.Revision = revision
+		m.replicaClaims[claimKey] = current
+	}
+	return nil
+}
+
+// ---- Encryption wrapper (claims carry no user content — pure delegation) ----
+
+func (e *encryptedStore) TryClaimReplica(ctx context.Context, claim ReplicaClaim, staleAfter time.Duration) (ReplicaClaim, bool, error) {
+	return e.inner.TryClaimReplica(ctx, claim, staleAfter)
+}
+
+func (e *encryptedStore) RenewReplicaClaim(ctx context.Context, claimKey, ownerReplica string) (bool, error) {
+	return e.inner.RenewReplicaClaim(ctx, claimKey, ownerReplica)
+}
+
+func (e *encryptedStore) ReleaseReplicaClaim(ctx context.Context, claimKey, ownerReplica string) error {
+	return e.inner.ReleaseReplicaClaim(ctx, claimKey, ownerReplica)
+}
+
+func (e *encryptedStore) GetReplicaClaim(ctx context.Context, claimKey string) (ReplicaClaim, bool, error) {
+	return e.inner.GetReplicaClaim(ctx, claimKey)
+}
+
+func (e *encryptedStore) LiveReplicaClaims(ctx context.Context, scopeKey string, staleAfter time.Duration) ([]ReplicaClaim, error) {
+	return e.inner.LiveReplicaClaims(ctx, scopeKey, staleAfter)
+}
+
+func (e *encryptedStore) BumpReplicaClaimRevision(ctx context.Context, claimKey, ownerReplica string, revision int64) error {
+	return e.inner.BumpReplicaClaimRevision(ctx, claimKey, ownerReplica, revision)
+}

--- a/providers/app-studio/store/claims_test.go
+++ b/providers/app-studio/store/claims_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func testClaim(owner, addr string) ReplicaClaim {
+	return ReplicaClaim{
+		Key:          "activity/org-1/ws-1/proj/uid-1",
+		Kind:         ReplicaClaimKindActivity,
+		ScopeKey:     "org-1/ws-1/proj/uid-1",
+		OwnerReplica: owner,
+		OwnerAddr:    addr,
+		Detail:       "run-1",
+	}
+}
+
+func TestReplicaClaimAcquireRenewReleaseSemantics(t *testing.T) {
+	ctx := context.Background()
+	m := NewMemoryStore()
+	ttl := time.Minute
+
+	// First acquire wins.
+	_, held, err := m.TryClaimReplica(ctx, testClaim("replica-a", "10.0.0.1:8091"), ttl)
+	if err != nil || !held {
+		t.Fatalf("first acquire = %v/%v, want held", held, err)
+	}
+	// A fresh foreign claim is declined and reports the current holder.
+	current, held, err := m.TryClaimReplica(ctx, testClaim("replica-b", "10.0.0.2:8091"), ttl)
+	if err != nil || held {
+		t.Fatalf("fresh foreign acquire = %v/%v, want declined", held, err)
+	}
+	if current.OwnerReplica != "replica-a" || current.OwnerAddr != "10.0.0.1:8091" {
+		t.Fatalf("declined claim reports %q@%q, want the live holder", current.OwnerReplica, current.OwnerAddr)
+	}
+	// The owner renews; a foreigner does not.
+	if held, err := m.RenewReplicaClaim(ctx, current.Key, "replica-a"); err != nil || !held {
+		t.Fatalf("owner renew = %v/%v, want held", held, err)
+	}
+	if held, err := m.RenewReplicaClaim(ctx, current.Key, "replica-b"); err != nil || held {
+		t.Fatalf("foreign renew = %v/%v, want not held", held, err)
+	}
+	// Foreign release is a no-op; owner release frees the claim.
+	if err := m.ReleaseReplicaClaim(ctx, current.Key, "replica-b"); err != nil {
+		t.Fatalf("foreign release: %v", err)
+	}
+	if _, ok, _ := m.GetReplicaClaim(ctx, current.Key); !ok {
+		t.Fatal("foreign release deleted an owned claim")
+	}
+	if err := m.ReleaseReplicaClaim(ctx, current.Key, "replica-a"); err != nil {
+		t.Fatalf("owner release: %v", err)
+	}
+	if _, ok, _ := m.GetReplicaClaim(ctx, current.Key); ok {
+		t.Fatal("owner release left the claim behind")
+	}
+}
+
+func TestReplicaClaimStaleTakeoverPreservesRevision(t *testing.T) {
+	ctx := context.Background()
+	m := NewMemoryStore()
+
+	if _, held, err := m.TryClaimReplica(ctx, testClaim("replica-a", ""), time.Minute); err != nil || !held {
+		t.Fatalf("acquire: %v/%v", held, err)
+	}
+	if err := m.BumpReplicaClaimRevision(ctx, testClaim("", "").Key, "replica-a", 42); err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+	// Backdate the heartbeat so the claim is stale, then take it over.
+	m.mu.Lock()
+	c := m.replicaClaims[testClaim("", "").Key]
+	c.HeartbeatAt = time.Now().Add(-2 * time.Minute)
+	m.replicaClaims[c.Key] = c
+	m.mu.Unlock()
+
+	taken, held, err := m.TryClaimReplica(ctx, testClaim("replica-b", "10.0.0.2:8091"), time.Minute)
+	if err != nil || !held {
+		t.Fatalf("stale takeover = %v/%v, want held", held, err)
+	}
+	if taken.Revision != 42 {
+		t.Fatalf("takeover lost the revision floor: %d, want 42", taken.Revision)
+	}
+	// Revision never lowers, and only the owner bumps.
+	_ = m.BumpReplicaClaimRevision(ctx, taken.Key, "replica-b", 40)
+	_ = m.BumpReplicaClaimRevision(ctx, taken.Key, "replica-a", 99)
+	got, _, _ := m.GetReplicaClaim(ctx, taken.Key)
+	if got.Revision != 42 {
+		t.Fatalf("revision = %d, want floor preserved at 42", got.Revision)
+	}
+}
+
+func TestLiveReplicaClaimsFiltersByScopeAndFreshness(t *testing.T) {
+	ctx := context.Background()
+	m := NewMemoryStore()
+	ttl := time.Minute
+
+	fresh := testClaim("replica-a", "")
+	if _, held, err := m.TryClaimReplica(ctx, fresh, ttl); err != nil || !held {
+		t.Fatalf("acquire: %v/%v", held, err)
+	}
+	other := ReplicaClaim{Key: "activity/org-2/ws/proj/uid", Kind: ReplicaClaimKindActivity, ScopeKey: "org-2/ws/proj/uid", OwnerReplica: "replica-a"}
+	if _, held, err := m.TryClaimReplica(ctx, other, ttl); err != nil || !held {
+		t.Fatalf("acquire other scope: %v/%v", held, err)
+	}
+
+	live, err := m.LiveReplicaClaims(ctx, fresh.ScopeKey, ttl)
+	if err != nil || len(live) != 1 || live[0].Key != fresh.Key {
+		t.Fatalf("LiveReplicaClaims = %v/%v, want exactly the in-scope fresh claim", live, err)
+	}
+
+	// Expired claims disappear from the live view.
+	m.mu.Lock()
+	c := m.replicaClaims[fresh.Key]
+	c.HeartbeatAt = time.Now().Add(-2 * ttl)
+	m.replicaClaims[c.Key] = c
+	m.mu.Unlock()
+	live, err = m.LiveReplicaClaims(ctx, fresh.ScopeKey, ttl)
+	if err != nil || len(live) != 0 {
+		t.Fatalf("expired claim still live: %v/%v", live, err)
+	}
+}

--- a/providers/app-studio/store/memory.go
+++ b/providers/app-studio/store/memory.go
@@ -40,6 +40,10 @@ type MemoryStore struct {
 	// intentionally outlives retention deletions so a client resuming from an
 	// old sequence can never observe a later item with a reused sequence.
 	conversationSequences map[Scope]int64
+	// replicaClaims is the in-memory form of the fleet-wide ownership map
+	// (claims.go). Single-process by construction, which is exactly what the
+	// explicit in-memory mode promises.
+	replicaClaims map[string]ReplicaClaim
 	approvalModes         map[Scope]map[string]AssistantApprovalPreference
 	bootstrapPermits      map[Scope]projectBootstrapPermit
 }

--- a/providers/app-studio/store/postgres.go
+++ b/providers/app-studio/store/postgres.go
@@ -118,6 +118,9 @@ func (s *PostgresStore) EnsureSchema(ctx context.Context) error {
 	if err := ensureSchemaVersion(ctx, tx, assistantApprovalPolicySchemaVersion, assistantApprovalPolicySchemaStatements()...); err != nil {
 		return err
 	}
+	if err := ensureSchemaVersion(ctx, tx, replicaClaimSchemaVersion, replicaClaimSchemaStatements()...); err != nil {
+		return err
+	}
 	if err = tx.Commit(); err != nil {
 		return fmt.Errorf("commit schema migration: %w", err)
 	}

--- a/providers/app-studio/store/store.go
+++ b/providers/app-studio/store/store.go
@@ -223,6 +223,15 @@ type Store interface {
 	ListAssistantConversationItems(ctx context.Context, scope Scope, afterSequence int64, limit int) ([]AssistantConversationItem, error)
 	DeleteProjectMessages(ctx context.Context, scope Scope) error
 	DeleteMessagesOlderThan(ctx context.Context, before time.Time) (int64, error)
+	// Replica claims — the fleet-wide ownership map for assistant activity
+	// and project workspace pinning (see claims.go and
+	// docs/app-studio-replica-awareness.md).
+	TryClaimReplica(ctx context.Context, claim ReplicaClaim, staleAfter time.Duration) (ReplicaClaim, bool, error)
+	RenewReplicaClaim(ctx context.Context, claimKey, ownerReplica string) (bool, error)
+	ReleaseReplicaClaim(ctx context.Context, claimKey, ownerReplica string) error
+	GetReplicaClaim(ctx context.Context, claimKey string) (ReplicaClaim, bool, error)
+	LiveReplicaClaims(ctx context.Context, scopeKey string, staleAfter time.Duration) ([]ReplicaClaim, error)
+	BumpReplicaClaimRevision(ctx context.Context, claimKey, ownerReplica string, revision int64) error
 }
 
 func prepareAssistantConversationItem(scope Scope, item AssistantConversationItem) (AssistantConversationItem, error) {

--- a/providers/app-studio/workspace/source_state.go
+++ b/providers/app-studio/workspace/source_state.go
@@ -170,6 +170,44 @@ func (s *FileStore) bumpSourceRevision(ctx context.Context, scope Scope) error {
 	return nil
 }
 
+// EnsureSourceRevisionFloor raises the durable source revision to at least
+// floor. Replica adoption seeds it from the project claim's revision so the
+// monotonic fence the infrastructure agent enforces survives the project
+// moving between replicas — a fence restarting at 1 on a new owner would make
+// every subsequent sync look stale. Never lowers the local revision.
+func (s *FileStore) EnsureSourceRevisionFloor(ctx context.Context, scope Scope, floor uint64) error {
+	if s == nil {
+		return errors.New("project workspace store is not configured")
+	}
+	if floor <= 1 {
+		return nil
+	}
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+	current, err := s.sourceRevision(ctx, scope)
+	if err != nil {
+		return err
+	}
+	if current >= floor {
+		return nil
+	}
+	dir, revisionPath, err := s.sourceRevisionPath(scope)
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(workspaceSourceRevision{Revision: floor})
+	if err != nil {
+		return fmt.Errorf("encode workspace source revision: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create workspace source revision directory: %w", err)
+	}
+	if err := writeFileAtomically(dir, revisionPath, raw, 0o600, false); err != nil {
+		return fmt.Errorf("persist workspace source revision: %w", err)
+	}
+	return nil
+}
+
 // ClearUncommittedPaths removes the pending source set after the complete set
 // has been committed successfully through the repository bridge.
 func (s *FileStore) ClearUncommittedPaths(ctx context.Context, scope Scope) error {

--- a/providers/code/Dockerfile
+++ b/providers/code/Dockerfile
@@ -5,25 +5,27 @@
 #    package.json/lockfile + source.
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/code/portal/package.json providers/code/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/code/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. The binary serves two subcommands — `init` and
 #    `serve` — so the whole module source has to be present. assets.go
 #    //go:embeds portal/dist, overlaid from the node stage so the bundle is fresh.
 #
-# TODO(sdk-publish): this module now depends on
-# github.com/faroshq/faros-provider-sdk via a `replace => ../../provider-sdk`
-# that only resolves inside the monorepo (go.work). For a standalone image build
-# the SDK must be published to the module proxy (drop the replace) or vendored
-# into this build context. Host/Tilt dev builds work today via go.work.
+# The provider-sdk resolves IN-TREE via a go.mod replace, so the build
+# context is the repo root and the sdk is copied alongside the module below
+# (docker build -f providers/code/Dockerfile .).
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/code/go.mod providers/code/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/code/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY . ./
+COPY providers/code/ ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/code-provider .
 
@@ -32,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    /etc/faros/schemas (FAROS_SCHEMAS_DIR).
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/code-provider /code-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/code/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8083
 ENV PORT=8083
 USER nonroot:nonroot

--- a/providers/code/controller_manager.go
+++ b/providers/code/controller_manager.go
@@ -33,9 +33,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/faroshq/provider-sdk/leaderelection"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
@@ -62,17 +64,23 @@ const endpointSliceName = install.APIExportEndpointSliceName
 // lives in (root:faros:providers:<name>). Overridable via CODE_WORKSPACE_PATH.
 const defaultWorkspacePath = "root:faros:providers:code"
 
-// startControllerManager builds the multicluster manager and starts the
-// reconcilers, dispatching through the shared backend registry (built in
-// runServe so the HTTP packages handler shares it). A nil config means "skip
-// the manager, run REST/MCP-only".
+// controllerLeaseName gates the reconcilers on a Lease in the provider
+// workspace ("default" namespace — kcp serves Leases in every logical
+// cluster), so scaling the deployment past one replica keeps every CR
+// single-writer. Non-leaders keep serving REST/MCP/portal.
+const controllerLeaseName = "code-controllers"
+
+// startControllerManager ensures the APIExportEndpointSlice, then campaigns
+// for the controller lease and — while leader — runs the multicluster manager
+// with the reconcilers, dispatching through the shared backend registry
+// (built in runServe so the HTTP packages handler shares it). A nil config
+// means "skip the manager, run REST/MCP-only".
 func startControllerManager(ctx context.Context, config *rest.Config, registry *backend.Registry, bundles commitbundle.Store) error {
 	if config == nil {
 		return errControllerDisabled
 	}
 
 	ctrl.SetLogger(klog.NewKlogr())
-	scheme := codescheme.NewScheme()
 
 	// The hub provisioner does NOT create an APIExportEndpointSlice for the
 	// provider's APIExport, so the multicluster provider would have nothing to
@@ -87,14 +95,40 @@ func startControllerManager(ctx context.Context, config *rest.Config, registry *
 		log.Printf("controller manager: WARNING could not ensure APIExportEndpointSlice: %v", err)
 	}
 
+	go func() {
+		if err := leaderelection.Run(ctx, leaderelection.Options{
+			Config:    config,
+			Namespace: leaderelection.DefaultNamespace,
+			Name:      controllerLeaseName,
+		}, func(termCtx context.Context) {
+			if err := runControllerManager(termCtx, config, registry, bundles); err != nil {
+				log.Printf("controller manager exited: %v", err)
+			}
+		}); err != nil {
+			log.Printf("controller leader election failed; controllers are not running: %v", err)
+		}
+	}()
+	return nil
+}
+
+// runControllerManager builds the multicluster manager and blocks in Start
+// until the leadership term ends. Called once per term — a stopped
+// controller-runtime manager cannot be restarted.
+func runControllerManager(ctx context.Context, config *rest.Config, registry *backend.Registry, bundles commitbundle.Store) error {
+	scheme := codescheme.NewScheme()
+
 	provider, err := apiexport.New(config, endpointSliceName, apiexport.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("creating apiexport multicluster provider: %w", err)
 	}
 
+	skipNameValidation := true
 	mgr, err := mcmanager.New(config, provider, manager.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"}, // provider serves its own HTTP; disable controller-runtime metrics
+		// Controller names register process-globally; the manager built for a
+		// later leadership term must skip that check.
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipNameValidation},
 	})
 	if err != nil {
 		return fmt.Errorf("creating multicluster manager: %w", err)
@@ -125,13 +159,8 @@ func startControllerManager(ctx context.Context, config *rest.Config, registry *
 		return fmt.Errorf("repositorybuildstatus controller: %w", err)
 	}
 
-	go func() {
-		log.Printf("code controller manager starting (backends=%v, endpointSlice=%s)", registry.Names(), endpointSliceName)
-		if err := mgr.Start(ctx); err != nil {
-			log.Printf("controller manager exited: %v", err)
-		}
-	}()
-	return nil
+	log.Printf("code controller manager starting (backends=%v, endpointSlice=%s)", registry.Names(), endpointSliceName)
+	return mgr.Start(ctx)
 }
 
 // loadControllerConfig resolves the rest.Config for the provider's kcp

--- a/providers/code/deploy/chart/templates/deployment.yaml
+++ b/providers/code/deploy/chart/templates/deployment.yaml
@@ -71,6 +71,14 @@ spec:
           readinessProbe:
             httpGet: { path: /healthz, port: http }
             periodSeconds: 5
+          {{- if .Values.envFromSecret }}
+          # Bulk env injection (GitHub OAuth app credentials and other dev
+          # secrets) — the containerized equivalent of the host binary
+          # sourcing providers/code/.env.
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
           env:
             - name: PORT
               value: "8083"

--- a/providers/code/deploy/chart/values.yaml
+++ b/providers/code/deploy/chart/values.yaml
@@ -113,6 +113,11 @@ resources:
     memory: 64Mi
 
 # Optional name overrides + pod-level scheduling controls.
+# Optional Secret whose keys are injected wholesale as environment variables
+# (GitHub OAuth app credentials and other dev secrets) — the containerized
+# equivalent of sourcing providers/code/.env.
+envFromSecret: ""
+
 nameOverride: ""
 fullnameOverride: ""
 podLabels: {}

--- a/providers/code/go.mod
+++ b/providers/code/go.mod
@@ -113,3 +113,8 @@ replace (
 replace github.com/kcp-dev/apimachinery/v2 => github.com/kcp-dev/apimachinery/v2 v2.32.0
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.0
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/code/go.sum
+++ b/providers/code/go.sum
@@ -20,8 +20,6 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/providers/databricks/Dockerfile
+++ b/providers/databricks/Dockerfile
@@ -2,23 +2,27 @@
 
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/databricks/portal/package.json providers/databricks/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/databricks/portal/ ./
 RUN npm run build
 
 FROM golang:1.26-alpine AS build
 WORKDIR /src
 ARG VERSION=dev
-COPY go.mod go.sum ./
+COPY providers/databricks/go.mod providers/databricks/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/databricks/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY . ./
+COPY providers/databricks/ ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.buildVersion=${VERSION}" -o /out/databricks-provider .
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/databricks-provider /databricks-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/databricks/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8081
 ENV PORT=8081
 USER nonroot:nonroot

--- a/providers/databricks/controller_manager.go
+++ b/providers/databricks/controller_manager.go
@@ -8,13 +8,23 @@
 
 package main
 
+// Multicluster controller manager — reconciles the provider's tenant-authored
+// CRs (Connection / Warehouse / Table) across every workspace that bound the
+// APIExport.
+//
+// Leader-elected: serving resolves tenant clusters through the slice-backed
+// authority (tenant.SliceAuthority), never through this manager, so only the
+// replica holding the Lease runs the reconcilers while every replica keeps
+// serving actions/discovery/MCP. The manager is rebuilt fresh each term — a
+// stopped controller-runtime manager cannot be restarted — and a per-term
+// watchdog stops it when the endpoint slice loses its last usable URL, so the
+// next term rebuilds against live discovery instead of silently watching
+// nothing.
+
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -22,28 +32,26 @@ import (
 	"time"
 
 	sdkinstall "github.com/faroshq/provider-sdk/install"
+	"github.com/faroshq/provider-sdk/leaderelection"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
-	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	"github.com/faroshq/provider-databricks/backend"
 	"github.com/faroshq/provider-databricks/controller/connection"
 	"github.com/faroshq/provider-databricks/controller/table"
 	"github.com/faroshq/provider-databricks/controller/warehouse"
 	databricksscheme "github.com/faroshq/provider-databricks/scheme"
+	"github.com/faroshq/provider-databricks/tenant"
 )
 
 const (
@@ -54,11 +62,16 @@ const (
 	controllerStartupTimeout    = 1 * time.Minute
 	controllerStartupTimeoutMin = 1 * time.Second
 	controllerStartupTimeoutMax = 5 * time.Minute
+
+	// controllerLeaseName gates the reconcilers on a Lease in the provider
+	// workspace ("default" namespace — kcp serves Leases in every logical
+	// cluster).
+	controllerLeaseName = "databricks-controllers"
+
+	// slicePollInterval paces the per-term endpoint watchdog and the pre-start
+	// wait for a usable endpoint.
+	slicePollInterval = 5 * time.Second
 )
-
-var errControllerProviderDiscoveryTimeout = errors.New("multicluster provider discovery timed out")
-
-var errControllerProviderEndpointLost = errors.New("multicluster provider endpoint became unavailable")
 
 type controllerMode string
 
@@ -67,10 +80,10 @@ const (
 	controllerModeRequired controllerMode = "required"
 )
 
-// controllerState is independent from HTTP process liveness. A provider can
-// keep serving its REST surface while a required manager is starting or
-// recovering, but readiness and heartbeat eligibility remain false in those
-// states.
+// controllerState is independent from HTTP process liveness AND from
+// readiness: under leader election a standby replica never runs the manager,
+// so controller state is reported on /readyz for observability but does not
+// gate it — serving readiness is the slice-backed authority's.
 type controllerState string
 
 const (
@@ -79,6 +92,7 @@ const (
 	controllerStateReady    controllerState = "ready"
 	controllerStateFailed   controllerState = "failed"
 	controllerStateStopped  controllerState = "stopped"
+	controllerStateStandby  controllerState = "standby"
 )
 
 type controllerHealthSnapshot struct {
@@ -112,68 +126,33 @@ func (h *controllerHealth) snapshot() controllerHealthSnapshot {
 	return controllerHealthSnapshot{Required: h.required, State: h.state, Error: h.lastErr}
 }
 
-func (h *controllerHealth) markStarting() {
+func (h *controllerHealth) setState(state controllerState, err error) {
 	if h == nil {
 		return
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.state = controllerStateStarting
-	h.lastErr = ""
-}
-
-func (h *controllerHealth) markReady() {
-	if h == nil {
-		return
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.state = controllerStateReady
-	h.lastErr = ""
-}
-
-func (h *controllerHealth) markFailed(err error) {
-	if h == nil {
-		return
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.state = controllerStateFailed
+	h.state = state
 	h.lastErr = ""
 	if err != nil {
 		h.lastErr = err.Error()
 	}
 }
 
+func (h *controllerHealth) markStarting() { h.setState(controllerStateStarting, nil) }
+func (h *controllerHealth) markReady()    { h.setState(controllerStateReady, nil) }
+func (h *controllerHealth) markStandby()  { h.setState(controllerStateStandby, nil) }
+
+func (h *controllerHealth) markFailed(err error) { h.setState(controllerStateFailed, err) }
 func (h *controllerHealth) markStopped(err error) {
-	if h == nil {
-		return
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.state = controllerStateStopped
-	h.lastErr = ""
-	if err != nil {
-		h.lastErr = err.Error()
-	}
+	h.setState(controllerStateStopped, err)
 }
 
-func (h *controllerHealth) markRESTOnly() {
-	if h == nil {
-		return
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.required = false
-	h.state = controllerStateRESTOnly
-	h.lastErr = ""
-}
-
+// ready gates /readyz and heartbeat eligibility on SERVING readiness only:
+// the dependency check (tenant factory configured + slice authority
+// discovered). Controller state deliberately does not participate — under
+// leader election a standby replica runs no manager yet must serve traffic.
 func (h *controllerHealth) ready() bool {
-	snapshot := h.snapshot()
-	if snapshot.Required && snapshot.State != controllerStateReady {
-		return false
-	}
 	if h == nil {
 		return true
 	}
@@ -196,683 +175,210 @@ func (h *controllerHealth) setDependencyReady(check func() bool) {
 }
 
 func (h *controllerHealth) heartbeatStatus() string {
-	snapshot := h.snapshot()
-	if h.ready() && (!snapshot.Required || snapshot.State == controllerStateReady) {
+	if h.ready() {
 		return "healthy"
 	}
-	if snapshot.State == controllerStateStarting {
+	if h.snapshot().State == controllerStateStarting {
 		return "starting"
 	}
 	return "unhealthy"
-}
-
-// managerAuthority is installed in the tenant client factory once. The
-// controller retry loop swaps the currently running manager into it and clears
-// it after an exit, so requests cannot use a manager that is no longer alive.
-//
-// This coupling is also why the manager is deliberately NOT leader-elected
-// (unlike code/vibe-studio/infrastructure): the HTTP action path resolves
-// tenant clusters through the running manager via this authority, so it must
-// run on every replica — a lease-gated manager would leave non-leaders unable
-// to serve actions. The reconcilers are idempotent status stampers, so
-// active-active is churn, not corruption; keep replicaCount at 1 until the
-// serving path gets its own cluster resolver.
-type managerAuthority struct {
-	mu  sync.RWMutex
-	mgr mcmanager.Manager
-}
-
-// Ready reports whether the authority points at a currently running manager.
-// Tenant ClientFactory uses this as part of its readiness gate so a recovered
-// kubeconfig cannot make actions look usable before manager startup completes.
-func (a *managerAuthority) Ready() bool {
-	if a == nil {
-		return false
-	}
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return a.mgr != nil
-}
-
-func (a *managerAuthority) Set(mgr mcmanager.Manager) {
-	if a == nil {
-		return
-	}
-	a.mu.Lock()
-	a.mgr = mgr
-	a.mu.Unlock()
-}
-
-func (a *managerAuthority) Clear(mgr mcmanager.Manager) {
-	if a == nil {
-		return
-	}
-	a.mu.Lock()
-	if a.mgr == mgr {
-		a.mgr = nil
-	}
-	a.mu.Unlock()
-}
-
-func (a *managerAuthority) GetCluster(ctx context.Context, name multicluster.ClusterName) (cluster.Cluster, error) {
-	if a == nil {
-		return nil, errors.New("provider controller manager unavailable")
-	}
-	a.mu.RLock()
-	mgr := a.mgr
-	a.mu.RUnlock()
-	if mgr == nil {
-		return nil, errors.New("provider controller manager unavailable")
-	}
-	return mgr.GetCluster(ctx, name)
-}
-
-// controllerProviderRunnable preserves the provider's discovery lifecycle but
-// exposes the point at which multicluster-runtime has actually started it.
-// The readiness runnable waits for this signal before it checks the endpoint
-// slice, so a manager that has only been constructed cannot publish authority.
-type controllerProviderRunnable struct {
-	multicluster.Provider
-	runnable       multicluster.ProviderRunnable
-	started        chan struct{}
-	result         chan error
-	once           sync.Once
-	initialize     func(context.Context) error
-	startupTimeout time.Duration
-	withTimeout    func(context.Context, time.Duration) (context.Context, context.CancelFunc)
-}
-
-func (p *controllerProviderRunnable) Start(ctx context.Context, aware multicluster.Aware) error {
-	providerCtx, stopProvider := context.WithCancel(ctx)
-	defer stopProvider()
-	providerResult := make(chan error, 1)
-	go func() {
-		providerResult <- p.runnable.Start(providerCtx, aware)
-	}()
-
-	if p.initialize != nil {
-		initCtx, cancel, timeout := p.startupContext(ctx)
-		initResult := make(chan error, 1)
-		go func() {
-			err := p.initialize(initCtx)
-			if err == nil && initCtx.Err() != nil {
-				err = initCtx.Err()
-			}
-			initResult <- err
-		}()
-		select {
-		case err := <-providerResult:
-			cancel()
-			return p.report(err)
-		case err := <-initResult:
-			if err != nil {
-				err = controllerProviderReadinessWaitError(ctx, initCtx, timeout, err)
-				cancel()
-				return p.report(err)
-			}
-		}
-		cancel()
-	}
-
-	select {
-	case err := <-providerResult:
-		return p.report(err)
-	default:
-	}
-	p.once.Do(func() { close(p.started) })
-	err := <-providerResult
-	return p.report(err)
-}
-
-func (p *controllerProviderRunnable) report(err error) error {
-	if p.result != nil {
-		p.result <- err
-	}
-	return err
-}
-
-func (p *controllerProviderRunnable) startupContext(ctx context.Context) (context.Context, context.CancelFunc, time.Duration) {
-	timeout := controllerStartupTimeout
-	if p != nil && p.startupTimeout > 0 {
-		timeout = clampControllerDuration(p.startupTimeout, controllerStartupTimeout, controllerStartupTimeoutMin, controllerStartupTimeoutMax)
-	}
-	withTimeout := context.WithTimeout
-	if p != nil && p.withTimeout != nil {
-		withTimeout = p.withTimeout
-	}
-	derived, cancel := withTimeout(ctx, timeout)
-	return derived, cancel, timeout
 }
 
 var apiExportEndpointSliceGVR = schema.GroupVersionResource{
 	Group: "apis.kcp.io", Version: "v1alpha1", Resource: "apiexportendpointslices",
 }
 
-// controllerProviderTransportReadiness is driven by the actual apiexport
-// provider cache. Its wrapped transport observes the provider's first
-// successful LIST and WATCH for APIExportEndpointSlice, rather than using an
-// unrelated informer that could become ready before the provider itself.
-type controllerProviderTransportReadiness struct {
-	endpointSuffix string
-	ready          chan struct{}
-
-	mu           sync.Mutex
-	listComplete bool
-	watchStarted bool
-	once         sync.Once
+func controllerOptionsForRetryableManager() ctrlconfig.Controller {
+	skipNameValidation := true
+	// Controller names register process-globally; a manager rebuilt for a
+	// later leadership term must skip that check.
+	return ctrlconfig.Controller{SkipNameValidation: &skipNameValidation}
 }
 
-func newControllerProviderTransportReadiness() *controllerProviderTransportReadiness {
-	return &controllerProviderTransportReadiness{
-		endpointSuffix: "/" + apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version + "/" + apiExportEndpointSliceGVR.Resource,
-		ready:          make(chan struct{}),
-	}
-}
-
-func (r *controllerProviderTransportReadiness) Wait(ctx context.Context) error {
-	if r == nil {
-		return errors.New("multicluster provider readiness is not configured")
-	}
-	select {
-	case <-r.ready:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-func (r *controllerProviderTransportReadiness) wrap(rt http.RoundTripper) http.RoundTripper {
-	return &controllerProviderReadinessRoundTripper{next: rt, readiness: r}
-}
-
-func (r *controllerProviderTransportReadiness) matches(req *http.Request) bool {
-	if r == nil || req == nil || req.URL == nil || req.Method != http.MethodGet {
-		return false
-	}
-	return strings.HasSuffix(strings.TrimRight(req.URL.Path, "/"), r.endpointSuffix)
-}
-
-func (r *controllerProviderTransportReadiness) markListComplete() {
-	if r == nil {
-		return
-	}
-	r.mu.Lock()
-	r.listComplete = true
-	r.maybeReadyLocked()
-	r.mu.Unlock()
-}
-
-func (r *controllerProviderTransportReadiness) markWatchStarted() {
-	if r == nil {
-		return
-	}
-	r.mu.Lock()
-	r.watchStarted = true
-	r.maybeReadyLocked()
-	r.mu.Unlock()
-}
-
-func (r *controllerProviderTransportReadiness) maybeReadyLocked() {
-	if r.listComplete && r.watchStarted {
-		r.once.Do(func() { close(r.ready) })
-	}
-}
-
-type controllerProviderReadinessRoundTripper struct {
-	next      http.RoundTripper
-	readiness *controllerProviderTransportReadiness
-}
-
-func (r *controllerProviderReadinessRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := r.next.RoundTrip(req)
-	if err != nil || resp == nil || resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices || !r.readiness.matches(req) {
-		return resp, err
-	}
-	if strings.EqualFold(req.URL.Query().Get("watch"), "true") {
-		r.readiness.markWatchStarted()
-		if strings.EqualFold(req.URL.Query().Get("sendInitialEvents"), "true") && resp.Body != nil {
-			resp.Body = &controllerProviderReadinessBody{
-				ReadCloser: resp.Body,
-				onRead:     r.readiness.markListComplete,
-			}
-		}
-		return resp, nil
-	}
-	if resp.Body == nil {
-		r.readiness.markListComplete()
-		return resp, nil
-	}
-	resp.Body = &controllerProviderReadinessBody{
-		ReadCloser: resp.Body,
-		onEOF:      r.readiness.markListComplete,
-	}
-	return resp, nil
-}
-
-type controllerProviderReadinessBody struct {
-	io.ReadCloser
-	onRead   func()
-	onEOF    func()
-	readOnce sync.Once
-	eofOnce  sync.Once
-}
-
-func (r *controllerProviderReadinessBody) Read(p []byte) (int, error) {
-	n, err := r.ReadCloser.Read(p)
-	if n > 0 {
-		r.readOnce.Do(func() {
-			if r.onRead != nil {
-				r.onRead()
-			}
-		})
-	}
-	if err == io.EOF {
-		r.eofOnce.Do(func() {
-			if r.onEOF != nil {
-				r.onEOF()
-			}
-		})
-	}
-	return n, err
-}
-
-func controllerProviderConfig(config *rest.Config) (*rest.Config, *controllerProviderTransportReadiness) {
-	providerConfig := rest.CopyConfig(config)
-	readiness := newControllerProviderTransportReadiness()
-	providerConfig.WrapTransport = transport.Wrappers(providerConfig.WrapTransport, readiness.wrap)
-	return providerConfig, readiness
-}
-
-// controllerProviderReadiness is the startup gate for tenant actions. The
-// endpoint slice is the multicluster provider's discovery input; requiring a
-// non-empty status.endpoints list means the provider has a usable virtual
-// workspace to discover, rather than merely an informer that was registered.
-type controllerProviderReadiness struct {
-	started        <-chan struct{}
-	providerDone   <-chan error
-	endpoint       dynamic.ResourceInterface
-	endpointName   string
-	pollInterval   time.Duration
-	startupTimeout time.Duration
-	withTimeout    func(context.Context, time.Duration) (context.Context, context.CancelFunc)
-	pollGate       func(context.Context, time.Duration) bool
-}
-
-func (r *controllerProviderReadiness) Wait(ctx context.Context) error {
-	if r == nil {
-		return nil
-	}
-	waitCtx, cancel, timeout := r.startupContext(ctx)
-	defer cancel()
-	select {
-	case <-r.started:
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-waitCtx.Done():
-		return controllerProviderReadinessWaitError(ctx, waitCtx, timeout, nil)
-	case err := <-r.providerDone:
-		return controllerProviderExitError(err)
-	}
-
-	interval := r.pollInterval
-	if interval <= 0 {
-		interval = 250 * time.Millisecond
-	}
+// runLeaderElectedControllers waits for a provider kubeconfig, then campaigns
+// for the controller lease forever; every won term runs one freshly built
+// manager. Setup failures inside a term (endpoint slice missing, VW not
+// published) step down and re-campaign, which replaces the old bespoke
+// retry/readiness machinery — the election loop IS the retry loop.
+func runLeaderElectedControllers(ctx context.Context, health *controllerHealth, loadConfig func() (*rest.Config, error), onConfig func(*rest.Config) error, validator backend.Validator) {
+	retryInterval := controllerRetryIntervalFromEnv()
+	var config *rest.Config
 	for {
-		ready, err := r.endpointDiscovered(waitCtx)
-		if err != nil {
-			return controllerProviderReadinessWaitError(ctx, waitCtx, timeout, err)
-		}
-		if ready {
-			if err := r.providerExitError(); err != nil {
-				return err
-			}
-			return nil
-		}
-		if err := r.providerExitError(); err != nil {
-			return err
-		}
-		if !r.waitForPoll(waitCtx, interval) {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			return controllerProviderReadinessWaitError(ctx, waitCtx, timeout, nil)
-		}
-	}
-}
-
-// Monitor keeps the manager gated after startup. A provider endpoint can
-// disappear or lose all usable URLs after the initial readiness check; that
-// must clear authority and force the lifecycle retry loop to rebuild it.
-func (r *controllerProviderReadiness) Monitor(ctx context.Context) error {
-	if r == nil {
-		return nil
-	}
-	interval := r.pollInterval
-	if interval <= 0 {
-		interval = 250 * time.Millisecond
-	}
-	for {
-		if err := r.providerExitError(); err != nil {
-			return err
-		}
-		checkCtx, cancel, timeout := r.startupContext(ctx)
-		ready, err := r.endpointDiscovered(checkCtx)
-		if err == nil && checkCtx.Err() != nil {
-			err = checkCtx.Err()
-		}
-		if err != nil {
-			err = controllerProviderReadinessWaitError(ctx, checkCtx, timeout, err)
-		}
-		cancel()
-		if err != nil {
-			return err
-		}
-		if !ready {
-			return fmt.Errorf("%w: APIExportEndpointSlice %q has no usable endpoint", errControllerProviderEndpointLost, r.endpointName)
-		}
-		if !r.waitForPoll(ctx, interval) {
-			return ctx.Err()
-		}
-	}
-}
-
-func (r *controllerProviderReadiness) waitForPoll(ctx context.Context, interval time.Duration) bool {
-	if interval <= 0 {
-		interval = 250 * time.Millisecond
-	}
-	if r.pollGate != nil {
-		return r.pollGate(ctx, interval)
-	}
-	timer := time.NewTimer(interval)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
-	}
-}
-
-func (r *controllerProviderReadiness) startupContext(ctx context.Context) (context.Context, context.CancelFunc, time.Duration) {
-	timeout := controllerStartupTimeout
-	if r != nil && r.startupTimeout > 0 {
-		timeout = clampControllerDuration(r.startupTimeout, controllerStartupTimeout, controllerStartupTimeoutMin, controllerStartupTimeoutMax)
-	}
-	withTimeout := context.WithTimeout
-	if r != nil && r.withTimeout != nil {
-		withTimeout = r.withTimeout
-	}
-	waitCtx, cancel := withTimeout(ctx, timeout)
-	return waitCtx, cancel, timeout
-}
-
-func controllerProviderReadinessWaitError(parent, waitCtx context.Context, timeout time.Duration, err error) error {
-	if parentErr := parent.Err(); parentErr != nil {
-		return parentErr
-	}
-	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+		c, err := loadConfig()
 		if err == nil {
-			return fmt.Errorf("%w after %s", errControllerProviderDiscoveryTimeout, timeout)
+			config = c
+			break
 		}
-		return fmt.Errorf("%w after %s: %v", errControllerProviderDiscoveryTimeout, timeout, err)
-	}
-	if err != nil {
-		return err
-	}
-	return waitCtx.Err()
-}
-
-func (r *controllerProviderReadiness) providerExitError() error {
-	if r.providerDone == nil {
-		return nil
-	}
-	select {
-	case err := <-r.providerDone:
-		return controllerProviderExitError(err)
-	default:
-		return nil
-	}
-}
-
-func controllerProviderExitError(err error) error {
-	if err == nil {
-		return errors.New("multicluster provider exited before readiness")
-	}
-	return fmt.Errorf("multicluster provider exited before readiness: %w", err)
-}
-
-func (r *controllerProviderReadiness) endpointDiscovered(ctx context.Context) (bool, error) {
-	if r.endpoint == nil {
-		return true, nil
-	}
-	obj, err := r.endpoint.Get(ctx, r.endpointName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("reading APIExportEndpointSlice %q: %w", r.endpointName, err)
-	}
-	endpoints, found, err := unstructured.NestedSlice(obj.Object, "status", "endpoints")
-	if err != nil {
-		return false, fmt.Errorf("reading APIExportEndpointSlice %q status.endpoints: %w", r.endpointName, err)
-	}
-	if !found {
-		return false, nil
-	}
-	for _, endpoint := range endpoints {
-		fields, ok := endpoint.(map[string]any)
-		if !ok {
-			continue
-		}
-		if url, ok := fields["url"].(string); ok && strings.TrimSpace(url) != "" {
-			return true, nil
+		health.markFailed(err)
+		log.Printf("controller manager waiting for kubeconfig: %v; retrying in %s", err, retryInterval)
+		select {
+		case <-ctx.Done():
+			health.markStopped(ctx.Err())
+			return
+		case <-time.After(retryInterval):
 		}
 	}
-	return false, nil
+	if onConfig != nil {
+		if err := onConfig(config); err != nil {
+			// Caller-token client configuration failed; actions fail closed
+			// with a clear error, controllers still run.
+			log.Printf("controller manager: %v", err)
+		}
+	}
+	health.markStandby()
+	if err := leaderelection.Run(ctx, leaderelection.Options{
+		Config:    config,
+		Namespace: leaderelection.DefaultNamespace,
+		Name:      controllerLeaseName,
+	}, func(termCtx context.Context) {
+		health.markStarting()
+		if err := runControllerManagerTerm(termCtx, config, validator, health); err != nil {
+			health.markFailed(err)
+			log.Printf("controller manager exited: %v", err)
+		}
+		if termCtx.Err() == nil {
+			// Still leader but the term callback returned — leaderelection
+			// releases the lease; record standby so /readyz introspection
+			// doesn't report a stale "ready".
+			health.markStandby()
+		}
+	}); err != nil {
+		health.markFailed(err)
+		log.Printf("controller leader election failed; controllers are not running: %v", err)
+		return
+	}
+	health.markStopped(ctx.Err())
 }
 
-func controllerBoundedSetup(ctx context.Context, timeout time.Duration, withTimeout func(context.Context, time.Duration) (context.Context, context.CancelFunc), setup func(context.Context) error) error {
-	if setup == nil {
-		return errors.New("controller manager setup is not configured")
-	}
-	timeout = clampControllerDuration(timeout, controllerStartupTimeout, controllerStartupTimeoutMin, controllerStartupTimeoutMax)
-	if withTimeout == nil {
-		withTimeout = context.WithTimeout
-	}
-	setupCtx, cancel := withTimeout(ctx, timeout)
-	err := setup(setupCtx)
-	if err == nil && setupCtx.Err() != nil {
-		err = setupCtx.Err()
-	}
-	if err != nil {
-		classified := controllerProviderReadinessWaitError(ctx, setupCtx, timeout, err)
-		cancel()
-		return classified
-	}
-	cancel()
-	return nil
-}
-
-// newControllerManager performs all setup that must succeed before a
-// controller can become ready. In particular, the endpoint slice is a hard
-// prerequisite: a manager without it would appear started while silently
-// watching no tenant workspaces.
-func newControllerManager(ctx context.Context, config *rest.Config, validator backend.Validator) (mcmanager.Manager, error) {
-	mgr, _, err := newControllerManagerWithReadiness(ctx, config, validator)
-	return mgr, err
-}
-
-func newControllerManagerWithReadiness(ctx context.Context, config *rest.Config, validator backend.Validator) (mcmanager.Manager, *controllerProviderReadiness, error) {
-	if config == nil {
-		return nil, nil, errControllerDisabled
-	}
+// runControllerManagerTerm builds and runs the manager for one leadership
+// term, blocking in Start until the term ends or the endpoint watchdog fires.
+func runControllerManagerTerm(ctx context.Context, config *rest.Config, validator backend.Validator, health *controllerHealth) error {
 	ctrl.SetLogger(klog.NewKlogr())
 	scheme := databricksscheme.NewScheme()
 
-	var dyn dynamic.Interface
-	setupTimeout := controllerStartupTimeoutFromEnv()
-	if err := controllerBoundedSetup(ctx, setupTimeout, nil, func(setupCtx context.Context) error {
-		var err error
-		dyn, err = dynamic.NewForConfig(config)
-		if err != nil {
-			return fmt.Errorf("dynamic client: %w", err)
-		}
-		workspacePath := envOr("DATABRICKS_WORKSPACE_PATH", defaultWorkspacePath)
-		if err := sdkinstall.EnsureAPIExportEndpointSlice(setupCtx, dyn, apiExportName, apiExportName, workspacePath); err != nil {
-			return fmt.Errorf("ensuring APIExportEndpointSlice: %w", err)
-		}
-		return nil
-	}); err != nil {
-		return nil, nil, fmt.Errorf("controller manager setup: %w", err)
+	dyn, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("dynamic client: %w", err)
+	}
+	workspacePath := envOr("DATABRICKS_WORKSPACE_PATH", defaultWorkspacePath)
+	if err := sdkinstall.EnsureAPIExportEndpointSlice(ctx, dyn, apiExportName, apiExportName, workspacePath); err != nil {
+		return fmt.Errorf("ensuring APIExportEndpointSlice: %w", err)
 	}
 
-	providerConfig, providerTransportReadiness := controllerProviderConfig(config)
-	provider, err := apiexport.New(providerConfig, apiExportName, apiexport.Options{Scheme: scheme})
+	// The endpoint slice is the multicluster provider's discovery input: a
+	// manager built before it carries a usable URL appears started while
+	// silently watching no tenant workspaces. Wait, bounded per term.
+	slice := dyn.Resource(apiExportEndpointSliceGVR)
+	if err := waitForSliceEndpoint(ctx, slice, apiExportName, controllerStartupTimeoutFromEnv()); err != nil {
+		return err
+	}
+
+	provider, err := apiexport.New(config, apiExportName, apiexport.Options{Scheme: scheme})
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating apiexport multicluster provider: %w", err)
+		return fmt.Errorf("creating apiexport multicluster provider: %w", err)
 	}
-	providerRunnable := &controllerProviderRunnable{
-		Provider:       provider,
-		runnable:       provider,
-		started:        make(chan struct{}),
-		result:         make(chan error, 1),
-		initialize:     providerTransportReadiness.Wait,
-		startupTimeout: setupTimeout,
-	}
-	// The lifecycle below reconstructs a manager after readiness loss while
-	// retaining stable controller names for metrics and logs. controller-runtime
-	// keeps its name registry for the process lifetime, so a replacement manager
-	// must skip that process-global check. The three names registered below are
-	// still explicit and distinct within every manager instance.
-	mgr, err := mcmanager.New(config, providerRunnable, manager.Options{
+	mgr, err := mcmanager.New(config, provider, manager.Options{
 		Scheme:     scheme,
 		Metrics:    metricsserver.Options{BindAddress: "0"},
 		Controller: controllerOptionsForRetryableManager(),
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating multicluster manager: %w", err)
+		return fmt.Errorf("creating multicluster manager: %w", err)
 	}
 	if err := (&connection.Reconciler{Validator: validator}).SetupWithManager(mgr); err != nil {
-		return nil, nil, fmt.Errorf("connection controller: %w", err)
+		return fmt.Errorf("connection controller: %w", err)
 	}
 	if err := (&warehouse.Reconciler{Validator: validator}).SetupWithManager(mgr); err != nil {
-		return nil, nil, fmt.Errorf("warehouse controller: %w", err)
+		return fmt.Errorf("warehouse controller: %w", err)
 	}
 	if err := (&table.Reconciler{Validator: validator}).SetupWithManager(mgr); err != nil {
-		return nil, nil, fmt.Errorf("table controller: %w", err)
+		return fmt.Errorf("table controller: %w", err)
 	}
-	return mgr, &controllerProviderReadiness{
-		started:        providerRunnable.started,
-		providerDone:   providerRunnable.result,
-		endpoint:       dyn.Resource(apiExportEndpointSliceGVR),
-		endpointName:   apiExportName,
-		startupTimeout: controllerStartupTimeoutFromEnv(),
-	}, nil
-}
 
-func controllerOptionsForRetryableManager() ctrlconfig.Controller {
-	skipNameValidation := true
-	return ctrlconfig.Controller{SkipNameValidation: &skipNameValidation}
-}
-
-// startControllerManager preserves the small setup API used by local callers:
-// it builds the manager and starts it in a goroutine. Production serving uses
-// startControllerManagerAttempt below so setup and manager exit participate in
-// the retry/readiness lifecycle.
-func startControllerManager(ctx context.Context, config *rest.Config, validator backend.Validator) (mcmanager.Manager, error) {
-	mgr, err := newControllerManager(ctx, config, validator)
-	if err != nil {
-		return nil, err
-	}
+	// Endpoint watchdog: the VW URL set can disappear after startup (shard
+	// topology change, slice rewritten). Stop the manager so the next term
+	// rebuilds against live discovery.
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	watchdogErr := make(chan error, 1)
 	go func() {
-		log.Printf("databricks controller manager starting (endpointSlice=%s)", apiExportName)
-		if err := mgr.Start(ctx); err != nil {
-			log.Printf("controller manager exited: %v", err)
+		ticker := time.NewTicker(slicePollInterval)
+		defer ticker.Stop()
+		misses := 0
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+			}
+			discovered, err := sliceEndpointDiscovered(runCtx, slice, apiExportName)
+			switch {
+			case err != nil || !discovered:
+				// Tolerate transient read failures; three consecutive misses
+				// (~15s) is a real loss.
+				misses++
+				if misses < 3 {
+					continue
+				}
+				if err == nil {
+					err = fmt.Errorf("APIExportEndpointSlice %q has no usable endpoint", apiExportName)
+				}
+				watchdogErr <- err
+				cancel()
+				return
+			default:
+				misses = 0
+			}
 		}
 	}()
-	return mgr, nil
-}
 
-func startControllerManagerAttempt(ctx context.Context, config *rest.Config, validator backend.Validator, health *controllerHealth, authority *managerAuthority) error {
-	mgr, providerReadiness, err := newControllerManagerWithReadiness(ctx, config, validator)
-	if err != nil {
-		return err
-	}
-	if authority != nil {
-		defer authority.Clear(mgr)
-	}
-	if health != nil || authority != nil {
-		if err := mgr.GetLocalManager().Add(controllerReadyRunnable(
-			health,
-			providerReadiness.Wait,
-			providerReadiness.Monitor,
-			func() {
-				if authority != nil {
-					authority.Set(mgr)
-				}
-				if health != nil {
-					health.markReady()
-				}
-			},
-			func() {
-				if authority != nil {
-					authority.Clear(mgr)
-				}
-			},
-		)); err != nil {
-			return fmt.Errorf("controller health runnable: %w", err)
-		}
-	}
+	health.markReady()
 	log.Printf("databricks controller manager starting (endpointSlice=%s)", apiExportName)
-	if err := mgr.Start(ctx); err != nil {
-		return fmt.Errorf("controller manager exited: %w", err)
+	err = mgr.Start(runCtx)
+	select {
+	case werr := <-watchdogErr:
+		return fmt.Errorf("multicluster provider lost readiness: %w", werr)
+	default:
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-	return errors.New("controller manager exited without an error")
+	return err
 }
 
-func controllerReadyRunnable(health *controllerHealth, waitForUsable, monitor func(context.Context) error, onReady, onStop func()) manager.Runnable {
-	return manager.RunnableFunc(func(ctx context.Context) error {
-		if waitForUsable != nil {
-			if err := waitForUsable(ctx); err != nil {
-				return fmt.Errorf("multicluster provider not discovered: %w", err)
-			}
-		}
-		if err := ctx.Err(); err != nil {
+// waitForSliceEndpoint blocks until the endpoint slice publishes at least one
+// usable URL, the timeout elapses, or ctx ends.
+func waitForSliceEndpoint(ctx context.Context, slice dynamic.ResourceInterface, name string, timeout time.Duration) error {
+	timeout = clampControllerDuration(timeout, controllerStartupTimeout, controllerStartupTimeoutMin, controllerStartupTimeoutMax)
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		discovered, err := sliceEndpointDiscovered(waitCtx, slice, name)
+		if err != nil && waitCtx.Err() == nil {
 			return err
 		}
-		if onReady != nil {
-			onReady()
-		} else if health != nil {
-			health.markReady()
-		}
-		if monitor != nil {
-			if err := monitor(ctx); err != nil {
-				if ctx.Err() != nil {
-					if onStop != nil {
-						onStop()
-					}
-					return nil
-				}
-				if health != nil {
-					health.markFailed(err)
-				}
-				if onStop != nil {
-					onStop()
-				}
-				return fmt.Errorf("multicluster provider lost readiness: %w", err)
-			}
+		if discovered {
 			return nil
 		}
-		<-ctx.Done()
-		if onStop != nil {
-			onStop()
+		select {
+		case <-waitCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("multicluster provider discovery timed out after %s: APIExportEndpointSlice %q has no usable endpoint", timeout, name)
+		case <-time.After(slicePollInterval):
 		}
-		return nil
-	})
+	}
+}
+
+// sliceEndpointDiscovered reports whether the slice carries at least one
+// endpoint with a non-empty URL. NotFound is "not yet", not an error.
+func sliceEndpointDiscovered(ctx context.Context, slice dynamic.ResourceInterface, name string) (bool, error) {
+	obj, err := slice.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading APIExportEndpointSlice %q: %w", name, err)
+	}
+	return len(tenant.SliceEndpointURLs(obj)) > 0, nil
 }
 
 func controllerModeFromEnv() controllerMode {
@@ -935,78 +441,6 @@ func clampControllerDuration(value, defaultValue, minValue, maxValue time.Durati
 		return maxValue
 	}
 	return value
-}
-
-func normalizeControllerRetryInterval(interval time.Duration) time.Duration {
-	if interval <= 0 {
-		return controllerRetryIntervalMin
-	}
-	return clampControllerDuration(interval, controllerRetryInterval, controllerRetryIntervalMin, controllerRetryIntervalMax)
-}
-
-// runControllerManager owns setup, manager start/exit, health transitions, and
-// bounded recovery. A configured provider keeps serving /healthz while this
-// loop retries, but /readyz and heartbeat eligibility remain false until the
-// manager's runnables have launched.
-func runControllerManager(ctx context.Context, health *controllerHealth, loadConfig func() (*rest.Config, error), start func(context.Context, *rest.Config) error, retryInterval time.Duration) {
-	runControllerManagerWithRetryGate(ctx, health, loadConfig, start, retryInterval, waitControllerRetry)
-}
-
-func waitControllerRetry(ctx context.Context, retryInterval time.Duration) bool {
-	retryInterval = normalizeControllerRetryInterval(retryInterval)
-	timer := time.NewTimer(retryInterval)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
-	}
-}
-
-func runControllerManagerWithRetryGate(ctx context.Context, health *controllerHealth, loadConfig func() (*rest.Config, error), start func(context.Context, *rest.Config) error, retryInterval time.Duration, retryGate func(context.Context, time.Duration) bool) {
-	if health == nil {
-		health = newControllerHealth(true)
-	}
-	if !health.snapshot().Required {
-		health.markRESTOnly()
-		log.Printf("controller manager disabled: explicit REST-only mode")
-		return
-	}
-	if loadConfig == nil || start == nil {
-		err := errors.New("controller manager lifecycle dependencies are not configured")
-		health.markFailed(err)
-		log.Printf("controller manager not ready: %v", err)
-		return
-	}
-	if retryGate == nil {
-		retryGate = waitControllerRetry
-	}
-	retryInterval = normalizeControllerRetryInterval(retryInterval)
-	for attempt := 1; ; attempt++ {
-		if err := ctx.Err(); err != nil {
-			health.markStopped(err)
-			return
-		}
-		health.markStarting()
-		config, err := loadConfig()
-		if err == nil {
-			err = start(ctx, config)
-		}
-		if ctx.Err() != nil {
-			health.markStopped(ctx.Err())
-			return
-		}
-		if err == nil {
-			err = errors.New("controller manager exited without an error")
-		}
-		health.markFailed(err)
-		log.Printf("controller manager not ready (attempt %d): %v; retrying in %s", attempt, err, retryInterval)
-		if !retryGate(ctx, retryInterval) {
-			health.markStopped(ctx.Err())
-			return
-		}
-	}
 }
 
 func parseBoolEnv(key string, defaultValue bool) bool {

--- a/providers/databricks/controller_manager.go
+++ b/providers/databricks/controller_manager.go
@@ -209,6 +209,14 @@ func (h *controllerHealth) heartbeatStatus() string {
 // managerAuthority is installed in the tenant client factory once. The
 // controller retry loop swaps the currently running manager into it and clears
 // it after an exit, so requests cannot use a manager that is no longer alive.
+//
+// This coupling is also why the manager is deliberately NOT leader-elected
+// (unlike code/vibe-studio/infrastructure): the HTTP action path resolves
+// tenant clusters through the running manager via this authority, so it must
+// run on every replica — a lease-gated manager would leave non-leaders unable
+// to serve actions. The reconcilers are idempotent status stampers, so
+// active-active is churn, not corruption; keep replicaCount at 1 until the
+// serving path gets its own cluster resolver.
 type managerAuthority struct {
 	mu  sync.RWMutex
 	mgr mcmanager.Manager

--- a/providers/databricks/controller_manager_test.go
+++ b/providers/databricks/controller_manager_test.go
@@ -10,239 +10,75 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/kcp-dev/multicluster-provider/apiexport"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
-	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
-
-	databricksscheme "github.com/faroshq/provider-databricks/scheme"
-	"github.com/faroshq/provider-databricks/tenant"
 )
 
-func TestControllerHealthLifecycle(t *testing.T) {
+func TestControllerHealthReadinessIsServingOnly(t *testing.T) {
 	health := newControllerHealth(true)
 	if got := health.snapshot(); got.State != controllerStateStarting || !got.Required {
 		t.Fatalf("initial controller health = %+v, want required/starting", got)
 	}
-	if health.ready() || health.heartbeatStatus() != "starting" {
-		t.Fatal("required controller should not be ready before start")
+	// Without a dependency gate, readiness no longer follows controller state:
+	// under leader election a standby replica runs no manager yet must serve.
+	if !health.ready() {
+		t.Fatal("health without a dependency gate must be ready regardless of controller state")
 	}
 	health.markFailed(errors.New("endpoint slice unavailable"))
 	if got := health.snapshot(); got.State != controllerStateFailed || got.Error != "endpoint slice unavailable" {
-		t.Fatalf("failed controller health = %+v, want failure", got)
+		t.Fatalf("failed controller health = %+v, want failure recorded", got)
 	}
-	if health.ready() || health.heartbeatStatus() != "unhealthy" {
-		t.Fatal("failed required controller should not be ready or healthy")
+	if !health.ready() {
+		t.Fatal("controller failure must not fail serving readiness")
 	}
-	health.markReady()
-	if got := health.snapshot(); got.State != controllerStateReady || !health.ready() || health.heartbeatStatus() != "healthy" {
-		t.Fatalf("running controller health = %+v, want ready/healthy", got)
+
+	// The dependency gate (factory configured + slice authority discovered)
+	// is the only readiness input.
+	serving := false
+	health.setDependencyReady(func() bool { return serving })
+	if health.ready() || health.heartbeatStatus() == "healthy" {
+		t.Fatal("dependency-gated health reported ready before the dependency was")
 	}
-	health.markStopped(context.Canceled)
-	if got := health.snapshot(); got.State != controllerStateStopped || got.Error != context.Canceled.Error() || health.ready() {
-		t.Fatalf("stopped controller health = %+v, want stopped/not ready", got)
+	serving = true
+	if !health.ready() || health.heartbeatStatus() != "healthy" {
+		t.Fatal("dependency-gated health not ready after the dependency became ready")
+	}
+
+	health.markStandby()
+	if got := health.snapshot(); got.State != controllerStateStandby {
+		t.Fatalf("standby controller health = %+v, want standby", got)
+	}
+	if !health.ready() {
+		t.Fatal("standby replica must stay ready")
+	}
+}
+
+func TestControllerHealthHeartbeatStatus(t *testing.T) {
+	health := newControllerHealth(true)
+	ready := false
+	health.setDependencyReady(func() bool { return ready })
+	if got := health.heartbeatStatus(); got != "starting" {
+		t.Fatalf("heartbeat while starting = %q, want starting", got)
+	}
+	health.markFailed(errors.New("boom"))
+	if got := health.heartbeatStatus(); got != "unhealthy" {
+		t.Fatalf("heartbeat while failed and unready = %q, want unhealthy", got)
+	}
+	ready = true
+	if got := health.heartbeatStatus(); got != "healthy" {
+		t.Fatalf("heartbeat while serving-ready = %q, want healthy", got)
 	}
 }
 
 func TestControllerOptionsForRetryableManagerAllowsStableNames(t *testing.T) {
 	options := controllerOptionsForRetryableManager()
 	if options.SkipNameValidation == nil || !*options.SkipNameValidation {
-		t.Fatal("retryable manager must allow stable controller names across process-lifetime rebuilds")
-	}
-}
-
-func TestControllerReadyRunnableGatesAuthorityUntilProviderDiscovery(t *testing.T) {
-	health := newControllerHealth(true)
-	authority := &managerAuthority{}
-	mgr := &startupGateManager{}
-	providerStarted := make(chan struct{})
-	providerDiscovered := make(chan struct{})
-	ready := make(chan struct{})
-	stopped := make(chan struct{})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	done := make(chan error, 1)
-	go func() {
-		done <- controllerReadyRunnable(
-			health,
-			func(waitCtx context.Context) error {
-				select {
-				case <-providerStarted:
-				case <-waitCtx.Done():
-					return waitCtx.Err()
-				}
-				select {
-				case <-providerDiscovered:
-					return nil
-				case <-waitCtx.Done():
-					return waitCtx.Err()
-				}
-			},
-			nil,
-			func() {
-				authority.Set(mgr)
-				health.markReady()
-				close(ready)
-			},
-			func() {
-				authority.Clear(mgr)
-				close(stopped)
-			},
-		).Start(ctx)
-	}()
-
-	close(providerStarted)
-	if got := health.snapshot(); got.State != controllerStateStarting {
-		t.Fatalf("health before provider discovery = %+v, want starting", got)
-	}
-	if _, err := authority.GetCluster(context.Background(), multicluster.ClusterName("tenant")); err == nil || err.Error() != "provider controller manager unavailable" {
-		t.Fatalf("authority before provider discovery = %v, want unavailable", err)
-	}
-
-	close(providerDiscovered)
-	select {
-	case <-ready:
-	case <-time.After(time.Second):
-		t.Fatal("controller did not become ready after provider discovery")
-	}
-	if got := health.snapshot(); got.State != controllerStateReady {
-		t.Fatalf("health after provider discovery = %+v, want ready", got)
-	}
-	if _, err := authority.GetCluster(context.Background(), multicluster.ClusterName("tenant")); err == nil || err.Error() != "startup gate manager" {
-		t.Fatalf("authority after provider discovery = %v, want live manager", err)
-	}
-
-	cancel()
-	select {
-	case <-stopped:
-	case <-time.After(time.Second):
-		t.Fatal("controller did not clear authority on exit")
-	}
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("controller ready runnable returned error: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("controller ready runnable did not stop")
-	}
-	if _, err := authority.GetCluster(context.Background(), multicluster.ClusterName("tenant")); err == nil || err.Error() != "provider controller manager unavailable" {
-		t.Fatalf("authority after manager exit = %v, want unavailable", err)
-	}
-}
-
-func TestRunControllerManagerRetriesSetupAndPostStartFailures(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	health := newControllerHealth(true)
-	var loads, starts atomic.Int32
-	firstRetry := make(chan struct{})
-	allowFirstRetry := make(chan struct{})
-	secondRetry := make(chan struct{})
-	allowSecondRetry := make(chan struct{})
-	secondReady := make(chan struct{})
-	done := make(chan struct{})
-
-	loadConfig := func() (*rest.Config, error) {
-		if loads.Add(1) == 1 {
-			return nil, errors.New("provider kubeconfig is not bootstrapped")
-		}
-		return &rest.Config{}, nil
-	}
-	start := func(startCtx context.Context, _ *rest.Config) error {
-		if starts.Add(1) == 1 {
-			return errors.New("manager exited after start")
-		}
-		health.markReady()
-		close(secondReady)
-		<-startCtx.Done()
-		return startCtx.Err()
-	}
-	retryCalls := atomic.Int32{}
-	retryGate := func(retryCtx context.Context, _ time.Duration) bool {
-		switch retryCalls.Add(1) {
-		case 1:
-			close(firstRetry)
-			select {
-			case <-allowFirstRetry:
-				return true
-			case <-retryCtx.Done():
-				return false
-			}
-		case 2:
-			close(secondRetry)
-			select {
-			case <-allowSecondRetry:
-				return true
-			case <-retryCtx.Done():
-				return false
-			}
-		default:
-			return false
-		}
-	}
-
-	go func() {
-		runControllerManagerWithRetryGate(ctx, health, loadConfig, start, 15*time.Second, retryGate)
-		close(done)
-	}()
-	waitForDatabricksControllerSignal(t, firstRetry)
-	if got := health.snapshot(); got.State != controllerStateFailed || got.Error != "provider kubeconfig is not bootstrapped" {
-		t.Fatalf("first failed health = %+v", got)
-	}
-	close(allowFirstRetry)
-	waitForDatabricksControllerSignal(t, secondRetry)
-	if got := health.snapshot(); got.State != controllerStateFailed || got.Error != "manager exited after start" {
-		t.Fatalf("second failed health = %+v", got)
-	}
-	close(allowSecondRetry)
-	waitForDatabricksControllerSignal(t, secondReady)
-	if starts.Load() != 2 || !health.ready() {
-		t.Fatalf("starts=%d ready=%v, want 2/true", starts.Load(), health.ready())
-	}
-	cancel()
-	waitForDatabricksControllerSignal(t, done)
-	if health.snapshot().State != controllerStateStopped {
-		t.Fatalf("final health = %+v, want stopped", health.snapshot())
-	}
-}
-
-func TestRunControllerManagerLeavesRESTOnlyModeReady(t *testing.T) {
-	health := newControllerHealth(false)
-	var loads, starts atomic.Int32
-	runControllerManager(context.Background(), health,
-		func() (*rest.Config, error) {
-			loads.Add(1)
-			return nil, errors.New("must not load")
-		},
-		func(context.Context, *rest.Config) error {
-			starts.Add(1)
-			return errors.New("must not start")
-		}, 0)
-	if got := health.snapshot(); got.State != controllerStateRESTOnly || !health.ready() || health.heartbeatStatus() != "healthy" {
-		t.Fatalf("REST-only health = %+v, want ready/rest-only", got)
-	}
-	if loads.Load() != 0 || starts.Load() != 0 {
-		t.Fatalf("REST-only lifecycle called dependencies: load=%d start=%d", loads.Load(), starts.Load())
+		t.Fatal("per-term managers must allow stable controller names across rebuilds")
 	}
 }
 
@@ -253,736 +89,19 @@ func TestControllerModeFromEnvRequiresExplicitRESTOnlyOptIn(t *testing.T) {
 	t.Setenv("DATABRICKS_KUBECONFIG", "")
 	t.Setenv("KUBECONFIG", "")
 	if got := controllerModeFromEnv(); got != controllerModeRESTOnly {
-		t.Fatalf("unset controller mode without kubeconfig = %q, want rest-only", got)
+		t.Fatalf("mode without kubeconfig = %q, want rest-only", got)
 	}
-	t.Setenv("DATABRICKS_KUBECONFIG", "/var/run/secrets/faros/provider-kubeconfig")
+	t.Setenv("KUBECONFIG", "/tmp/kubeconfig")
 	if got := controllerModeFromEnv(); got != controllerModeRequired {
-		t.Fatalf("DATABRICKS_KUBECONFIG controller mode = %q, want required", got)
+		t.Fatalf("mode with kubeconfig = %q, want required", got)
 	}
 	t.Setenv("DATABRICKS_REST_ONLY", "true")
 	if got := controllerModeFromEnv(); got != controllerModeRESTOnly {
-		t.Fatalf("explicit REST-only opt-in with DATABRICKS_KUBECONFIG = %q, want rest-only", got)
+		t.Fatalf("explicit REST-only opt-out = %q, want rest-only", got)
 	}
-	t.Setenv("DATABRICKS_REST_ONLY", "")
-
-	t.Setenv("DATABRICKS_CONTROLLER_MODE", "required")
+	t.Setenv("DATABRICKS_CONTROLLER_MODE", "definitely-not-a-mode")
 	if got := controllerModeFromEnv(); got != controllerModeRequired {
-		t.Fatalf("required controller mode = %q, want required", got)
-	}
-	t.Setenv("DATABRICKS_CONTROLLER_MODE", "rest-only")
-	if got := controllerModeFromEnv(); got != controllerModeRESTOnly {
-		t.Fatalf("rest-only controller mode = %q, want rest-only", got)
-	}
-	t.Setenv("DATABRICKS_CONTROLLER_MODE", "invalid")
-	if got := controllerModeFromEnv(); got != controllerModeRequired {
-		t.Fatalf("invalid controller mode = %q, want fail-closed required", got)
-	}
-}
-
-func TestControllerProviderReadinessTimesOutAndRecoversWithoutSleep(t *testing.T) {
-	started := make(chan struct{})
-	close(started)
-	missing := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()).Resource(apiExportEndpointSliceGVR)
-	var timeoutPassed time.Duration
-	timedOut := &controllerProviderReadiness{
-		started:        started,
-		endpoint:       missing,
-		endpointName:   apiExportName,
-		startupTimeout: time.Nanosecond,
-		withTimeout: func(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-			timeoutPassed = timeout
-			return context.WithDeadline(parent, time.Unix(0, 0))
-		},
-	}
-	err := timedOut.Wait(context.Background())
-	if !errors.Is(err, errControllerProviderDiscoveryTimeout) {
-		t.Fatalf("missing endpoint readiness error = %v, want classified timeout", err)
-	}
-	if timeoutPassed != controllerStartupTimeoutMin {
-		t.Fatalf("startup timeout passed to gate = %s, want safe minimum %s", timeoutPassed, controllerStartupTimeoutMin)
-	}
-
-	readyObject := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apis.kcp.io/v1alpha1",
-		"kind":       "APIExportEndpointSlice",
-		"metadata":   map[string]any{"name": apiExportName},
-		"status": map[string]any{
-			"endpoints": []any{map[string]any{"url": "https://provider.example"}},
-		},
-	}}
-	readyClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), readyObject).Resource(apiExportEndpointSliceGVR)
-	recovered := &controllerProviderReadiness{
-		started:      started,
-		endpoint:     readyClient,
-		endpointName: apiExportName,
-		withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-			return context.WithCancel(parent)
-		},
-	}
-	if err := recovered.Wait(context.Background()); err != nil {
-		t.Fatalf("recovered endpoint readiness error = %v, want ready", err)
-	}
-}
-
-func TestControllerProviderRunnableWaitsForInitializationBeforeReadiness(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	initRelease := make(chan struct{})
-	providerStarted := make(chan struct{})
-	providerDone := make(chan error, 1)
-	provider := &controllerProviderRunnable{
-		Provider: &controllerProviderStub{},
-		runnable: controllerProviderRunnableStub(func(providerCtx context.Context, _ multicluster.Aware) error {
-			close(providerStarted)
-			<-providerCtx.Done()
-			return providerCtx.Err()
-		}),
-		started: make(chan struct{}),
-		result:  providerDone,
-		initialize: func(initCtx context.Context) error {
-			select {
-			case <-initRelease:
-				return nil
-			case <-initCtx.Done():
-				return initCtx.Err()
-			}
-		},
-		startupTimeout: controllerStartupTimeoutMin,
-		withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-			return context.WithCancel(parent)
-		},
-	}
-	readyObject := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apis.kcp.io/v1alpha1",
-		"kind":       "APIExportEndpointSlice",
-		"metadata":   map[string]any{"name": apiExportName},
-		"status": map[string]any{
-			"endpoints": []any{map[string]any{"url": "https://provider.example"}},
-		},
-	}}
-	endpoint := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), readyObject).Resource(apiExportEndpointSliceGVR)
-	readiness := &controllerProviderReadiness{
-		started:      provider.started,
-		providerDone: provider.result,
-		endpoint:     endpoint,
-		endpointName: apiExportName,
-		withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-			return context.WithCancel(parent)
-		},
-	}
-	health := newControllerHealth(true)
-	authority := &managerAuthority{}
-	mgr := &startupGateManager{}
-	readySignal := make(chan struct{})
-	done := make(chan error, 1)
-	go func() {
-		done <- controllerReadyRunnable(
-			health,
-			readiness.Wait,
-			nil,
-			func() {
-				authority.Set(mgr)
-				health.markReady()
-				close(readySignal)
-			},
-			func() { authority.Clear(mgr) },
-		).Start(ctx)
-	}()
-	startDone := make(chan error, 1)
-	go func() { startDone <- provider.Start(ctx, nil) }()
-
-	waitForDatabricksControllerSignal(t, providerStarted)
-	if health.ready() || authority.Ready() {
-		t.Fatal("pre-existing endpoint made authority/health ready before provider initialization")
-	}
-	close(initRelease)
-	waitForDatabricksControllerSignal(t, providerStarted)
-	select {
-	case <-provider.started:
-	case <-time.After(time.Second):
-		t.Fatal("provider readiness signal did not follow initialization")
-	}
-	waitForDatabricksControllerSignal(t, readySignal)
-	if !health.ready() || !authority.Ready() {
-		t.Fatal("provider initialization did not unlock readiness")
-	}
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("readiness runnable did not stop")
-	}
-	select {
-	case <-startDone:
-	case <-time.After(time.Second):
-		t.Fatal("provider runnable did not stop")
-	}
-}
-
-func TestControllerProviderTransportReadinessTracksActualProviderCache(t *testing.T) {
-	endpointPath := "/apis/" + apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version + "/" + apiExportEndpointSliceGVR.Resource
-	listStarted := make(chan struct{})
-	watchStarted := make(chan struct{})
-	var listOnce, watchOnce sync.Once
-	providerTransport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		response := func(body any) (*http.Response, error) {
-			encoded, err := json.Marshal(body)
-			if err != nil {
-				return nil, err
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       io.NopCloser(strings.NewReader(string(encoded))),
-				Request:    r,
-			}, nil
-		}
-		switch strings.TrimRight(r.URL.Path, "/") {
-		case "/api":
-			return response(map[string]any{"apiVersion": "v1", "kind": "APIVersions", "versions": []any{"v1"}})
-		case "/apis":
-			return response(map[string]any{
-				"apiVersion": "v1",
-				"kind":       "APIGroupList",
-				"groups": []any{map[string]any{
-					"name":             apiExportEndpointSliceGVR.Group,
-					"preferredVersion": map[string]any{"groupVersion": apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version, "version": apiExportEndpointSliceGVR.Version},
-					"versions":         []any{map[string]any{"groupVersion": apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version, "version": apiExportEndpointSliceGVR.Version}},
-				}},
-			})
-		case "/apis/" + apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version:
-			return response(map[string]any{
-				"apiVersion":   apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version,
-				"kind":         "APIResourceList",
-				"groupVersion": apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version,
-				"resources": []any{map[string]any{
-					"name":  apiExportEndpointSliceGVR.Resource,
-					"kind":  "APIExportEndpointSlice",
-					"verbs": []any{"get", "list", "watch"},
-				}},
-			})
-		}
-		if !strings.HasSuffix(r.URL.Path, endpointPath) {
-			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Request: r}, nil
-		}
-		if strings.EqualFold(r.URL.Query().Get("watch"), "true") {
-			watchOnce.Do(func() { close(watchStarted) })
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body:       &controllerBlockingReadCloser{ctx: r.Context(), initial: []byte(`{"type":"BOOKMARK","object":{"metadata":{"resourceVersion":"1"}}}`)},
-				Request:    r,
-			}, nil
-		}
-		listOnce.Do(func() { close(listStarted) })
-		listBody, err := json.Marshal(map[string]any{
-			"apiVersion": "apis.kcp.io/v1alpha1",
-			"kind":       "APIExportEndpointSliceList",
-			"metadata":   map[string]any{"resourceVersion": "1"},
-			"items":      []any{},
-		})
-		if err != nil {
-			return nil, err
-		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body:       io.NopCloser(strings.NewReader(string(listBody))),
-			Request:    r,
-		}, nil
-	})
-
-	providerConfig, providerReadiness := controllerProviderConfig(&rest.Config{Host: "https://kcp.example", Transport: providerTransport})
-	provider, err := apiexport.New(providerConfig, apiExportName, apiexport.Options{Scheme: databricksscheme.NewScheme()})
-	if err != nil {
-		t.Fatalf("create apiexport provider: %v", err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- provider.Start(ctx, nil) }()
-	waitForDatabricksControllerSignal(t, listStarted)
-	waitForDatabricksControllerSignal(t, watchStarted)
-	if err := providerReadiness.Wait(ctx); err != nil {
-		t.Fatalf("actual provider cache readiness = %v, want ready after list/watch", err)
-	}
-	cancel()
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("actual provider stopped with error: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("actual provider did not stop after cancellation")
-	}
-}
-
-func TestControllerProviderTransportReadinessPreservesExistingWrapper(t *testing.T) {
-	var existingCalls atomic.Int32
-	config := &rest.Config{
-		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
-			return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				existingCalls.Add(1)
-				return rt.RoundTrip(req)
-			})
-		},
-	}
-	providerConfig, _ := controllerProviderConfig(config)
-	wrapped := providerConfig.WrapTransport(roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))}, nil
-	}))
-	if _, err := wrapped.RoundTrip(httptest.NewRequest(http.MethodGet, "https://kcp.example/api/v1/healthz", nil)); err != nil {
-		t.Fatalf("wrapped transport request: %v", err)
-	}
-	if existingCalls.Load() != 1 {
-		t.Fatalf("existing transport wrapper calls = %d, want 1", existingCalls.Load())
-	}
-}
-
-func TestControllerProviderTransportReadinessTimeoutCancelsAttemptBeforeRetry(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	health := newControllerHealth(true)
-	authority := &managerAuthority{}
-	var starts atomic.Int32
-	listStarted := make(chan struct{})
-	providerStopped := make(chan struct{})
-	retryStarted := make(chan struct{})
-	allowRetry := make(chan struct{})
-	recovered := make(chan struct{})
-	done := make(chan struct{})
-	loadConfig := func() (*rest.Config, error) { return &rest.Config{Host: "https://kcp.example"}, nil }
-	start := func(startCtx context.Context, _ *rest.Config) error {
-		if starts.Add(1) == 1 {
-			endpointPath := "/apis/" + apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version + "/" + apiExportEndpointSliceGVR.Resource
-			listStartedOnce := sync.Once{}
-			providerTransport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-				response := func(body any) (*http.Response, error) {
-					encoded, err := json.Marshal(body)
-					if err != nil {
-						return nil, err
-					}
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Header:     http.Header{"Content-Type": []string{"application/json"}},
-						Body:       io.NopCloser(strings.NewReader(string(encoded))),
-						Request:    r,
-					}, nil
-				}
-				switch strings.TrimRight(r.URL.Path, "/") {
-				case "/api":
-					return response(map[string]any{"apiVersion": "v1", "kind": "APIVersions", "versions": []any{"v1"}})
-				case "/apis":
-					return response(map[string]any{
-						"apiVersion": "v1",
-						"kind":       "APIGroupList",
-						"groups": []any{map[string]any{
-							"name":             apiExportEndpointSliceGVR.Group,
-							"preferredVersion": map[string]any{"groupVersion": apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version, "version": apiExportEndpointSliceGVR.Version},
-							"versions":         []any{map[string]any{"groupVersion": apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version, "version": apiExportEndpointSliceGVR.Version}},
-						}},
-					})
-				case "/apis/" + apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version:
-					return response(map[string]any{
-						"apiVersion":   apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version,
-						"kind":         "APIResourceList",
-						"groupVersion": apiExportEndpointSliceGVR.Group + "/" + apiExportEndpointSliceGVR.Version,
-						"resources": []any{map[string]any{
-							"name":  apiExportEndpointSliceGVR.Resource,
-							"kind":  "APIExportEndpointSlice",
-							"verbs": []any{"get", "list", "watch"},
-						}},
-					})
-				}
-				if !strings.HasSuffix(r.URL.Path, endpointPath) {
-					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Request: r}, nil
-				}
-				listStartedOnce.Do(func() { close(listStarted) })
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       &controllerBlockingReadCloser{ctx: r.Context(), stopped: providerStopped},
-					Request:    r,
-				}, nil
-			})
-			providerConfig, providerReadiness := controllerProviderConfig(&rest.Config{Host: "https://kcp.example", Transport: providerTransport})
-			provider, err := apiexport.New(providerConfig, apiExportName, apiexport.Options{Scheme: databricksscheme.NewScheme()})
-			if err != nil {
-				return err
-			}
-			providerRunnable := &controllerProviderRunnable{
-				Provider:       provider,
-				runnable:       provider,
-				started:        make(chan struct{}),
-				result:         make(chan error, 1),
-				initialize:     providerReadiness.Wait,
-				startupTimeout: controllerStartupTimeoutMin,
-			}
-			deadlineReady := make(chan *controllerTestDeadlineContext, 1)
-			providerRunnable.withTimeout = func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-				deadline := newControllerTestDeadlineContext(parent)
-				deadlineReady <- deadline
-				return deadline, deadline.expire
-			}
-			readyObject := &unstructured.Unstructured{Object: map[string]any{
-				"apiVersion": "apis.kcp.io/v1alpha1",
-				"kind":       "APIExportEndpointSlice",
-				"metadata":   map[string]any{"name": apiExportName},
-				"status": map[string]any{
-					"endpoints": []any{map[string]any{"url": "https://provider.example"}},
-				},
-			}}
-			endpoint := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), readyObject).Resource(apiExportEndpointSliceGVR)
-			readiness := &controllerProviderReadiness{
-				started:      providerRunnable.started,
-				providerDone: providerRunnable.result,
-				endpoint:     endpoint,
-				endpointName: apiExportName,
-				withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-					return context.WithCancel(parent)
-				},
-			}
-			attemptCtx, cancelAttempt := context.WithCancel(startCtx)
-			defer cancelAttempt()
-			providerDone := make(chan error, 1)
-			go func() { providerDone <- providerRunnable.Start(attemptCtx, nil) }()
-			readyDone := make(chan error, 1)
-			go func() {
-				readyDone <- controllerReadyRunnable(health, readiness.Wait, nil, func() {
-					authority.Set(&startupGateManager{})
-					health.markReady()
-				}, nil).Start(attemptCtx)
-			}()
-			select {
-			case <-listStarted:
-			case <-time.After(time.Second):
-				return errors.New("actual provider did not start the blocked endpoint request")
-			}
-			if health.ready() || authority.Ready() {
-				return errors.New("preexisting endpoint made readiness authoritative before actual provider startup")
-			}
-			deadline := <-deadlineReady
-			deadline.expire()
-			providerErr := <-providerDone
-			if !errors.Is(providerErr, errControllerProviderDiscoveryTimeout) {
-				return fmt.Errorf("provider timeout = %v, want classified discovery timeout", providerErr)
-			}
-			waitErr := <-readyDone
-			if waitErr == nil {
-				return errors.New("readiness gate unexpectedly succeeded before actual provider signal")
-			}
-			select {
-			case <-providerStopped:
-			case <-time.After(time.Second):
-				return errors.New("stuck provider request was not canceled after startup timeout")
-			}
-			return providerErr
-		}
-		mgr := &startupGateManager{}
-		authority.Set(mgr)
-		health.markReady()
-		close(recovered)
-		<-startCtx.Done()
-		authority.Clear(mgr)
-		return startCtx.Err()
-	}
-	retryGate := func(retryCtx context.Context, _ time.Duration) bool {
-		close(retryStarted)
-		select {
-		case <-allowRetry:
-			return true
-		case <-retryCtx.Done():
-			return false
-		}
-	}
-	go func() {
-		runControllerManagerWithRetryGate(ctx, health, loadConfig, start, 0, retryGate)
-		close(done)
-	}()
-	waitForDatabricksControllerSignal(t, retryStarted)
-	if got := health.snapshot(); got.State != controllerStateFailed || !strings.Contains(got.Error, errControllerProviderDiscoveryTimeout.Error()) {
-		t.Fatalf("stuck provider health = %+v, want classified timeout failure", got)
-	}
-	if health.ready() || authority.Ready() {
-		t.Fatal("stuck provider left readiness or authority enabled before retry")
-	}
-	close(allowRetry)
-	waitForDatabricksControllerSignal(t, recovered)
-	if starts.Load() != 2 || !health.ready() || !authority.Ready() {
-		t.Fatalf("recovered attempt starts=%d ready=%v authority=%v, want 2/true/true", starts.Load(), health.ready(), authority.Ready())
-	}
-	cancel()
-	waitForDatabricksControllerSignal(t, done)
-}
-
-func TestControllerSetupDeadlineClassifiesStalledSetup(t *testing.T) {
-	called := make(chan struct{})
-	err := controllerBoundedSetup(context.Background(), time.Nanosecond, func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-		return context.WithDeadline(parent, time.Unix(0, 0))
-	}, func(setupCtx context.Context) error {
-		close(called)
-		return setupCtx.Err()
-	})
-	if !errors.Is(err, errControllerProviderDiscoveryTimeout) {
-		t.Fatalf("stalled setup error = %v, want classified timeout", err)
-	}
-	select {
-	case <-called:
-	default:
-		t.Fatal("bounded setup callback was not invoked")
-	}
-}
-
-func TestControllerReadinessTimeoutRetriesUntilEndpointRecovery(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	health := newControllerHealth(true)
-	started := make(chan struct{})
-	close(started)
-	missing := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()).Resource(apiExportEndpointSliceGVR)
-	readyObject := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "apis.kcp.io/v1alpha1",
-		"kind":       "APIExportEndpointSlice",
-		"metadata":   map[string]any{"name": apiExportName},
-		"status": map[string]any{
-			"endpoints": []any{map[string]any{"url": "https://provider.example"}},
-		},
-	}}
-	readyClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), readyObject).Resource(apiExportEndpointSliceGVR)
-	var starts atomic.Int32
-	retryStarted := make(chan struct{})
-	allowRetry := make(chan struct{})
-	ready := make(chan struct{})
-	done := make(chan struct{})
-	loadConfig := func() (*rest.Config, error) { return &rest.Config{Host: "https://kcp.example"}, nil }
-	start := func(startCtx context.Context, _ *rest.Config) error {
-		if starts.Add(1) == 1 {
-			readiness := &controllerProviderReadiness{
-				started:        started,
-				endpoint:       missing,
-				endpointName:   apiExportName,
-				startupTimeout: controllerStartupTimeoutMin,
-				withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-					return context.WithDeadline(parent, time.Unix(0, 0))
-				},
-			}
-			return readiness.Wait(startCtx)
-		}
-		readiness := &controllerProviderReadiness{
-			started:      started,
-			endpoint:     readyClient,
-			endpointName: apiExportName,
-			withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-				return context.WithCancel(parent)
-			},
-		}
-		if err := readiness.Wait(startCtx); err != nil {
-			return err
-		}
-		health.markReady()
-		close(ready)
-		<-startCtx.Done()
-		return startCtx.Err()
-	}
-	retryGate := func(retryCtx context.Context, _ time.Duration) bool {
-		close(retryStarted)
-		select {
-		case <-allowRetry:
-			return true
-		case <-retryCtx.Done():
-			return false
-		}
-	}
-
-	go func() {
-		runControllerManagerWithRetryGate(ctx, health, loadConfig, start, 0, retryGate)
-		close(done)
-	}()
-	waitForDatabricksControllerSignal(t, retryStarted)
-	if got := health.snapshot(); got.State != controllerStateFailed || !strings.Contains(got.Error, errControllerProviderDiscoveryTimeout.Error()) {
-		t.Fatalf("timeout health = %+v, want failed classified timeout", got)
-	}
-	close(allowRetry)
-	waitForDatabricksControllerSignal(t, ready)
-	if !health.ready() || starts.Load() != 2 {
-		t.Fatalf("recovered controller starts=%d ready=%v, want 2/true", starts.Load(), health.ready())
-	}
-	cancel()
-	waitForDatabricksControllerSignal(t, done)
-}
-
-func TestControllerEndpointLossClearsAuthorityAndRetries(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	health := newControllerHealth(true)
-	authority := &managerAuthority{}
-	var starts atomic.Int32
-	retryStarted := make(chan struct{})
-	allowRetry := make(chan struct{})
-	recovered := make(chan struct{})
-	providerStopped := make(chan struct{})
-	done := make(chan struct{})
-	loadConfig := func() (*rest.Config, error) { return &rest.Config{Host: "https://kcp.example"}, nil }
-	start := func(startCtx context.Context, _ *rest.Config) error {
-		attempt := starts.Add(1)
-		attemptCtx, cancelAttempt := context.WithCancel(startCtx)
-		if attempt == 1 {
-			go func() {
-				<-attemptCtx.Done()
-				close(providerStopped)
-			}()
-		}
-		started := make(chan struct{})
-		close(started)
-		object := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "apis.kcp.io/v1alpha1",
-			"kind":       "APIExportEndpointSlice",
-			"metadata":   map[string]any{"name": apiExportName},
-			"status": map[string]any{
-				"endpoints": []any{map[string]any{"url": "https://provider.example"}},
-			},
-		}}
-		client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), object).Resource(apiExportEndpointSliceGVR)
-		mgr := &startupGateManager{}
-		readiness := &controllerProviderReadiness{
-			started:      started,
-			endpoint:     client,
-			endpointName: apiExportName,
-			withTimeout: func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
-				return context.WithCancel(parent)
-			},
-			pollGate: func(pollCtx context.Context, _ time.Duration) bool {
-				if attempt == 1 {
-					if err := client.Delete(context.Background(), apiExportName, metav1.DeleteOptions{}); err != nil {
-						return false
-					}
-					return true
-				}
-				<-pollCtx.Done()
-				return false
-			},
-		}
-		onReady := func() {
-			authority.Set(mgr)
-			health.markReady()
-			if attempt == 2 {
-				close(recovered)
-			}
-		}
-		onStop := func() {
-			authority.Clear(mgr)
-			cancelAttempt()
-		}
-		return controllerReadyRunnable(health, readiness.Wait, readiness.Monitor, onReady, onStop).Start(attemptCtx)
-	}
-	retryGate := func(retryCtx context.Context, _ time.Duration) bool {
-		if starts.Load() == 1 {
-			select {
-			case <-providerStopped:
-			case <-retryCtx.Done():
-				return false
-			}
-		}
-		close(retryStarted)
-		select {
-		case <-allowRetry:
-			return true
-		case <-retryCtx.Done():
-			return false
-		}
-	}
-
-	go func() {
-		runControllerManagerWithRetryGate(ctx, health, loadConfig, start, 0, retryGate)
-		close(done)
-	}()
-	waitForDatabricksControllerSignal(t, retryStarted)
-	if got := health.snapshot(); got.State != controllerStateFailed || !strings.Contains(got.Error, errControllerProviderEndpointLost.Error()) {
-		t.Fatalf("endpoint-loss health = %+v, want failed endpoint loss", got)
-	}
-	if authority.Ready() || health.ready() {
-		t.Fatal("endpoint loss left authority or readiness enabled")
-	}
-	close(allowRetry)
-	waitForDatabricksControllerSignal(t, recovered)
-	if starts.Load() != 2 || !authority.Ready() || !health.ready() {
-		t.Fatalf("recovered controller starts=%d authority=%v ready=%v, want 2/true/true", starts.Load(), authority.Ready(), health.ready())
-	}
-	cancel()
-	waitForDatabricksControllerSignal(t, done)
-	if health.snapshot().State != controllerStateStopped || authority.Ready() {
-		t.Fatalf("post-stop state = health:%+v authority:%v, want stopped/false", health.snapshot(), authority.Ready())
-	}
-}
-
-func TestControllerRecoveryRebindsTenantFactoryBeforeReady(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	health := newControllerHealth(true)
-	authority := &managerAuthority{}
-	factory := tenant.NewDeferredClientFactory()
-	factory.SetAuthority(authority)
-	health.setDependencyReady(func() bool {
-		return factory.Configured() && factory.Ready()
-	})
-
-	var loads atomic.Int32
-	retryStarted := make(chan struct{})
-	allowRetry := make(chan struct{})
-	recovered := make(chan struct{})
-	done := make(chan struct{})
-	loadConfig := func() (*rest.Config, error) {
-		if loads.Add(1) == 1 {
-			return nil, errors.New("provider kubeconfig unavailable")
-		}
-		return &rest.Config{Host: "https://kcp.example"}, nil
-	}
-	start := func(startCtx context.Context, config *rest.Config) error {
-		if err := factory.SetBaseConfig(config); err != nil {
-			return err
-		}
-		mgr := &startupGateManager{}
-		authority.Set(mgr)
-		defer authority.Clear(mgr)
-		health.markReady()
-		close(recovered)
-		<-startCtx.Done()
-		return startCtx.Err()
-	}
-	retryGate := func(retryCtx context.Context, _ time.Duration) bool {
-		close(retryStarted)
-		select {
-		case <-allowRetry:
-			return true
-		case <-retryCtx.Done():
-			return false
-		}
-	}
-
-	go func() {
-		runControllerManagerWithRetryGate(ctx, health, loadConfig, start, 0, retryGate)
-		close(done)
-	}()
-	waitForDatabricksControllerSignal(t, retryStarted)
-	if got := health.snapshot(); got.State != controllerStateFailed || got.Error != "provider kubeconfig unavailable" {
-		t.Fatalf("initial unavailable health = %+v", got)
-	}
-	if factory.Configured() || factory.Ready() || health.ready() {
-		t.Fatal("tenant dependency became ready before recovered config")
-	}
-
-	close(allowRetry)
-	waitForDatabricksControllerSignal(t, recovered)
-	if !factory.Configured() || !factory.Ready() || !health.ready() {
-		t.Fatalf("recovered dependency state = configured:%v ready:%v health:%v, want true/true/true", factory.Configured(), factory.Ready(), health.ready())
-	}
-	if _, err := factory.For("tenant-cluster", "caller-token"); err != nil {
-		t.Fatalf("tenant action client after config recovery: %v", err)
-	}
-
-	cancel()
-	waitForDatabricksControllerSignal(t, done)
-	if health.snapshot().State != controllerStateStopped || factory.Ready() {
-		t.Fatalf("post-stop state = health:%+v factoryReady:%v, want stopped/false", health.snapshot(), factory.Ready())
+		t.Fatalf("invalid mode must fail closed to required, got %q", got)
 	}
 }
 
@@ -999,15 +118,6 @@ func TestControllerDurationsStayWithinSafeBounds(t *testing.T) {
 	if got := controllerRetryIntervalFromEnv(); got != controllerRetryInterval {
 		t.Fatalf("invalid retry interval = %s, want default %s", got, controllerRetryInterval)
 	}
-	for _, input := range []time.Duration{0, -time.Second, 500 * time.Millisecond} {
-		if got := normalizeControllerRetryInterval(input); got != controllerRetryIntervalMin {
-			t.Fatalf("direct retry interval %s normalized to %s, want %s", input, got, controllerRetryIntervalMin)
-		}
-	}
-	if got := normalizeControllerRetryInterval(10 * time.Minute); got != controllerRetryIntervalMax {
-		t.Fatalf("direct retry interval above maximum = %s, want %s", got, controllerRetryIntervalMax)
-	}
-
 	t.Setenv("DATABRICKS_CONTROLLER_STARTUP_TIMEOUT", "500ms")
 	if got := controllerStartupTimeoutFromEnv(); got != controllerStartupTimeoutMin {
 		t.Fatalf("startup timeout below minimum = %s, want %s", got, controllerStartupTimeoutMin)
@@ -1018,98 +128,59 @@ func TestControllerDurationsStayWithinSafeBounds(t *testing.T) {
 	}
 }
 
-func waitForDatabricksControllerSignal(t *testing.T, ch <-chan struct{}) {
-	t.Helper()
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("controller lifecycle did not reach expected transition")
+func endpointSliceObject(name string, urls ...string) *unstructured.Unstructured {
+	endpoints := make([]any, 0, len(urls))
+	for _, u := range urls {
+		endpoints = append(endpoints, map[string]any{"url": u})
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apis.kcp.io/v1alpha1",
+		"kind":       "APIExportEndpointSlice",
+		"metadata":   map[string]any{"name": name},
+		"status":     map[string]any{"endpoints": endpoints},
+	}}
+}
+
+func TestSliceEndpointDiscovered(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), endpointSliceObject(apiExportName, "https://shard-a.example/services/apiexport/x/y"))
+	slice := dyn.Resource(apiExportEndpointSliceGVR)
+
+	discovered, err := sliceEndpointDiscovered(context.Background(), slice, apiExportName)
+	if err != nil || !discovered {
+		t.Fatalf("discovered=%v err=%v, want true/nil", discovered, err)
+	}
+
+	// Missing slice is "not yet", not an error.
+	discovered, err = sliceEndpointDiscovered(context.Background(), slice, "missing")
+	if err != nil || discovered {
+		t.Fatalf("missing slice discovered=%v err=%v, want false/nil", discovered, err)
+	}
+
+	// A slice whose endpoints all lack URLs is not discovered.
+	empty := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), endpointSliceObject(apiExportName, "", "   "))
+	discovered, err = sliceEndpointDiscovered(context.Background(), empty.Resource(apiExportEndpointSliceGVR), apiExportName)
+	if err != nil || discovered {
+		t.Fatalf("empty-url slice discovered=%v err=%v, want false/nil", discovered, err)
 	}
 }
 
-type startupGateManager struct {
-	mcmanager.Manager
-}
-
-func (*startupGateManager) GetCluster(context.Context, multicluster.ClusterName) (cluster.Cluster, error) {
-	return nil, errors.New("startup gate manager")
-}
-
-type controllerProviderStub struct{}
-
-func (*controllerProviderStub) Get(context.Context, multicluster.ClusterName) (cluster.Cluster, error) {
-	return nil, errors.New("provider cluster unavailable")
-}
-
-func (*controllerProviderStub) IndexField(context.Context, client.Object, string, client.IndexerFunc) error {
-	return nil
-}
-
-type controllerProviderRunnableStub func(context.Context, multicluster.Aware) error
-
-func (f controllerProviderRunnableStub) Start(ctx context.Context, aware multicluster.Aware) error {
-	return f(ctx, aware)
-}
-
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-type controllerBlockingReadCloser struct {
-	ctx     context.Context
-	initial []byte
-	offset  int
-	stopped chan struct{}
-	once    sync.Once
-}
-
-func (r *controllerBlockingReadCloser) Read(p []byte) (int, error) {
-	if r.offset < len(r.initial) {
-		n := copy(p, r.initial[r.offset:])
-		r.offset += n
-		return n, nil
+func TestWaitForSliceEndpointTimesOut(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), endpointSliceObject(apiExportName))
+	slice := dyn.Resource(apiExportEndpointSliceGVR)
+	start := time.Now()
+	err := waitForSliceEndpoint(context.Background(), slice, apiExportName, controllerStartupTimeoutMin)
+	if err == nil {
+		t.Fatal("expected a discovery timeout for a slice with no endpoints")
 	}
-	<-r.ctx.Done()
-	if r.stopped != nil {
-		r.once.Do(func() { close(r.stopped) })
-	}
-	return 0, r.ctx.Err()
-}
-
-func (r *controllerBlockingReadCloser) Close() error {
-	if r.stopped != nil {
-		r.once.Do(func() { close(r.stopped) })
-	}
-	return nil
-}
-
-type controllerTestDeadlineContext struct {
-	parent context.Context
-	done   chan struct{}
-	once   sync.Once
-}
-
-func newControllerTestDeadlineContext(parent context.Context) *controllerTestDeadlineContext {
-	return &controllerTestDeadlineContext{parent: parent, done: make(chan struct{})}
-}
-
-func (c *controllerTestDeadlineContext) Deadline() (time.Time, bool) {
-	return time.Unix(0, 0), true
-}
-
-func (c *controllerTestDeadlineContext) Done() <-chan struct{} { return c.done }
-
-func (c *controllerTestDeadlineContext) Err() error {
-	select {
-	case <-c.done:
-		return context.DeadlineExceeded
-	default:
-		return c.parent.Err()
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("wait did not respect the bounded timeout: %s", elapsed)
 	}
 }
 
-func (c *controllerTestDeadlineContext) Value(key any) any { return c.parent.Value(key) }
-
-func (c *controllerTestDeadlineContext) expire() { c.once.Do(func() { close(c.done) }) }
+func TestWaitForSliceEndpointReturnsOnceDiscovered(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), endpointSliceObject(apiExportName, "https://shard-a.example/services/apiexport/x/y"))
+	slice := dyn.Resource(apiExportEndpointSliceGVR)
+	if err := waitForSliceEndpoint(context.Background(), slice, apiExportName, time.Minute); err != nil {
+		t.Fatalf("waitForSliceEndpoint with a published URL: %v", err)
+	}
+}

--- a/providers/databricks/deploy/chart/values.yaml
+++ b/providers/databricks/deploy/chart/values.yaml
@@ -68,6 +68,11 @@ resources:
 
 podSecurityContext:
   runAsNonRoot: true
+  # Numeric UID/GID for the distroless "nonroot" user: kubelet cannot verify
+  # runAsNonRoot against a non-numeric image USER and refuses to start the
+  # container without these.
+  runAsUser: 65532
+  runAsGroup: 65532
   seccompProfile:
     type: RuntimeDefault
 

--- a/providers/databricks/deploy/chart/values.yaml
+++ b/providers/databricks/deploy/chart/values.yaml
@@ -3,6 +3,9 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# Safe to scale: serving resolves tenant clusters through the APIExport
+# endpoint slice on every replica, and the controllers are leader-elected
+# (one active set per Lease in the provider workspace).
 replicaCount: 1
 
 service:

--- a/providers/databricks/go.mod
+++ b/providers/databricks/go.mod
@@ -103,3 +103,8 @@ replace (
 	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20260602065202-e006560fc76a
 	k8s.io/kms => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kms v0.0.0-20260602065202-e006560fc76a
 )
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/databricks/go.sum
+++ b/providers/databricks/go.sum
@@ -20,8 +20,6 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/providers/databricks/main.go
+++ b/providers/databricks/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/faroshq/provider-databricks/importapi"
 	"github.com/faroshq/provider-databricks/mcpserver"
 	"github.com/faroshq/provider-databricks/queryapi"
+	databricksscheme "github.com/faroshq/provider-databricks/scheme"
 	"github.com/faroshq/provider-databricks/tenant"
 )
 
@@ -94,12 +95,17 @@ func runServe() {
 		tenantFactory = tenant.NewDeferredClientFactory()
 	}
 	controllerHealth := newControllerHealth(controllerModeFromEnv() == controllerModeRequired)
-	controllerAuthority := &managerAuthority{}
-	if tenantFactory != nil {
-		// Keep the authority wrapper installed for the provider lifetime. The
-		// controller retry loop swaps live managers into it and clears them after
-		// an exit, so tenant actions fail closed during recovery.
-		tenantFactory.SetAuthority(controllerAuthority)
+	if kcpConfig != nil {
+		// Provider-authority reads resolve tenant clusters through the
+		// APIExport virtual-workspace URLs on the endpoint slice — never
+		// through the controller manager — so every replica serves actions
+		// while the controllers are leader-elected.
+		authority, err := tenant.NewSliceAuthority(kcpConfig, apiExportName, databricksscheme.NewScheme())
+		if err != nil {
+			log.Printf("slice authority unavailable (%v); tenant actions fail closed", err)
+		} else {
+			tenantFactory.SetAuthority(authority)
+		}
 	}
 	mux, err := newServeMuxWithHealth(tables, devStaticTables, tenantFactory, controllerHealth, statementClient)
 	if err != nil {
@@ -120,17 +126,17 @@ func runServe() {
 	}()
 	go runHeartbeat(ctx, controllerHealth)
 	if controllerHealth.snapshot().Required {
-		go runControllerManager(
+		go runLeaderElectedControllers(
 			ctx,
 			controllerHealth,
 			loadControllerConfig,
-			func(startCtx context.Context, config *rest.Config) error {
+			func(config *rest.Config) error {
 				if err := tenantFactory.SetBaseConfig(config); err != nil {
 					return fmt.Errorf("tenant client configuration: %w", err)
 				}
-				return startControllerManagerAttempt(startCtx, config, validator, controllerHealth, controllerAuthority)
+				return nil
 			},
-			controllerRetryIntervalFromEnv(),
+			validator,
 		)
 	} else {
 		log.Printf("controller manager: disabled (explicit REST-only mode)")

--- a/providers/databricks/main_test.go
+++ b/providers/databricks/main_test.go
@@ -78,7 +78,11 @@ func TestMCPEnabledDefaultsOnAndInvalidValuesFailClosed(t *testing.T) {
 	}
 }
 
-func TestReadinessSeparatesControllerFromLiveness(t *testing.T) {
+func TestReadinessIsServingOnlyAndReportsControllerState(t *testing.T) {
+	// Under leader election a standby replica never runs the manager, so
+	// controller state is reported on /readyz but does not gate it — serving
+	// readiness comes from the dependency gate (tenant factory + slice
+	// authority), covered by the dependency tests below.
 	health := newControllerHealth(true)
 	mux, err := newServeMuxWithHealth(seedTablesFromEnv(), true, nil, health)
 	if err != nil {
@@ -92,22 +96,22 @@ func TestReadinessSeparatesControllerFromLiveness(t *testing.T) {
 	}
 	readiness := httptest.NewRecorder()
 	mux.ServeHTTP(readiness, httptest.NewRequest(http.MethodGet, "/readyz", nil))
-	if readiness.Code != http.StatusServiceUnavailable || !strings.Contains(readiness.Body.String(), `"controller":"starting"`) {
-		t.Fatalf("GET /readyz while starting = %d %q, want 503/starting", readiness.Code, readiness.Body.String())
-	}
-
-	health.markReady()
-	readiness = httptest.NewRecorder()
-	mux.ServeHTTP(readiness, httptest.NewRequest(http.MethodGet, "/readyz", nil))
-	if readiness.Code != http.StatusOK || !strings.Contains(readiness.Body.String(), `"status":"ready"`) {
-		t.Fatalf("GET /readyz while running = %d %q, want 200/ready", readiness.Code, readiness.Body.String())
+	if readiness.Code != http.StatusOK || !strings.Contains(readiness.Body.String(), `"controller":"starting"`) {
+		t.Fatalf("GET /readyz while controller starting = %d %q, want 200 with controller state reported", readiness.Code, readiness.Body.String())
 	}
 
 	health.markFailed(errors.New("manager exited"))
 	readiness = httptest.NewRecorder()
 	mux.ServeHTTP(readiness, httptest.NewRequest(http.MethodGet, "/readyz", nil))
-	if readiness.Code != http.StatusServiceUnavailable || !strings.Contains(readiness.Body.String(), "manager exited") {
-		t.Fatalf("GET /readyz after exit = %d %q, want 503/error", readiness.Code, readiness.Body.String())
+	if readiness.Code != http.StatusOK || !strings.Contains(readiness.Body.String(), `"controller":"failed"`) {
+		t.Fatalf("GET /readyz after controller exit = %d %q, want 200 with controller state reported", readiness.Code, readiness.Body.String())
+	}
+
+	health.markStandby()
+	readiness = httptest.NewRecorder()
+	mux.ServeHTTP(readiness, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if readiness.Code != http.StatusOK || !strings.Contains(readiness.Body.String(), `"controller":"standby"`) {
+		t.Fatalf("GET /readyz on standby = %d %q, want 200/standby", readiness.Code, readiness.Body.String())
 	}
 }
 
@@ -151,13 +155,17 @@ func TestReadinessWithoutHealthStateDoesNotPanic(t *testing.T) {
 }
 
 func TestHeartbeatEligibilityAndBuildVersion(t *testing.T) {
-	if heartbeatCanSend(newControllerHealth(true)) {
-		t.Fatal("starting required controller must not heartbeat")
+	// Heartbeat eligibility follows serving readiness, not controller state:
+	// a standby replica serves traffic and must heartbeat.
+	serving := false
+	gated := newControllerHealth(true)
+	gated.setDependencyReady(func() bool { return serving })
+	if heartbeatCanSend(gated) {
+		t.Fatal("serving-unready replica must not heartbeat")
 	}
-	required := newControllerHealth(true)
-	required.markReady()
-	if !heartbeatCanSend(required) {
-		t.Fatal("running required controller should heartbeat")
+	serving = true
+	if !heartbeatCanSend(gated) {
+		t.Fatal("serving-ready replica should heartbeat regardless of controller state")
 	}
 	if !heartbeatCanSend(newControllerHealth(false)) {
 		t.Fatal("REST-only mode should heartbeat")

--- a/providers/databricks/tenant/authority.go
+++ b/providers/databricks/tenant/authority.go
@@ -1,0 +1,266 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package tenant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	databricksv1alpha1 "github.com/faroshq/provider-databricks/apis/databricks/v1alpha1"
+)
+
+// SliceAuthority resolves tenant logical clusters through the APIExport
+// virtual-workspace URLs published on the provider's APIExportEndpointSlice,
+// authenticated with the provider's own credential. It replaces the previous
+// design where the running multicluster manager doubled as the serving path's
+// cluster resolver — serving no longer depends on the controller lifecycle,
+// which is what lets the controller manager be leader-elected and the
+// provider scale horizontally.
+//
+// Reads through the returned clients are live GETs against the VW (no
+// informer cache): slightly slower per action than the old cached reads, but
+// with no warm-up, no engagement precondition, and no per-replica informer
+// memory. A tenant whose APIBinding is not yet Ready gets kcp's 403/404
+// instead of the old "cluster unavailable".
+type SliceAuthority struct {
+	base      *rest.Config
+	sliceName string
+	scheme    *runtime.Scheme
+
+	// getSlice, probe, and newClient are injectable for tests; production
+	// wiring is installed by NewSliceAuthority.
+	getSlice  func(ctx context.Context) (*unstructured.Unstructured, error)
+	probe     func(ctx context.Context, shardURL, clusterID string) bool
+	newClient func(cfg *rest.Config) (client.Client, error)
+	now       func() time.Time
+
+	mu           sync.RWMutex
+	shardURLs    []string
+	clusterShard map[string]string
+	clients      map[string]client.Client
+	lastRefresh  time.Time
+}
+
+// sliceRefreshInterval bounds how often a Ready()/miss re-reads the endpoint
+// slice. kcp publishes one endpoint per shard and the set changes only on
+// shard topology changes, so a short cache is plenty.
+const sliceRefreshInterval = 10 * time.Second
+
+// authorityClientCacheCap bounds the per-cluster client cache. Clients hold a
+// lazy RESTMapper (one discovery round-trip each), so they are worth keeping,
+// but the set must not grow unbounded with tenant churn. On overflow the whole
+// map is dropped — rebuilding is cheap and keeps the bookkeeping trivial.
+const authorityClientCacheCap = 256
+
+var errNoEndpoints = errors.New("APIExportEndpointSlice has no endpoint with a url yet")
+
+var apiExportEndpointSliceGVR = schema.GroupVersionResource{
+	Group: "apis.kcp.io", Version: "v1alpha1", Resource: "apiexportendpointslices",
+}
+
+// NewSliceAuthority builds the production authority: the slice is read from
+// the provider workspace base config, shards are probed with a bounded Table
+// list, and clients are controller-runtime clients over the given scheme.
+func NewSliceAuthority(base *rest.Config, sliceName string, scheme *runtime.Scheme) (*SliceAuthority, error) {
+	if base == nil {
+		return nil, errors.New("provider kubeconfig is required")
+	}
+	dyn, err := dynamic.NewForConfig(base)
+	if err != nil {
+		return nil, fmt.Errorf("slice client: %w", err)
+	}
+	a := &SliceAuthority{
+		base:      rest.CopyConfig(base),
+		sliceName: sliceName,
+		scheme:    scheme,
+		getSlice: func(ctx context.Context) (*unstructured.Unstructured, error) {
+			return dyn.Resource(apiExportEndpointSliceGVR).Get(ctx, sliceName, metav1.GetOptions{})
+		},
+		now: time.Now,
+	}
+	a.probe = a.probeShard
+	a.newClient = func(cfg *rest.Config) (client.Client, error) {
+		return client.New(cfg, client.Options{Scheme: scheme})
+	}
+	a.clusterShard = map[string]string{}
+	a.clients = map[string]client.Client{}
+	return a, nil
+}
+
+// Ready reports whether at least one virtual-workspace endpoint is known —
+// the ClientFactory's readiness probe. It refreshes opportunistically so
+// readiness converges without any background goroutine.
+func (a *SliceAuthority) Ready() bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	known := len(a.shardURLs) > 0
+	a.mu.RUnlock()
+	if known {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return a.refreshShards(ctx, true) == nil
+}
+
+// ClusterClient returns a provider-credential client scoped to one tenant
+// logical cluster, resolving which shard's VW serves it.
+func (a *SliceAuthority) ClusterClient(ctx context.Context, clusterID string) (client.Client, error) {
+	if a == nil {
+		return nil, errors.New("provider authority client unavailable")
+	}
+	shardURL, err := a.shardFor(ctx, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	key := shardURL + "|" + clusterID
+	a.mu.RLock()
+	cl, ok := a.clients[key]
+	a.mu.RUnlock()
+	if ok {
+		return cl, nil
+	}
+	cfg := rest.CopyConfig(a.base)
+	cfg.Host = shardURL + "/clusters/" + clusterID
+	cl, err = a.newClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("provider authority client for cluster %q: %w", clusterID, err)
+	}
+	a.mu.Lock()
+	if len(a.clients) >= authorityClientCacheCap {
+		a.clients = map[string]client.Client{}
+	}
+	a.clients[key] = cl
+	a.mu.Unlock()
+	return cl, nil
+}
+
+// shardFor resolves which shard's VW serves a tenant cluster: answered from
+// cache once known, shortcut when there is a single shard, otherwise probed —
+// a shard that does not host the logical cluster rejects the read, the one
+// that does answers (an empty list is still an answer).
+func (a *SliceAuthority) shardFor(ctx context.Context, clusterID string) (string, error) {
+	a.mu.RLock()
+	url, cached := a.clusterShard[clusterID]
+	shards := append([]string(nil), a.shardURLs...)
+	a.mu.RUnlock()
+	if cached {
+		return url, nil
+	}
+	if len(shards) == 0 {
+		if err := a.refreshShards(ctx, true); err != nil {
+			return "", err
+		}
+		a.mu.RLock()
+		shards = append([]string(nil), a.shardURLs...)
+		a.mu.RUnlock()
+	}
+	switch len(shards) {
+	case 0:
+		return "", errNoEndpoints
+	case 1:
+		return shards[0], nil
+	}
+	for _, shardURL := range shards {
+		if a.probe(ctx, shardURL, clusterID) {
+			a.mu.Lock()
+			a.clusterShard[clusterID] = shardURL
+			a.mu.Unlock()
+			return shardURL, nil
+		}
+	}
+	return "", fmt.Errorf("tenant workspace %q is not served by any of the %d APIExport virtual workspace endpoints", clusterID, len(shards))
+}
+
+func (a *SliceAuthority) probeShard(ctx context.Context, shardURL, clusterID string) bool {
+	cfg := rest.CopyConfig(a.base)
+	cfg.Host = shardURL + "/clusters/" + clusterID
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return false
+	}
+	gvr := databricksv1alpha1.SchemeGroupVersion.WithResource("tables")
+	_, err = dyn.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+	return err == nil
+}
+
+// refreshShards re-reads the endpoint slice. It is rate-limited unless
+// force is set (a miss forces it so a fresh shard is picked up immediately);
+// bindings whose shard disappeared are forgotten so they re-resolve instead
+// of pinning a dead URL — same shape as the agents provider's ensureVW.
+func (a *SliceAuthority) refreshShards(ctx context.Context, force bool) error {
+	a.mu.RLock()
+	last := a.lastRefresh
+	a.mu.RUnlock()
+	if !force && a.now().Sub(last) < sliceRefreshInterval {
+		return nil
+	}
+	obj, err := a.getSlice(ctx)
+	if err != nil {
+		return fmt.Errorf("reading APIExportEndpointSlice %q: %w", a.sliceName, err)
+	}
+	urls := SliceEndpointURLs(obj)
+	if len(urls) == 0 {
+		return errNoEndpoints
+	}
+	seen := make(map[string]bool, len(urls))
+	for _, u := range urls {
+		seen[u] = true
+	}
+	a.mu.Lock()
+	a.shardURLs = urls
+	a.lastRefresh = a.now()
+	for cluster, shardURL := range a.clusterShard {
+		if !seen[shardURL] {
+			delete(a.clusterShard, cluster)
+		}
+	}
+	for key := range a.clients {
+		if shardURL, _, ok := strings.Cut(key, "|"); ok && !seen[shardURL] {
+			delete(a.clients, key)
+		}
+	}
+	a.mu.Unlock()
+	return nil
+}
+
+// SliceEndpointURLs reads EVERY endpoint URL off an APIExportEndpointSlice,
+// trimmed and de-duplicated in slice order. kcp publishes one endpoint per
+// shard, so taking only the first would silently drop every tenant workspace
+// bound on the other shards.
+func SliceEndpointURLs(u *unstructured.Unstructured) []string {
+	endpoints, _, _ := unstructured.NestedSlice(u.Object, "status", "endpoints")
+	urls := make([]string, 0, len(endpoints))
+	seen := map[string]bool{}
+	for _, e := range endpoints {
+		m, _ := e.(map[string]any)
+		raw, _ := m["url"].(string)
+		trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		urls = append(urls, trimmed)
+	}
+	return urls
+}

--- a/providers/databricks/tenant/authority_test.go
+++ b/providers/databricks/tenant/authority_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package tenant
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func sliceWithEndpoints(urls ...string) *unstructured.Unstructured {
+	endpoints := make([]any, 0, len(urls))
+	for _, u := range urls {
+		endpoints = append(endpoints, map[string]any{"url": u})
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"endpoints": endpoints},
+	}}
+}
+
+// testAuthority builds a SliceAuthority with every external dependency faked.
+func testAuthority(getSlice func(context.Context) (*unstructured.Unstructured, error)) *SliceAuthority {
+	a := &SliceAuthority{
+		base:         &rest.Config{Host: "https://kcp.example/clusters/root:faros:providers:databricks"},
+		sliceName:    "databricks.providers.faros.sh",
+		getSlice:     getSlice,
+		now:          time.Now,
+		clusterShard: map[string]string{},
+		clients:      map[string]client.Client{},
+	}
+	a.newClient = func(cfg *rest.Config) (client.Client, error) {
+		_ = cfg
+		return fakeclient.NewClientBuilder().Build(), nil
+	}
+	a.probe = func(context.Context, string, string) bool { return false }
+	return a
+}
+
+func TestSliceEndpointURLsDeduplicatesAndTrims(t *testing.T) {
+	urls := SliceEndpointURLs(sliceWithEndpoints(
+		" https://shard-a.example/services/apiexport/a/x/ ",
+		"https://shard-a.example/services/apiexport/a/x",
+		"",
+		"https://shard-b.example/services/apiexport/b/x",
+	))
+	if len(urls) != 2 || urls[0] != "https://shard-a.example/services/apiexport/a/x" || urls[1] != "https://shard-b.example/services/apiexport/b/x" {
+		t.Fatalf("SliceEndpointURLs = %v, want the two deduplicated shard URLs in order", urls)
+	}
+}
+
+func TestSliceAuthorityReadyRequiresAnEndpoint(t *testing.T) {
+	a := testAuthority(func(context.Context) (*unstructured.Unstructured, error) {
+		return sliceWithEndpoints(), nil
+	})
+	if a.Ready() {
+		t.Fatal("authority with no endpoint URLs reported ready")
+	}
+	a.getSlice = func(context.Context) (*unstructured.Unstructured, error) {
+		return sliceWithEndpoints("https://shard-a.example/services/apiexport/a/x"), nil
+	}
+	if !a.Ready() {
+		t.Fatal("authority with a published endpoint URL reported not ready")
+	}
+	// Once discovered, readiness answers from cache without re-reading.
+	a.getSlice = func(context.Context) (*unstructured.Unstructured, error) {
+		return nil, errors.New("slice read must not happen")
+	}
+	if !a.Ready() {
+		t.Fatal("authority forgot its discovered endpoints")
+	}
+}
+
+func TestSliceAuthoritySingleShardSkipsProbe(t *testing.T) {
+	a := testAuthority(func(context.Context) (*unstructured.Unstructured, error) {
+		return sliceWithEndpoints("https://shard-a.example/services/apiexport/a/x"), nil
+	})
+	var hosts []string
+	a.newClient = func(cfg *rest.Config) (client.Client, error) {
+		hosts = append(hosts, cfg.Host)
+		return fakeclient.NewClientBuilder().Build(), nil
+	}
+	a.probe = func(context.Context, string, string) bool {
+		t.Fatal("single-shard resolution must not probe")
+		return false
+	}
+	cl, err := a.ClusterClient(context.Background(), "tenant-cluster-1")
+	if err != nil || cl == nil {
+		t.Fatalf("ClusterClient: %v", err)
+	}
+	if len(hosts) != 1 || hosts[0] != "https://shard-a.example/services/apiexport/a/x/clusters/tenant-cluster-1" {
+		t.Fatalf("client host = %v, want the shard VW URL scoped to the tenant cluster", hosts)
+	}
+	// Second call is served from the client cache.
+	if _, err := a.ClusterClient(context.Background(), "tenant-cluster-1"); err != nil {
+		t.Fatalf("cached ClusterClient: %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("client rebuilt despite cache: %d constructions", len(hosts))
+	}
+}
+
+func TestSliceAuthorityProbesShardsAndCachesTheAnswer(t *testing.T) {
+	a := testAuthority(func(context.Context) (*unstructured.Unstructured, error) {
+		return sliceWithEndpoints(
+			"https://shard-a.example/services/apiexport/a/x",
+			"https://shard-b.example/services/apiexport/b/x",
+		), nil
+	})
+	probes := 0
+	a.probe = func(_ context.Context, shardURL, clusterID string) bool {
+		probes++
+		return strings.HasPrefix(shardURL, "https://shard-b") && clusterID == "tenant-2"
+	}
+	cl, err := a.ClusterClient(context.Background(), "tenant-2")
+	if err != nil || cl == nil {
+		t.Fatalf("ClusterClient across shards: %v", err)
+	}
+	if probes == 0 {
+		t.Fatal("multi-shard resolution did not probe")
+	}
+	probes = 0
+	if _, err := a.ClusterClient(context.Background(), "tenant-2"); err != nil {
+		t.Fatalf("cached multi-shard ClusterClient: %v", err)
+	}
+	if probes != 0 {
+		t.Fatal("shard binding was not cached")
+	}
+}
+
+func TestSliceAuthorityUnservedClusterFailsLoudly(t *testing.T) {
+	a := testAuthority(func(context.Context) (*unstructured.Unstructured, error) {
+		return sliceWithEndpoints(
+			"https://shard-a.example/services/apiexport/a/x",
+			"https://shard-b.example/services/apiexport/b/x",
+		), nil
+	})
+	if _, err := a.ClusterClient(context.Background(), "nowhere"); err == nil {
+		t.Fatal("cluster served by no shard must fail loudly, not guess a shard")
+	}
+}
+
+func TestSliceAuthorityForgetsBindingsForRemovedShards(t *testing.T) {
+	current := sliceWithEndpoints(
+		"https://shard-a.example/services/apiexport/a/x",
+		"https://shard-b.example/services/apiexport/b/x",
+	)
+	a := testAuthority(func(context.Context) (*unstructured.Unstructured, error) { return current, nil })
+	a.probe = func(_ context.Context, shardURL, _ string) bool {
+		return strings.HasPrefix(shardURL, "https://shard-b")
+	}
+	if _, err := a.ClusterClient(context.Background(), "tenant-2"); err != nil {
+		t.Fatalf("initial resolution: %v", err)
+	}
+	// Shard B disappears; a forced refresh must drop its binding and client.
+	current = sliceWithEndpoints("https://shard-a.example/services/apiexport/a/x")
+	if err := a.refreshShards(context.Background(), true); err != nil {
+		t.Fatalf("refreshShards: %v", err)
+	}
+	a.mu.RLock()
+	_, bound := a.clusterShard["tenant-2"]
+	clients := len(a.clients)
+	a.mu.RUnlock()
+	if bound || clients != 0 {
+		t.Fatalf("dead-shard state retained: bound=%v clients=%d", bound, clients)
+	}
+}

--- a/providers/databricks/tenant/client.go
+++ b/providers/databricks/tenant/client.go
@@ -27,8 +27,6 @@ import (
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	multicluster "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	databricksv1alpha1 "github.com/faroshq/provider-databricks/apis/databricks/v1alpha1"
 	"github.com/faroshq/provider-databricks/queryapi"
@@ -67,12 +65,15 @@ type ClientFactory struct {
 	cacheClock    uint64
 }
 
-// ClusterAuthority is the provider-owned multicluster manager. Its client is
-// authenticated with the provider ServiceAccount, so provider-owned Tables,
-// Warehouses, Connections, and credential Secrets are resolved with provider
-// authority rather than the forwarded caller token.
+// ClusterAuthority resolves a provider-credential client for one tenant
+// logical cluster, so provider-owned Tables, Warehouses, Connections, and
+// credential Secrets are read with provider authority rather than the
+// forwarded caller token. Production wiring is SliceAuthority (VW URLs from
+// the APIExportEndpointSlice) — deliberately independent of the controller
+// manager so serving works on every replica while controllers are
+// leader-elected.
 type ClusterAuthority interface {
-	GetCluster(context.Context, multicluster.ClusterName) (cluster.Cluster, error)
+	ClusterClient(ctx context.Context, clusterID string) (client.Client, error)
 }
 
 func NewClientFactory(base *rest.Config) *ClientFactory {
@@ -202,14 +203,14 @@ func (f *ClientFactory) AuthorityClient(ctx context.Context, clusterID string) (
 	if clusterID == "" || clusterID == "." || clusterID == ".." || url.PathEscape(clusterID) != clusterID {
 		return nil, errors.New("invalid tenant logical-cluster ID")
 	}
-	cl, err := authority.GetCluster(ctx, multicluster.ClusterName(clusterID))
+	cl, err := authority.ClusterClient(ctx, clusterID)
 	if err != nil {
 		return nil, fmt.Errorf("provider authority cluster %q: %w", clusterID, err)
 	}
-	if cl == nil || cl.GetClient() == nil {
+	if cl == nil {
 		return nil, fmt.Errorf("provider authority cluster %q has no client", clusterID)
 	}
-	return cl.GetClient(), nil
+	return cl, nil
 }
 
 func (f *ClientFactory) For(clusterID, token string) (dynamic.Interface, error) {

--- a/providers/databricks/tenant/client.go
+++ b/providers/databricks/tenant/client.go
@@ -169,10 +169,14 @@ func (f *ClientFactory) SetAuthority(authority ClusterAuthority) {
 	}
 }
 
-// Ready reports whether the factory has both caller-token client configuration
-// and a live provider authority. The optional Ready method is implemented by
-// the production manager wrapper; test and embedding implementations that do
-// not expose it are treated as available once configured.
+// Ready reports whether the factory has caller-token client configuration
+// and an installed provider authority. Deliberately NOT gated on the
+// authority having discovered virtual-workspace endpoints: those only exist
+// once a tenant binds the APIExport, and gating pod readiness on them makes
+// a chicken-and-egg — the hub 503s an unready provider, so no tenant could
+// ever Enable it to create the first binding. The authority resolves shards
+// lazily per request; a tenant action before any binding fails with a clear
+// per-call error instead.
 func (f *ClientFactory) Ready() bool {
 	if f == nil || !f.Configured() {
 		return false
@@ -180,13 +184,7 @@ func (f *ClientFactory) Ready() bool {
 	f.authorityMu.RLock()
 	authority := f.authority
 	f.authorityMu.RUnlock()
-	if authority == nil {
-		return false
-	}
-	if ready, ok := authority.(interface{ Ready() bool }); ok {
-		return ready.Ready()
-	}
-	return true
+	return authority != nil
 }
 
 func (f *ClientFactory) AuthorityClient(ctx context.Context, clusterID string) (client.Client, error) {

--- a/providers/databricks/tenant/client_test.go
+++ b/providers/databricks/tenant/client_test.go
@@ -22,8 +22,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	multicluster "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/faroshq/provider-databricks/queryapi"
 )
@@ -250,7 +249,7 @@ func samePointer(a, b any) bool {
 
 type readyAuthority struct{}
 
-func (*readyAuthority) GetCluster(context.Context, multicluster.ClusterName) (cluster.Cluster, error) {
+func (*readyAuthority) ClusterClient(context.Context, string) (client.Client, error) {
 	return nil, errors.New("test authority does not resolve clusters")
 }
 

--- a/providers/edges/Dockerfile
+++ b/providers/edges/Dockerfile
@@ -10,18 +10,22 @@
 #    binary via //go:embed in assets.go.
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/edges/portal/package.json providers/edges/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/edges/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary standalone (no go.work — each module resolves via its
 #    own go.mod; the SDK is fetched from the module proxy).
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/edges/go.mod providers/edges/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/edges/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY . ./
+COPY providers/edges/ ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOWORK=off go build -trimpath -ldflags="-s -w" -o /out/edges-provider .
 
@@ -30,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    (FAROS_SCHEMAS_DIR), synced there by `make codegen-edges-provider`.
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/edges-provider /edges-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/edges/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8088
 ENV PORT=8088
 USER nonroot:nonroot

--- a/providers/edges/controller_manager.go
+++ b/providers/edges/controller_manager.go
@@ -61,6 +61,14 @@ const eventsMaxAge = 6 * time.Hour
 // edge token / RBAC / lifecycle reconcilers. connManager wires the lifecycle
 // reconciler's tunnel-liveness cross-check to the provider's live ConnManager.
 // A nil config means "skip the manager" (healthz-only / dev).
+//
+// Deliberately NOT leader-elected (unlike code/vibe-studio/infrastructure):
+// this manager doubles as the tunnel plane's tenant-config resolver
+// (SetTenantConfigGetter below goes through mgr.GetCluster) and the lifecycle
+// reconcilers cross-check liveness against this replica's ConnManager, so
+// gating it would break serving on non-leaders. The provider is single-replica
+// by design anyway (revdial tunnels + in-memory event store; the chart pins
+// replicaCount: 1) — revisit both together if it ever scales out.
 func startEdgeControllerManager(ctx context.Context, config *rest.Config, tsrv *sdktunnel.Server, hubExternalURL string, hubCAData []byte, devMode bool) error {
 	if config == nil {
 		return errControllerDisabled

--- a/providers/edges/controller_manager.go
+++ b/providers/edges/controller_manager.go
@@ -59,16 +59,18 @@ const eventsMaxAge = 6 * time.Hour
 
 // startEdgeControllerManager builds the multicluster manager and starts the
 // edge token / RBAC / lifecycle reconcilers. connManager wires the lifecycle
-// reconciler's tunnel-liveness cross-check to the provider's live ConnManager.
-// A nil config means "skip the manager" (healthz-only / dev).
+// reconciler's tunnel-liveness cross-check to the provider's ConnManager —
+// cluster-aware with replica routing enabled, so liveness reflects the whole
+// fleet, not this replica. A nil config means "skip the manager"
+// (healthz-only / dev).
 //
-// Deliberately NOT leader-elected (unlike code/vibe-studio/infrastructure):
-// this manager doubles as the tunnel plane's tenant-config resolver
-// (SetTenantConfigGetter below goes through mgr.GetCluster) and the lifecycle
-// reconcilers cross-check liveness against this replica's ConnManager, so
-// gating it would break serving on non-leaders. The provider is single-replica
-// by design anyway (revdial tunnels + in-memory event store; the chart pins
-// replicaCount: 1) — revisit both together if it ever scales out.
+// Still NOT leader-elected: this manager doubles as the tunnel plane's
+// tenant-config resolver (SetTenantConfigGetter below goes through
+// mgr.GetCluster), so it must run on every replica. With cluster-aware
+// liveness and relayed dials the reconcilers are CORRECT active-active (no
+// status flapping), just duplicated; leader-electing them requires first
+// giving the serving path a slice-backed tenant resolver (see the databricks
+// SliceAuthority pattern) — tracked in docs/provider-horizontal-scaling.md.
 func startEdgeControllerManager(ctx context.Context, config *rest.Config, tsrv *sdktunnel.Server, hubExternalURL string, hubCAData []byte, devMode bool) error {
 	if config == nil {
 		return errControllerDisabled
@@ -156,8 +158,11 @@ func startEdgeControllerManager(ctx context.Context, config *rest.Config, tsrv *
 	// Edge event subscribers (currently UniFi Protect): a per-tenant, per-service
 	// event store the validation reconciler feeds via WebSocket subscribers, and
 	// the MCP `events` tool reads. The in-memory store is bounded per service and
-	// sits behind an interface so it can be swapped for Redis once the provider
-	// scales past the revdial single-replica invariant. Both the writer (manager)
+	// sits behind an interface so it can be swapped for Redis (or another shared
+	// backend). Multi-replica caveat: subscribers are gated to the replica that
+	// terminates the edge's tunnel, so events buffer on THAT replica only — an
+	// `events` MCP call the Service hands to a different replica sees an empty
+	// buffer until the store moves to a shared backend. Both the writer (manager)
 	// and reader (tunnel Server) share the one store; subscriber goroutines live
 	// under ctx, so they stop on shutdown.
 	eventStore := events.NewMemoryStore(events.DefaultPerServiceCap, eventsMaxAge)

--- a/providers/edges/deploy/chart/Chart.yaml
+++ b/providers/edges/deploy/chart/Chart.yaml
@@ -5,9 +5,10 @@ description: |
   servers, under one group edges.faros.sh. Terminates the agent reverse
   tunnel (revdial) in-process, owns the KubernetesCluster + LinuxServer API + its
   APIExport, and exposes kubectl/SSH/MCP through the hub backend proxy. Ships the
-  provider Deployment (SINGLE-REPLICA — the revdial dialer map is process-global,
-  strategy Recreate), a ClusterIP Service, and the CatalogEntry that registers
-  the provider with the faros hub.
+  provider Deployment (horizontally scalable — each agent dials one replica and
+  a Lease registry + pod-to-pod relay route requests to the tunnel's owner), a
+  ClusterIP Service, and the CatalogEntry that registers the provider with the
+  faros hub.
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/providers/edges/deploy/chart/templates/deployment.yaml
+++ b/providers/edges/deploy/chart/templates/deployment.yaml
@@ -6,11 +6,14 @@ metadata:
     {{- include "edges.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  # revdial's dialer map is process-global: Recreate guarantees the old pod is
-  # gone before the new one starts, so a rollout never briefly runs two replicas
-  # (which would split agent control/pickup connections across processes).
+  # Tunnel routing (Lease registry + pod-to-pod relay) lets replicas coexist:
+  # rolling updates only disconnect the agents on the replaced pod, and they
+  # reconnect to a survivor. maxUnavailable 0 keeps capacity during rollouts.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "edges.selectorLabels" . | nindent 6 }}
@@ -63,6 +66,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            # Replica-to-replica tunnel relay + forwarded pickups. Reached by
+            # pod IP from peer replicas; deliberately NOT on the Service.
+            - name: internal
+              containerPort: {{ .Values.internalPort }}
+              protocol: TCP
           livenessProbe:
             httpGet: { path: /healthz, port: http }
             initialDelaySeconds: 5
@@ -73,6 +81,18 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.service.port | quote }}
+            # Replica identity + relay address for multi-replica tunnel
+            # routing (see internalPort in values.yaml).
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: EDGES_INTERNAL_PORT
+              value: {{ .Values.internalPort | quote }}
             - name: FAROS_PROVIDER_NAME
               value: "edges"
             - name: FAROS_HUB_URL

--- a/providers/edges/deploy/chart/values.yaml
+++ b/providers/edges/deploy/chart/values.yaml
@@ -12,11 +12,17 @@ image:
   tag: ""  # empty → defaults to .Chart.AppVersion
   pullPolicy: IfNotPresent
 
-# HARD CONSTRAINT: revdial registers tunnel dialers in a process-global map, so
-# an agent's control connection and every later pickup connection MUST reach the
-# same process. Run exactly one replica; the Deployment uses strategy Recreate so
-# a rollout never briefly runs two. Provider HA is a v1 non-goal.
+# Safe to scale: each agent dials ONE replica; the replica terminating the
+# tunnel claims it in a Lease registry in the provider workspace, and every
+# other replica relays pickups and data-plane requests to the owner over the
+# internal listener (pod-to-pod on internalPort, never exposed on the
+# Service). Killing a replica disconnects only its agents, which reconnect to
+# a survivor.
 replicaCount: 1
+
+# internalPort carries the replica-to-replica tunnel relay and forwarded
+# revdial pickups. Deliberately not part of the Service.
+internalPort: 8090
 
 service:
   type: ClusterIP

--- a/providers/edges/go.mod
+++ b/providers/edges/go.mod
@@ -227,3 +227,8 @@ replace (
 	k8s.io/sample-controller => github.com/kcp-dev/kubernetes/staging/src/k8s.io/sample-controller v0.0.0-20260602065202-e006560fc76a
 	k8s.io/streaming => github.com/kcp-dev/kubernetes/staging/src/k8s.io/streaming v0.0.0-20260602065202-e006560fc76a
 )
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/edges/go.sum
+++ b/providers/edges/go.sum
@@ -102,8 +102,6 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/providers/edges/internal/servicectrl/agentapi.go
+++ b/providers/edges/internal/servicectrl/agentapi.go
@@ -24,14 +24,18 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/faroshq/provider-sdk/revdial"
+	"github.com/faroshq/provider-edges/internal/tunnel"
 )
 
 // ConnManager is the subset of the tunnel ConnManager the reconcilers need.
-// *tunnel.ConnManager satisfies it structurally.
+// *tunnel.ConnManager satisfies it structurally. Load/HasConnection are
+// cluster-aware (a peer-held tunnel resolves to a relayed dialer);
+// HasLocalConnection is replica-local and gates the event subscribers so one
+// replica — the tunnel owner — subscribes per service, not the whole fleet.
 type ConnManager interface {
-	Load(key string) (*revdial.Dialer, bool)
+	Load(key string) (tunnel.Dialer, bool)
 	HasConnection(key string) bool
+	HasLocalConnection(key string) bool
 }
 
 // connKey mirrors edgeConnKey in the tunnel package: "{resource}/{cluster}/{name}".
@@ -51,7 +55,7 @@ type discoveredService struct {
 
 // fetchServices pulls the agent's discovered services by GETting /api/v1/services
 // over the reverse tunnel.
-func fetchServices(ctx context.Context, dialer *revdial.Dialer) ([]discoveredService, error) {
+func fetchServices(ctx context.Context, dialer tunnel.Dialer) ([]discoveredService, error) {
 	conn, err := dialer.Dial(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("dialing edge agent: %w", err)

--- a/providers/edges/internal/servicectrl/validation_reconciler.go
+++ b/providers/edges/internal/servicectrl/validation_reconciler.go
@@ -148,7 +148,11 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 			return
 		}
 		key := eventsKey(req)
-		if subReady && subDialer != nil {
+		// Only the replica terminating the edge's tunnel subscribes: every
+		// replica runs this reconciler, and without the local gate a fleet of
+		// N replicas would open N relayed WebSocket sessions per service.
+		local := r.connManager.HasLocalConnection(connKey(connResource(es), string(req.ClusterName), es.Spec.EdgeRef.Name))
+		if subReady && subDialer != nil && local {
 			r.events.Ensure(events.SubscriberConfig{
 				Key:           key,
 				ResolveDialer: r.dialerResolver(connResource(es), string(req.ClusterName), es.Spec.EdgeRef.Name),

--- a/providers/edges/internal/tunnel/agent_proxy_builder_v2.go
+++ b/providers/edges/internal/tunnel/agent_proxy_builder_v2.go
@@ -73,7 +73,20 @@ func (p *Server) buildEdgeAgentProxyHandler() http.Handler {
 	// message to the agent telling it to open a new WebSocket to this path.
 	// The path passed to revdial.NewDialer below must match the absolute URL
 	// path where this handler is mounted.
+	//
+	// Kept for single-replica mode and for dialers created before replica
+	// routing was enabled; replica-addressed pickups go through /proxy/{id}.
 	mux.Handle("/proxy", revdial.ConnHandler(upgrader))
+
+	// /proxy/{replicaID} — replica-addressed pick-up. With replica routing
+	// enabled, each dialer's advertised pickup path names the replica whose
+	// process holds it (the revdial dialer map is process-global and the
+	// dialer closes over the accepted socket), so a pickup the Service hands
+	// to any OTHER replica is forwarded — as a WebSocket upgrade — to the
+	// owner's internal listener. The agent treats the pickup path as opaque,
+	// so this needs no agent changes and each agent keeps ONE control
+	// connection no matter how many replicas run.
+	mux.Handle("/proxy/", p.pickupRouter(revdial.ConnHandler(upgrader)))
 
 	// / — initial agent connection handler.
 	// Path (after mount-prefix stripping):
@@ -175,7 +188,14 @@ func (p *Server) buildEdgeAgentProxyHandler() http.Handler {
 		p.logger.Info("Edge agent connecting", "key", key)
 
 		conn := wsconnadapter.New(wsConn)
-		dialer := revdial.NewDialer(conn, p.agentPickupPath)
+		// With replica routing enabled the pickup path is replica-addressed so
+		// pickups reach THIS process (the dialer closes over the socket) no
+		// matter which replica the Service hands them to.
+		pickupPath := p.agentPickupPath
+		if p.replicaID != "" {
+			pickupPath += "/" + p.replicaID
+		}
+		dialer := revdial.NewDialer(conn, pickupPath)
 		p.edgeConnManager.Store(key, dialer)
 		p.logger.Info("Edge agent tunnel established", "key", key)
 

--- a/providers/edges/internal/tunnel/connman.go
+++ b/providers/edges/internal/tunnel/connman.go
@@ -17,16 +17,21 @@ limitations under the License.
 // Package tunnel is the edges provider's reverse-tunnel plane:
 // the revdial ConnManager, the agent-ingress handler that terminates agent
 // tunnels, and the consumer edgeproxy handler that streams k8s/ssh back down
-// them. Relocated from the hub's pkg/virtual/builder; the low-level engine
-// (pkg/util/revdial, pkg/util/ssh, pkg/util/http) stays a shared library the
-// provider imports from the monorepo module.
+// them.
 //
-// IMPORTANT: the ConnManager holds live revdial dialers in an in-process map,
-// so this provider MUST run as a single replica — an agent's control
-// connection and every later pickup connection must reach the same process.
+// Multi-replica: revdial dialers are still process-local (the dialer IS the
+// accepted socket), but with a Registry wired (SetRegistry) the ConnManager
+// becomes cluster-aware — Load resolves peer-held tunnels to relayed
+// remoteDialers, HasConnection/Keys answer fleet-wide, and revdial pickups
+// are forwarded to the owning replica by the replica-addressed pickup path.
+// Each agent keeps exactly one control connection, to whichever replica the
+// Service handed it. Without a Registry the historical single-replica
+// behavior is unchanged.
 package tunnel
 
 import (
+	"context"
+	"net"
 	"sync"
 	"time"
 
@@ -36,30 +41,64 @@ import (
 )
 
 // connManagerSweepInterval is how often the ConnManager checks for and evicts
-// stale (closed) tunnel entries. This catches race conditions where the
-// <-dialer.Done() goroutine hasn't fired yet but the underlying connection is
-// already dead.
+// stale (closed) tunnel entries, and renews this replica's registry leases.
 const connManagerSweepInterval = 30 * time.Second
 
-// ConnManager manages revdial.Dialer connections keyed by "edges/cluster/name".
+// registryWriteTimeout bounds the lease writes hooked onto Store/Delete so a
+// slow kcp cannot stall the agent-ingress handler.
+const registryWriteTimeout = 10 * time.Second
+
+// Dialer opens connections down an edge tunnel. Locally held tunnels are
+// *revdial.Dialer; tunnels held by a peer replica are relayed remoteDialers.
+type Dialer interface {
+	Dial(ctx context.Context) (net.Conn, error)
+}
+
+// closable is the optional liveness facet of a local entry; *revdial.Dialer
+// implements it and the sweeper uses it to evict dead tunnels.
+type closable interface {
+	IsClosed() bool
+}
+
+// ConnManager manages edge tunnels keyed by "{resource}/{cluster}/{name}".
 // It is shared between the agent-ingress handler (writes) and the edgeproxy
-// handler (reads) so that tunnel registrations are visible to user-facing
-// requests within this single provider process.
+// handler (reads). Local entries are live revdial dialers; with a Registry
+// wired, reads fall through to the fleet-wide ownership map.
 type ConnManager struct {
 	mu    sync.RWMutex
-	dials map[string]*revdial.Dialer
+	dials map[string]Dialer
+
+	registry   *Registry // nil = single-replica mode
+	relayToken string
 }
 
 // NewConnManager creates a new, empty ConnManager.
 func NewConnManager() *ConnManager {
 	return &ConnManager{
-		dials: make(map[string]*revdial.Dialer),
+		dials: make(map[string]Dialer),
 	}
 }
 
+// SetRegistry enables cluster-aware mode: Store/Delete claim and release
+// registry leases, Load resolves peer-held tunnels to relayed dialers
+// authenticated with relayToken. Call once before serving.
+func (c *ConnManager) SetRegistry(reg *Registry, relayToken string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.registry = reg
+	c.relayToken = relayToken
+}
+
+func (c *ConnManager) getRegistry() (*Registry, string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.registry, c.relayToken
+}
+
 // StartSweeper starts a background goroutine that periodically evicts closed
-// dialers from the connection map. Call this once after creating the ConnManager.
-// The goroutine exits when stop is closed.
+// dialers from the connection map and renews this replica's registry leases.
+// Call this once after creating the ConnManager. The goroutine exits when
+// stop is closed.
 func (c *ConnManager) StartSweeper(stop <-chan struct{}) {
 	logger := klog.Background().WithName("connman-sweeper")
 	go func() {
@@ -71,6 +110,11 @@ func (c *ConnManager) StartSweeper(stop <-chan struct{}) {
 				return
 			case <-ticker.C:
 				c.sweepClosed(logger)
+				if reg, _ := c.getRegistry(); reg != nil {
+					ctx, cancel := context.WithTimeout(context.Background(), registryWriteTimeout)
+					reg.RenewOwned(ctx, c.LocalKeys())
+					cancel()
+				}
 			}
 		}
 	}()
@@ -82,24 +126,55 @@ func (c *ConnManager) sweepClosed(logger klog.Logger) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for key, d := range c.dials {
-		if d != nil && d.IsClosed() {
+		if cl, ok := d.(closable); ok && cl.IsClosed() {
 			logger.Info("Evicting stale tunnel entry", "key", key)
 			delete(c.dials, key)
 		}
 	}
 }
 
-// Store saves d under key, replacing any existing entry.
+// Store saves d under key, replacing any existing entry, and claims the
+// edge's registry lease so peers route to this replica.
 func (c *ConnManager) Store(key string, d *revdial.Dialer) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.dials[key] = d
+	c.mu.Unlock()
+	if reg, _ := c.getRegistry(); reg != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), registryWriteTimeout)
+		defer cancel()
+		if err := reg.ClaimTunnel(ctx, key); err != nil {
+			klog.Background().Error(err, "claiming tunnel lease; peers cannot route to this edge until the sweeper retries", "key", key)
+		}
+	}
 }
 
-// Load returns the Dialer registered under key, or (nil, false) if absent.
-// It also returns (nil, false) if the stored Dialer has been closed, cleaning
-// up the stale entry on the fly.
-func (c *ConnManager) Load(key string) (*revdial.Dialer, bool) {
+// Load returns a Dialer for key: the local revdial dialer when this replica
+// terminates the tunnel, a relayed dialer when a fresh registry lease names a
+// peer, or (nil, false) when no replica holds it.
+func (c *ConnManager) Load(key string) (Dialer, bool) {
+	if d, ok := c.LoadLocal(key); ok {
+		return d, true
+	}
+	reg, token := c.getRegistry()
+	if reg == nil {
+		return nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	addr, ok := reg.LookupTunnel(ctx, key)
+	if !ok || addr == reg.SelfAddr() {
+		// A self-addressed lease without a local dialer is a stale claim from
+		// a tunnel that just died; report unavailable rather than relaying to
+		// ourselves.
+		return nil, false
+	}
+	return &remoteDialer{addr: addr, key: key, token: token}, true
+}
+
+// LoadLocal returns the locally terminated dialer for key, never a relayed
+// one — the relay handler and event-subscriber gating use it to avoid relay
+// recursion and duplicate subscribers.
+func (c *ConnManager) LoadLocal(key string) (Dialer, bool) {
 	c.mu.RLock()
 	d, ok := c.dials[key]
 	c.mu.RUnlock()
@@ -109,7 +184,7 @@ func (c *ConnManager) Load(key string) (*revdial.Dialer, bool) {
 	// Fast-path stale entry eviction: if the dialer is already closed,
 	// remove it and report not-found so callers get a clean 502 immediately
 	// rather than a confusing dial error.
-	if d != nil && d.IsClosed() {
+	if cl, isClosable := d.(closable); isClosable && cl.IsClosed() {
 		c.mu.Lock()
 		// Re-check under write lock in case another goroutine already replaced it.
 		if current, exists := c.dials[key]; exists && current == d {
@@ -121,21 +196,55 @@ func (c *ConnManager) Load(key string) (*revdial.Dialer, bool) {
 	return d, true
 }
 
-// Delete removes the entry for key (no-op if key is not present).
+// Delete removes the entry for key and releases the registry claim (owner-
+// checked, so a reconnect that moved to a peer is not erased).
 func (c *ConnManager) Delete(key string) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	delete(c.dials, key)
+	c.mu.Unlock()
+	if reg, _ := c.getRegistry(); reg != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), registryWriteTimeout)
+		defer cancel()
+		reg.ReleaseTunnel(ctx, key)
+	}
 }
 
-// HasConnection returns true if there is an active dialer registered for key.
+// HasConnection returns true if ANY replica holds an active tunnel for key.
 func (c *ConnManager) HasConnection(key string) bool {
 	_, ok := c.Load(key)
 	return ok
 }
 
-// Keys returns all registered connection keys.
+// HasLocalConnection returns true only when THIS replica terminates the
+// tunnel for key.
+func (c *ConnManager) HasLocalConnection(key string) bool {
+	_, ok := c.LoadLocal(key)
+	return ok
+}
+
+// Keys returns the fleet-wide set of connected edge keys: this replica's live
+// dialers plus every fresh registry claim.
 func (c *ConnManager) Keys() []string {
+	seen := map[string]bool{}
+	for _, k := range c.LocalKeys() {
+		seen[k] = true
+	}
+	if reg, _ := c.getRegistry(); reg != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for k := range reg.ListTunnels(ctx) {
+			seen[k] = true
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// LocalKeys returns the keys of tunnels terminated by this replica.
+func (c *ConnManager) LocalKeys() []string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	keys := make([]string, 0, len(c.dials))

--- a/providers/edges/internal/tunnel/registry.go
+++ b/providers/edges/internal/tunnel/registry.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+)
+
+// Registry is the shared tunnel-ownership map that makes the edges provider
+// horizontally scalable while every agent keeps exactly ONE control
+// connection: when an agent's tunnel terminates on this replica, the replica
+// claims the edge's Lease in the provider workspace (kcp serves Leases in
+// every logical cluster); any replica can then look up which peer holds a
+// tunnel and relay to it (see remote.go) instead of the agent dialing every
+// replica.
+//
+// Two lease families, both in the provider workspace's "default" namespace:
+//   - tunnel leases (edge-tunnel-<hash>): holder = the owning replica's
+//     "ip:internalPort" relay address; the edge key rides an annotation so
+//     List can rebuild the key→addr map.
+//   - presence leases (edge-replica-<id>): holder = the same address, keyed
+//     by replica ID — how the replica-addressed pickup path is resolved to a
+//     peer to forward to.
+//
+// Owned leases are renewed by the ConnManager sweeper (30s); a lease not
+// renewed within registryLeaseTTL is dead and its edge unreachable until the
+// agent reconnects (to any replica).
+type Registry struct {
+	leases    coordinationv1client.LeaseInterface
+	replicaID string
+	selfAddr  string
+	now       func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]registryCacheEntry
+}
+
+type registryCacheEntry struct {
+	addr    string
+	ok      bool
+	fetched time.Time
+}
+
+const (
+	// registryNamespace is where the Leases live. kcp creates the "default"
+	// namespace in every logical cluster.
+	registryNamespace = "default"
+	// registryLeaseTTL is how stale a lease may be and still count as held.
+	// Must comfortably exceed the sweeper's 30s renew cadence.
+	registryLeaseTTL = 90 * time.Second
+	// registryCacheTTL bounds data-path lease reads: edgeproxy/MCP lookups
+	// answer from this cache, so a burst of kubectl traffic costs one lease
+	// GET per key per interval, not one per request.
+	registryCacheTTL = 3 * time.Second
+
+	tunnelLeaseLabel    = "edges.faros.sh/tunnel-registry"
+	tunnelLeaseKeyAnno  = "edges.faros.sh/conn-key"
+	tunnelLeasePrefix   = "edge-tunnel-"
+	presenceLeasePrefix = "edge-replica-"
+)
+
+// NewRegistry builds the registry from the provider's workspace-scoped kcp
+// config. replicaID must be pickup-path- and lease-name-safe (SanitizeReplicaID);
+// selfAddr is this replica's relay address ("podIP:internalPort").
+func NewRegistry(cfg *rest.Config, replicaID, selfAddr string) (*Registry, error) {
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("registry client: %w", err)
+	}
+	return &Registry{
+		leases:    cs.CoordinationV1().Leases(registryNamespace),
+		replicaID: replicaID,
+		selfAddr:  selfAddr,
+		now:       time.Now,
+		cache:     map[string]registryCacheEntry{},
+	}, nil
+}
+
+// SelfAddr returns this replica's relay address as recorded in claimed leases.
+func (r *Registry) SelfAddr() string { return r.selfAddr }
+
+// ReplicaID returns the sanitized replica identity embedded in pickup paths.
+func (r *Registry) ReplicaID() string { return r.replicaID }
+
+// SanitizeReplicaID makes an identity (pod name, hostname) safe for both a
+// URL path segment and a Lease name suffix.
+func SanitizeReplicaID(id string) string {
+	id = strings.ToLower(id)
+	var b strings.Builder
+	for _, c := range id {
+		if c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-' {
+			b.WriteRune(c)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" || len(out) > 60 {
+		sum := sha256.Sum256([]byte(id))
+		out = hex.EncodeToString(sum[:])[:16]
+	}
+	return out
+}
+
+func tunnelLeaseName(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return tunnelLeasePrefix + hex.EncodeToString(sum[:])[:16]
+}
+
+// ClaimTunnel records this replica as the edge's tunnel owner. Unconditional:
+// a live agent socket on this replica is ground truth, so an existing claim
+// (a previous owner whose agent reconnected here) is overwritten.
+func (r *Registry) ClaimTunnel(ctx context.Context, key string) error {
+	err := r.upsertLease(ctx, tunnelLeaseName(key), func(lease *coordinationv1.Lease) {
+		if lease.Labels == nil {
+			lease.Labels = map[string]string{}
+		}
+		lease.Labels[tunnelLeaseLabel] = "true"
+		if lease.Annotations == nil {
+			lease.Annotations = map[string]string{}
+		}
+		lease.Annotations[tunnelLeaseKeyAnno] = key
+	})
+	r.invalidate(key)
+	return err
+}
+
+// ReleaseTunnel drops the claim if this replica still holds it — the holder
+// check keeps a slow disconnect cleanup from erasing a newer claim written by
+// the replica the agent reconnected to.
+func (r *Registry) ReleaseTunnel(ctx context.Context, key string) {
+	name := tunnelLeaseName(key)
+	lease, err := r.leases.Get(ctx, name, metav1.GetOptions{})
+	if err != nil || ptr.Deref(lease.Spec.HolderIdentity, "") != r.selfAddr {
+		return
+	}
+	_ = r.leases.Delete(ctx, name, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &lease.UID},
+	})
+	r.invalidate(key)
+}
+
+// RenewOwned refreshes this replica's presence lease and the tunnel leases
+// for the keys it still holds locally. Called from the ConnManager sweeper.
+func (r *Registry) RenewOwned(ctx context.Context, localKeys []string) {
+	_ = r.upsertLease(ctx, presenceLeasePrefix+r.replicaID, nil)
+	for _, key := range localKeys {
+		name := tunnelLeaseName(key)
+		lease, err := r.leases.Get(ctx, name, metav1.GetOptions{})
+		if err != nil || ptr.Deref(lease.Spec.HolderIdentity, "") != r.selfAddr {
+			// Missing or foreign (agent reconnected elsewhere while our socket
+			// lingers): re-claiming here would fight the live owner. The local
+			// dialer dies on its own when the agent side closes.
+			continue
+		}
+		now := metav1.NewMicroTime(r.now())
+		lease.Spec.RenewTime = &now
+		_, _ = r.leases.Update(ctx, lease, metav1.UpdateOptions{})
+	}
+}
+
+// LookupTunnel resolves the relay address of the replica holding an edge's
+// tunnel. Cached for registryCacheTTL; expired leases report not-held.
+func (r *Registry) LookupTunnel(ctx context.Context, key string) (string, bool) {
+	r.mu.Lock()
+	entry, cached := r.cache[key]
+	r.mu.Unlock()
+	if cached && r.now().Sub(entry.fetched) < registryCacheTTL {
+		return entry.addr, entry.ok
+	}
+	addr, ok := r.lookupLive(ctx, key)
+	r.mu.Lock()
+	r.cache[key] = registryCacheEntry{addr: addr, ok: ok, fetched: r.now()}
+	r.mu.Unlock()
+	return addr, ok
+}
+
+func (r *Registry) lookupLive(ctx context.Context, key string) (string, bool) {
+	lease, err := r.leases.Get(ctx, tunnelLeaseName(key), metav1.GetOptions{})
+	if err != nil {
+		return "", false
+	}
+	if !r.leaseFresh(lease) {
+		return "", false
+	}
+	addr := ptr.Deref(lease.Spec.HolderIdentity, "")
+	return addr, addr != ""
+}
+
+// ListTunnels returns the fleet-wide key→relay-address map of fresh tunnel
+// claims — the cluster-aware Keys() backing MCP tool enumeration.
+func (r *Registry) ListTunnels(ctx context.Context) map[string]string {
+	list, err := r.leases.List(ctx, metav1.ListOptions{LabelSelector: tunnelLeaseLabel + "=true"})
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]string, len(list.Items))
+	for i := range list.Items {
+		lease := &list.Items[i]
+		key := lease.Annotations[tunnelLeaseKeyAnno]
+		addr := ptr.Deref(lease.Spec.HolderIdentity, "")
+		if key == "" || addr == "" || !r.leaseFresh(lease) {
+			continue
+		}
+		out[key] = addr
+	}
+	return out
+}
+
+// ReplicaAddr resolves a replica ID (from a replica-addressed pickup path) to
+// its relay address via its presence lease.
+func (r *Registry) ReplicaAddr(ctx context.Context, replicaID string) (string, bool) {
+	if replicaID == r.replicaID {
+		return r.selfAddr, true
+	}
+	lease, err := r.leases.Get(ctx, presenceLeasePrefix+replicaID, metav1.GetOptions{})
+	if err != nil || !r.leaseFresh(lease) {
+		return "", false
+	}
+	addr := ptr.Deref(lease.Spec.HolderIdentity, "")
+	return addr, addr != ""
+}
+
+func (r *Registry) leaseFresh(lease *coordinationv1.Lease) bool {
+	return lease.Spec.RenewTime != nil && r.now().Sub(lease.Spec.RenewTime.Time) <= registryLeaseTTL
+}
+
+func (r *Registry) invalidate(key string) {
+	r.mu.Lock()
+	delete(r.cache, key)
+	r.mu.Unlock()
+}
+
+// upsertLease creates or takes over a lease with holder=selfAddr, applying
+// decorate (labels/annotations) on the object before writing. One conflict
+// retry: the loser of a race re-reads and overwrites — last live socket wins.
+func (r *Registry) upsertLease(ctx context.Context, name string, decorate func(*coordinationv1.Lease)) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		now := metav1.NewMicroTime(r.now())
+		lease, err := r.leases.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			lease = &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: coordinationv1.LeaseSpec{
+					HolderIdentity:       ptr.To(r.selfAddr),
+					LeaseDurationSeconds: ptr.To(int32(registryLeaseTTL.Seconds())),
+					AcquireTime:          &now,
+					RenewTime:            &now,
+				},
+			}
+			if decorate != nil {
+				decorate(lease)
+			}
+			if _, err := r.leases.Create(ctx, lease, metav1.CreateOptions{}); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					continue
+				}
+				return err
+			}
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if ptr.Deref(lease.Spec.HolderIdentity, "") != r.selfAddr {
+			lease.Spec.AcquireTime = &now
+			lease.Spec.LeaseTransitions = ptr.To(ptr.Deref(lease.Spec.LeaseTransitions, 0) + 1)
+		}
+		lease.Spec.HolderIdentity = ptr.To(r.selfAddr)
+		lease.Spec.LeaseDurationSeconds = ptr.To(int32(registryLeaseTTL.Seconds()))
+		lease.Spec.RenewTime = &now
+		if decorate != nil {
+			decorate(lease)
+		}
+		if _, err := r.leases.Update(ctx, lease, metav1.UpdateOptions{}); err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("lease %s: lost two consecutive update races", name)
+}

--- a/providers/edges/internal/tunnel/registry_test.go
+++ b/providers/edges/internal/tunnel/registry_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func testRegistry(replicaID, addr string, cs *kubefake.Clientset, now func() time.Time) *Registry {
+	return &Registry{
+		leases:    cs.CoordinationV1().Leases(registryNamespace),
+		replicaID: replicaID,
+		selfAddr:  addr,
+		now:       now,
+		cache:     map[string]registryCacheEntry{},
+	}
+}
+
+func TestRegistryClaimLookupAndTakeover(t *testing.T) {
+	ctx := context.Background()
+	cs := kubefake.NewClientset()
+	current := time.Now()
+	clock := func() time.Time { return current }
+	a := testRegistry("replica-a", "10.0.0.1:8090", cs, clock)
+	b := testRegistry("replica-b", "10.0.0.2:8090", cs, clock)
+
+	const key = "kubernetesclusters/cl-1/edge-1"
+	if err := a.ClaimTunnel(ctx, key); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if addr, ok := b.LookupTunnel(ctx, key); !ok || addr != "10.0.0.1:8090" {
+		t.Fatalf("lookup from peer = %q/%v, want owner address", addr, ok)
+	}
+
+	// The agent reconnects to B: an unconditional re-claim overwrites A —
+	// the live socket is ground truth.
+	if err := b.ClaimTunnel(ctx, key); err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	a.invalidate(key)
+	if addr, ok := a.LookupTunnel(ctx, key); !ok || addr != "10.0.0.2:8090" {
+		t.Fatalf("lookup after reconnect = %q/%v, want new owner", addr, ok)
+	}
+
+	// A's late disconnect cleanup must NOT erase B's newer claim.
+	a.ReleaseTunnel(ctx, key)
+	b.invalidate(key)
+	if addr, ok := b.LookupTunnel(ctx, key); !ok || addr != "10.0.0.2:8090" {
+		t.Fatalf("lookup after stale release = %q/%v, want claim intact", addr, ok)
+	}
+
+	// The owner's release drops it.
+	b.ReleaseTunnel(ctx, key)
+	b.invalidate(key)
+	if _, ok := b.LookupTunnel(ctx, key); ok {
+		t.Fatal("released tunnel still resolves")
+	}
+}
+
+func TestRegistryExpiredLeasesDoNotResolve(t *testing.T) {
+	ctx := context.Background()
+	cs := kubefake.NewClientset()
+	current := time.Now()
+	clock := func() time.Time { return current }
+	a := testRegistry("replica-a", "10.0.0.1:8090", cs, clock)
+	b := testRegistry("replica-b", "10.0.0.2:8090", cs, clock)
+
+	const key = "kubernetesclusters/cl-1/edge-1"
+	if err := a.ClaimTunnel(ctx, key); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	current = current.Add(registryLeaseTTL + time.Second)
+	if _, ok := b.LookupTunnel(ctx, key); ok {
+		t.Fatal("expired tunnel lease still resolves")
+	}
+	if tunnels := b.ListTunnels(ctx); len(tunnels) != 0 {
+		t.Fatalf("expired lease listed: %v", tunnels)
+	}
+
+	// Renewal by the owner brings it back.
+	a.RenewOwned(ctx, []string{key})
+	b.invalidate(key)
+	if _, ok := b.LookupTunnel(ctx, key); !ok {
+		t.Fatal("renewed tunnel lease does not resolve")
+	}
+}
+
+func TestRegistryListAndPresence(t *testing.T) {
+	ctx := context.Background()
+	cs := kubefake.NewClientset()
+	clock := time.Now
+	a := testRegistry("replica-a", "10.0.0.1:8090", cs, clock)
+	b := testRegistry("replica-b", "10.0.0.2:8090", cs, clock)
+
+	_ = a.ClaimTunnel(ctx, "kubernetesclusters/cl-1/edge-1")
+	_ = b.ClaimTunnel(ctx, "linuxservers/cl-2/edge-2")
+	a.RenewOwned(ctx, nil) // writes presence
+	b.RenewOwned(ctx, nil)
+
+	tunnels := a.ListTunnels(ctx)
+	if len(tunnels) != 2 ||
+		tunnels["kubernetesclusters/cl-1/edge-1"] != "10.0.0.1:8090" ||
+		tunnels["linuxservers/cl-2/edge-2"] != "10.0.0.2:8090" {
+		t.Fatalf("ListTunnels = %v, want both claims with owner addresses", tunnels)
+	}
+
+	if addr, ok := a.ReplicaAddr(ctx, "replica-b"); !ok || addr != "10.0.0.2:8090" {
+		t.Fatalf("ReplicaAddr(replica-b) = %q/%v, want peer address", addr, ok)
+	}
+	if addr, ok := a.ReplicaAddr(ctx, "replica-a"); !ok || addr != "10.0.0.1:8090" {
+		t.Fatalf("ReplicaAddr(self) = %q/%v, want self address without a lease read", addr, ok)
+	}
+	if _, ok := a.ReplicaAddr(ctx, "replica-zombie"); ok {
+		t.Fatal("unknown replica resolved")
+	}
+}
+
+func TestSanitizeReplicaID(t *testing.T) {
+	cases := map[string]bool{ // input → expect same string back
+		"edges-5b8f7c9d4-x2vlp": true,
+		"MacBook.local":         false,
+		"":                      false,
+	}
+	for in, wantSame := range cases {
+		got := SanitizeReplicaID(in)
+		if got == "" {
+			t.Fatalf("SanitizeReplicaID(%q) produced empty id", in)
+		}
+		if wantSame && got != in {
+			t.Fatalf("SanitizeReplicaID(%q) = %q, want unchanged", in, got)
+		}
+		for _, c := range got {
+			if !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-') {
+				t.Fatalf("SanitizeReplicaID(%q) = %q contains %q", in, got, string(c))
+			}
+		}
+	}
+}

--- a/providers/edges/internal/tunnel/remote.go
+++ b/providers/edges/internal/tunnel/remote.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+// The relay plane: how a replica that does NOT hold an edge's tunnel still
+// serves requests for it. ConnManager.Load returns a remoteDialer for
+// peer-held tunnels; its Dial opens a raw byte stream to the owning replica's
+// internal listener (/relay), which bridges it onto a local revdial
+// Dial — so every consumer (edgeproxy k8s/ssh, service proxy, MCP tools,
+// reconcilers, event subscribers) works unchanged from any replica, at the
+// cost of one intra-cluster hop.
+//
+// The internal listener is pod-to-pod only (its port is not in the provider's
+// Service) and the relay additionally requires the provider's own bearer
+// token, which every replica shares via the minted provider kubeconfig.
+
+import (
+	"bufio"
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// relayPath is the internal-listener endpoint that bridges a raw stream onto
+// a locally held tunnel.
+const relayPath = "/relay"
+
+// relayUpgradeProto marks the 101 handshake so a misrouted HTTP client gets a
+// clean error instead of half a byte stream.
+const relayUpgradeProto = "faros-tunnel-relay"
+
+// remoteDialer opens connections to an edge whose tunnel is held by a peer
+// replica, by relaying through that peer's internal listener.
+type remoteDialer struct {
+	addr  string // peer relay address ("ip:internalPort")
+	key   string // edge conn key
+	token string // shared provider bearer authenticating the relay
+}
+
+func (d *remoteDialer) Dial(ctx context.Context) (net.Conn, error) {
+	var nd net.Dialer
+	conn, err := nd.DialContext(ctx, "tcp", d.addr)
+	if err != nil {
+		return nil, fmt.Errorf("dialing peer replica %s: %w", d.addr, err)
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		// Bound the handshake; cleared once the stream is established.
+		_ = conn.SetDeadline(time.Now().Add(15 * time.Second))
+	}
+	req := fmt.Sprintf("GET %s?key=%s HTTP/1.1\r\nHost: %s\r\nAuthorization: Bearer %s\r\nConnection: Upgrade\r\nUpgrade: %s\r\n\r\n",
+		relayPath, url.QueryEscape(d.key), d.addr, d.token, relayUpgradeProto)
+	if _, err := io.WriteString(conn, req); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("relay handshake write to %s: %w", d.addr, err)
+	}
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("relay handshake read from %s: %w", d.addr, err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		_ = resp.Body.Close()
+		_ = conn.Close()
+		return nil, fmt.Errorf("peer replica %s refused relay for %s: %s %s", d.addr, d.key, resp.Status, strings.TrimSpace(string(msg)))
+	}
+	_ = conn.SetDeadline(time.Time{})
+	return &relayConn{Conn: conn, r: br}, nil
+}
+
+// relayConn drains bytes the handshake reader buffered past the 101 before
+// reading from the socket.
+type relayConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *relayConn) Read(p []byte) (int, error) {
+	if c.r.Buffered() > 0 {
+		return c.r.Read(p)
+	}
+	return c.Conn.Read(p)
+}
+
+// pickupRouter dispatches replica-addressed pickup connections
+// (/proxy/{replicaID}?revdial.dialer=...): local replica → the revdial
+// ConnHandler; a peer → a proxied WebSocket upgrade to that peer's internal
+// listener, resolved through its presence lease. Unknown or dead replicas get
+// 502 — the agent reports pickup-failed and the pending Dial errors cleanly.
+func (s *Server) pickupRouter(local http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		replicaID := strings.TrimPrefix(r.URL.Path, "/proxy/")
+		if replicaID == "" || strings.Contains(replicaID, "/") {
+			http.Error(w, "invalid pickup path", http.StatusBadRequest)
+			return
+		}
+		if s.registry == nil || replicaID == s.replicaID {
+			local.ServeHTTP(w, r)
+			return
+		}
+		addr, ok := s.registry.ReplicaAddr(r.Context(), replicaID)
+		if !ok {
+			s.logger.Info("pickup for unknown or dead replica", "replica", replicaID)
+			http.Error(w, "unknown replica", http.StatusBadGateway)
+			return
+		}
+		target := &url.URL{Scheme: "http", Host: addr}
+		proxy := &httputil.ReverseProxy{
+			Rewrite: func(pr *httputil.ProxyRequest) {
+				pr.SetURL(target)
+				pr.Out.URL.Path = "/agent-pickup"
+				// Query (the revdial dialer id) rides along untouched.
+			},
+		}
+		proxy.ServeHTTP(w, r)
+	})
+}
+
+// relayHandler serves the owning side of the relay: authenticate the peer,
+// dial the LOCAL tunnel (never recursing into another relay), hijack, 101,
+// and pipe until either side closes.
+func (s *Server) relayHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.relayToken == "" ||
+			subtle.ConstantTimeCompare([]byte(extractBearerToken(r)), []byte(s.relayToken)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		key := r.URL.Query().Get("key")
+		if key == "" {
+			http.Error(w, "missing key", http.StatusBadRequest)
+			return
+		}
+		dialer, ok := s.edgeConnManager.LoadLocal(key)
+		if !ok {
+			// The forwarding replica acted on a stale lease; it will re-resolve
+			// after its cache TTL.
+			http.Error(w, "no local tunnel for key", http.StatusBadGateway)
+			return
+		}
+		down, err := dialer.Dial(r.Context())
+		if err != nil {
+			http.Error(w, "tunnel dial failed: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			_ = down.Close()
+			http.Error(w, "hijack unsupported", http.StatusInternalServerError)
+			return
+		}
+		up, bufrw, err := hj.Hijack()
+		if err != nil {
+			_ = down.Close()
+			return
+		}
+		_, _ = bufrw.WriteString("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: " + relayUpgradeProto + "\r\n\r\n")
+		_ = bufrw.Flush()
+
+		logger := klog.Background().WithName("tunnel-relay").WithValues("key", key)
+		logger.V(4).Info("relay stream open")
+		done := make(chan struct{}, 2)
+		go func() {
+			// Drain anything the hijacked reader buffered before splicing.
+			if n := bufrw.Reader.Buffered(); n > 0 {
+				buffered, _ := bufrw.Reader.Peek(n)
+				_, _ = down.Write(buffered)
+				_, _ = bufrw.Reader.Discard(n)
+			}
+			_, _ = io.Copy(down, up)
+			done <- struct{}{}
+		}()
+		go func() {
+			_, _ = io.Copy(up, down)
+			done <- struct{}{}
+		}()
+		<-done
+		_ = up.Close()
+		_ = down.Close()
+		<-done
+		logger.V(4).Info("relay stream closed")
+	}
+}

--- a/providers/edges/internal/tunnel/remote_test.go
+++ b/providers/edges/internal/tunnel/remote_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+// pipeAgent fakes the agent side of a locally held tunnel: every Dial hands
+// back one end of a net.Pipe and the "agent" echoes everything it reads.
+type pipeAgent struct{}
+
+func (pipeAgent) Dial(ctx context.Context) (net.Conn, error) {
+	local, remote := net.Pipe()
+	go func() {
+		_, _ = io.Copy(remote, remote) // echo
+		_ = remote.Close()
+	}()
+	return local, nil
+}
+
+// relayServer runs the owner-side relay over a real TCP listener with a fake
+// locally held tunnel, returning the relay address.
+func relayServer(t *testing.T, s *Server) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(s.relayHandler()))
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
+}
+
+func newRelayTestServer(t *testing.T, token string) *Server {
+	t.Helper()
+	s, err := New(Config{
+		Kinds: []KindConfig{{
+			GVR:  schema.GroupVersionResource{Group: "edges.faros.sh", Version: "v1alpha1", Resource: "kubernetesclusters"},
+			Kind: "KubernetesCluster",
+		}},
+		AgentPickupPath: "/services/providers/edges/agent/proxy",
+		Logger:          klog.Background(),
+	})
+	if err != nil {
+		t.Fatalf("tunnel server: %v", err)
+	}
+	s.relayToken = token
+	return s
+}
+
+// The full remote path: a peer-held key resolves to a remoteDialer whose Dial
+// relays through the owner and carries bytes both ways.
+func TestRelayRoundTrip(t *testing.T) {
+	owner := newRelayTestServer(t, "shared-token")
+
+	// The relay only serves LOCALLY held tunnels; inject a live one by
+	// storing a real revdial dialer is heavy, so go through the map with a
+	// fake — the relay handler only needs Dial.
+	const key = "kubernetesclusters/cl-1/edge-1"
+	owner.edgeConnManager.storeLocalForTest(key, pipeAgent{})
+
+	addr := relayServer(t, owner)
+
+	d := &remoteDialer{addr: addr, key: key, token: "shared-token"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := d.Dial(ctx)
+	if err != nil {
+		t.Fatalf("remote dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	payload := []byte("kubectl get pods --through-the-relay")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, len(payload))
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("echo = %q, want %q", got, payload)
+	}
+}
+
+func TestRelayRefusesBadTokenAndUnknownKey(t *testing.T) {
+	owner := newRelayTestServer(t, "shared-token")
+	owner.edgeConnManager.storeLocalForTest("kubernetesclusters/cl-1/edge-1", pipeAgent{})
+	addr := relayServer(t, owner)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	bad := &remoteDialer{addr: addr, key: "kubernetesclusters/cl-1/edge-1", token: "wrong"}
+	if _, err := bad.Dial(ctx); err == nil {
+		t.Fatal("relay accepted a wrong bearer token")
+	}
+	missing := &remoteDialer{addr: addr, key: "kubernetesclusters/cl-1/edge-9", token: "shared-token"}
+	if _, err := missing.Dial(ctx); err == nil {
+		t.Fatal("relay accepted a key it does not hold")
+	}
+}
+
+// Pickup routing: the local replica serves pickups itself; a peer-addressed
+// pickup is forwarded to the peer's internal listener, an unknown replica 502s.
+func TestPickupRouterDispatch(t *testing.T) {
+	s := newRelayTestServer(t, "shared-token")
+	s.replicaID = "replica-a"
+
+	localHits := 0
+	router := s.pickupRouter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		localHits++
+		w.WriteHeader(http.StatusTeapot) // sentinel
+	}))
+
+	// Without a registry every pickup is local (single-replica mode).
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/proxy/replica-a?revdial.dialer=abc", nil))
+	if localHits != 1 || rec.Code != http.StatusTeapot {
+		t.Fatalf("self pickup: hits=%d code=%d, want local dispatch", localHits, rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/proxy/replica-b?revdial.dialer=abc", nil))
+	if localHits != 2 {
+		t.Fatal("registry-less router must serve every pickup locally")
+	}
+
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/proxy/", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty replica segment = %d, want 400", rec.Code)
+	}
+}
+
+// storeLocalForTest lets tests install a fake locally held tunnel without a
+// live revdial socket.
+func (c *ConnManager) storeLocalForTest(key string, d Dialer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dials[key] = d
+}

--- a/providers/edges/internal/tunnel/server.go
+++ b/providers/edges/internal/tunnel/server.go
@@ -20,13 +20,17 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
+	"github.com/gorilla/websocket"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	"github.com/faroshq/provider-edges/internal/events"
 	"github.com/faroshq/provider-edges/internal/kcpurl"
+	utilhttp "github.com/faroshq/provider-edges/internal/wsutil"
+	"github.com/faroshq/provider-sdk/revdial"
 )
 
 // KindConfig declares one connectable kind the tunnel serves. All kinds a
@@ -78,7 +82,7 @@ type Server struct {
 	version string
 
 	// edgeConnManager is the tunnel registry: agent-ingress writes, edgeproxy
-	// reads. Single-replica invariant applies (see connman.go).
+	// reads. Cluster-aware when replica routing is enabled (see connman.go).
 	edgeConnManager *ConnManager
 
 	// kcpConfig is the provider's kcp credential. Used for delegated agent-token
@@ -123,7 +127,43 @@ type Server struct {
 	// events tool. Set via SetEventStore from the controller manager.
 	eventStore events.Store
 
+	// registry/replicaID/relayToken enable multi-replica tunnel routing (see
+	// EnableReplicaRouting). All nil/empty in single-replica mode.
+	registry   *Registry
+	replicaID  string
+	relayToken string
+
 	logger klog.Logger
+}
+
+// EnableReplicaRouting turns on multi-replica tunnel routing: new dialers
+// advertise a replica-addressed pickup path, the ConnManager becomes
+// cluster-aware through the registry, and the internal listener (see
+// InternalHandler) serves the relay + forwarded pickups. relayToken is the
+// shared provider bearer peers authenticate relays with. Call once before
+// serving.
+func (s *Server) EnableReplicaRouting(reg *Registry, relayToken string) {
+	s.registry = reg
+	s.replicaID = reg.ReplicaID()
+	s.relayToken = relayToken
+	s.edgeConnManager.SetRegistry(reg, relayToken)
+}
+
+// InternalHandler serves the pod-to-pod surface on the internal listener
+// (never mounted on the public Service): the tunnel relay and forwarded
+// revdial pickups.
+func (s *Server) InternalHandler() http.Handler {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return utilhttp.CheckSameOrAllowedOrigin(r, []url.URL{})
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayPath, s.relayHandler())
+	// Forwarded pickups land here; the revdial dialer id in the query is the
+	// capability (same model as the public pickup path).
+	mux.Handle("/agent-pickup", revdial.ConnHandler(upgrader))
+	return mux
 }
 
 // SetEventStore wires the read side of the events tools to the store the event

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -6,8 +6,8 @@
 //
 //	http://www.apache.org/licenses/LICENSE-2.0
 //
-// edges is the single, privileged, single-replica provider that owns the whole
-// edge connectivity plane for BOTH connectable kinds — KubernetesCluster and
+// edges is the single, privileged provider that owns the whole edge
+// connectivity plane for BOTH connectable kinds — KubernetesCluster and
 // LinuxServer, under one group edges.faros.sh. It terminates agent reverse
 // tunnels (revdial) with one in-process ConnManager, runs the token/RBAC/
 // lifecycle controllers per kind, and serves the k8s/ssh/mcp data-plane
@@ -18,12 +18,16 @@
 //
 //   - /healthz                                          liveness/readiness gate
 //   - /agent/{cluster}/apis/edges.faros.sh/v1alpha1/{kubernetesclusters|linuxservers}/{name}/proxy  agent control-tunnel ingress
-//   - /agent/proxy?revdial.dialer=<id>                  agent revdial pickup ingress
+//   - /agent/proxy?revdial.dialer=<id>                  agent revdial pickup ingress (single-replica / legacy)
+//   - /agent/proxy/{replica}?revdial.dialer=<id>        replica-addressed pickup ingress
 //   - /edgeproxy/clusters/{cluster}/.../{name}/{k8s|ssh|mcp}  consumer egress
 //
-// IMPORTANT: this provider MUST run as a single replica — revdial registers
-// dialers in a process-global map, so an agent's control connection and every
-// later pickup connection must reach the same process.
+// Multi-replica: revdial dialers stay process-local (the dialer closes over
+// the accepted socket), but each agent dials only ONE replica. The replica
+// terminating a tunnel claims it in a Lease registry in the provider
+// workspace, and the other replicas relay pickups and data-plane requests to
+// the owner over the internal listener (EDGES_INTERNAL_PORT, pod-to-pod
+// only). See internal/tunnel/{registry,remote}.go.
 package main
 
 import (
@@ -112,8 +116,9 @@ func runServe() error {
 	hubExternalURL := os.Getenv("FAROS_HUB_EXTERNAL_URL")
 
 	// Tunnel plane. The provider owns the ConnManager and terminates agent
-	// reverse tunnels in-process (single-replica). Both prefixes sit behind the
-	// hub backend proxy at /services/providers/edges/*.
+	// reverse tunnels in-process; with replica routing enabled below, peer
+	// replicas relay to whichever replica holds a tunnel. Both prefixes sit
+	// behind the hub backend proxy at /services/providers/edges/*.
 	tsrv, err := sdktunnel.New(sdktunnel.Config{
 		Kinds: []sdktunnel.KindConfig{
 			{GVR: edgesv1alpha1.KubernetesClusterGVR, Kind: "KubernetesCluster"},
@@ -129,6 +134,52 @@ func runServe() error {
 	})
 	if err != nil {
 		return fmt.Errorf("build tunnel server: %w", err)
+	}
+
+	// Multi-replica tunnel routing. Each agent dials ONE replica; the replica
+	// terminating the tunnel claims it in a workspace Lease registry, and
+	// every other replica relays pickups and data-plane requests to the owner
+	// over the internal listener (pod-to-pod only — its port is not on the
+	// Service). Requires POD_IP (downward API) and a bearer-token provider
+	// credential; without them the provider runs in the historical
+	// single-replica mode.
+	if kcpConfig != nil {
+		podIP := os.Getenv("POD_IP")
+		internalPort := os.Getenv("EDGES_INTERNAL_PORT")
+		if internalPort == "" {
+			internalPort = "8090"
+		}
+		switch {
+		case podIP == "":
+			log.Info("replica tunnel routing disabled (POD_IP unset); single-replica mode")
+		case kcpConfig.BearerToken == "":
+			log.Info("replica tunnel routing disabled (provider credential has no bearer token to authenticate the relay); single-replica mode")
+		default:
+			replicaID := sdktunnel.SanitizeReplicaID(envOrHostname("POD_NAME"))
+			reg, rerr := sdktunnel.NewRegistry(kcpConfig, replicaID, podIP+":"+internalPort)
+			if rerr != nil {
+				log.Error(rerr, "replica tunnel routing disabled (registry unavailable); single-replica mode")
+				break
+			}
+			tsrv.EnableReplicaRouting(reg, kcpConfig.BearerToken)
+			internalSrv := &http.Server{
+				Addr:              ":" + internalPort,
+				Handler:           tsrv.InternalHandler(),
+				ReadHeaderTimeout: 10 * time.Second,
+			}
+			go func() {
+				log.Info("edges internal listener (relay + forwarded pickups)", "port", internalPort, "replica", replicaID)
+				if lerr := internalSrv.ListenAndServe(); lerr != nil && !errors.Is(lerr, http.ErrServerClosed) {
+					log.Error(lerr, "internal listener failed; peer replicas cannot relay to this one")
+				}
+			}()
+			go func() {
+				<-ctx.Done()
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = internalSrv.Shutdown(shutdownCtx)
+			}()
+		}
 	}
 	tsrv.Start(ctx.Done())
 
@@ -282,4 +333,18 @@ func splitEnv(v string) []string {
 		}
 	}
 	return out
+}
+
+// envOrHostname returns the named env var (the chart sets POD_NAME via the
+// downward API) falling back to the hostname — which in a pod is the pod
+// name anyway.
+func envOrHostname(key string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return "replica"
+	}
+	return host
 }

--- a/providers/edges/manifest.yaml
+++ b/providers/edges/manifest.yaml
@@ -4,7 +4,8 @@
 # + LinuxServer) under one group edges.faros.sh. It terminates the agent
 # reverse tunnel (revdial) in-process, owns the API + its APIExport, runs the
 # token/RBAC/lifecycle controllers, and proxies kubectl/SSH/MCP through the hub
-# backend proxy. Runs SINGLE-REPLICA (revdial dialer map is process-global).
+# backend proxy. Scales horizontally: each agent dials one replica and a Lease
+# registry + pod-to-pod relay route requests to the tunnel's owner.
 ---
 apiVersion: providers.faros.sh/v1alpha1
 kind: CatalogEntry

--- a/providers/infrastructure/Dockerfile
+++ b/providers/infrastructure/Dockerfile
@@ -3,19 +3,24 @@
 # 1. Build the portal micro-frontend (Vite + TS → portal/dist).
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/infrastructure/portal/package.json providers/infrastructure/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/infrastructure/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. The binary serves `init` + `serve`, so the whole
-#    module source has to be present. The faros-provider-sdk is now a published
-#    dependency (no replace), so `go mod download` fetches it from the proxy.
+#    module source has to be present. The provider-sdk resolves IN-TREE via a
+#    go.mod replace, so the build context is the repo root and the sdk is
+#    copied alongside the module below.
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/infrastructure/go.mod providers/infrastructure/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/infrastructure/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY . ./
+COPY providers/infrastructure/ ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/infrastructure-provider .
 

--- a/providers/infrastructure/Dockerfile.access-proxy
+++ b/providers/infrastructure/Dockerfile.access-proxy
@@ -7,10 +7,14 @@ ARG TARGETARCH
 ARG TARGETOS=linux
 
 WORKDIR /src
-COPY go.mod go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from WORKDIR
+# /src that resolves to /provider-sdk). Build context is the REPO ROOT:
+# docker build -f providers/infrastructure/Dockerfile.access-proxy .
+COPY provider-sdk/ /provider-sdk/
+COPY providers/infrastructure/go.mod providers/infrastructure/go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
-COPY . .
+COPY providers/infrastructure/ ./
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \

--- a/providers/infrastructure/controller/instance/controller.go
+++ b/providers/infrastructure/controller/instance/controller.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -177,9 +178,13 @@ func New(cfg Config) (*Controller, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating apiexport multicluster provider: %w", err)
 	}
+	skipNameValidation := true
 	mgr, err := mcmanager.New(cfg.ProviderConfig, provider, manager.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
+		// The serve binary rebuilds this controller for every leadership term,
+		// and controller names register process-globally.
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipNameValidation},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating multicluster manager: %w", err)

--- a/providers/infrastructure/controller_manager.go
+++ b/providers/infrastructure/controller_manager.go
@@ -31,8 +31,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/faroshq/provider-sdk/leaderelection"
 
 	"github.com/faroshq/provider-infrastructure/backend"
 	krobackend "github.com/faroshq/provider-infrastructure/backend/kro"
@@ -41,11 +44,23 @@ import (
 	"github.com/faroshq/provider-infrastructure/install"
 )
 
-// startControllerManager builds a controller-runtime manager pointed
-// at the provider's own kcp workspace, installs the platform CRDs,
-// registers the stub backend, and starts the Template controller.
-// The caller loads the kcp config (shared with the tenant client) and
-// passes it in; a nil config means "skip the manager, run REST-only".
+// Leases gating this binary's singleton write loops, all held in the provider
+// workspace ("default" namespace — kcp serves Leases in every logical
+// cluster). One lease per loop so each is independently singleton; which
+// replica holds which does not matter. REST/MCP/portal serving is untouched —
+// non-leaders keep serving.
+const (
+	controllerLeaseName = "infrastructure-controllers"
+	instanceLeaseName   = "infrastructure-instance"
+	bootstrapLeaseName  = "infrastructure-bootstrap"
+)
+
+// startControllerManager installs the platform CRDs (legacy single-binary
+// mode), then campaigns for the controller lease and — while leader — runs a
+// controller-runtime manager pointed at the provider's own kcp workspace with
+// the Template controller on it. The caller loads the kcp config (shared with
+// the tenant client) and passes it in; a nil config means "skip the manager,
+// run REST-only".
 func startControllerManager(ctx context.Context, config *rest.Config) error {
 	if config == nil {
 		return errControllerDisabled
@@ -90,11 +105,38 @@ func startControllerManager(ctx context.Context, config *rest.Config) error {
 	// called" stack trace and swallows all controller-runtime logs.
 	ctrl.SetLogger(klog.NewKlogr())
 
+	// Leader-elected: only the replica holding the lease runs the Template
+	// controller, so scaling the serve deployment past one replica stops the
+	// two-active-managers conflict churn. The manager is rebuilt fresh each
+	// term — a stopped controller-runtime manager cannot be restarted.
+	go func() {
+		if err := leaderelection.Run(ctx, leaderelection.Options{
+			Config:    config,
+			Namespace: leaderelection.DefaultNamespace,
+			Name:      controllerLeaseName,
+		}, func(termCtx context.Context) {
+			if err := runTemplateControllerManager(termCtx, config); err != nil {
+				log.Printf("controller manager exited: %v", err)
+			}
+		}); err != nil {
+			log.Printf("controller leader election failed; Template controller is not running: %v", err)
+		}
+	}()
+	return nil
+}
+
+// runTemplateControllerManager builds the Template controller manager and
+// blocks in Start until the leadership term ends. Called once per term.
+func runTemplateControllerManager(ctx context.Context, config *rest.Config) error {
+	skipNameValidation := true
 	mgr, err := manager.New(config, manager.Options{
 		// Disable the metrics server in PR A; the bind on :8080 would
 		// collide with the provider's own HTTP server in dev. PR E
 		// adds it back on a configurable port.
 		Metrics: metricsserver.Options{BindAddress: "0"},
+		// Controller names register process-globally; the manager built for a
+		// later leadership term must skip that check.
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipNameValidation},
 	})
 	if err != nil {
 		return fmt.Errorf("manager.New: %w", err)
@@ -145,13 +187,8 @@ func startControllerManager(ctx context.Context, config *rest.Config) error {
 		return fmt.Errorf("template controller: %w", err)
 	}
 
-	go func() {
-		log.Printf("infrastructure controller manager starting (backends=%v)", registry.Names())
-		if err := mgr.Start(ctx); err != nil {
-			log.Printf("controller manager exited: %v", err)
-		}
-	}()
-	return nil
+	log.Printf("infrastructure controller manager starting (backends=%v)", registry.Names())
+	return mgr.Start(ctx)
 }
 
 // loadControllerConfig returns a rest.Config for the workspace the

--- a/providers/infrastructure/deploy/chart/templates/operator.yaml
+++ b/providers/infrastructure/deploy/chart/templates/operator.yaml
@@ -29,6 +29,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  # Leader election (controller-runtime Lease in the operator's namespace) plus
+  # the events it records on leadership transitions.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/providers/infrastructure/go.mod
+++ b/providers/infrastructure/go.mod
@@ -105,3 +105,8 @@ require (
 )
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.0
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/infrastructure/go.sum
+++ b/providers/infrastructure/go.sum
@@ -27,8 +27,6 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/infrastructure/install/identity.go
+++ b/providers/infrastructure/install/identity.go
@@ -270,6 +270,15 @@ func ensureClusterRole(ctx context.Context, cs kubernetes.Interface) error {
 				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},
 			},
+			// Leader election: the serve replicas gate their singleton
+			// controllers (Template, Instance, bootstrap loop) on Leases in
+			// the provider workspace so scaling past one replica keeps each
+			// write loop single-active.
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+			},
 		},
 	}
 	// API discovery non-resource URLs. Required for the kcp-apiexport

--- a/providers/infrastructure/instance_controller.go
+++ b/providers/infrastructure/instance_controller.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/faroshq/provider-sdk/leaderelection"
+
 	"github.com/faroshq/provider-infrastructure/controller/instance"
 	"github.com/faroshq/provider-infrastructure/install"
 )
@@ -51,21 +53,32 @@ func startInstanceController(ctx context.Context, providerConfig *rest.Config) {
 
 	baseDomain := os.Getenv("FAROS_APP_BASE_DOMAIN")
 
-	ctrl, err := instance.New(instance.Config{
-		ProviderConfig: providerConfig,
-		APIExportName:  install.APIExportName,
-		BaseDomain:     baseDomain,
-		Runtime:        runtimeClient,
-	})
-	if err != nil {
-		log.Printf("instance controller: NOT started: %v", err)
-		return
-	}
-
+	// Leader-elected: instances own runtime-cluster state (kro CRs, bridged
+	// secrets), so exactly one replica may reconcile them. The controller —
+	// and its manager — is rebuilt fresh each term; a stopped
+	// controller-runtime manager cannot be restarted.
 	go func() {
-		log.Printf("instance controller: starting (apiExport=%s baseDomain=%q runtime=%s)", install.APIExportName, baseDomain, runtimeSrc)
-		if err := ctrl.Start(ctx); err != nil {
-			log.Printf("instance controller: stopped: %v", err)
+		if err := leaderelection.Run(ctx, leaderelection.Options{
+			Config:    providerConfig,
+			Namespace: leaderelection.DefaultNamespace,
+			Name:      instanceLeaseName,
+		}, func(termCtx context.Context) {
+			ctrl, err := instance.New(instance.Config{
+				ProviderConfig: providerConfig,
+				APIExportName:  install.APIExportName,
+				BaseDomain:     baseDomain,
+				Runtime:        runtimeClient,
+			})
+			if err != nil {
+				log.Printf("instance controller: NOT started: %v", err)
+				return
+			}
+			log.Printf("instance controller: starting (apiExport=%s baseDomain=%q runtime=%s)", install.APIExportName, baseDomain, runtimeSrc)
+			if err := ctrl.Start(termCtx); err != nil {
+				log.Printf("instance controller: stopped: %v", err)
+			}
+		}); err != nil {
+			log.Printf("instance controller: leader election failed; controller is not running: %v", err)
 		}
 	}()
 }

--- a/providers/infrastructure/operator.go
+++ b/providers/infrastructure/operator.go
@@ -43,6 +43,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/faroshq/provider-sdk/leaderelection"
+
 	"github.com/faroshq/provider-infrastructure/operator"
 )
 
@@ -92,7 +94,20 @@ func runOperator() error {
 	}
 
 	// Reconcile loop runs in the background; serve blocks in the foreground.
-	go runBootstrapLoop(ctx, providerCfg, runtimeCfg, providerKubeconfig)
+	// Leader-elected so multi-replica deployments run one bootstrap loop at a
+	// time: every step is idempotent, but two replicas applying the same
+	// objects on independent tickers is pure conflict churn.
+	go func() {
+		if err := leaderelection.Run(ctx, leaderelection.Options{
+			Config:    providerCfg,
+			Namespace: leaderelection.DefaultNamespace,
+			Name:      bootstrapLeaseName,
+		}, func(termCtx context.Context) {
+			runBootstrapLoop(termCtx, providerCfg, runtimeCfg, providerKubeconfig)
+		}); err != nil {
+			log.Printf("operator: bootstrap leader election failed; bootstrap loop is not running: %v", err)
+		}
+	}()
 
 	log.Printf("operator: starting serve loop on provider kubeconfig")
 	serveWithConfig(ctx, providerCfg)

--- a/providers/infrastructure/operator/controller.go
+++ b/providers/infrastructure/operator/controller.go
@@ -242,6 +242,14 @@ func Run(ctx context.Context, cfg *rest.Config, catalogEntryManifest []byte) err
 	mgr, err := manager.New(cfg, manager.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
+		// The operator reconciles CRs on a plain Kubernetes cluster, so
+		// controller-runtime's built-in Lease election is the right tool (unlike
+		// the serve binary, whose leases live in the kcp provider workspace).
+		// A replica that loses the lease exits Start with an error; the process
+		// exits and the pod restarts into a fresh campaign.
+		LeaderElection:          true,
+		LeaderElectionID:        "infrastructure-operator",
+		LeaderElectionNamespace: leaseNamespace(),
 	})
 	if err != nil {
 		return fmt.Errorf("manager.New: %w", err)
@@ -251,6 +259,21 @@ func Run(ctx context.Context, cfg *rest.Config, catalogEntryManifest []byte) err
 	}
 	klog.FromContext(ctx).Info("infrastructure operator manager starting")
 	return mgr.Start(ctx)
+}
+
+// leaseNamespace resolves where the operator's leader-election Lease lives:
+// POD_NAMESPACE when set, controller-runtime's in-cluster detection (empty
+// string) when running as a pod, and "default" for out-of-cluster dev runs —
+// where controller-runtime would otherwise fail with "unable to find leader
+// election namespace".
+func leaseNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		return ""
+	}
+	return "default"
 }
 
 // restConfigForWorkspace builds a rest.Config from kubeconfig bytes and

--- a/providers/infrastructure/operator/serve.go
+++ b/providers/infrastructure/operator/serve.go
@@ -80,6 +80,15 @@ func EnsureProviderServe(
 		{Name: "FAROS_PROVIDER_NAME", Value: "infrastructure"},
 		{Name: "INFRASTRUCTURE_KUBECONFIG", Value: providerKubeconfigMount},
 	}
+	if cr.Spec.ProviderWorkspace != "" {
+		// The mounted kubeconfig may be root-scoped (the supplied-admin flow,
+		// where spec.providerWorkspace is set; hub-minted kubeconfigs are
+		// already workspace-scoped and leave it empty). Without this, serve's
+		// controllers watch the root cluster, where the platform kinds don't
+		// exist — the Template cache never syncs and instances never
+		// reconcile or finalize.
+		env = append(env, corev1.EnvVar{Name: "INFRASTRUCTURE_WORKSPACE_PATH", Value: cr.Spec.ProviderWorkspace})
+	}
 	if cr.Spec.Hub.URL != "" {
 		env = append(env, corev1.EnvVar{Name: "FAROS_HUB_URL", Value: cr.Spec.Hub.URL})
 	}

--- a/providers/kuery/Dockerfile
+++ b/providers/kuery/Dockerfile
@@ -5,9 +5,9 @@
 #    package.json/lockfile + source — no host-side npm install required.
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/kuery/portal/package.json providers/kuery/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/kuery/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. assets.go embeds portal/dist via //go:embed, so
@@ -22,13 +22,17 @@ WORKDIR /src
 # TODO(sdk-publish): depends on github.com/faroshq/faros-provider-sdk via a
 # `replace => ../../provider-sdk` that only resolves in the monorepo (go.work).
 # Standalone image builds need the SDK published (drop the replace) or vendored.
-COPY go.mod go.sum ./
+COPY providers/kuery/go.mod providers/kuery/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/kuery/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY main.go assets.go init_cmd.go ./
-COPY core/ ./core/
-COPY engagement/ ./engagement/
-COPY mcpserver/ ./mcpserver/
-COPY queryapi/ ./queryapi/
+COPY providers/kuery/main.go providers/kuery/assets.go providers/kuery/init_cmd.go ./
+COPY providers/kuery/core/ ./core/
+COPY providers/kuery/engagement/ ./engagement/
+COPY providers/kuery/mcpserver/ ./mcpserver/
+COPY providers/kuery/queryapi/ ./queryapi/
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=1 go build -trimpath -ldflags="-s -w" -o /out/kuery-provider .
 
@@ -38,7 +42,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    /etc/faros/schemas (FAROS_SCHEMAS_DIR).
 FROM gcr.io/distroless/base-debian12:nonroot
 COPY --from=build /out/kuery-provider /kuery-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/kuery/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8081
 ENV PORT=8081
 ENV KUERY_STORE_DSN=/data/kuery.db

--- a/providers/kuery/deploy/chart/templates/catalogentry.yaml
+++ b/providers/kuery/deploy/chart/templates/catalogentry.yaml
@@ -46,13 +46,15 @@ data:
 
       apiExport:
         name: "kuery.providers.faros.sh"
-        # The engagement controller watches the tenant's Edge objects (via the
-        # APIExport virtual workspace) to know which edges to engage/disengage.
-        # First-party claim: the init container stamps its identityHash from
-        # apiExport.edgesIdentityHash (Helm value, copied from /bonkers).
+        # The engagement controller watches the tenant's KubernetesCluster
+        # edges (via the APIExport virtual workspace) to know which edges to
+        # engage/disengage. LinuxServer edges carry no Kubernetes API and are
+        # not claimed. First-party claim: the init container stamps its
+        # identityHash from apiExport.edgesIdentityHash (Helm value, copied
+        # from /bonkers).
         permissionClaims:
-          - resource: edges
-            group: faros.sh
+          - resource: kubernetesclusters
+            group: edges.faros.sh
             verbs: [get, list, watch]
             tenantScoped: true
 {{- end }}

--- a/providers/kuery/deploy/chart/templates/deployment.yaml
+++ b/providers/kuery/deploy/chart/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and (gt (int .Values.replicaCount) 1) (ne .Values.store.driver "postgres") }}
+{{- fail "kuery replicaCount > 1 requires store.driver=postgres: with per-pod SQLite each replica syncs into (and answers from) a different database" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/providers/kuery/deploy/chart/values.yaml
+++ b/providers/kuery/deploy/chart/values.yaml
@@ -13,6 +13,10 @@ image:
 
 # Number of Deployment replicas. Phase 1 is stateless; Phase 2 introduces
 # the local store, which pins this to 1.
+# Safe to scale WITH store.driver=postgres: engagement is sharded across
+# replicas by per-edge Leases in the provider workspace, and queries/edge
+# listings are answered from the shared store on every replica. The template
+# refuses replicaCount > 1 with the default SQLite store.
 replicaCount: 1
 
 service:

--- a/providers/kuery/engagement/claims.go
+++ b/providers/kuery/engagement/claims.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package engagement
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+)
+
+// Edge-engagement sharding: one coordination.k8s.io Lease per engaged edge,
+// held in the provider's own kcp workspace (kcp serves Leases in every
+// logical cluster — the same mechanism provider-sdk/leaderelection uses,
+// generalized from one lease to one per edge). Whichever replica claims an
+// edge's Lease syncs it; the others skip it and periodically re-check so a
+// dead replica's edges are taken over within claimTTL.
+const (
+	// claimNamespace is where the per-edge Leases live. kcp creates the
+	// "default" namespace in every logical cluster.
+	claimNamespace = "default"
+	// claimTTL is how long a claim survives without renewal before a peer
+	// may take it over. Handover cost is one TTL plus an engage.
+	claimTTL = 60 * time.Second
+	// renewInterval is the owning replica's reconcile requeue: each pass
+	// renews the claim AND re-asserts the kuery cluster row (status=active +
+	// tenant label), healing the transient markStale a previous owner's
+	// disengage left behind.
+	renewInterval = 20 * time.Second
+)
+
+// edgeClaims implements try-acquire/renew/release over per-edge Leases.
+type edgeClaims struct {
+	leases   coordinationv1client.LeaseInterface
+	identity string
+	now      func() time.Time
+}
+
+func newEdgeClaims(cfg *rest.Config) (*edgeClaims, error) {
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("claims client: %w", err)
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("claims identity: %w", err)
+	}
+	return &edgeClaims{
+		leases:   cs.CoordinationV1().Leases(claimNamespace),
+		identity: fmt.Sprintf("%s_%d", host, os.Getpid()),
+		now:      time.Now,
+	}, nil
+}
+
+// claimName derives a Lease name from the path-based store name. Hashed:
+// workspace paths contain characters Lease names cannot.
+func claimName(storeName string) string {
+	sum := sha256.Sum256([]byte(storeName))
+	return "kuery-engage-" + hex.EncodeToString(sum[:])[:16]
+}
+
+// tryAcquire reports whether this replica holds the edge's claim after the
+// attempt: it acquires a free or expired Lease, renews one it already holds,
+// and declines a fresh foreign one. Update conflicts mean a peer moved first
+// — treated as "not held" and settled on the next reconcile.
+func (c *edgeClaims) tryAcquire(ctx context.Context, storeName string) (bool, error) {
+	name := claimName(storeName)
+	now := metav1.NewMicroTime(c.now())
+	lease, err := c.leases.Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := c.leases.Create(ctx, &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       ptr.To(c.identity),
+				LeaseDurationSeconds: ptr.To(int32(claimTTL.Seconds())),
+				AcquireTime:          &now,
+				RenewTime:            &now,
+			},
+		}, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return err == nil, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	holder := ptr.Deref(lease.Spec.HolderIdentity, "")
+	if holder == c.identity {
+		lease.Spec.RenewTime = &now
+		if _, err := c.leases.Update(ctx, lease, metav1.UpdateOptions{}); err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	}
+
+	expired := lease.Spec.RenewTime == nil ||
+		c.now().Sub(lease.Spec.RenewTime.Time) > claimTTL
+	if !expired {
+		return false, nil
+	}
+	lease.Spec.HolderIdentity = ptr.To(c.identity)
+	lease.Spec.AcquireTime = &now
+	lease.Spec.RenewTime = &now
+	lease.Spec.LeaseTransitions = ptr.To(ptr.Deref(lease.Spec.LeaseTransitions, 0) + 1)
+	if _, err := c.leases.Update(ctx, lease, metav1.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// release deletes the claim if this replica holds it, so a peer takes the
+// edge over immediately instead of after claimTTL. Best-effort: an expired
+// claim hands over by TTL anyway.
+func (c *edgeClaims) release(ctx context.Context, storeName string) {
+	name := claimName(storeName)
+	lease, err := c.leases.Get(ctx, name, metav1.GetOptions{})
+	if err != nil || ptr.Deref(lease.Spec.HolderIdentity, "") != c.identity {
+		return
+	}
+	_ = c.leases.Delete(ctx, name, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &lease.UID},
+	})
+}

--- a/providers/kuery/engagement/controller.go
+++ b/providers/kuery/engagement/controller.go
@@ -118,6 +118,13 @@ type engagedEdge struct {
 
 // New builds the multicluster manager (APIExport VW) and registers the
 // Edge reconciler. Call Start to run it.
+//
+// Deliberately NOT leader-elected (unlike code/vibe-studio/infrastructure):
+// engagement is per-replica serving state — each replica engages edges into
+// its own kuery sync engine, and the HTTP layer reads TenantEdges /
+// EngagedCount from this process. Gating it on a lease would leave
+// non-leaders serving queries with zero engaged edges. Scaling past one
+// replica needs a shared engagement design first (chart default is 1).
 func New(cfg Config) (*Controller, error) {
 	if cfg.ProviderConfig == nil || cfg.Sync == nil || cfg.Store == nil {
 		return nil, fmt.Errorf("engagement: ProviderConfig, Sync, and Store are required")

--- a/providers/kuery/engagement/controller.go
+++ b/providers/kuery/engagement/controller.go
@@ -6,16 +6,27 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Package engagement watches Edge objects across all tenant workspaces that
-// enabled the kuery provider (through the APIExport virtual workspace — the
-// tenant-scoped permission claim on edges from the CatalogEntry) and feeds
-// connected kubernetes edges into kuery's sync controller.
+// Package engagement watches KubernetesCluster edges across all tenant
+// workspaces that enabled the kuery provider (through the APIExport virtual
+// workspace — the tenant-scoped permission claim on edges.faros.sh
+// kubernetesclusters from the CatalogEntry) and feeds connected edges into
+// kuery's sync controller.
 //
-// Per edge, the data path is the hub's edges-proxy: a rest.Config pointing
-// at /services/edges-proxy/clusters/{tenant}/.../edges/{name}/k8s with the
-// provider SA's token. The Enable-time grant (verb "proxy" on edges, bound
-// to the SA's system:kcp:serviceaccount identity) authorizes it; see
-// docs/kuery-provider-architecture.md in the faros repo.
+// Per edge, the data path is the edges provider's consumer proxy: a
+// rest.Config pointing at
+// /services/providers/edges/edgeproxy/clusters/{cluster}/apis/edges.faros.sh/v1alpha1/kubernetesclusters/{name}/k8s
+// with the provider SA's token. The Enable-time edge-proxy grant (verb
+// "proxy" on the edge kinds, bound to the SA's cluster-qualified identity)
+// authorizes it; see docs/kuery-provider-architecture.md in the faros repo.
+//
+// Horizontally scalable: engagement is sharded across replicas with one
+// Lease per edge in the provider workspace (see claims.go) — each connected
+// edge is synced by exactly one replica, and a dead replica's edges are
+// taken over within claimTTL. Query serving needs no affinity at all: every
+// replica answers from the shared SQL store, and TenantEdges lists engaged
+// edges from that store rather than from this process. Scaling past one
+// replica therefore requires the Postgres store — with per-pod SQLite each
+// replica would sync into (and answer from) a different database.
 package engagement
 
 import (
@@ -61,9 +72,10 @@ import (
 // key would be parsed as JSON path segments.
 const TenantLabel = "tenant"
 
-// edgeGVK is read with unstructured so the provider does not import the
-// faros monorepo module just for one type.
-var edgeGVK = schema.GroupVersionKind{Group: "faros.sh", Version: "v1alpha1", Kind: "Edge"}
+// edgeGVK is the edges provider's kubernetes-cluster kind, read unstructured
+// so this module does not import the edges provider module for one type.
+// LinuxServer edges carry no Kubernetes API and are not watched at all.
+var edgeGVK = schema.GroupVersionKind{Group: "edges.faros.sh", Version: "v1alpha1", Kind: "KubernetesCluster"}
 
 // clusterTTLSeconds is how long a disengaged cluster's rows survive before
 // kuery's GC reaps them (matches kuery's default).
@@ -73,30 +85,33 @@ const clusterTTLSeconds = 3600
 type Config struct {
 	// ProviderConfig is the minted provider kubeconfig's rest.Config. Its
 	// host is scoped to the provider workspace (/clusters/...) and must
-	// reach the kcp API — the APIExport VW discovery and the apiexport
-	// multicluster provider's APIExportEndpointSlice cache are built from
-	// it. Its bearer token (the provider SA token) also authorizes the
-	// per-edge edges-proxy data path.
+	// reach the kcp API — the APIExport VW discovery, the apiexport
+	// multicluster provider's APIExportEndpointSlice cache, and the per-edge
+	// claim Leases are all built from it. Its bearer token (the provider SA
+	// token) also authorizes the per-edge edgeproxy data path.
 	ProviderConfig *rest.Config
-	// HubBaseURL is the faros hub root that serves the edges-proxy virtual
-	// workspace (/services/edges-proxy/...). When the hub and the kcp API
-	// share one front-proxy host (in-cluster production) this is empty and
-	// the base is derived from ProviderConfig.Host; in host-binary/Tilt dev
-	// the kcp API (kcp front proxy) and the edges-proxy (hub) are split
-	// across two ports, so the hub URL is passed explicitly via FAROS_HUB_URL.
+	// HubBaseURL is the faros hub root that serves the edges provider's
+	// consumer proxy (/services/providers/edges/edgeproxy/...). When the hub
+	// and the kcp API share one front-proxy host (in-cluster production)
+	// this is empty and the base is derived from ProviderConfig.Host; in
+	// host-binary/Tilt dev the kcp API (kcp front proxy) and the hub are
+	// split across two ports, so the hub URL is passed via FAROS_HUB_URL.
 	HubBaseURL string
 	// APIExportName is the provider's APIExport ("kuery.providers.faros.sh").
 	APIExportName string
 	// Sync is the kuery sync controller clusters are engaged into.
 	Sync *kuerysync.SyncController
-	// Store is used to (re-)assert tenant labels on engaged clusters.
+	// Store is used to (re-)assert tenant labels on engaged clusters and to
+	// answer TenantEdges from shared state.
 	Store kuerystore.Store
 }
 
-// Controller reconciles Edge objects into kuery Engage/Disengage calls.
+// Controller reconciles KubernetesCluster edges into kuery Engage/Disengage
+// calls, sharded across replicas by per-edge claims.
 type Controller struct {
 	cfg     Config
 	hubBase string // ProviderConfig host with the /clusters/... suffix stripped
+	claims  *edgeClaims
 
 	mgr mcmanager.Manager
 
@@ -104,33 +119,26 @@ type Controller struct {
 	engaged map[string]engagedEdge // "{tenantCluster}/{edgeName}" → engagement handle
 }
 
-// engagedEdge tracks one engaged edge. The map key stays cluster-based
-// ("{tenantCluster}/{edgeName}") so it's computable on delete (when the Edge —
-// and its status.workspacePath — is already gone), but the tenant identity
-// queries scope by is the workspace PATH the hub stamped onto the Edge status,
-// which is what X-Faros-Tenant carries. Keeping both decouples the data-path
-// key (cluster) from the tenant-scoping key (path).
+// engagedEdge tracks one locally engaged edge. The map key stays
+// cluster-based ("{tenantCluster}/{edgeName}") so it's computable on delete
+// (when the edge — and its status.workspacePath — is already gone), but the
+// tenant identity queries scope by is the workspace PATH the edges provider
+// stamped onto the status, which is what X-Faros-Tenant carries.
 type engagedEdge struct {
 	cancel   context.CancelFunc
-	tenant   string // workspace path, used as the kuery cluster label + TenantEdges scope
+	tenant   string // workspace path, used as the kuery cluster label
 	edgeName string
 }
 
-// New builds the multicluster manager (APIExport VW) and registers the
-// Edge reconciler. Call Start to run it.
-//
-// Deliberately NOT leader-elected (unlike code/vibe-studio/infrastructure):
-// engagement is per-replica serving state — each replica engages edges into
-// its own kuery sync engine, and the HTTP layer reads TenantEdges /
-// EngagedCount from this process. Gating it on a lease would leave
-// non-leaders serving queries with zero engaged edges. Scaling past one
-// replica needs a shared engagement design first (chart default is 1).
+// New builds the multicluster manager (APIExport VW) and registers the edge
+// reconciler. Call Start to run it — on every replica; the per-edge claims
+// shard the actual sync work.
 func New(cfg Config) (*Controller, error) {
 	if cfg.ProviderConfig == nil || cfg.Sync == nil || cfg.Store == nil {
 		return nil, fmt.Errorf("engagement: ProviderConfig, Sync, and Store are required")
 	}
 
-	// edges-proxy lives on the hub, which in dev is a different host than
+	// The edgeproxy lives on the hub, which in dev is a different host than
 	// the kcp API ProviderConfig points at — prefer the explicit hub URL,
 	// fall back to the ProviderConfig host for the unified production case.
 	hubBase := strings.TrimRight(cfg.HubBaseURL, "/")
@@ -138,9 +146,15 @@ func New(cfg Config) (*Controller, error) {
 		hubBase = stripClusterSuffix(cfg.ProviderConfig.Host)
 	}
 
+	claims, err := newEdgeClaims(cfg.ProviderConfig)
+	if err != nil {
+		return nil, fmt.Errorf("engagement claims: %w", err)
+	}
+
 	c := &Controller{
 		cfg:     cfg,
 		hubBase: hubBase,
+		claims:  claims,
 		engaged: map[string]engagedEdge{},
 	}
 
@@ -183,32 +197,43 @@ func (c *Controller) Start(ctx context.Context) error {
 	return c.mgr.Start(ctx)
 }
 
-// EngagedCount reports how many edges are currently engaged (status surface).
+// EngagedCount reports how many edges THIS replica currently syncs — a
+// per-replica introspection surface (/api/status), not the tenant-facing
+// listing (that is TenantEdges, answered from the shared store).
 func (c *Controller) EngagedCount() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.engaged)
 }
 
-// TenantEdges lists the edge names currently engaged for one tenant —
-// the portal's edge selector. The tenant key is the workspace PATH (matching
-// the X-Faros-Tenant the hub injects), stored per-entry rather than parsed
-// from the cluster-based map key.
-func (c *Controller) TenantEdges(tenant string) []string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// TenantEdges lists the queryable edge names for one tenant — the portal's
+// edge selector. Answered from the shared store (active cluster rows carrying
+// the tenant label), so any replica serves the full fleet regardless of which
+// replica syncs each edge. The tenant key is the workspace PATH (matching the
+// X-Faros-Tenant the hub injects).
+func (c *Controller) TenantEdges(ctx context.Context, tenant string) ([]string, error) {
+	var rows []kuerystore.ClusterModel
+	if err := c.cfg.Store.RawDB().WithContext(ctx).
+		Where("status = ?", "active").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("listing engaged clusters: %w", err)
+	}
+	prefix := tenant + "/"
 	var edges []string
-	for _, e := range c.engaged {
-		if e.tenant == tenant {
-			edges = append(edges, e.edgeName)
+	for _, row := range rows {
+		var labels map[string]string
+		_ = json.Unmarshal(row.Labels, &labels)
+		if labels[TenantLabel] != tenant || !strings.HasPrefix(row.Name, prefix) {
+			continue
 		}
+		edges = append(edges, strings.TrimPrefix(row.Name, prefix))
 	}
 	sort.Strings(edges)
-	return edges
+	return edges, nil
 }
 
-// Reconcile maps one Edge's state to an Engage/Disengage of the
-// corresponding kuery cluster "{tenantCluster}/{edgeName}".
+// Reconcile maps one edge's state to an Engage/Disengage of the
+// corresponding kuery cluster, gated by this replica's claim on the edge.
 func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
 	tenantCluster := string(req.ClusterName)
 	logger := klog.FromContext(ctx).WithValues("cluster", tenantCluster, "edge", req.Name)
@@ -223,52 +248,71 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	edge.SetGroupVersionKind(edgeGVK)
 	if err := cl.GetClient().Get(ctx, req.NamespacedName, edge); err != nil {
 		if apierrors.IsNotFound(err) {
-			c.disengage(ctx, key)
+			c.dropLocal(ctx, key, true)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	edgeType, _, _ := unstructured.NestedString(edge.Object, "spec", "type")
 	connected, _, _ := unstructured.NestedBool(edge.Object, "status", "connected")
-
-	// Only kubernetes edges carry an API to sync; server (SSH) edges and
-	// disconnected edges are disengaged — kuery marks their rows stale and
-	// the GC reaps them after the TTL.
-	if edgeType != "kubernetes" || !connected {
-		c.disengage(ctx, key)
+	if !connected {
+		// Globally down: whoever holds it marks the rows stale (Disengage)
+		// and releases the claim; kuery's GC reaps after the TTL.
+		c.dropLocal(ctx, key, true)
 		return ctrl.Result{}, nil
 	}
 
-	// Tenant identity is the workspace PATH the hub stamps onto the Edge status
-	// (status.workspacePath). Both the kuery cluster row's NAME and its tenant
-	// LABEL are keyed by it so tenant-scoped queries match — the list query
-	// scopes by label, and the impact query re-pins the path prefix onto the
-	// cluster name (queryapi.ScopeToTenant). Until the hub has stamped it,
-	// requeue rather than engage under the logical-cluster name: that would
-	// create a store row the portal — which only ever sends the path — could
-	// never match (impact would report "object not found").
+	// Tenant identity is the workspace PATH the edges provider stamps onto
+	// the status. Both the kuery cluster row's NAME and its tenant LABEL are
+	// keyed by it so tenant-scoped queries match — the list query scopes by
+	// label, and the impact query re-pins the path prefix onto the cluster
+	// name (queryapi.ScopeToTenant). Until it is stamped, requeue rather
+	// than engage under the logical-cluster name: that would create a store
+	// row the portal — which only ever sends the path — could never match.
 	tenant, _, _ := unstructured.NestedString(edge.Object, "status", "workspacePath")
 	if tenant == "" {
-		logger.V(4).Info("workspacePath not yet stamped by hub; requeuing")
+		logger.V(4).Info("workspacePath not yet stamped; requeuing")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	storeName := tenant + "/" + req.Name
+
+	held, err := c.claims.tryAcquire(ctx, storeName)
+	if err != nil {
+		logger.Error(err, "claiming edge")
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+	if !held {
+		// Another replica owns this edge. If we used to, hand it over
+		// locally (its re-assert pass heals the transient stale our
+		// Disengage writes). Re-check on the claim TTL so an expired claim
+		// is taken over promptly.
+		c.dropLocal(ctx, key, false)
+		return ctrl.Result{RequeueAfter: claimTTL}, nil
 	}
 
 	if err := c.engage(ctx, key, tenantCluster, req.Name, tenant); err != nil {
 		logger.Error(err, "engaging edge")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	return ctrl.Result{}, nil
+
+	// Owner heartbeat: every pass re-asserts the cluster row (status=active,
+	// tenant label, LastSeen) — kuery's engine marks rows stale when a
+	// previous owner's context ended, and its own upserts wipe the labels
+	// column, so the row must be continuously re-claimed by the syncing
+	// replica or tenant-scoped queries lose the edge.
+	if err := c.assertTenantLabel(ctx, storeName, tenant); err != nil {
+		logger.Error(err, "re-asserting cluster row")
+	}
+	return ctrl.Result{RequeueAfter: renewInterval}, nil
 }
 
-// engage builds the edges-proxy cluster client and hands it to kuery,
-// then asserts the tenant label used for query scoping. tenant is the
-// workspace path.
+// engage builds the edgeproxy cluster client and hands it to kuery. Idempotent
+// for an already-engaged edge. tenant is the workspace path.
 //
 // Two distinct identifiers are at play:
 //   - key ("{logicalCluster}/{edge}") is the internal engaged-map key. It's
 //     derived purely from the reconcile request so it stays computable on
-//     delete, when the Edge (and its status.workspacePath) is already gone.
+//     delete, when the edge (and its status.workspacePath) is already gone.
 //   - storeName ("{workspacePath}/{edge}") is the name kuery records the
 //     cluster under. queryapi.ScopeToTenant rebuilds exactly this form from
 //     the caller's tenant + edge for impact queries, so the store name MUST
@@ -344,7 +388,13 @@ func (c *Controller) assertTenantLabel(ctx context.Context, storeName, tenant st
 	})
 }
 
-func (c *Controller) disengage(ctx context.Context, key string) {
+// dropLocal stops this replica's sync of an edge, if it has one. When the
+// edge is gone for good (deleted or disconnected — releaseClaim=true) the
+// claim is released so no replica re-engages and the stale rows age out; on
+// a lost claim (releaseClaim=false) the new owner immediately re-asserts the
+// row active, so the stale status Disengage writes lasts at most one of its
+// renew passes.
+func (c *Controller) dropLocal(ctx context.Context, key string, releaseClaim bool) {
 	c.mu.Lock()
 	entry, ok := c.engaged[key]
 	if ok {
@@ -356,20 +406,26 @@ func (c *Controller) disengage(ctx context.Context, key string) {
 	}
 	entry.cancel()
 	// kuery recorded the cluster under the path-based store name (see engage),
-	// not the cluster-based map key — disengage the same name.
+	// not the cluster-based map key — disengage the same name. Disengage also
+	// clears the engine's per-process cluster registration; without it a later
+	// re-engage of the same name would be silently deduplicated.
 	storeName := entry.tenant + "/" + entry.edgeName
 	if err := c.cfg.Sync.Disengage(ctx, storeName); err != nil {
 		klog.FromContext(ctx).Error(err, "disengaging edge", "edge", storeName)
 	}
+	if releaseClaim {
+		c.claims.release(ctx, storeName)
+	}
 	klog.FromContext(ctx).Info("edge disengaged", "edge", storeName)
 }
 
-// edgeProxyURL mirrors pkg/apiurl.EdgeProxyURL in the faros monorepo —
-// inlined so the provider module doesn't depend on the monorepo. Keep the
-// pattern in lockstep:
-// {hub}/services/edges-proxy/clusters/{cluster}/apis/faros.sh/v1alpha1/edges/{name}/k8s
+// edgeProxyURL is the edges provider's consumer-proxy endpoint for a
+// KubernetesCluster edge's Kubernetes API — pkg/apiurl.EdgeProviderCoordinates
+// + the edgeproxy mount in the faros monorepo, inlined so this module doesn't
+// depend on it. Keep the pattern in lockstep:
+// {hub}/services/providers/edges/edgeproxy/clusters/{cluster}/apis/edges.faros.sh/v1alpha1/kubernetesclusters/{name}/k8s
 func edgeProxyURL(hubBase, cluster, edgeName string) string {
-	return fmt.Sprintf("%s/services/edges-proxy/clusters/%s/apis/faros.sh/v1alpha1/edges/%s/k8s",
+	return fmt.Sprintf("%s/services/providers/edges/edgeproxy/clusters/%s/apis/edges.faros.sh/v1alpha1/kubernetesclusters/%s/k8s",
 		strings.TrimRight(hubBase, "/"), cluster, edgeName)
 }
 

--- a/providers/kuery/engagement/controller_test.go
+++ b/providers/kuery/engagement/controller_test.go
@@ -9,14 +9,21 @@
 package engagement
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	kuerystore "github.com/faroshq/kuery/pkg/store"
 )
 
 // TestEdgeProxyURL keeps the inlined URL pattern in lockstep with the faros
-// monorepo's pkg/apiurl.EdgeProxyURL — the cases mirror its tests.
+// monorepo's pkg/apiurl (EdgeProviderCoordinates + the edges provider's
+// edgeproxy mount).
 func TestEdgeProxyURL(t *testing.T) {
 	got := edgeProxyURL("https://hub.example.com/", "2hx82dl9ncmepp5l", "edge-1")
-	want := "https://hub.example.com/services/edges-proxy/clusters/2hx82dl9ncmepp5l/apis/faros.sh/v1alpha1/edges/edge-1/k8s"
+	want := "https://hub.example.com/services/providers/edges/edgeproxy/clusters/2hx82dl9ncmepp5l/apis/edges.faros.sh/v1alpha1/kubernetesclusters/edge-1/k8s"
 	if got != want {
 		t.Fatalf("edgeProxyURL = %q, want %q", got, want)
 	}
@@ -45,20 +52,144 @@ func TestTenantLabelIsBareIdentifier(t *testing.T) {
 	}
 }
 
-func TestTenantEdges(t *testing.T) {
-	// The map key is cluster-based, but TenantEdges scopes by the stored
-	// workspace-path tenant — so a key whose cluster segment differs from the
-	// tenant (cl-x/edge-2) must still surface under its tenant (tenant-a).
-	c := &Controller{engaged: map[string]engagedEdge{
-		"cl-x/edge-2":     {tenant: "tenant-a", edgeName: "edge-2", cancel: func() {}},
-		"tenant-a/edge-1": {tenant: "tenant-a", edgeName: "edge-1", cancel: func() {}},
-		"tenant-b/edge-9": {tenant: "tenant-b", edgeName: "edge-9", cancel: func() {}},
-	}}
-	got := c.TenantEdges("tenant-a")
+func testStore(t *testing.T) kuerystore.Store {
+	t.Helper()
+	s, err := kuerystore.NewStore(kuerystore.Config{Driver: "sqlite", DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("in-memory store: %v", err)
+	}
+	if err := s.AutoMigrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TenantEdges answers from the shared store — the whole point of the sharded
+// design: any replica lists the full fleet, not just its own engagements.
+func TestTenantEdgesListsActiveStoreRowsForTenant(t *testing.T) {
+	ctx := context.Background()
+	s := testStore(t)
+	c := &Controller{cfg: Config{Store: s}, engaged: map[string]engagedEdge{}}
+
+	now := time.Now()
+	seed := []struct {
+		name, tenant, status string
+	}{
+		{"tenant-a/edge-2", "tenant-a", "active"},
+		{"tenant-a/edge-1", "tenant-a", "active"},
+		{"tenant-b/edge-9", "tenant-b", "active"},
+		{"tenant-a/edge-3", "tenant-a", "stale"}, // disengaged: hidden
+	}
+	for _, row := range seed {
+		if err := s.UpsertCluster(ctx, &kuerystore.ClusterModel{
+			Name:     row.name,
+			Status:   row.status,
+			LastSeen: now,
+			TTL:      clusterTTLSeconds,
+			Labels:   tenantLabelsJSON(row.tenant),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", row.name, err)
+		}
+	}
+
+	got, err := c.TenantEdges(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("TenantEdges: %v", err)
+	}
 	if len(got) != 2 || got[0] != "edge-1" || got[1] != "edge-2" {
 		t.Fatalf("TenantEdges = %v, want sorted [edge-1 edge-2]", got)
 	}
-	if got := c.TenantEdges("tenant-c"); len(got) != 0 {
-		t.Fatalf("foreign tenant sees %v", got)
+	foreign, err := c.TenantEdges(ctx, "tenant-c")
+	if err != nil {
+		t.Fatalf("TenantEdges foreign: %v", err)
+	}
+	if len(foreign) != 0 {
+		t.Fatalf("foreign tenant sees %v", foreign)
+	}
+}
+
+func testClaims(identity string, cs *kubefake.Clientset, now func() time.Time) *edgeClaims {
+	return &edgeClaims{
+		leases:   cs.CoordinationV1().Leases(claimNamespace),
+		identity: identity,
+		now:      now,
+	}
+}
+
+// Exactly one replica may hold an edge's claim; a fresh foreign claim is
+// declined, an expired one is taken over.
+func TestEdgeClaimsShardsAndTakesOverExpired(t *testing.T) {
+	ctx := context.Background()
+	cs := kubefake.NewClientset()
+	current := time.Now()
+	clock := func() time.Time { return current }
+	a := testClaims("replica-a", cs, clock)
+	b := testClaims("replica-b", cs, clock)
+
+	held, err := a.tryAcquire(ctx, "tenant-a/edge-1")
+	if err != nil || !held {
+		t.Fatalf("first acquire = %v/%v, want held", held, err)
+	}
+	held, err = b.tryAcquire(ctx, "tenant-a/edge-1")
+	if err != nil || held {
+		t.Fatalf("foreign fresh claim = %v/%v, want declined", held, err)
+	}
+	// The owner renews.
+	held, err = a.tryAcquire(ctx, "tenant-a/edge-1")
+	if err != nil || !held {
+		t.Fatalf("owner renew = %v/%v, want held", held, err)
+	}
+	// Owner dies: after the TTL the peer takes over.
+	current = current.Add(claimTTL + time.Second)
+	held, err = b.tryAcquire(ctx, "tenant-a/edge-1")
+	if err != nil || !held {
+		t.Fatalf("expired takeover = %v/%v, want held", held, err)
+	}
+	// The old owner comes back and must NOT reclaim a freshly held lease.
+	held, err = a.tryAcquire(ctx, "tenant-a/edge-1")
+	if err != nil || held {
+		t.Fatalf("stale owner reclaim = %v/%v, want declined", held, err)
+	}
+}
+
+// Release hands the edge over immediately; a foreign release is a no-op.
+func TestEdgeClaimsReleaseIsOwnerOnly(t *testing.T) {
+	ctx := context.Background()
+	cs := kubefake.NewClientset()
+	clock := time.Now
+	a := testClaims("replica-a", cs, clock)
+	b := testClaims("replica-b", cs, clock)
+
+	if held, err := a.tryAcquire(ctx, "tenant-a/edge-1"); err != nil || !held {
+		t.Fatalf("acquire = %v/%v", held, err)
+	}
+	// Foreign release must not free the claim.
+	b.release(ctx, "tenant-a/edge-1")
+	if held, _ := b.tryAcquire(ctx, "tenant-a/edge-1"); held {
+		t.Fatal("foreign release freed an owned claim")
+	}
+	// Owner release frees it for the peer without waiting out the TTL.
+	a.release(ctx, "tenant-a/edge-1")
+	if held, err := b.tryAcquire(ctx, "tenant-a/edge-1"); err != nil || !held {
+		t.Fatalf("acquire after owner release = %v/%v, want held", held, err)
+	}
+}
+
+// Claim names must be valid object names regardless of the characters in the
+// workspace path, and distinct per edge.
+func TestClaimNameIsStableAndDistinct(t *testing.T) {
+	a := claimName("root:org:team/edge-1")
+	b := claimName("root:org:team/edge-2")
+	if a == b {
+		t.Fatal("distinct edges produced the same claim name")
+	}
+	if a != claimName("root:org:team/edge-1") {
+		t.Fatal("claim name is not stable")
+	}
+	for _, c := range a {
+		if !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-') {
+			t.Fatalf("claim name %q contains invalid character %q", a, string(c))
+		}
 	}
 }

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -111,3 +111,8 @@ require (
 replace github.com/kcp-dev/apimachinery/v2 => github.com/kcp-dev/apimachinery/v2 v2.32.0
 
 replace github.com/kcp-dev/multicluster-provider/client => github.com/kcp-dev/multicluster-provider/client v0.8.0
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/kcp-dev/multicluster-provider v0.8.0
 	github.com/kcp-dev/sdk v0.32.3
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/multicluster-runtime v0.24.1
 )
@@ -98,10 +100,8 @@ require (
 	gorm.io/driver/postgres v1.6.0 // indirect
 	gorm.io/driver/sqlite v1.6.0 // indirect
 	gorm.io/gorm v1.31.1 // indirect
-	k8s.io/api v0.36.2 // indirect
 	k8s.io/apiextensions-apiserver v0.36.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
-	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -52,8 +52,6 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/faroshq/kuery v0.0.0-20260621053041-5342a07fc777 h1:K50qMui1ThmLOYKz9Dwau3UFxKU0DJwsmYcD8ShoWFs=
 github.com/faroshq/kuery v0.0.0-20260621053041-5342a07fc777/go.mod h1:TfZU4DmN/ir3/3XSkVoLhXXoIed8cu8jaQMBYWigJmY=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=

--- a/providers/kuery/manifest.yaml
+++ b/providers/kuery/manifest.yaml
@@ -47,10 +47,12 @@ spec:
 
   apiExport:
     name: "kuery.providers.faros.sh"
-    # The engagement controller watches the tenant's Edge objects (via the
-    # APIExport virtual workspace) to know which edges to engage/disengage.
+    # The engagement controller watches the tenant's KubernetesCluster edges
+    # (via the APIExport virtual workspace) to know which edges to
+    # engage/disengage. LinuxServer edges carry no Kubernetes API and are
+    # not claimed.
     permissionClaims:
-      - resource: edges
-        group: faros.sh
+      - resource: kubernetesclusters
+        group: edges.faros.sh
         verbs: [get, list, watch]
         tenantScoped: true

--- a/providers/kuery/queryapi/edges.go
+++ b/providers/kuery/queryapi/edges.go
@@ -9,15 +9,19 @@
 package queryapi
 
 import (
+	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 )
 
 // EdgeLister is the slice of the engagement controller the edges endpoint
-// needs. Nil-able: with engagement disabled the endpoint serves an empty
-// list rather than 404, so the portal renders consistently in dev.
+// needs. Answered from the shared store, so any replica lists the full
+// fleet regardless of which replica syncs each edge. Nil-able: with
+// engagement disabled the endpoint serves an empty list rather than 404, so
+// the portal renders consistently in dev.
 type EdgeLister interface {
-	TenantEdges(tenant string) []string
+	TenantEdges(ctx context.Context, tenant string) ([]string, error)
 }
 
 // EdgesHandler serves GET /api/edges: the caller's currently-engaged edge
@@ -42,7 +46,13 @@ func (h *EdgesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := edgesResponse{Edges: []string{}}
 	if h.Lister != nil {
-		if edges := h.Lister.TenantEdges(id.Tenant); edges != nil {
+		edges, err := h.Lister.TenantEdges(r.Context(), id.Tenant)
+		if err != nil {
+			log.Printf("listing tenant edges: %v", err)
+			http.Error(w, "listing edges failed", http.StatusInternalServerError)
+			return
+		}
+		if edges != nil {
 			resp.Edges = edges
 		}
 	}

--- a/providers/quickstart/Dockerfile
+++ b/providers/quickstart/Dockerfile
@@ -3,18 +3,22 @@
 # 1. Build the portal micro-frontend (Vite + TS → portal/dist).
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/quickstart/portal/package.json providers/quickstart/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
-COPY portal/ ./
+COPY providers/quickstart/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. assets.go //go:embeds portal/dist; init_cmd.go uses
 #    the published faros-provider-sdk (no replace), fetched from the proxy.
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/quickstart/go.mod providers/quickstart/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/quickstart/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY main.go assets.go init_cmd.go ./
+COPY providers/quickstart/main.go providers/quickstart/assets.go providers/quickstart/init_cmd.go ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/quickstart-provider .
 
@@ -22,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    baked at /etc/faros/schemas (FAROS_SCHEMAS_DIR).
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/quickstart-provider /quickstart-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/quickstart/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8081
 ENV PORT=8081
 USER nonroot:nonroot

--- a/providers/quickstart/go.mod
+++ b/providers/quickstart/go.mod
@@ -25,7 +25,6 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.36.2 // indirect
 	k8s.io/apimachinery v0.36.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
@@ -48,3 +47,8 @@ replace (
 	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20260602065202-e006560fc76a
 	k8s.io/kms => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kms v0.0.0-20260602065202-e006560fc76a
 )
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/quickstart/go.sum
+++ b/providers/quickstart/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/providers/vibe-studio/Dockerfile
+++ b/providers/vibe-studio/Dockerfile
@@ -3,26 +3,21 @@
 # 1. Build the portal micro-frontend (Vite + TS → portal/dist).
 FROM node:22-alpine AS portal
 WORKDIR /portal
-COPY portal/package.json portal/package-lock.json* ./
+COPY providers/vibe-studio/portal/package.json providers/vibe-studio/portal/package-lock.json* ./
 RUN --mount=type=cache,target=/root/.npm npm install --no-audit --no-fund
-COPY portal/ ./
+COPY providers/vibe-studio/portal/ ./
 RUN npm run build
 
 # 2. Build the Go binary. assets.go //go:embeds portal/dist.
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-COPY go.mod go.sum ./
+COPY providers/vibe-studio/go.mod providers/vibe-studio/go.sum ./
+# In-tree provider-sdk (go.mod replace => ../../provider-sdk; from
+# WORKDIR /src that resolves to /provider-sdk). Build context is the
+# REPO ROOT: docker build -f providers/vibe-studio/Dockerfile .
+COPY provider-sdk/ /provider-sdk/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
-COPY main.go assets.go init_cmd.go controller_manager.go ./
-COPY apis/ ./apis/
-COPY api/ ./api/
-COPY client/ ./client/
-COPY controller/ ./controller/
-COPY engine/ ./engine/
-COPY scheme/ ./scheme/
-COPY session/ ./session/
-COPY store/ ./store/
-COPY tenant/ ./tenant/
+COPY providers/vibe-studio/ ./
 COPY --from=portal /portal/dist ./portal/dist
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/vibe-studio-provider .
 
@@ -30,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 #    are baked at /etc/faros/schemas (FAROS_SCHEMAS_DIR).
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/vibe-studio-provider /vibe-studio-provider
-COPY deploy/chart/files/schemas /etc/faros/schemas
+COPY providers/vibe-studio/deploy/chart/files/schemas /etc/faros/schemas
 EXPOSE 8081
 ENV PORT=8081
 USER nonroot:nonroot

--- a/providers/vibe-studio/controller_manager.go
+++ b/providers/vibe-studio/controller_manager.go
@@ -31,9 +31,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/faroshq/provider-sdk/leaderelection"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
@@ -48,15 +50,43 @@ import (
 // (sdkinstall.Bootstrap creates the slice under the same name at init).
 const endpointSliceName = apiExportName
 
-// startControllerManager builds the multicluster manager and starts the
-// Project + Session reconcilers. A nil config means "skip the manager, run
-// REST-only". st backs the Session reconciler's status mirror + purge.
+// controllerLeaseName gates the reconcilers on a Lease in the provider
+// workspace ("default" namespace — kcp serves Leases in every logical
+// cluster), so the chart's multi-replica default runs one set of controllers,
+// not one per replica. Non-leaders keep serving REST/portal.
+const controllerLeaseName = "vibe-studio-controllers"
+
+// startControllerManager campaigns for the controller lease and — while
+// leader — runs the multicluster manager with the Project + Session
+// reconcilers. A nil config means "skip the manager, run REST-only". st backs
+// the Session reconciler's status mirror + purge.
 func startControllerManager(ctx context.Context, config *rest.Config, st store.Store, hubBase string, hubInsecure bool) error {
 	if config == nil {
 		return errControllerDisabled
 	}
 
 	ctrl.SetLogger(klog.NewKlogr())
+
+	go func() {
+		if err := leaderelection.Run(ctx, leaderelection.Options{
+			Config:    config,
+			Namespace: leaderelection.DefaultNamespace,
+			Name:      controllerLeaseName,
+		}, func(termCtx context.Context) {
+			if err := runControllerManager(termCtx, config, st, hubBase, hubInsecure); err != nil {
+				log.Printf("controller manager exited: %v", err)
+			}
+		}); err != nil {
+			log.Printf("controller leader election failed; controllers are not running: %v", err)
+		}
+	}()
+	return nil
+}
+
+// runControllerManager builds the multicluster manager and blocks in Start
+// until the leadership term ends. Called once per term — a stopped
+// controller-runtime manager cannot be restarted.
+func runControllerManager(ctx context.Context, config *rest.Config, st store.Store, hubBase string, hubInsecure bool) error {
 	scheme := vibescheme.NewScheme()
 
 	provider, err := apiexport.New(config, endpointSliceName, apiexport.Options{Scheme: scheme})
@@ -64,9 +94,13 @@ func startControllerManager(ctx context.Context, config *rest.Config, st store.S
 		return fmt.Errorf("creating apiexport multicluster provider: %w", err)
 	}
 
+	skipNameValidation := true
 	mgr, err := mcmanager.New(config, provider, manager.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"}, // provider serves its own HTTP; disable controller-runtime metrics
+		// Controller names register process-globally; the manager built for a
+		// later leadership term must skip that check.
+		Controller: ctrlconfig.Controller{SkipNameValidation: &skipNameValidation},
 	})
 	if err != nil {
 		return fmt.Errorf("creating multicluster manager: %w", err)
@@ -82,13 +116,8 @@ func startControllerManager(ctx context.Context, config *rest.Config, st store.S
 		return fmt.Errorf("session controller: %w", err)
 	}
 
-	go func() {
-		log.Printf("vibe-studio controller manager starting (endpointSlice=%s)", endpointSliceName)
-		if err := mgr.Start(ctx); err != nil {
-			log.Printf("controller manager exited: %v", err)
-		}
-	}()
-	return nil
+	log.Printf("vibe-studio controller manager starting (endpointSlice=%s)", endpointSliceName)
+	return mgr.Start(ctx)
 }
 
 // loadControllerConfig resolves the rest.Config for the provider's kcp

--- a/providers/vibe-studio/go.mod
+++ b/providers/vibe-studio/go.mod
@@ -129,3 +129,8 @@ replace (
 	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20260602065202-e006560fc76a
 	k8s.io/kms => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kms v0.0.0-20260602065202-e006560fc76a
 )
+
+// In-tree SDK: the monorepo is the source of truth until the SDK is
+// published with every package providers use (leaderelection landed after
+// v0.1.0). Image builds copy provider-sdk into the build context.
+replace github.com/faroshq/provider-sdk => ../../provider-sdk

--- a/providers/vibe-studio/go.sum
+++ b/providers/vibe-studio/go.sum
@@ -50,8 +50,6 @@ github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/faroshq/provider-sdk v0.1.0 h1:SUBgdGrH8h/NB9KtyqKvaJx3f0cSk02c+ZXR+cnGz7Q=
-github.com/faroshq/provider-sdk v0.1.0/go.mod h1:9auM/cMbf6K6XvrldbOu6FEqkUV056fewS5Ct6ae9EY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=


### PR DESCRIPTION
## What this does

Makes every provider horizontally scalable and rebuilds the tilt-cluster dev loop to run the whole platform as pods, so in-cluster behavior (replicas, leader election, Service round-robin) is what development exercises. Verified live on a tilt-cluster: all providers at 2 replicas, and a 10-hour-stuck Instance delete finalized once the last fix landed.

### Scaling, per provider

- **Leader election** (`provider-sdk/leaderelection`, ported from the hub): code, vibe-studio, infrastructure (Template manager, Instance controller, bootstrap loop — each on its own Lease in the provider workspace), plus the CRD operator via controller-runtime's built-in election. Non-leaders keep serving; managers rebuild fresh per term with `SkipNameValidation`.
- **databricks**: the serving path resolves tenant clusters through a slice-backed authority (APIExport endpoint-slice URLs, multi-shard probe — the agents provider's proven pattern) instead of the running manager; readiness/heartbeat decouple from controller lifecycle; controllers leader-elect. ~600 lines of bespoke retry/readiness machinery deleted.
- **kuery**: the dead edge-sync path is revived (`edges.faros.sh/kubernetesclusters` + the edges provider's `edgeproxy` mount); engagement shards across replicas via per-edge Leases; `/api/edges` serves from the shared store; the chart refuses >1 replica on SQLite.
- **edges**: agents dial ONE replica; a tunnel-ownership Lease registry + pod-to-pod byte relay route pickups and data-plane requests (kubectl/exec/SSH/MCP) to whichever replica holds each tunnel — zero agent changes (the pickup path is opaque to agents). Rolling updates replace Recreate.
- **app-studio** (phases A–C of `docs/app-studio-replica-awareness.md`): durable run claims in Postgres (cluster-wide Busy/reservations; the orphan-interrupt reconciler fires on claim expiry instead of local-map absence), project pinning with peer forwarding on an internal listener, git re-hydration on adoption, `emptyDir` workspaces, owner-gated commit convergence.

Design records: `docs/provider-horizontal-scaling.md`, `docs/app-studio-replica-awareness.md`.

### Dev loop (tilt-cluster)

- All providers run as pods from their production charts (Tilt-built images), most at `replicaCount=2`; the hub runs 2 replicas in external-kcp mode; infrastructure uses full CRD-operator mode in-cluster.
- Provider images build from the repo root with the in-tree `provider-sdk` (go.mod `replace` per provider) — this also fixes CI `provider-release`, which broke the moment `leaderelection` landed (proxy `provider-sdk@v0.1.0` predates it).
- Supporting plumbing: cluster-wide CoreDNS resolution of `(kcp|*.kcp).localhost` to the Envoy gateway so pods use operator-issued kubeconfigs unchanged; kubeconfig-Secret sync from the existing `register/init` flows; one shared in-cluster Postgres (kuery/appstudio/agents); APIExport identityHash discovery with Tilt re-render; `.env`→Secret injection for code (GitHub OAuth) and agents. All traffic routes hub → Service; the sole host forward is code's browser-direct OAuth callback.

### Fixes found by running it

- Operator-owned serve Deployments now get `INFRASTRUCTURE_WORKSPACE_PATH` in the supplied-admin flow — without it, serve's controllers watched the root cluster, the Template cache never synced, the manager died every 2 minutes, and Instance finalizers never ran (hub-minted flow was and stays unaffected).
- vibe-studio's Dockerfile COPY list had rotted (missing packages); databricks needed a numeric `runAsUser` for distroless.

### Notes for reviewers

- kuery tenants need re-Enable for the new `edges.faros.sh` APIBinding claim; app-studio's first deploy with `emptyDir` discards PVC workspace trees (git is the durable truth).
- Known follow-ups (documented in-code / in the plan doc): edges event store stays owner-local until Redis; edges controllers remain active-active pending a slice-backed tenant resolver; app-studio phase D (WIP snapshots) is optional hardening; the hub's own per-term managers still need `SkipNameValidation` for its second leadership term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)