### PR TITLE
Fix two blockers in the self-hosted infrastructure provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2194,6 +2194,7 @@ helm-deploy-provider-infrastructure: ## (experimental) Build+load image, helm in
 		--set replicaCount=2 \
 		--set bootstrap.enabled=true \
 		--set hub.url=$(HUB_INTERNAL_URL) \
+		--set hub.tokenSecretRef.name=faros-infrastructure-hub-token \
 		--set hub.insecure=true \
 		--set catalogEntry.enabled=false
 	@echo ">>> deployed. The pod stays in ContainerCreating until the hub delivers"

--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -146,7 +146,6 @@ the Secret appears.
 helm install code providers/code/deploy/chart \
   -n code --create-namespace \
   --set hub.url=https://faros-hub.faros.svc.cluster.local:9443 \
-  --set hub.tokenSecretRef.name=faros-code-hub-token \
   --set image.tag=0.1.0
 ```
 
@@ -164,7 +163,6 @@ kubectl -n code create secret generic faros-code-github-oauth \
 helm install code providers/code/deploy/chart \
   -n code --create-namespace \
   --set hub.url=https://faros-hub.faros.svc.cluster.local:9443 \
-  --set hub.tokenSecretRef.name=faros-code-hub-token \
   --set githubOAuth.enabled=true \
   --set githubOAuth.clientId=<oauth-app-client-id> \
   --set githubOAuth.clientSecretRef.name=faros-code-github-oauth \

--- a/providers/code/deploy/chart/README.md
+++ b/providers/code/deploy/chart/README.md
@@ -43,7 +43,7 @@ helm upgrade --install code oci://ghcr.io/faroshq/charts/faros-code-provider \
 | `hub` |  | Hub the provider POSTs heartbeats to. Must be reachable from the provider pod (in-cluster Service DNS works). |
 | `hub.url` | `https://faros-hub.faros.svc.cluster.local:9443` |  |
 | `hub.tokenSecretRef` |  | Bearer token used in the heartbeat POST. Provided as a Secret because it MUST NOT land in values.yaml in plaintext for prod. |
-| `hub.tokenSecretRef.name` | `faros-code-hub-token` |  |
+| `hub.tokenSecretRef.name` | `""` | Empty omits the Authorization header — the heartbeat endpoint does not require it. Set this ONLY when the Secret already exists in the release namespace; the reference is not optional, so a missing Secret wedges the pod in `CreateContainerConfigError`. |
 | `hub.tokenSecretRef.key` | `token` |  |
 | `hub.insecure` | `false` | Skip TLS verification on heartbeat — dev only, defaults off. |
 | `providerKubeconfig` |  | Secret the provider mounts read-only at /var/run/secrets/faros/faros-provider-kubeconfig to reach kcp (CODE_KUBECONFIG). The hub catalog controller mints it when it reconciles the CatalogEntry; the volume is `optional`, so the pod stays schedulable and serves portal/MCP reads until the Secret app… |

--- a/providers/code/deploy/chart/values.yaml
+++ b/providers/code/deploy/chart/values.yaml
@@ -23,8 +23,12 @@ hub:
   url: https://faros-hub.faros.svc.cluster.local:9443
   # Bearer token used in the heartbeat POST. Provided as a Secret because it
   # MUST NOT land in values.yaml in plaintext for prod.
+  # Empty (the default) omits the Authorization header entirely — the
+  # heartbeat endpoint does not require it. Set the name ONLY when the Secret
+  # already exists in the release namespace: the reference is not optional, so
+  # a missing Secret leaves the pod in CreateContainerConfigError forever.
   tokenSecretRef:
-    name: faros-code-hub-token
+    name: ""
     key: token
   # Skip TLS verification on heartbeat — dev only, defaults off.
   insecure: false

--- a/providers/databricks/deploy/chart/README.md
+++ b/providers/databricks/deploy/chart/README.md
@@ -42,7 +42,7 @@ helm upgrade --install databricks oci://ghcr.io/faroshq/charts/faros-databricks-
 | `service.port` | `8081` |  |
 | `hub` |  |  |
 | `hub.url` | `https://faros-hub.faros.svc.cluster.local:9443` |  |
-| `hub.tokenSecretRef.name` | `faros-databricks-hub-token` |  |
+| `hub.tokenSecretRef.name` | `""` | Empty omits the Authorization header — the heartbeat endpoint does not require it. Set this ONLY when the Secret already exists in the release namespace; the reference is not optional, so a missing Secret wedges the pod in `CreateContainerConfigError`. |
 | `hub.tokenSecretRef.key` | `token` |  |
 | `hub.insecure` | `false` |  |
 | `controller` |  | The multicluster controller is required for production: it validates the Connection -> Warehouse -> Table dependency chain and serves provider authority for actions. Set mode=rest-only only for an intentional local UI/API process; /readyz and heartbeat then describe that explicit mode. |

--- a/providers/databricks/deploy/chart/values.yaml
+++ b/providers/databricks/deploy/chart/values.yaml
@@ -14,8 +14,13 @@ service:
 
 hub:
   url: https://faros-hub.faros.svc.cluster.local:9443
+  # Bearer token for the heartbeat POST. Empty (the default) omits the
+  # Authorization header entirely — the heartbeat endpoint does not require
+  # it. Set the name ONLY when the Secret already exists in the release
+  # namespace: the reference is not optional, so a missing Secret leaves the
+  # pod in CreateContainerConfigError forever.
   tokenSecretRef:
-    name: faros-databricks-hub-token
+    name: ""
     key: token
   insecure: false
 

--- a/providers/infrastructure/README.md
+++ b/providers/infrastructure/README.md
@@ -352,7 +352,6 @@ kubectl -n infrastructure create secret generic faros-provider-kubeconfig \
 helm install infrastructure deploy/chart \
   -n infrastructure --create-namespace \
   --set hub.url=https://faros-hub.faros.svc.cluster.local:9443 \
-  --set hub.tokenSecretRef.name=faros-infrastructure-hub-token \
   --set bootstrap.enabled=true
 ```
 

--- a/providers/infrastructure/controller_config_test.go
+++ b/providers/infrastructure/controller_config_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeKubeconfig drops a minimal but valid kubeconfig on disk and returns its
+// path. The server URL identifies which file a resolution picked.
+func writeKubeconfig(t *testing.T, name, server string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	content := `apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: ` + server + `
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: u
+current-context: c
+users:
+- name: u
+  user:
+    token: t
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	return path
+}
+
+// clearControllerKubeconfigEnv unsets every variable the resolver consults so a
+// developer's own environment cannot leak into the test.
+func clearControllerKubeconfigEnv(t *testing.T) {
+	t.Helper()
+	for _, env := range controllerKubeconfigEnvs {
+		t.Setenv(env, "")
+	}
+	t.Setenv("INFRASTRUCTURE_WORKSPACE_PATH", "")
+}
+
+// The regression: the charts set FAROS_PROVIDER_KUBECONFIG on the serve
+// container and nothing else. When it was not consulted, serve fell through to
+// the in-cluster ServiceAccount and pointed every kcp controller at the HOST
+// cluster — which surfaced as leases in "default" being forbidden rather than
+// as a missing kubeconfig.
+func TestLoadControllerConfigHonorsStandardizedName(t *testing.T) {
+	clearControllerKubeconfigEnv(t)
+	t.Setenv("FAROS_PROVIDER_KUBECONFIG", writeKubeconfig(t, "provider", "https://kcp.example/clusters/root:faros:providers:infrastructure"))
+
+	cfg, source, err := loadControllerConfigRaw()
+	if err != nil {
+		t.Fatalf("loadControllerConfigRaw: %v", err)
+	}
+	if source != "FAROS_PROVIDER_KUBECONFIG" {
+		t.Errorf("source = %q, want FAROS_PROVIDER_KUBECONFIG", source)
+	}
+	if cfg.Host != "https://kcp.example/clusters/root:faros:providers:infrastructure" {
+		t.Errorf("Host = %q — resolved the wrong kubeconfig", cfg.Host)
+	}
+}
+
+// The operator sets only INFRASTRUCTURE_KUBECONFIG, so that path must keep
+// working; and the standardized name must win when both are present.
+func TestLoadControllerConfigResolutionOrder(t *testing.T) {
+	standardized := writeKubeconfig(t, "standardized", "https://standardized.example")
+	operator := writeKubeconfig(t, "operator", "https://operator.example")
+	legacy := writeKubeconfig(t, "legacy", "https://legacy.example")
+
+	for _, tc := range []struct {
+		name       string
+		env        map[string]string
+		wantSource string
+		wantHost   string
+	}{{
+		name:       "operator-only still works",
+		env:        map[string]string{"INFRASTRUCTURE_KUBECONFIG": operator},
+		wantSource: "INFRASTRUCTURE_KUBECONFIG",
+		wantHost:   "https://operator.example",
+	}, {
+		name: "standardized wins over the provider-specific names",
+		env: map[string]string{
+			"FAROS_PROVIDER_KUBECONFIG":            standardized,
+			"INFRASTRUCTURE_KUBECONFIG":            operator,
+			"INFRASTRUCTURE_CONTROLLER_KUBECONFIG": legacy,
+		},
+		wantSource: "FAROS_PROVIDER_KUBECONFIG",
+		wantHost:   "https://standardized.example",
+	}, {
+		name:       "legacy override is still an escape hatch",
+		env:        map[string]string{"INFRASTRUCTURE_CONTROLLER_KUBECONFIG": legacy},
+		wantSource: "INFRASTRUCTURE_CONTROLLER_KUBECONFIG",
+		wantHost:   "https://legacy.example",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearControllerKubeconfigEnv(t)
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			cfg, source, err := loadControllerConfigRaw()
+			if err != nil {
+				t.Fatalf("loadControllerConfigRaw: %v", err)
+			}
+			if source != tc.wantSource {
+				t.Errorf("source = %q, want %q", source, tc.wantSource)
+			}
+			if cfg.Host != tc.wantHost {
+				t.Errorf("Host = %q, want %q", cfg.Host, tc.wantHost)
+			}
+		})
+	}
+}
+
+// Outside a pod, with nothing configured, the caller must get the sentinel it
+// checks for rather than a config pointing somewhere arbitrary.
+func TestLoadControllerConfigDisabledWithoutAnySource(t *testing.T) {
+	clearControllerKubeconfigEnv(t)
+	// rest.InClusterConfig keys off these; unset they yield ErrNotInCluster.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	if _, _, err := loadControllerConfigRaw(); err != errControllerDisabled { //nolint:errorlint // sentinel is returned directly
+		t.Fatalf("err = %v, want errControllerDisabled", err)
+	}
+}

--- a/providers/infrastructure/controller_manager.go
+++ b/providers/infrastructure/controller_manager.go
@@ -194,10 +194,19 @@ func runTemplateControllerManager(ctx context.Context, config *rest.Config) erro
 // loadControllerConfig returns a rest.Config for the workspace the
 // platform controllers target. Looked up in this order:
 //
+//	FAROS_PROVIDER_KUBECONFIG             — standardized across all providers
 //	INFRASTRUCTURE_KUBECONFIG             — minted SA kubeconfig from `init`
 //	INFRASTRUCTURE_CONTROLLER_KUBECONFIG  — legacy provider-specific override
 //	KUBECONFIG                            — standard env var
 //	in-cluster service account            — when run as a pod
+//
+// FAROS_PROVIDER_KUBECONFIG is the name every chart sets on the serve
+// container, and the name the other eight providers read. Until it was
+// honored here, a chart-deployed serve container found none of the
+// provider-specific names — only `init` is given INFRASTRUCTURE_KUBECONFIG —
+// and fell through to the in-cluster ServiceAccount. That silently pointed
+// every kcp controller at the HOST cluster, surfacing as an unrelated-looking
+// RBAC error the first time something touched the API (leases in "default").
 //
 // The minted path wins because serve mode is supposed to run with
 // the lowest-privilege identity available. If init has already run,
@@ -206,12 +215,21 @@ func runTemplateControllerManager(ctx context.Context, config *rest.Config) erro
 // stay as escape hatches for dev clusters that haven't migrated to
 // the init/serve split.
 //
-// Returns errControllerDisabled when none of the four resolve; the
+// Returns errControllerDisabled when none of them resolve; the
 // caller logs + continues without the controller.
 func loadControllerConfig() (*rest.Config, error) {
-	c, err := loadControllerConfigRaw()
+	c, source, err := loadControllerConfigRaw()
 	if err != nil {
 		return nil, err
+	}
+	// Say which source won. Every controller and both leader elections run
+	// against this config, so picking the wrong one misdirects the whole
+	// provider — and the symptom surfaces far from the cause.
+	log.Printf("kcp config resolved from %s (host=%s)", source, c.Host)
+	if source == sourceInCluster {
+		log.Printf("WARNING: no provider kubeconfig in scope, so controllers will run "+
+			"against the HOST cluster, not kcp. Set %s to the mounted provider kubeconfig.",
+			"FAROS_PROVIDER_KUBECONFIG")
 	}
 	// When INFRASTRUCTURE_WORKSPACE_PATH is set, retarget the config host at
 	// /clusters/<path>. This lets serve run with a root-scoped (admin)
@@ -228,36 +246,41 @@ func loadControllerConfig() (*rest.Config, error) {
 	return c, nil
 }
 
-func loadControllerConfigRaw() (*rest.Config, error) {
-	if p := os.Getenv("INFRASTRUCTURE_KUBECONFIG"); p != "" {
+// sourceInCluster names the last-resort branch of loadControllerConfigRaw.
+const sourceInCluster = "the in-cluster ServiceAccount"
+
+// controllerKubeconfigEnvs is the resolution order, most-specific first. The
+// standardized FAROS_PROVIDER_KUBECONFIG leads: it is what every chart sets on
+// the serve container and what the other providers read.
+var controllerKubeconfigEnvs = []string{
+	"FAROS_PROVIDER_KUBECONFIG",
+	"INFRASTRUCTURE_KUBECONFIG",
+	"INFRASTRUCTURE_CONTROLLER_KUBECONFIG",
+	"KUBECONFIG",
+}
+
+// loadControllerConfigRaw returns the config and the name of the source it
+// came from, so the caller can report which one won.
+func loadControllerConfigRaw() (*rest.Config, string, error) {
+	for _, env := range controllerKubeconfigEnvs {
+		p := os.Getenv(env)
+		if p == "" {
+			continue
+		}
 		c, err := clientcmd.BuildConfigFromFlags("", p)
 		if err != nil {
-			return nil, fmt.Errorf("INFRASTRUCTURE_KUBECONFIG: %w", err)
+			return nil, "", fmt.Errorf("%s: %w", env, err)
 		}
-		return c, nil
-	}
-	if p := os.Getenv("INFRASTRUCTURE_CONTROLLER_KUBECONFIG"); p != "" {
-		c, err := clientcmd.BuildConfigFromFlags("", p)
-		if err != nil {
-			return nil, fmt.Errorf("INFRASTRUCTURE_CONTROLLER_KUBECONFIG: %w", err)
-		}
-		return c, nil
-	}
-	if p := os.Getenv("KUBECONFIG"); p != "" {
-		c, err := clientcmd.BuildConfigFromFlags("", p)
-		if err != nil {
-			return nil, fmt.Errorf("KUBECONFIG: %w", err)
-		}
-		return c, nil
+		return c, env, nil
 	}
 	// In-cluster fallback. The error returned by InClusterConfig is
 	// the right "not running in a pod" signal so we let it surface
 	// up the chain as errControllerDisabled.
 	c, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, errControllerDisabled
+		return nil, "", errControllerDisabled
 	}
-	return c, nil
+	return c, sourceInCluster, nil
 }
 
 // errControllerDisabled is the sentinel main() checks for so it can

--- a/providers/infrastructure/deploy/chart/README.md
+++ b/providers/infrastructure/deploy/chart/README.md
@@ -43,7 +43,7 @@ helm upgrade --install infrastructure oci://ghcr.io/faroshq/charts/faros-infrast
 | `hub` |  | Hub the provider POSTs heartbeats to. Must be reachable from the provider pod (in-cluster Service DNS works). |
 | `hub.url` | `https://faros-hub.faros.svc.cluster.local:9443` |  |
 | `hub.tokenSecretRef` |  | Bearer token used in the heartbeat POST. Provided as a Secret because it MUST NOT land in values.yaml in plaintext for prod. |
-| `hub.tokenSecretRef.name` | `faros-infrastructure-hub-token` |  |
+| `hub.tokenSecretRef.name` | `""` | Empty omits the Authorization header — the heartbeat endpoint does not require it. Set this ONLY when the Secret already exists in the release namespace; the reference is not optional, so a missing Secret wedges the pod in `CreateContainerConfigError`. |
 | `hub.tokenSecretRef.key` | `token` |  |
 | `hub.insecure` | `false` | Skip TLS verification on heartbeat — dev only, defaults off. |
 | `centralKro` |  | Central kro cluster kubeconfig. Two ways to provide it: 1. Inline `centralKro.kubeconfig` (rendered into a Secret by the chart; convenient for dev, NOT recommended for prod). 2. `centralKro.kubeconfigSecretRef` pointing at an existing Secret this chart did NOT create. Use this in prod. |

--- a/providers/infrastructure/deploy/chart/values.yaml
+++ b/providers/infrastructure/deploy/chart/values.yaml
@@ -23,8 +23,13 @@ hub:
   url: https://faros-hub.faros.svc.cluster.local:9443
   # Bearer token used in the heartbeat POST. Provided as a Secret
   # because it MUST NOT land in values.yaml in plaintext for prod.
+  # Empty (the default) omits the Authorization header entirely — the
+  # heartbeat endpoint does not require it. Set the name ONLY when the
+  # Secret already exists in the release namespace: the reference is not
+  # optional, so a missing Secret leaves the pod in
+  # CreateContainerConfigError forever.
   tokenSecretRef:
-    name: faros-infrastructure-hub-token
+    name: ""
     key: token
   # Skip TLS verification on heartbeat — dev only, defaults off.
   insecure: false


### PR DESCRIPTION
Two independent bugs stop a self-hosted infrastructure provider (the flow added in #541) from ever reaching a running state. Both are invisible on the dev path, which compensates for each of them by hand.

---

## 1. The chart requires a heartbeat Secret nobody creates

```
Warning  Failed  3s (x16 over 3m14s)  kubelet  Error: secret "faros-infrastructure-hub-token" not found
```

`hub.tokenSecretRef.name` defaulted to `faros-infrastructure-hub-token`, but **the chart never creates that Secret**. The env var is a plain `secretKeyRef` with no `optional: true`, so kubelet refuses to build the container until it exists — the pod retries forever.

The token isn't even required: `runHeartbeat` only sets the `Authorization` header when non-empty, and the heartbeat endpoint is registered without auth middleware. It worked in dev only because the Makefile creates the Secret before installing.

`infrastructure`, `code`, and `databricks` were the three charts carrying a non-empty default; the other six already used `""`. This brings them in line and documents why the field is dangerous to set casually.

- three `values.yaml` → `name: ""`, noting that a missing Secret wedges the pod in `CreateContainerConfigError`
- three chart `README.md` value tables updated
- `providers/code/README.md` — **both** install recipes set that name without creating the Secret, so following either reproduced the failure. Same for one recipe in `providers/infrastructure/README.md`. Flag dropped.
- `Makefile` — the dev target genuinely wants the token and relied on the default, so it now sets the name explicitly, right below the step that creates the Secret.

## 2. The serve container talks to the host cluster instead of kcp

```
leases.coordination.k8s.io "infrastructure-instance" is forbidden:
User "system:serviceaccount:faros-provider-infrastructure:..." cannot get
resource "leases" in the namespace "default"
```

The identity in that error is a **host-cluster** ServiceAccount, which is the tell. The Lease is meant to live in the provider's own kcp workspace — kcp serves Leases in every logical cluster, and the minted identity already holds `get/list/watch/create/update/patch` on them (`install/identity.go`). Nothing about the lease is misconfigured; the controllers were talking to the wrong API server.

`loadControllerConfigRaw` consulted `INFRASTRUCTURE_KUBECONFIG`, `INFRASTRUCTURE_CONTROLLER_KUBECONFIG`, and `KUBECONFIG`. The chart sets **none** of those on the serve container — it sets `FAROS_PROVIDER_KUBECONFIG`, the standardized name that the other **eight** providers all read. `INFRASTRUCTURE_KUBECONFIG` is set only on the *init* container, pointing into that container's own `/tmp`. So serve found nothing and fell through to `rest.InClusterConfig()`.

- read the standardized name first, keeping the provider-specific names as fallbacks — the operator sets `INFRASTRUCTURE_KUBECONFIG` and must keep working
- report which source won, and warn loudly when it is the in-cluster ServiceAccount. Every controller and both leader elections share this config, so choosing wrong misdirects the whole provider and the symptom surfaces far from the cause

Local `make run-provider-infrastructure` sets `INFRASTRUCTURE_KUBECONFIG`, which is why this only bit the chart-deployed path.

---

## Verification

- all three charts render **0** `FAROS_HUB_TOKEN` references with defaults; an explicit `--set` still renders the `secretKeyRef` (dev path intact); `helm lint` clean
- new tests cover the kubeconfig regression, the operator's env, precedence, and the disabled sentinel — and were confirmed to **fail** without the fix (the standardized case resolves to the operator's kubeconfig, or to nothing at all)
- `go build` / `go test` / `gofmt` clean on the package

## Note for anyone hitting #1 before this ships

The chart published at `oci://ghcr.io/faroshq/charts` still carries the old default, so the portal's rendered install command keeps reproducing it. Bridge:

```sh
helm upgrade infrastructure <chart> -n faros-provider-infrastructure --reuse-values \
  --set hub.tokenSecretRef.name=""
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
