### PR TITLE
Grant the agent what it already had, and let edge installs work

### DIFF
--- a/deploy/charts/faros-agent/templates/rbac.yaml
+++ b/deploy/charts/faros-agent/templates/rbac.yaml
@@ -6,9 +6,6 @@ metadata:
   labels:
     {{- include "faros-agent.labels" . | nindent 4 }}
 rules:
-  # Cluster-admin. The agent installs whatever a tenant deploys through it,
-  # including provider charts whose CRs live in API groups no fixed list can
-  # enumerate ahead of time. See docs/byo-providers.md.
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["*"]

--- a/deploy/charts/faros-agent/templates/rbac.yaml
+++ b/deploy/charts/faros-agent/templates/rbac.yaml
@@ -6,39 +6,32 @@ metadata:
   labels:
     {{- include "faros-agent.labels" . | nindent 4 }}
 rules:
-  # The agent needs broad permissions to manage workloads on behalf of the hub
-  - apiGroups: [""]
+  # The agent manages workloads on behalf of the hub, and installs whatever a
+  # tenant deploys through it — including provider charts, whose CRs live in API
+  # groups no fixed list can enumerate ahead of time.
+  #
+  # This is a wildcard rather than the allowlist it used to be, because the
+  # allowlist was never a boundary. It granted rbac.authorization.k8s.io/* with
+  # verbs ["*"], and "*" includes escalate and bind: an agent could always
+  # create a ClusterRole with any permission and bind itself to it. Verified by
+  # doing exactly that with the old rules — self-granted cluster-admin, then
+  # `auth can-i '*' '*'` returned yes.
+  #
+  # So the list bought no containment. What it did buy was a confusing failure:
+  # installing a provider through an edge kubeconfig got far enough to create
+  # the CRD (apiextensions.k8s.io was listed) and then died on the provider's
+  # own custom resource, looking like a bug in the chart.
+  #
+  # Narrowing this for real means removing the escalate/bind path, which needs
+  # its own design — the agent legitimately creates RBAC for the workloads it
+  # deploys. Until then, state the privilege honestly instead of implying a
+  # limit that does not hold.
+  - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["*"]
-  - apiGroups: ["apps"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["batch"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["policy"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["autoscaling"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["*"]
+  # Non-resource URLs (/healthz, /version, /openapi) are not covered by
+  # apiGroups and are needed for discovery.
+  - nonResourceURLs: ["*"]
     verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/faros-agent/templates/rbac.yaml
+++ b/deploy/charts/faros-agent/templates/rbac.yaml
@@ -6,31 +6,13 @@ metadata:
   labels:
     {{- include "faros-agent.labels" . | nindent 4 }}
 rules:
-  # The agent manages workloads on behalf of the hub, and installs whatever a
-  # tenant deploys through it — including provider charts, whose CRs live in API
-  # groups no fixed list can enumerate ahead of time.
-  #
-  # This is a wildcard rather than the allowlist it used to be, because the
-  # allowlist was never a boundary. It granted rbac.authorization.k8s.io/* with
-  # verbs ["*"], and "*" includes escalate and bind: an agent could always
-  # create a ClusterRole with any permission and bind itself to it. Verified by
-  # doing exactly that with the old rules — self-granted cluster-admin, then
-  # `auth can-i '*' '*'` returned yes.
-  #
-  # So the list bought no containment. What it did buy was a confusing failure:
-  # installing a provider through an edge kubeconfig got far enough to create
-  # the CRD (apiextensions.k8s.io was listed) and then died on the provider's
-  # own custom resource, looking like a bug in the chart.
-  #
-  # Narrowing this for real means removing the escalate/bind path, which needs
-  # its own design — the agent legitimately creates RBAC for the workloads it
-  # deploys. Until then, state the privilege honestly instead of implying a
-  # limit that does not hold.
+  # Cluster-admin. The agent installs whatever a tenant deploys through it,
+  # including provider charts whose CRs live in API groups no fixed list can
+  # enumerate ahead of time. See docs/byo-providers.md.
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["*"]
-  # Non-resource URLs (/healthz, /version, /openapi) are not covered by
-  # apiGroups and are needed for discovery.
+  # apiGroups does not cover non-resource URLs; discovery needs them.
   - nonResourceURLs: ["*"]
     verbs: ["*"]
 ---

--- a/docs/byo-providers.md
+++ b/docs/byo-providers.md
@@ -464,26 +464,28 @@ in URL paths.
 
 ## Known gaps
 
-- **The install is not edge-driven, and an edge kubeconfig cannot stand in for
-  one.** The generated commands run against the Org's own cluster with the
-  Org's own cluster-admin credential. A `faros kubeconfig edge` context looks
-  like it should work — it reaches the right cluster — but it authenticates as
-  the agent, whose ClusterRole
-  ([deploy/charts/faros-agent/templates/rbac.yaml](../deploy/charts/faros-agent/templates/rbac.yaml))
-  is an allowlist of API groups that deliberately excludes provider groups. The
-  chart gets far enough to install the CRD (`apiextensions.k8s.io` is on the
-  list) and then fails on its own custom resource:
+- **The agent holds cluster-admin in the tenant's cluster, and its ClusterRole
+  now says so.** It used to be an allowlist of API groups, which read like a
+  containment boundary and was not one: it granted
+  `rbac.authorization.k8s.io/*` with `verbs: ["*"]`, and `*` covers `escalate`
+  and `bind`, so the agent could always mint a ClusterRole with any permission
+  and bind itself to it. Verified by doing exactly that with the old rules — the
+  ServiceAccount self-granted `cluster-admin`, after which
+  `auth can-i '*' '*'` returned `yes`.
+
+  What the list did buy was a confusing failure. Installing a provider through
+  an edge kubeconfig got far enough to create the CRD (`apiextensions.k8s.io`
+  was on the list) and then died on the provider's own custom resource:
 
   ```
   infrastructureproviders.infrastructure.faros.sh "…" is forbidden:
   User "system:serviceaccount:faros-agent:faros-agent" cannot get …
   ```
 
-  Widening that allowlist is not the fix. The agent is the platform's foothold
-  in a tenant's cluster, and letting it create arbitrary provider resources
-  would grow the platform's reach there — the opposite of what BYO is for.
-  Installing a provider is an administrative act by the tenant, performed with
-  the tenant's own credential. The install steps now say so explicitly.
+  Bounding the agent for real means removing that escalate/bind path, which
+  needs its own design — the agent legitimately creates RBAC for the workloads
+  it deploys. Until then the grant is stated honestly rather than implying a
+  limit that does not hold.
 
 - **Nothing checks the virtual-workspace URL before handing out a credential.**
   On a multi-shard platform whose shards advertise unreachable virtual-workspace

--- a/docs/byo-providers.md
+++ b/docs/byo-providers.md
@@ -464,6 +464,27 @@ in URL paths.
 
 ## Known gaps
 
+- **The install is not edge-driven, and an edge kubeconfig cannot stand in for
+  one.** The generated commands run against the Org's own cluster with the
+  Org's own cluster-admin credential. A `faros kubeconfig edge` context looks
+  like it should work — it reaches the right cluster — but it authenticates as
+  the agent, whose ClusterRole
+  ([deploy/charts/faros-agent/templates/rbac.yaml](../deploy/charts/faros-agent/templates/rbac.yaml))
+  is an allowlist of API groups that deliberately excludes provider groups. The
+  chart gets far enough to install the CRD (`apiextensions.k8s.io` is on the
+  list) and then fails on its own custom resource:
+
+  ```
+  infrastructureproviders.infrastructure.faros.sh "…" is forbidden:
+  User "system:serviceaccount:faros-agent:faros-agent" cannot get …
+  ```
+
+  Widening that allowlist is not the fix. The agent is the platform's foothold
+  in a tenant's cluster, and letting it create arbitrary provider resources
+  would grow the platform's reach there — the opposite of what BYO is for.
+  Installing a provider is an administrative act by the tenant, performed with
+  the tenant's own credential. The install steps now say so explicitly.
+
 - **Nothing checks the virtual-workspace URL before handing out a credential.**
   On a multi-shard platform whose shards advertise unreachable virtual-workspace
   URLs (see [Platform prerequisite](#platform-prerequisite-a-publicly-dialable-virtual-workspace-url)),

--- a/pkg/hub/providers/selfhosting.go
+++ b/pkg/hub/providers/selfhosting.go
@@ -287,9 +287,19 @@ func RenderInstallInstructions(sh *SelfHosting, opts InstallOptions) InstallInst
 
 	out.Steps = []InstallStep{
 		{
-			Title:       "Create the namespace",
-			Description: "Where the provider runs in your cluster.",
-			Command:     fmt.Sprintf("kubectl create namespace %s", namespace),
+			Title: "Create the namespace",
+			// Which credential these run with is the one thing the commands
+			// cannot show, and getting it wrong fails deep inside helm rather
+			// than up front. Three kubeconfigs are plausibly in scope here: the
+			// one shown above (kcp, and only ever the content of a Secret), an
+			// edge kubeconfig from `faros kubeconfig edge` (which authenticates
+			// as the agent, whose ClusterRole is an allowlist that excludes
+			// provider API groups), and the cluster-admin credential these
+			// actually need. Say so where the reader is looking.
+			Description: "Where the provider runs in your cluster. Run every command below with your OWN " +
+				"cluster-admin credentials for that cluster — not the kubeconfig shown above, and not a " +
+				"`faros kubeconfig edge` one.",
+			Command: fmt.Sprintf("kubectl create namespace %s", namespace),
 		},
 		{
 			Title: "Store the credential",
@@ -301,9 +311,11 @@ func RenderInstallInstructions(sh *SelfHosting, opts InstallOptions) InstallInst
 				namespace, KubeconfigSecretName, KubeconfigSecretKey, kubeconfigFile),
 		},
 		{
-			Title:       "Install the provider",
-			Description: "The chart's init job registers the provider into your organization's workspace.",
-			Command:     helm.String(),
+			Title: "Install the provider",
+			Description: "The chart's init job registers the provider into your organization's workspace. " +
+				"It installs a CRD, ClusterRoles and its own custom resource, so it needs cluster-admin " +
+				"in the target cluster.",
+			Command: helm.String(),
 		},
 	}
 	return out

--- a/pkg/hub/providers/selfhosting.go
+++ b/pkg/hub/providers/selfhosting.go
@@ -289,16 +289,15 @@ func RenderInstallInstructions(sh *SelfHosting, opts InstallOptions) InstallInst
 		{
 			Title: "Create the namespace",
 			// Which credential these run with is the one thing the commands
-			// cannot show, and getting it wrong fails deep inside helm rather
-			// than up front. Three kubeconfigs are plausibly in scope here: the
-			// one shown above (kcp, and only ever the content of a Secret), an
-			// edge kubeconfig from `faros kubeconfig edge` (which authenticates
-			// as the agent, whose ClusterRole is an allowlist that excludes
-			// provider API groups), and the cluster-admin credential these
-			// actually need. Say so where the reader is looking.
-			Description: "Where the provider runs in your cluster. Run every command below with your OWN " +
-				"cluster-admin credentials for that cluster — not the kubeconfig shown above, and not a " +
-				"`faros kubeconfig edge` one.",
+			// cannot show, and the kubeconfig displayed directly above them is
+			// the wrong one — it addresses kcp, and only ever belongs inside the
+			// Secret step 2 creates. Naming the alternatives is the whole point:
+			// either a cluster-admin credential for the target cluster, or a
+			// `faros kubeconfig edge` context, which reaches that cluster
+			// through the agent.
+			Description: "Where the provider runs in your cluster. Run every command below against that " +
+				"cluster — with your own cluster-admin credentials, or a `faros kubeconfig edge` context " +
+				"for it. Not the kubeconfig shown above: that one addresses faros, not your cluster.",
 			Command: fmt.Sprintf("kubectl create namespace %s", namespace),
 		},
 		{
@@ -313,8 +312,8 @@ func RenderInstallInstructions(sh *SelfHosting, opts InstallOptions) InstallInst
 		{
 			Title: "Install the provider",
 			Description: "The chart's init job registers the provider into your organization's workspace. " +
-				"It installs a CRD, ClusterRoles and its own custom resource, so it needs cluster-admin " +
-				"in the target cluster.",
+				"It installs a CRD, ClusterRoles and its own custom resource, so whichever credential you " +
+				"use needs cluster-admin in the target cluster.",
 			Command: helm.String(),
 		},
 	}

--- a/pkg/hub/providers/selfhosting_test.go
+++ b/pkg/hub/providers/selfhosting_test.go
@@ -369,16 +369,10 @@ func unresolved(values []ResolvedValue, name string) bool {
 	return false
 }
 
-// The commands cannot show which credential they need, and using the wrong one
-// fails deep inside helm — as it did with a `faros kubeconfig edge` context,
-// which authenticates as the agent whose ClusterRole excludes provider API
-// groups:
-//
-//	infrastructureproviders.infrastructure.faros.sh "..." is forbidden:
-//	User "system:serviceaccount:faros-agent:faros-agent" cannot get ...
-//
-// Three kubeconfigs are plausibly in scope, so the steps have to name the right
-// one rather than leave the reader to infer it.
+// The commands cannot show which credential they run with, and the kubeconfig
+// displayed directly above them is the wrong one — it addresses kcp, not the
+// tenant's cluster. Proximity makes it the likely mistake, so the steps have to
+// rule it out by name and point at the two that do work.
 func TestRenderInstallInstructionsNamesTheCredentialToUse(t *testing.T) {
 	got := RenderInstallInstructions(baseSelfHosting(), baseOptions())
 
@@ -389,14 +383,13 @@ func TestRenderInstallInstructionsNamesTheCredentialToUse(t *testing.T) {
 	if !strings.Contains(joined, "cluster-admin") {
 		t.Errorf("no step says cluster-admin is required:\n%s", joined)
 	}
-	// Naming what NOT to use matters as much: the kcp kubeconfig is displayed
-	// immediately above these commands, which is what makes it the tempting
-	// wrong answer.
-	if !strings.Contains(joined, "not the kubeconfig shown above") {
-		t.Errorf("steps do not warn against the credential shown above them:\n%s", joined)
+	if !strings.Contains(joined, "Not the kubeconfig shown above") {
+		t.Errorf("steps do not rule out the credential shown above them:\n%s", joined)
 	}
+	// An edge context is a legitimate way to reach the cluster — the agent holds
+	// cluster-admin there — so the steps must offer it rather than warn it off.
 	if !strings.Contains(joined, "faros kubeconfig edge") {
-		t.Errorf("steps do not warn against an edge kubeconfig:\n%s", joined)
+		t.Errorf("steps do not mention an edge context as a way to reach the cluster:\n%s", joined)
 	}
 }
 

--- a/pkg/hub/providers/selfhosting_test.go
+++ b/pkg/hub/providers/selfhosting_test.go
@@ -369,6 +369,37 @@ func unresolved(values []ResolvedValue, name string) bool {
 	return false
 }
 
+// The commands cannot show which credential they need, and using the wrong one
+// fails deep inside helm — as it did with a `faros kubeconfig edge` context,
+// which authenticates as the agent whose ClusterRole excludes provider API
+// groups:
+//
+//	infrastructureproviders.infrastructure.faros.sh "..." is forbidden:
+//	User "system:serviceaccount:faros-agent:faros-agent" cannot get ...
+//
+// Three kubeconfigs are plausibly in scope, so the steps have to name the right
+// one rather than leave the reader to infer it.
+func TestRenderInstallInstructionsNamesTheCredentialToUse(t *testing.T) {
+	got := RenderInstallInstructions(baseSelfHosting(), baseOptions())
+
+	joined := ""
+	for _, s := range got.Steps {
+		joined += s.Title + "\n" + s.Description + "\n"
+	}
+	if !strings.Contains(joined, "cluster-admin") {
+		t.Errorf("no step says cluster-admin is required:\n%s", joined)
+	}
+	// Naming what NOT to use matters as much: the kcp kubeconfig is displayed
+	// immediately above these commands, which is what makes it the tempting
+	// wrong answer.
+	if !strings.Contains(joined, "not the kubeconfig shown above") {
+		t.Errorf("steps do not warn against the credential shown above them:\n%s", joined)
+	}
+	if !strings.Contains(joined, "faros kubeconfig edge") {
+		t.Errorf("steps do not warn against an edge kubeconfig:\n%s", joined)
+	}
+}
+
 func TestSelfHostingInstallable(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -695,10 +695,9 @@ function dependencyNotice(p: ProviderDTO): string {
               {{ providers.deletionBlocked(p.name) }}
             </p>
             <p class="mt-1.5 text-[10px] leading-relaxed text-text-muted">
-              kcp removes a provider's resources before the binding itself. Resources
-              holding a finalizer wait for their controller to release it — if that
-              controller is gone, delete the listed resources (or strip their
-              finalizers) to let the disable finish.
+              Some of this provider's resources are still waiting to be cleaned
+              up. If this doesn't resolve on its own, delete the resources listed
+              above (or remove their finalizers) to let the disable finish.
             </p>
           </div>
 


### PR DESCRIPTION
Installing a self-hosted provider through a `faros kubeconfig edge` context failed:

```
Error: Unable to continue with install: could not get information about the resource
InfrastructureProvider "infrastructure-faros-infrastructure-provider" …:
infrastructureproviders.infrastructure.faros.sh "…" is forbidden:
User "system:serviceaccount:faros-agent:faros-agent" cannot get resource
"infrastructureproviders" in API group "infrastructure.faros.sh"
```

## The allowlist was not a boundary

The agent's ClusterRole listed API groups, which reads like deliberate containment. It is not. It granted `rbac.authorization.k8s.io/*` with `verbs: ["*"]`, and `*` covers **`escalate`** and **`bind`** — so the agent could always mint a ClusterRole carrying any permission and bind itself to it.

Verified rather than argued. A ServiceAccount holding exactly the old rules:

```
$ kubectl create clusterrolebinding probe-selfadmin \
    --clusterrole=cluster-admin --serviceaccount=rbac-probe:probe
clusterrolebinding.rbac.authorization.k8s.io/probe-selfadmin created

$ kubectl auth can-i '*' '*' --all-namespaces
yes
```

The agent has been cluster-admin-equivalent all along.

## What the list actually cost

No containment, and one bad failure mode: the chart got far enough to install its CRD (`apiextensions.k8s.io` was listed) and then died on its own custom resource — which reads as a bug in the chart rather than a permissions gap. Provider CRs live in API groups no fixed list can enumerate ahead of time, so this recurs for every new provider.

## Change

State the grant honestly — `apiGroups: ["*"]` plus `nonResourceURLs` for discovery — and edge-driven installs work. This widens the *nominal* grant while changing no real privilege.

The install steps now **offer** an edge context alongside a cluster-admin credential. They still rule out the kubeconfig displayed directly above them: that one addresses faros, not the tenant's cluster, and proximity is what makes it the likely mistake.

Bounding the agent for real means removing the escalate/bind path, which needs its own design — it legitimately creates RBAC for the workloads it deploys. Recorded in `docs/byo-providers.md` as the open item.

## Verification

`pkg/hub/providers` suite, `make lint`, `helm lint deploy/charts/faros-agent`, and `vue-tsc` all clean. A test pins that the steps name cluster-admin, rule out the kubeconfig shown above, and offer the edge context.

## Note for review

The earlier revision of this PR argued the refusal was correct security behaviour and told users to avoid the edge kubeconfig. That was wrong — the escalation probe above is what settled it. The commits reflect both steps rather than hiding the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
