### PR TITLE
Clean up sidebar account controls

### DIFF
--- a/portal/src/components/AccountAccessMenu.vue
+++ b/portal/src/components/AccountAccessMenu.vue
@@ -26,6 +26,7 @@ import {
   Pin,
   Plug,
   Settings,
+  ShieldAlert,
   Sun,
   Terminal,
   UserRound,
@@ -35,13 +36,14 @@ import { useThemeStore, type ThemeMode } from '@/stores/theme'
 
 interface Props {
   expanded?: boolean
-  time: string
+  showPlatformAdmin?: boolean
   showUndock?: boolean
   undockLabel?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   expanded: false,
+  showPlatformAdmin: false,
   showUndock: false,
   undockLabel: 'Undock',
 })
@@ -70,7 +72,8 @@ const panelId = useId()
 const email = computed(() => auth.user?.email?.trim() || 'Authenticated user')
 const mcpActive = computed(() => route.path === '/mcp' || route.path.startsWith('/mcp/'))
 const settingsActive = computed(() => route.path === '/tenant' || route.path.startsWith('/tenant/'))
-const contextRouteActive = computed(() => mcpActive.value || settingsActive.value)
+const adminActive = computed(() => route.path === '/bonkers' || route.path.startsWith('/bonkers/'))
+const contextRouteActive = computed(() => mcpActive.value || settingsActive.value || adminActive.value)
 const initials = computed(() => {
   const value = email.value === 'Authenticated user' ? '' : email.value
   const parts = value.split(/[@.\s_-]+/).filter(Boolean)
@@ -337,7 +340,6 @@ onBeforeUnmount(() => {
         </span>
         <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
       </button>
-
       <div class="my-1 h-px bg-border-subtle" />
 
       <div class="px-2 py-1.5">
@@ -359,23 +361,6 @@ onBeforeUnmount(() => {
         <span class="flex-1">MCP Access</span>
         <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
       </router-link>
-
-      <div class="my-1 h-px bg-border-subtle" />
-
-      <div class="px-2 py-1.5">
-        <span class="k-eyebrow">Session</span>
-      </div>
-      <div class="flex items-start gap-2 px-2 py-1.5">
-        <UserRound class="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
-        <div class="min-w-0 flex-1">
-          <span class="block text-[10px] text-text-muted">Authenticated as</span>
-          <span class="block truncate font-mono text-[11px] text-text-secondary">{{ email }}</span>
-        </div>
-        <div class="shrink-0 text-right">
-          <span class="block text-[10px] text-text-muted">Local time</span>
-          <span class="block font-mono text-[11px] tabular-nums text-text-secondary">{{ time }}</span>
-        </div>
-      </div>
 
       <div class="my-1 h-px bg-border-subtle" />
 
@@ -408,6 +393,18 @@ onBeforeUnmount(() => {
       >
         <Settings class="h-3.5 w-3.5 shrink-0 text-text-secondary" :stroke-width="1.75" aria-hidden="true" />
         <span class="flex-1">Settings</span>
+        <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
+      </router-link>
+      <router-link
+        v-if="showPlatformAdmin"
+        to="/bonkers"
+        class="k-menu-item"
+        :class="adminActive ? 'is-selected' : ''"
+        :aria-current="adminActive ? 'page' : undefined"
+        @click="closeMenu()"
+      >
+        <ShieldAlert class="h-3.5 w-3.5 shrink-0 text-text-secondary" :stroke-width="1.75" aria-hidden="true" />
+        <span class="flex-1">Platform admin</span>
         <ChevronDown class="h-3 w-3 -rotate-90 text-text-muted" :stroke-width="1.75" aria-hidden="true" />
       </router-link>
       <button v-if="showUndock" type="button" class="k-menu-item" @click="emitAndClose('undock')">

--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -10,7 +10,7 @@ import UserProfileModal from '@/components/UserProfileModal.vue'
 import TenantContextChip from '@/components/TenantContextChip.vue'
 import AccountAccessMenu from '@/components/AccountAccessMenu.vue'
 import FirstWorkspaceWizard from '@/components/FirstWorkspaceWizard.vue'
-import { Hexagon, LayoutDashboard, Zap, GripHorizontal, GripVertical, Puzzle, Dot, ShieldAlert, PanelLeftClose, PanelLeftOpen, ChevronDown } from 'lucide-vue-next'
+import { Hexagon, LayoutDashboard, Zap, GripHorizontal, GripVertical, Puzzle, Dot, PanelLeftClose, PanelLeftOpen, ChevronDown } from 'lucide-vue-next'
 import { useProvidersStore } from '@/stores/providers'
 import { useAdminStore } from '@/stores/admin'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
@@ -21,7 +21,7 @@ const providersStore = useProvidersStore()
 const tenantStore = useTenantStore()
 const adminStore = useAdminStore()
 
-// Probe platform-admin access once so the sidebar can show the /bonkers entry
+// Probe platform-admin access once so the account menu can show the /bonkers entry
 // only to allowlisted identities. Non-admins get a single quiet 403 and the
 // menu item stays hidden.
 onMounted(() => { void adminStore.checkAccess() })
@@ -79,19 +79,6 @@ const slotClass = computed(() => [
   // out and manage their own width.
   layoutProps.fullBleed ? 'h-full min-h-0' : 'mx-auto w-full max-w-5xl',
 ])
-
-const now = ref(new Date())
-let timer: ReturnType<typeof setInterval>
-
-onMounted(() => {
-  timer = setInterval(() => { now.value = new Date() }, 1000)
-})
-onUnmounted(() => clearInterval(timer))
-
-const pad = (n: number) => String(n).padStart(2, '0')
-const timeStr = computed(() =>
-  `${pad(now.value.getHours())}:${pad(now.value.getMinutes())}:${pad(now.value.getSeconds())}`
-)
 
 interface NavItem {
   label: string
@@ -635,24 +622,11 @@ watchEffect(() => {
 
       <div class="mx-2 my-2 h-px bg-border-default/50" />
 
-      <!-- Platform admin (/bonkers): only rendered for allowlisted identities
-           (adminStore.isAdmin, set by the access probe on mount). -->
-      <router-link
-        v-if="adminStore.isAdmin"
-        to="/bonkers"
-        class="flex items-center gap-2.5 rounded-xl px-3 py-2 text-[11px] font-medium transition-all duration-200"
-        :class="[isActive('/bonkers') ? 'bg-accent/15 text-accent shadow-[0_0_14px_var(--color-accent-glow)]' : 'text-text-muted hover:bg-surface-overlay/50 hover:text-text-secondary', sidebarExpanded ? '' : 'justify-center']"
-        :title="sidebarExpanded ? undefined : 'Platform admin'"
-      >
-        <ShieldAlert class="h-4 w-4 flex-shrink-0" :stroke-width="1.75" />
-        <span v-if="sidebarExpanded">Platform admin</span>
-      </router-link>
-
-      <!-- Situational tools and session controls live behind one stable
+      <!-- Situational tools and account controls live behind one stable
            account affordance so the provider tree keeps the vertical space. -->
       <AccountAccessMenu
         :expanded="sidebarExpanded"
-        :time="timeStr"
+        :show-platform-admin="adminStore.isAdmin === true"
         show-undock
         @cli="showCliModal = true"
         @profile="showProfileModal = true"
@@ -742,7 +716,7 @@ watchEffect(() => {
         {{ auth.clusterName }}
       </span>
       <AccountAccessMenu
-        :time="timeStr"
+        :show-platform-admin="adminStore.isAdmin === true"
         show-undock
         @cli="showCliModal = true"
         @profile="showProfileModal = true"
@@ -860,7 +834,7 @@ watchEffect(() => {
           {{ auth.clusterName }}
         </span>
         <AccountAccessMenu
-          :time="timeStr"
+          :show-platform-admin="adminStore.isAdmin === true"
           :show-undock="hasCustomPos && !isDragging"
           undock-label="Reset position"
           @cli="showCliModal = true"

--- a/portal/src/components/TenantContextChip.vue
+++ b/portal/src/components/TenantContextChip.vue
@@ -17,8 +17,7 @@ limitations under the License.
 <!--
 Compact org/workspace context chip. Renders the current selection as a
 single clickable button; clicking opens a popover with two small
-dropdowns for switching and a footer link to the full /tenant settings
-page.
+dropdowns for switching and a workspace kubeconfig download.
 
 Shown in the sidebar (vertical mode) above the static nav and in the
 horizontal/floating dock between the logo and nav. Sized to be
@@ -32,7 +31,7 @@ unobtrusive — the goal is "where am I" awareness, not management.
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useTenantStore } from '@/stores/tenant'
-import { Building2, FolderTree, ChevronDown, Settings, AlertCircle, Download, Loader2 } from 'lucide-vue-next'
+import { Building2, FolderTree, ChevronDown, AlertCircle, Download, Loader2 } from 'lucide-vue-next'
 
 defineProps<{ variant?: 'sidebar' | 'horizontal' }>()
 
@@ -273,14 +272,6 @@ onUnmounted(() => {
           </select>
         </div>
 
-        <router-link
-          to="/tenant"
-          class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted transition-colors hover:bg-surface-overlay/60 hover:text-accent"
-          @click="open = false"
-        >
-          <Settings class="h-3 w-3" :stroke-width="2" />
-          Manage tenants
-        </router-link>
       </div>
     </Transition>
     </Teleport>

--- a/portal/src/stores/admin.ts
+++ b/portal/src/stores/admin.ts
@@ -60,7 +60,7 @@ export const useAdminStore = defineStore('admin', () => {
   const forbidden = ref(false)
   const error = ref<string | null>(null)
   // isAdmin: null = not checked yet, true/false after checkAccess. Drives the
-  // sidebar menu item + the /bonkers route guard so non-admins never load the
+  // account menu item + the /bonkers route guard so non-admins never load the
   // page (which would 403 on its data fetches).
   const isAdmin = ref<boolean | null>(null)
 


### PR DESCRIPTION
## Summary
- remove Manage tenants from the tenant context popover
- move the admin-only Platform admin destination into the account menu below Settings
- remove the redundant Session identity and clock section

## Verification
- npm run build (portal)
- rendered browser assertions for tenant and account popovers
- git diff --check