### PR TITLE
Fix two blockers in the self-hosted infrastructure provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2194,6 +2194,7 @@ helm-deploy-provider-infrastructure: ## (experimental) Build+load image, helm in
 		--set replicaCount=2 \
 		--set bootstrap.enabled=true \
 		--set hub.url=$(HUB_INTERNAL_URL) \
+		--set hub.tokenSecretRef.name=faros-infrastructure-hub-token \
 		--set hub.insecure=true \
 		--set catalogEntry.enabled=false
 	@echo ">>> deployed. The pod stays in ContainerCreating until the hub delivers"

--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -146,7 +146,6 @@ the Secret appears.
 helm install code providers/code/deploy/chart \
   -n code --create-namespace \
   --set hub.url=https://faros-hub.faros.svc.cluster.local:9443 \
-  --set hub.tokenSecretRef.name=faros-code-hub-token \
   --set image.tag=0.1.0
 ```
 
@@ -164,7 +163,6 @@ kubectl -n code create secret generic faros-code-github-oauth \
 helm install code providers/code/deploy/chart \
   -n code --create-namespace \
   --set hub.url=https://faros-hub.faros.svc.cluster.local:9443 \
-  --set hub.tokenSecretRef.name=faros-code-hub-token \
   --set githubOAuth.enabled=true \
   --set githubOAuth.clientId=<oauth-app-client-id> \
   --set githubOAuth.clientSecretRef.name=faros-code-github-oauth \

--- a/providers/code/deploy/chart/README.md
+++ b/providers/code/deploy/chart/README.md
@@ -43,7 +43,7 @@ helm upgrade --install code oci://ghcr.io/faroshq/charts/faros-code-provider \
 | `hub` |  | Hub the provider POSTs heartbeats to. Must be reachable from the provider pod (in-cluster Service DNS works). |
 | `hub.url` | `https://faros-hub.faros.svc.cluster.local:9443` |  |
 | `hub.tokenSecretRef` |  | Bearer token used in the heartbeat POST. Provided as a Secret because it MUST NOT land in values.yaml in plaintext for prod. |
-| `hub.tokenSecretRef.name` | `faros-code-hub-token` |  |
+| `hub.tokenSecretRef.name` | `""` | Empty omits the Authorization header — the heartbeat endpoint does not require it. Set this ONLY when the Secret already exists in the release namespace; the reference is not optional, so a missing Secret wedges the pod in `CreateContainerConfigError`. |
 | `hub.tokenSecretRef.key` | `token` |  |
 | `hub.insecure` | `false` | Skip TLS verification on heartbeat — dev only, defaults off. |
 | `providerKubeconfig` |  | Secret the provider mounts read-only at /var/run/secrets/faros/faros-provider-kubeconfig to reach kcp (CODE_KUBECONFIG). The hub catalog controller mints it when it reconciles the CatalogEntry; the volume is `optional`, so the pod stays schedulable and serves portal/MCP reads until the Secret app… |

--- a/providers/code/deploy/chart/values.yaml
+++ b/providers/code/deploy/chart/values.yaml
@@ -23,8 +23,12 @@ hub:
   url: https://faros-hub.faros.svc.cluster.local:9443
   # Bearer token used in the heartbeat POST. Provided as a Secret because it
   # MUST NOT land in values.yaml in plaintext for prod.
+  # Empty (the default) omits the Authorization header entirely — the
+  # heartbeat endpoint does not require it. Set the name ONLY when the Secret
+  # already exists in the release namespace: the reference is not optional, so
+  # a missing Secret leaves the pod in CreateContainerConfigError forever.
   tokenSecretRef:
-    name: faros-code-hub-token
+    name: ""
     key: token
   # Skip TLS verification on heartbeat — dev only, defaults off.
   insecure: false

--- a/providers/databricks/deploy/chart/README.md
+++ b/providers/databricks/deploy/chart/README.md
@@ -42,7 +42,7 @@ helm upgrade --install databricks oci://ghcr.io/faroshq/charts/faros-databricks-
 | `service.port` | `8081` |  |
 | `hub` |  |  |
 | `hub.url` | `https://faros-hub.faros.svc.cluster.local:9443` |  |
-| `hub.tokenSecretRef.name` | `faros-databricks-hub-token` |  |
+| `hub.tokenSecretRef.name` | `""` | Empty omits the Authorization header — the heartbeat endpoint does not require it. Set this ONLY when the Secret already exists in the release namespace; the reference is not optional, so a missing Secret wedges the pod in `CreateContainerConfigError`. |
 | `hub.tokenSecretRef.key` | `token` |  |
 | `hub.insecure` | `false` |  |
 | `controller` |  | The multicluster controller is required for production: it validates the Connection -> Warehouse -> Table dependency chain and serves provider authority for actions. Set mode=rest-only only for an intentional local UI/API process; /readyz and heartbeat then describe that explicit mode. |

--- a/providers/databricks/deploy/chart/values.yaml
+++ b/providers/databricks/deploy/chart/values.yaml
@@ -14,8 +14,13 @@ service:
 
 hub:
   url: https://faros-hub.faros.svc.cluster.local:9443
+  # Bearer token for the heartbeat POST. Empty (the default) omits the
+  # Authorization header entirely — the heartbeat endpoint does not require
+  # it. Set the name ONLY when the Secret already exists in the release
+  # namespace: the reference is not optional, so a missing Secret leaves the
+  # pod in CreateContainerConfigError forever.
   tokenSecretRef:
-    name: faros-databricks-hub-token
+    name: ""
     key: token
   insecure: false
 

--- a/providers/infrastructure/README.md
+++ b/providers/infrastructure/README.md
@@ -352,7 +352,6 @@ kubectl -n infrastructure create secret generic faros-provider-kubeconfig \
 helm install infrastructure deploy/chart \
   -n infrastructure --create-namespace \
   --set hub.url=https://faros-hub.faros.svc.cluster.local:9443 \
-  --set hub.tokenSecretRef.name=faros-infrastructure-hub-token \
   --set bootstrap.enabled=true
 ```
 

--- a/providers/infrastructure/deploy/chart/README.md
+++ b/providers/infrastructure/deploy/chart/README.md
@@ -43,7 +43,7 @@ helm upgrade --install infrastructure oci://ghcr.io/faroshq/charts/faros-infrast
 | `hub` |  | Hub the provider POSTs heartbeats to. Must be reachable from the provider pod (in-cluster Service DNS works). |
 | `hub.url` | `https://faros-hub.faros.svc.cluster.local:9443` |  |
 | `hub.tokenSecretRef` |  | Bearer token used in the heartbeat POST. Provided as a Secret because it MUST NOT land in values.yaml in plaintext for prod. |
-| `hub.tokenSecretRef.name` | `faros-infrastructure-hub-token` |  |
+| `hub.tokenSecretRef.name` | `""` | Empty omits the Authorization header — the heartbeat endpoint does not require it. Set this ONLY when the Secret already exists in the release namespace; the reference is not optional, so a missing Secret wedges the pod in `CreateContainerConfigError`. |
 | `hub.tokenSecretRef.key` | `token` |  |
 | `hub.insecure` | `false` | Skip TLS verification on heartbeat — dev only, defaults off. |
 | `centralKro` |  | Central kro cluster kubeconfig. Two ways to provide it: 1. Inline `centralKro.kubeconfig` (rendered into a Secret by the chart; convenient for dev, NOT recommended for prod). 2. `centralKro.kubeconfigSecretRef` pointing at an existing Secret this chart did NOT create. Use this in prod. |

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -23,8 +23,13 @@ hub:
   url: https://faros-hub.faros.svc.cluster.local:9443
   # Bearer token used in the heartbeat POST. Provided as a Secret
   # because it MUST NOT land in values.yaml in plaintext for prod.
+  # Empty (the default) omits the Authorization header entirely — the
+  # heartbeat endpoint does not require it. Set the name ONLY when the
+  # Secret already exists in the release namespace: the reference is not
+  # optional, so a missing Secret leaves the pod in
+  # CreateContainerConfigError forever.
   tokenSecretRef:
-    name: faros-infrastructure-hub-token
+    name: ""
     key: token
   # Skip TLS verification on heartbeat — dev only, defaults off.
   insecure: false


### PR DESCRIPTION
Two independent bugs stop a self-hosted infrastructure provider (the flow added in #541) from ever reaching a running state. Both are invisible on the dev path, which compensates for each of them by hand.

---

## 1. The chart requires a heartbeat Secret nobody creates

```
Warning  Failed  3s (x16 over 3m14s)  kubelet  Error: secret "faros-infrastructure-hub-token" not found
```

`hub.tokenSecretRef.name` defaulted to `faros-infrastructure-hub-token`, but **the chart never creates that Secret**. The env var is a plain `secretKeyRef` with no `optional: true`, so kubelet refuses to build the container until it exists — the pod retries forever.

The token isn't even required: `runHeartbeat` only sets the `Authorization` header when non-empty, and the heartbeat endpoint is registered without auth middleware. It worked in dev only because the Makefile creates the Secret before installing.

`infrastructure`, `code`, and `databricks` were the three charts carrying a non-empty default; the other six already used `""`. This brings them in line and documents why the field is dangerous to set casually.

- three `values.yaml` → `name: ""`, noting that a missing Secret wedges the pod in `CreateContainerConfigError`
- three chart `README.md` value tables updated
- `providers/code/README.md` — **both** install recipes set that name without creating the Secret, so following either reproduced the failure. Same for one recipe in `providers/infrastructure/README.md`. Flag dropped.
- `Makefile` — the dev target genuinely wants the token and relied on the default, so it now sets the name explicitly, right below the step that creates the Secret.

## 2. The serve container talks to the host cluster instead of kcp

```
leases.coordination.k8s.io "infrastructure-instance" is forbidden:
User "system:serviceaccount:faros-provider-infrastructure:..." cannot get
resource "leases" in the namespace "default"
```

The identity in that error is a **host-cluster** ServiceAccount, which is the tell. The Lease is meant to live in the provider's own kcp workspace — kcp serves Leases in every logical cluster, and the minted identity already holds `get/list/watch/create/update/patch` on them (`install/identity.go`). Nothing about the lease is misconfigured; the controllers were talking to the wrong API server.

`loadControllerConfigRaw` consulted `INFRASTRUCTURE_KUBECONFIG`, `INFRASTRUCTURE_CONTROLLER_KUBECONFIG`, and `KUBECONFIG`. The chart sets **none** of those on the serve container — it sets `FAROS_PROVIDER_KUBECONFIG`, the standardized name that the other **eight** providers all read. `INFRASTRUCTURE_KUBECONFIG` is set only on the *init* container, pointing into that container's own `/tmp`. So serve found nothing and fell through to `rest.InClusterConfig()`.

- read the standardized name first, keeping the provider-specific names as fallbacks — the operator sets `INFRASTRUCTURE_KUBECONFIG` and must keep working
- report which source won, and warn loudly when it is the in-cluster ServiceAccount. Every controller and both leader elections share this config, so choosing wrong misdirects the whole provider and the symptom surfaces far from the cause

Local `make run-provider-infrastructure` sets `INFRASTRUCTURE_KUBECONFIG`, which is why this only bit the chart-deployed path.

---

## Verification

- all three charts render **0** `FAROS_HUB_TOKEN` references with defaults; an explicit `--set` still renders the `secretKeyRef` (dev path intact); `helm lint` clean
- new tests cover the kubeconfig regression, the operator's env, precedence, and the disabled sentinel — and were confirmed to **fail** without the fix (the standardized case resolves to the operator's kubeconfig, or to nothing at all)
- `go build` / `go test` / `gofmt` clean on the package

## Note for anyone hitting #1 before this ships

The chart published at `oci://ghcr.io/faroshq/charts` still carries the old default, so the portal's rendered install command keeps reproducing it. Bridge:

```sh
helm upgrade infrastructure <chart> -n faros-provider-infrastructure --reuse-values \
  --set hub.tokenSecretRef.name=""
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
