### PR TITLE
Point self-hosting at operator mode, the production install path

### DIFF
--- a/providers/infrastructure/README.md
+++ b/providers/infrastructure/README.md
@@ -399,8 +399,14 @@ creates a workspace for it in your organization, mints a credential scoped to
 that workspace alone, and generates the exact `helm` commands — under
 **Providers → Self-Hosting** in the portal.
 
-Nothing to fill in: this provider self-bootstraps, and the workspace path plus
-kubeconfig Secret reference are substituted into the generated command.
+Nothing to fill in: the generated command turns on **operator mode** — the same
+mode the production install runs in — and substitutes the kubeconfig Secret
+reference. The operator bootstraps the workspace, installs kro, and owns the
+serve Deployment plus the runtime-cluster RBAC it needs, so a self-hosted copy
+stands up unattended in a cluster that has nothing but the credential.
+
+The `bootstrap.*` init-container flow documented above is superseded and is
+*not* what self-hosting uses: it installs neither kro nor the serve pod's RBAC.
 
 Once installed, the provider registers itself and your workspaces enable it
 exactly like the platform copy. See

--- a/providers/infrastructure/deploy/chart/templates/catalogentry.yaml
+++ b/providers/infrastructure/deploy/chart/templates/catalogentry.yaml
@@ -122,24 +122,26 @@ data:
         # The chart carries its own values reference, so the portal can show it
         # offline and for the version actually installed.
         valuesDoc: |{{ .Files.Get "README.md" | nindent 10 }}
+        # Operator mode — the same mode the production install runs in, and the
+        # only one that stands a provider up unattended. It bootstraps your
+        # workspace, installs kro, and owns the serve Deployment together with
+        # the runtime-cluster RBAC that Deployment needs. The superseded
+        # bootstrap.* init-container flow does none of the last two, so a
+        # self-hoster following it lands a serve pod with no permissions on its
+        # own runtime cluster.
         requiredValues:
-          - name: bootstrap.enabled
+          - name: operator.enabled
             value: "true"
             description: >-
-              Runs the provider's own init container, which installs its CRDs and
-              APIExport into your workspace.
-          - name: bootstrap.kubeconfigSource
-            value: supplied
-            description: >-
-              Use the credential you created rather than waiting for the platform
-              to deliver one — the hub cannot write Secrets into your cluster.
-          - name: bootstrap.kcpKubeconfigSecretRef.name
+              Installs the provider's operator, which bootstraps your workspace,
+              installs kro, and runs the provider itself.
+          - name: operator.providerKubeconfigSecret.name
             value: "{{`{{kubeconfigSecret}}`}}"
             description: Secret holding the workspace credential.
-          - name: bootstrap.kcpKubeconfigSecretRef.key
+          - name: operator.providerKubeconfigSecret.key
             value: "{{`{{kubeconfigSecretKey}}`}}"
             description: Data key inside that Secret.
-          - name: bootstrap.workspacePath
-            value: "{{`{{workspacePath}}`}}"
-            description: Your organization's workspace for this provider.
+          - name: hub.url
+            value: "{{`{{hubURL}}`}}"
+            description: Where the provider reports its health.
 {{- end }}

--- a/providers/infrastructure/manifest.yaml
+++ b/providers/infrastructure/manifest.yaml
@@ -118,23 +118,24 @@ spec:
     namespace: "faros-provider-infrastructure"
     releaseName: "infrastructure"
     docsURL: "https://github.com/faroshq/faros/blob/main/providers/infrastructure/deploy/chart/README.md"
+    # Operator mode — the same mode the production install runs in, and the only
+    # one that stands a provider up unattended. It bootstraps your workspace,
+    # installs kro, and owns the serve Deployment together with the
+    # runtime-cluster RBAC that Deployment needs. The superseded bootstrap.*
+    # init-container flow does none of the last two, so a self-hoster following
+    # it lands a serve pod with no permissions on its own runtime cluster.
     requiredValues:
-      - name: bootstrap.enabled
+      - name: operator.enabled
         value: "true"
         description: >-
-          Runs the provider's own init container, which installs its CRDs and
-          APIExport into your workspace.
-      - name: bootstrap.kubeconfigSource
-        value: supplied
-        description: >-
-          Use the credential you created rather than waiting for the platform to
-          deliver one — the hub cannot write Secrets into your cluster.
-      - name: bootstrap.kcpKubeconfigSecretRef.name
+          Installs the provider's operator, which bootstraps your workspace,
+          installs kro, and runs the provider itself.
+      - name: operator.providerKubeconfigSecret.name
         value: "{{kubeconfigSecret}}"
         description: Secret holding the workspace credential.
-      - name: bootstrap.kcpKubeconfigSecretRef.key
+      - name: operator.providerKubeconfigSecret.key
         value: "{{kubeconfigSecretKey}}"
         description: Data key inside that Secret.
-      - name: bootstrap.workspacePath
-        value: "{{workspacePath}}"
-        description: Your organization's workspace for this provider.
+      - name: hub.url
+        value: "{{hubURL}}"
+        description: Where the provider reports its health.


### PR DESCRIPTION
You were right to question this: **operator mode is the infrastructure provider's delivery method, and the self-hosting recipe was not using it.**

## The mistake

The `selfHosting` recipe added in #541 turned on the `bootstrap.*` init container. That is the superseded flow, by the repo's own account:

- `values.yaml` on `operator.enabled`: *"This supersedes the `bootstrap.*` init-container flow."*
- `docs/application-template-architecture.md` on operator mode: *"**This is the mode the production install runs in.**"*

## Why it matters — this is the cause of the stall

A self-hosted provider comes up and then fails every template identically:

```
backend "kro" SetupTemplate: get: resourcegraphdefinitions.kro.run "cron-job" is forbidden:
User "system:serviceaccount:faros-provider-infrastructure:infrastructure-..." cannot get
resource "resourcegraphdefinitions" in API group "kro.run" at the cluster scope
```

In bootstrap mode the chart renders **no RBAC at all** — `ConfigMap, Deployment, Service, ServiceAccount` and nothing else — so the serve pod has zero permissions on the runtime cluster it is supposed to drive. It also assumes kro is already installed there.

Operator mode does both:

| | bootstrap mode | operator mode |
|---|---|---|
| bootstraps the kcp workspace | yes | yes |
| installs kro on the runtime cluster | **no** | `EnsureKroChartCRDs` + `EnsureKroRelease` |
| grants the serve pod runtime RBAC | **no** | `ensureServeRBAC` |
| owns the serve Deployment | chart | operator (via the CR) |

Those two gaps are exactly what a self-hoster cannot be expected to have done already — so bootstrap mode can never stand a provider up unattended. Patching RBAC into the bootstrap path would have been treating the symptom.

## The change

The recipe now sets `operator.enabled=true`, the provider kubeconfig Secret reference, and `hub.url`. Omitting `runtimeKubeconfigSecret` makes the operator use its own cluster as the runtime — what self-hosting wants — and the CatalogEntry manifest is embedded in the operator binary, so no ConfigMap plumbing is needed either.

No renderer change was required: `hubKnownValue` already resolved `operator.providerKubeconfigSecret.name/key`, and every placeholder used here was already supported. `manifest.yaml` and the chart's `catalogentry.yaml` are kept in lockstep as their comments require.

## Verification

The recipe renders a complete install — `ClusterRole`, two `ClusterRoleBindings`, the operator `Deployment`, and an `InfrastructureProvider` CR with an in-cluster runtime and kro release config. `helm lint` clean; `pkg/hub/providers` and `providers/infrastructure` tests pass.

## Still open, not addressed here

A self-hosted provider cannot reach its own APIExport virtual workspace, so the instance controller never starts:

```
error starting endpoint watcher: Get "https://alpha-shard-kcp.kcp-system.svc.cluster.local:6443
/services/apiexport/.../clusters/*/api": ... no such host
```

The APIExportEndpointSlice publishes the hub's cluster-internal shard DNS, which by construction cannot resolve from a tenant's cluster. The hub's external URL is not a substitute either — `/clusters/root/api` returns 401 (route exists) but `/services/apiexport/...` returns 404, since the front proxy only handles `/clusters/…`. That needs a design decision and is filed separately from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
