### PR TITLE
Stop a superseded edge tunnel from erasing the one that replaced it

### DIFF
--- a/providers/edges/internal/tunnel/agent_proxy_builder_v2.go
+++ b/providers/edges/internal/tunnel/agent_proxy_builder_v2.go
@@ -229,13 +229,32 @@ func (p *Server) buildEdgeAgentProxyHandler() http.Handler {
 		// look-ups don't succeed.
 		<-dialer.Done()
 		cancelHeartbeat()
-		p.edgeConnManager.Delete(key)
+
+		// Identity-checked: the key is stable across reconnects, so if the agent
+		// has already dialled a replacement tunnel it — not us — owns this entry
+		// and the edge's status. Deleting unconditionally here erased a live
+		// registration and left a healthy agent unroutable until it restarted.
+		if !p.edgeConnManager.DeleteIf(key, dialer) {
+			p.logger.Info("Superseded edge agent tunnel closed; a newer tunnel owns this edge", "key", key)
+			return
+		}
 		p.logger.Info("Edge agent tunnel closed", "key", key)
 
 		// Proactively mark the Edge as Disconnected in the hub.  Agents may die
 		// without sending a clean disconnect heartbeat (e.g. SIGKILL), so the
 		// hub must be the authoritative source for connectivity state.
-		go p.markEdgeDisconnected(context.Background(), gvr, cluster, name)
+		//
+		// Re-check for a live tunnel first: a disconnect immediately followed by
+		// a reconnect can otherwise land this write after the new tunnel's
+		// markEdgeConnected and flap the edge to Disconnected. The
+		// LifecycleReconciler would repair it on its next pass, but not before
+		// the UI and CLI have shown a connected edge as down.
+		go func() {
+			if p.edgeConnManager.HasLocalConnection(key) {
+				return
+			}
+			p.markEdgeDisconnected(context.Background(), gvr, cluster, name)
+		}()
 	})
 
 	return mux

--- a/providers/edges/internal/tunnel/connman.go
+++ b/providers/edges/internal/tunnel/connman.go
@@ -135,10 +135,25 @@ func (c *ConnManager) sweepClosed(logger klog.Logger) {
 
 // Store saves d under key, replacing any existing entry, and claims the
 // edge's registry lease so peers route to this replica.
+//
+// An agent that reconnects — pod restart, chart upgrade, network blip — dials a
+// fresh tunnel under the SAME key while the superseded handler is still parked
+// on <-dialer.Done(). Store therefore closes the dialer it displaces, so that
+// handler wakes now instead of whenever its half-open socket happens to die.
+// Paired with DeleteIf, that keeps a stale handler's cleanup from tearing down
+// the live tunnel that replaced it.
 func (c *ConnManager) Store(key string, d *revdial.Dialer) {
 	c.mu.Lock()
+	prev := c.dials[key]
 	c.dials[key] = d
 	c.mu.Unlock()
+
+	// Only local entries are ever stored, so this assertion holds; relayed
+	// remoteDialers are built per-Load and belong to a peer, never to us.
+	if old, ok := prev.(*revdial.Dialer); ok && old != d {
+		_ = old.Close()
+	}
+
 	if reg, _ := c.getRegistry(); reg != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), registryWriteTimeout)
 		defer cancel()
@@ -196,17 +211,33 @@ func (c *ConnManager) LoadLocal(key string) (Dialer, bool) {
 	return d, true
 }
 
-// Delete removes the entry for key and releases the registry claim (owner-
-// checked, so a reconnect that moved to a peer is not erased).
-func (c *ConnManager) Delete(key string) {
+// DeleteIf removes the entry for key only if it is still d, releases the
+// registry claim when it does, and reports whether it deleted anything.
+//
+// The delete MUST be identity-checked. Keys are stable across reconnects
+// ("{resource}/{cluster}/{name}"), so an unconditional delete on the tunnel-
+// close path is a use-after-replace: by the time a superseded handler runs its
+// cleanup, the agent has often already registered a healthy tunnel under the
+// same key, and erasing it strands a connected agent with no route. The failure
+// is silent and permanent — the hub answers "no active tunnel found for edge"
+// while the agent, whose socket is genuinely fine, sees no error and so never
+// reconnects. Only the sweeper's IsClosed check or an agent restart clears it.
+func (c *ConnManager) DeleteIf(key string, d Dialer) bool {
 	c.mu.Lock()
+	current, exists := c.dials[key]
+	if !exists || current != d {
+		c.mu.Unlock()
+		return false
+	}
 	delete(c.dials, key)
 	c.mu.Unlock()
+
 	if reg, _ := c.getRegistry(); reg != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), registryWriteTimeout)
 		defer cancel()
 		reg.ReleaseTunnel(ctx, key)
 	}
+	return true
 }
 
 // HasConnection returns true if ANY replica holds an active tunnel for key.

--- a/providers/edges/internal/tunnel/connman_test.go
+++ b/providers/edges/internal/tunnel/connman_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/faroshq/provider-sdk/revdial"
+)
+
+// newTestDialer returns a live *revdial.Dialer over an in-memory pipe. The peer
+// end is drained because NewDialer immediately starts a keep-alive write loop
+// and net.Pipe is unbuffered — an undrained peer would wedge it.
+func newTestDialer(t *testing.T) *revdial.Dialer {
+	t.Helper()
+	local, peer := net.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, peer) }()
+	d := revdial.NewDialer(local, "/pickup")
+	t.Cleanup(func() {
+		_ = d.Close()
+		_ = peer.Close()
+	})
+	return d
+}
+
+// TestDeleteIfKeepsTunnelThatSupersededUs reproduces the reconnect race that
+// left a healthy agent unroutable: the agent restarts, its new tunnel registers
+// under the same stable key, and only then does the old handler wake up and run
+// its cleanup. That cleanup must not evict the replacement.
+func TestDeleteIfKeepsTunnelThatSupersededUs(t *testing.T) {
+	c := NewConnManager()
+	key := EdgeConnKey("kubernetesclusters", "1ngen6o0so3jwz2h", "minis")
+
+	old := newTestDialer(t)
+	c.Store(key, old)
+
+	// Agent reconnects: a second tunnel registers under the same key while the
+	// first handler is still parked on <-dialer.Done().
+	fresh := newTestDialer(t)
+	c.Store(key, fresh)
+
+	if c.DeleteIf(key, old) {
+		t.Fatal("DeleteIf reported a delete for a dialer that no longer owns the key")
+	}
+
+	got, ok := c.LoadLocal(key)
+	if !ok {
+		t.Fatal("live tunnel was evicted by the superseded handler's cleanup; the agent is now unroutable")
+	}
+	if got != Dialer(fresh) {
+		t.Fatalf("LoadLocal returned the wrong dialer: got %p, want %p", got, fresh)
+	}
+}
+
+// TestStoreClosesDisplacedDialer covers the other half: the superseded handler
+// has to be woken at all. Without this it stays parked on <-dialer.Done() until
+// its half-open socket happens to die.
+func TestStoreClosesDisplacedDialer(t *testing.T) {
+	c := NewConnManager()
+	key := EdgeConnKey("kubernetesclusters", "1ngen6o0so3jwz2h", "minis")
+
+	old := newTestDialer(t)
+	c.Store(key, old)
+	if old.IsClosed() {
+		t.Fatal("dialer closed before it was displaced")
+	}
+
+	fresh := newTestDialer(t)
+	c.Store(key, fresh)
+
+	select {
+	case <-old.Done():
+	default:
+		t.Fatal("displaced dialer was not closed; its handler stays parked on Done()")
+	}
+	if fresh.IsClosed() {
+		t.Fatal("Store closed the dialer it was asked to store")
+	}
+}
+
+// TestStoreSameDialerTwiceIsNotSelfClosing guards the degenerate case: a
+// re-Store of the identical dialer must not close the entry it is storing.
+func TestStoreSameDialerTwiceIsNotSelfClosing(t *testing.T) {
+	c := NewConnManager()
+	key := EdgeConnKey("linuxservers", "1ngen6o0so3jwz2h", "minis-server")
+
+	d := newTestDialer(t)
+	c.Store(key, d)
+	c.Store(key, d)
+
+	if d.IsClosed() {
+		t.Fatal("re-storing the same dialer closed it")
+	}
+	if _, ok := c.LoadLocal(key); !ok {
+		t.Fatal("re-storing the same dialer dropped the entry")
+	}
+}
+
+// TestDeleteIfRemovesOwnEntry is the ordinary path: a genuine disconnect with
+// no replacement still cleans up, otherwise stale entries would accumulate and
+// edgeproxy would dial dead tunnels.
+func TestDeleteIfRemovesOwnEntry(t *testing.T) {
+	c := NewConnManager()
+	key := EdgeConnKey("kubernetesclusters", "1ngen6o0so3jwz2h", "home")
+
+	d := newTestDialer(t)
+	c.Store(key, d)
+
+	if !c.DeleteIf(key, d) {
+		t.Fatal("owner's DeleteIf did not delete its own entry")
+	}
+	if _, ok := c.LoadLocal(key); ok {
+		t.Fatal("entry survived its owner's DeleteIf")
+	}
+	if c.DeleteIf(key, d) {
+		t.Fatal("second DeleteIf reported a delete for an already-removed key")
+	}
+}


### PR DESCRIPTION
An agent that reconnects can end up connected but unroutable, permanently.

## The race

Tunnel keys are stable across reconnects (`{resource}/{cluster}/{name}`), and the close path deleted unconditionally:

```go
<-dialer.Done()
cancelHeartbeat()
p.edgeConnManager.Delete(key)   // whose entry?
```

When an agent reconnects — pod restart, chart upgrade, network blip — the new tunnel registers under the **same key** while the superseded handler is still parked on `<-dialer.Done()`. That handler then wakes and deletes the entry the *new* tunnel owns.

## Why it doesn't heal

It's silent from both ends. The hub answers `no active tunnel found for edge`; the agent's socket is genuinely fine, so it sees no error and never reconnects to repair things. Only the sweeper's `IsClosed` check or an agent restart clears it.

## Three parts

**`DeleteIf` replaces `Delete`.** Remove the entry only when it is still the dialer we own, so a late cleanup cannot touch a live registration.

**`Store` closes the dialer it displaces.** The superseded handler then wakes immediately rather than whenever its half-open socket happens to die — without this the race window is however long that takes.

**The disconnect marker re-checks for a live tunnel before writing.** A disconnect immediately followed by a reconnect could otherwise land after the new tunnel's `markEdgeConnected` and flap the edge to `Disconnected`. `LifecycleReconciler` repairs that on its next pass, but not before the UI and CLI have shown a connected edge as down.

## Tests

Both orderings — a superseded handler leaving a newer tunnel alone, and a handler still owning its entry deleting it — plus `Store` closing a displaced dialer and *not* closing itself when the same dialer is stored twice.

Verified the identity check is load-bearing rather than decorative: removing it makes `TestDeleteIfKeepsTunnelThatSupersededUs` fail.

`go build`, the `internal/tunnel` suite, and `make lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)