### PR TITLE
Standardize route-owned create flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync-portalkit verify-portalkit verify-ui-conformance test-portal-settings-conformance build-portal
+.PHONY: sync-portalkit verify-portalkit verify-ui-conformance test-portal-settings-conformance test-create-flow-conformance build-portal
 .PHONY: build-access-proxy docker-build-access-proxy
 .PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-build-dev-agent load-dev-agent-image docker-build-universal-dev-image load-universal-dev-image docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery kuery-db-up kuery-db-down install-provider-kuery init-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart init-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-app-studio-provider build-app-studio-provider-portal codegen-app-studio-provider app-studio-preview-console-dev-key verify-app-studio-preview-console-dev-key verify-app-studio-eval app-studio-db-up app-studio-db-down run-provider-app-studio install-provider-app-studio init-provider-app-studio uninstall-provider-app-studio build-agents-provider build-agents-provider-portal codegen-agents-provider agents-db-up agents-db-down run-provider-agents install-provider-agents init-provider-agents uninstall-provider-agents build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code build-databricks-provider build-databricks-provider-portal codegen-databricks-provider run-provider-databricks install-provider-databricks init-provider-databricks uninstall-provider-databricks test-databricks-provider-chart dev-kro-up dev-kro-down dev-kro-seed e2e-infrastructure e2e-provider e2e-provider-flags e2e-provider-all
 
@@ -370,7 +370,10 @@ verify-portalkit: ## Verify vendored portalkit copies are in sync with the canon
 test-portal-settings-conformance: ## Verify organization/workspace settings source contracts
 	@node --test portal/src/pages/OrganizationsWorkspace.conformance.test.mjs
 
-verify-ui-conformance: test-portal-settings-conformance ## Verify provider UI source uses the canonical k-* design vocabulary
+test-create-flow-conformance: ## Verify route-owned creation uses the canonical page skeleton
+	@node --test hack/create-flow-conformance.test.mjs
+
+verify-ui-conformance: test-portal-settings-conformance test-create-flow-conformance ## Verify provider UI source uses the canonical k-* design vocabulary
 	@node hack/verify-ui-conformance.test.mjs
 	@node hack/verify-ui-conformance.mjs
 

--- a/docs/design-book.md
+++ b/docs/design-book.md
@@ -493,6 +493,36 @@ title hierarchy. They are adoption examples, not a universal field schema.
 The canonical Vue sources live under `provider-sdk/portalkit-vue`; edit them
 there and run `make sync-portalkit` to update provider copies.
 
+### Resource creation
+
+Use a focused, route-owned flow when creating an independently managed resource
+or when creation requires prerequisites, sensitive input, multiple meaningful
+decisions, or follow-up progress.
+
+Use a dialog, drawer, or inline control for compact additions whose meaning
+depends on the current parent. Do not insert substantial creation forms into
+collection pages where they reflow or compete with the collection.
+
+Choose the surface based on the user's task—not field count, API shape, or
+implementation convenience. Use the operation's truthful domain verb, such as
+**Connect**, **Provision**, or **Deploy**.
+
+Use readable, provider-owned creation routes. Avoid collisions between action
+routes and valid resource identifiers; prefer `/create/<resource-type>` when
+existing detail routes use `/<collection>/:name`.
+
+Route-owned creation uses one back action, one page title and description, one
+principal form surface, and a right-aligned **Cancel → primary action** footer.
+Simple forms are constrained; dense provisioning forms may use the full content
+column. Wizards keep this page skeleton and place progress inside it rather than
+retaining dialog chrome.
+
+After creation, navigate to the resource when it owns status or recovery;
+otherwise return to the collection with the result clearly visible.
+
+This is the target standard. Existing creation flows will adopt it
+incrementally.
+
 ### Select / combobox
 - Closed control: exactly `.k-input` (4px, overlay bg, focus ring + glow) with
   a 3.5px chevron in `text-muted`. Native `<select>` popups cannot be styled —
@@ -673,6 +703,10 @@ Before merging any UI change:
 - [ ] Works in BOTH themes (toggle it — don't trust the default).
 - [ ] Uses `k-*` / portalkit primitives instead of re-derived markup.
 - [ ] No per-page `max-w-*` wrapper (width is owned by `AppLayout`).
+- [ ] The creation surface matches the task: focused and route-owned for
+      independently managed resources; contextual for compact, parent-dependent
+      additions. Route-owned flows use the canonical creation skeleton, and
+      substantial forms do not reflow collection pages.
 - [ ] Mono for identifiers; tabular-nums for aligned digits.
 - [ ] Icons are Lucide (or portalkit `ic()`) per §11 — no emoji, no Unicode
       glyph icons; stroke/size on the law; only status icons carry color.

--- a/hack/create-flow-conformance.test.mjs
+++ b/hack/create-flow-conformance.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const root = new URL('../', import.meta.url)
+
+async function source(path) {
+  return readFile(new URL(path, root), 'utf8')
+}
+
+function expectSkeleton(name, text, { wide = false } = {}) {
+  for (const className of [
+    'k-create-page',
+    'k-back-action',
+    'k-create-header',
+    'k-create-title',
+    'k-create-description',
+    'k-create-surface',
+    'k-create-actions',
+  ]) {
+    assert.match(text, new RegExp(className), `${name} is missing ${className}`)
+  }
+  if (wide) assert.match(text, /k-create-surface--wide/, `${name} should use the wide provisioning surface`)
+  assert.match(text, /Cancel[\s\S]*k-btn--primary/, `${name} must order Cancel before its primary action`)
+}
+
+test('the canonical create-page vocabulary defines one shared hierarchy', async () => {
+  const css = await source('provider-sdk/portalkit/faros-ui.css')
+  for (const selector of [
+    '.k-create-page',
+    '.k-create-header',
+    '.k-create-title',
+    '.k-create-description',
+    '.k-create-surface',
+    '.k-create-surface--wide',
+    '.k-create-body',
+    '.k-create-actions',
+  ]) {
+    assert.match(css, new RegExp(selector.replace('.', '\\.')))
+  }
+  assert.match(css, /\.k-create-surface\s*\{[\s\S]*max-width: 42rem/)
+  assert.match(css, /\.k-create-surface\s*\{[\s\S]*overflow: clip/)
+  assert.match(css, /\.k-create-actions\s*\{[\s\S]*justify-content: flex-end/)
+  assert.match(css, /@media \(max-width: 620px\)[\s\S]*\.k-create-actions\s*\{[\s\S]*position: sticky/)
+})
+
+test('Vue route-owned create flows use the shared skeleton', async () => {
+  const cases = [
+    ['MCP', ['portal/src/pages/MCPPage.vue'], false],
+    ['Code connection', ['providers/code/portal/src/views/ConnectionCreateView.vue'], false],
+    ['Code repository', ['providers/code/portal/src/views/RepositoryCreateView.vue'], false],
+    ['Databricks connection', ['providers/databricks/portal/src/views/CreateConnectionView.vue'], false],
+    ['Databricks warehouse', ['providers/databricks/portal/src/views/CreateWarehouseView.vue'], false],
+    ['Databricks table', ['providers/databricks/portal/src/views/CreateTableView.vue'], true],
+    ['Databricks import', ['providers/databricks/portal/src/ResourceImportWizard.vue'], true],
+    ['Edges service', ['providers/edges/portal/src/ServiceCreate.vue'], true],
+    ['Edges workload', ['providers/edges/portal/src/WorkloadCreate.vue'], true],
+    ['Infrastructure provision', ['providers/infrastructure/portal/src/views/ProvisionPage.vue'], true],
+    ['App Studio model', ['providers/app-studio/portal/src/App.vue', 'providers/app-studio/portal/src/ModelsSettings.vue'], true],
+  ]
+  for (const [name, paths, wide] of cases) {
+    expectSkeleton(name, (await Promise.all(paths.map(source))).join('\n'), { wide })
+  }
+})
+
+test('Agents route-owned create flows use the shared skeleton while dialogs remain contextual', async () => {
+  const cases = [
+    ['agent', 'providers/agents/portal/src/views/agent-create.ts'],
+    ['connection', 'providers/agents/portal/src/views/connections.ts'],
+    ['assisted search', 'providers/agents/portal/src/views/assisted-search.ts'],
+    ['model', 'providers/agents/portal/src/views/models.ts'],
+    ['toolset', 'providers/agents/portal/src/views/toolsets.ts'],
+  ]
+  for (const [name, path] of cases) {
+    const text = await source(path)
+    expectSkeleton(`Agents ${name}`, text)
+  }
+  const [agent, assistedSearch] = await Promise.all([
+    source('providers/agents/portal/src/views/agent-create.ts'),
+    source('providers/agents/portal/src/views/assisted-search.ts'),
+  ])
+  assert.match(agent, /agents-dialog/)
+  assert.match(assistedSearch, /agents-dialog/)
+})
+
+test('App Studio removes collection tabs and nested settings chrome from model creation', async () => {
+  const [app, settings] = await Promise.all([
+    source('providers/app-studio/portal/src/App.vue'),
+    source('providers/app-studio/portal/src/ModelsSettings.vue'),
+  ])
+  assert.match(app, /<Tabs[\s\S]*v-if="!isCreateModelRoute"/)
+  assert.match(app, /v-if="!publishingInWorkbench && !historyInWorkbench && !isCreateModelRoute"/)
+  assert.match(settings, /v-if="!creationRoute" class="flex flex-wrap items-start/)
+})
+
+test('route-owned Databricks import removes modal close chrome', async () => {
+  const wizard = await source('providers/databricks/portal/src/ResourceImportWizard.vue')
+  assert.match(wizard, /v-if="!props\.routeOwned" class="import-head"/)
+  assert.match(wizard, /v-if="props\.routeOwned" class="k-btn k-btn--ghost k-back-action"/)
+})

--- a/portal/src/assets/faros-ui.css
+++ b/portal/src/assets/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/portal/src/components/DashboardTile.vue
+++ b/portal/src/components/DashboardTile.vue
@@ -176,10 +176,12 @@ function pushContext() {
 }
 
 function onNavigate(e: Event) {
-  const ce = e as CustomEvent<{ path: string }>
+  const ce = e as CustomEvent<{ path: string; replace?: boolean }>
   const p = ce.detail?.path
   if (typeof p !== 'string') return
-  router.push(`/providers/${props.provider.name}/${p.replace(/^\//, '')}`)
+  const target = `/providers/${props.provider.name}/${p.replace(/^\//, '')}`
+  if (ce.detail.replace === true) void router.replace(target)
+  else void router.push(target)
 }
 
 onMounted(() => mountRef.value?.addEventListener('faros-navigate', onNavigate))

--- a/portal/src/components/ProviderNavigation.conformance.test.mjs
+++ b/portal/src/components/ProviderNavigation.conformance.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const frame = fs.readFileSync(new URL('../pages/ProviderFrame.vue', import.meta.url), 'utf8')
+const tile = fs.readFileSync(new URL('./DashboardTile.vue', import.meta.url), 'utf8')
+
+test('provider host consumers honor replace navigation while preserving push by default', () => {
+  for (const source of [frame, tile]) {
+    assert.match(source, /CustomEvent<\{ path: string; replace\?: boolean \}>/)
+    assert.match(source, /if \(ce\.detail\.replace === true\) void router\.replace\(target\)/)
+    assert.match(source, /else void router\.push\(target\)/)
+  }
+})

--- a/portal/src/pages/MCPPage.conformance.test.mjs
+++ b/portal/src/pages/MCPPage.conformance.test.mjs
@@ -11,7 +11,7 @@ test('MCP detail keeps the canonical borderless backlink before its resource pag
   const hover = css.match(/\.k-back-action:hover\s*\{([^}]*)\}/s)?.[1] ?? ''
   const focus = css.match(/\.k-back-action:focus-visible\s*\{([^}]*)\}/s)?.[1] ?? ''
   const active = css.match(/\.k-back-action:active\s*\{([^}]*)\}/s)?.[1] ?? ''
-  const detailStart = page.indexOf('<template v-else>')
+  const detailStart = page.indexOf('<template v-if="!isCreate && selected">')
   const backStart = page.indexOf('<a', detailStart)
   const resourceStart = page.indexOf('<ResourcePage', detailStart)
 
@@ -45,6 +45,10 @@ test('MCP detail keeps the canonical borderless backlink before its resource pag
 })
 
 test('MCP detail keeps the shared resource composition and deep-link contract', () => {
+  assert.match(router, /path: '\/mcp'/)
+  assert.match(router, /name: 'mcp'/)
+  assert.match(router, /path: '\/create\/mcp-server'/)
+  assert.match(router, /name: 'mcp-create'/)
   assert.match(router, /path: '\/mcp\/:name'/)
   assert.match(router, /name: 'mcp-detail'/)
   assert.match(page, /<a[\s\S]*href="\/ui\/mcp"/)
@@ -55,6 +59,27 @@ test('MCP detail keeps the shared resource composition and deep-link contract', 
   assert.match(page, /<ResourceSectionCard/)
   assert.match(page, /<StatusBadge/)
   assert.match(page, /<ResourceTableDeleteButton/)
+})
+
+test('MCP creation is route-owned and replaces the form entry on exit', () => {
+  assert.match(page, /const isCreate = computed\(\(\) => route\.name === 'mcp-create'\)/)
+  assert.match(page, /@click="openCreate"/)
+  assert.match(page, /router\.push\(\{ name: 'mcp-create' \}\)/)
+  assert.match(page, /function cancelCreate\(\)/)
+  assert.match(page, /router\.replace\(\{ name: 'mcp' \}\)/)
+  assert.match(page, /<form[\s\S]*@submit\.prevent="create"/)
+  assert.match(page, /await router\.replace\(\{ name: 'mcp-detail', params: \{ name: createdName \} \}\)/)
+  assert.doesNotMatch(page, /showCreate/)
+})
+
+test('MCP creation fences stale route sessions and preserves its collection instance', () => {
+  assert.match(page, /let createSessionGeneration = 0/)
+  assert.match(page, /createSessionGeneration \+= 1/)
+  assert.match(page, /const sessionGeneration = createSessionGeneration/)
+  assert.match(page, /sessionGeneration === createSessionGeneration/)
+  assert.match(page, /if \(!currentSession\(\)\) return/)
+  assert.match(page, /v-show="!isCreate && !selected" data-mcp-route-surface="collection"/)
+  assert.match(page, /v-show="isCreate" class="k-create-page" data-mcp-route-surface="create"/)
 })
 
 test('MCP connect snippets stay masked and selectors expose state', () => {
@@ -119,8 +144,8 @@ test('MCP reads preserve snapshots and expose recoverable failures', () => {
 })
 
 test('MCP delete failures remain visible from both list and detail views', () => {
-  const listStart = page.indexOf('<template v-if="!selected">')
-  const detailStart = page.indexOf('<template v-else>', listStart)
+  const listStart = page.indexOf('data-mcp-route-surface="collection"')
+  const detailStart = page.indexOf('<template v-if="!isCreate && selected">', listStart)
   assert.notEqual(listStart, -1)
   assert.notEqual(detailStart, -1)
 

--- a/portal/src/pages/MCPPage.vue
+++ b/portal/src/pages/MCPPage.vue
@@ -20,9 +20,10 @@ CRD (distributed to tenant workspaces via the core.faros.sh APIExport), and the
 in-core reconciler provisions each server's identity. A workspace can have many
 servers — e.g. a read-only "audit" endpoint and a full-access "ops" one.
 
-List view: a table of servers with create/delete. Detail view: per-server
-connect snippets plus the live federated-provider tool inventory (stamped on
-status.federatedProviders by the reconciler using that server's own identity).
+List view: a table of servers with delete. Creation is a focused, route-owned
+form at /create/mcp-server. Detail view: per-server connect snippets plus the
+live federated-provider tool inventory (stamped on status.federatedProviders by
+the reconciler using that server's own identity).
 -->
 
 <script setup lang="ts">
@@ -105,6 +106,7 @@ const selected = computed<string | null>(() => {
   const name = route.params.name
   return typeof name === 'string' && name.length > 0 ? name : null
 })
+const isCreate = computed(() => route.name === 'mcp-create')
 const selectedServer = computed(() => servers.value.find((s) => s.name === selected.value) ?? null)
 const selectedResourceMissing = computed(() => Boolean(selected.value && loaded.value && !selectedServer.value))
 
@@ -199,9 +201,41 @@ const statCards = computed<ResourceStatCard[]>(() => [
   },
 ])
 
-const showCreate = ref(false)
-const draft = ref({ name: '', displayName: '', instructions: '', readOnly: false })
+const emptyDraft = () => ({ name: '', displayName: '', instructions: '', readOnly: false })
+const draft = ref(emptyDraft())
 const busy = ref(false)
+let createSessionGeneration = 0
+
+function resetDraft() {
+  draft.value = emptyDraft()
+}
+
+function openCreate() {
+  resetDraft()
+  mutationError.value = null
+  void router.push({ name: 'mcp-create' })
+}
+
+function cancelCreate() {
+  resetDraft()
+  mutationError.value = null
+  void router.replace({ name: 'mcp' })
+}
+
+watch(isCreate, (creating, wasCreating) => {
+  // Each visit owns a distinct async session. Leaving and re-entering the same
+  // route must not let an older POST reset the new draft or redirect it.
+  createSessionGeneration += 1
+  busy.value = false
+  if (creating && !wasCreating) {
+    resetDraft()
+    mutationError.value = null
+  } else if (!creating && wasCreating) {
+    // Creation failures belong to the form. Do not carry one into the
+    // collection after browser-back or another route transition.
+    mutationError.value = null
+  }
+}, { immediate: true })
 
 const copiedField = ref<string | null>(null)
 async function copy(text: string, field: string) {
@@ -262,6 +296,8 @@ watch([orgUUID, workspaceUUID], () => {
   // cached token from the previous tenant to survive a context switch.
   listRequestID += 1
   connectRequestID += 1
+  createSessionGeneration += 1
+  busy.value = false
   connect.value = {}
   connectError.value = null
   // The list is a tenant-owned snapshot too. Drop it before the replacement
@@ -317,23 +353,49 @@ async function loadConnect(name: string) {
 
 async function create() {
   const b = base()
-  if (!b || !draft.value.name.trim()) return
+  const name = draft.value.name.trim()
+  if (!b) {
+    if (isCreate.value) mutationError.value = 'Select an organization and workspace to create an MCP server.'
+    return
+  }
+  if (!name || busy.value || !isCreate.value) return
+  const identity = tenantIdentity()
+  const sessionGeneration = createSessionGeneration
+  const currentSession = () => (
+    sessionGeneration === createSessionGeneration &&
+    identity === tenantIdentity() &&
+    isCreate.value
+  )
   busy.value = true
+  mutationError.value = null
   try {
     const res = await authFetch(b, {
       tenant: true,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(draft.value),
+      body: JSON.stringify({ ...draft.value, name }),
     })
     if (!res.ok) throw new Error(`Create failed (${res.status})`)
-    showCreate.value = false
-    draft.value = { name: '', displayName: '', instructions: '', readOnly: false }
+
+    // The API returns the accepted resource name. Fall back to the trimmed
+    // draft for compatible deployments that return an empty 201 response.
+    let createdName = name
+    try {
+      const body = (await res.json()) as { name?: unknown }
+      if (typeof body.name === 'string' && body.name.trim()) createdName = body.name.trim()
+    } catch {
+      // A successful create is still actionable when the response has no JSON.
+    }
+    if (!currentSession()) return
+
+    resetDraft()
     await load()
+    if (!currentSession()) return
+    await router.replace({ name: 'mcp-detail', params: { name: createdName } })
   } catch (e) {
-    error.value = (e as Error).message
+    if (currentSession()) mutationError.value = (e as Error).message
   } finally {
-    busy.value = false
+    if (sessionGeneration === createSessionGeneration) busy.value = false
   }
 }
 
@@ -455,8 +517,59 @@ function rel(ts?: string): string {
 <template>
   <AppLayout>
     <div>
+      <!-- ─── CREATE VIEW ────────────────────────────────────────────── -->
+      <section v-show="isCreate" class="k-create-page" data-mcp-route-surface="create">
+        <a
+          class="k-btn k-btn--ghost k-back-action"
+          href="/ui/mcp"
+          @click.prevent="cancelCreate"
+        >
+          <ArrowLeft :size="14" aria-hidden="true" />
+          MCP Access
+        </a>
+
+        <header class="k-create-header">
+          <h1 id="mcp-create-title" class="k-create-title">Create MCP server</h1>
+          <p class="k-create-description">Create a named endpoint for this workspace's tools.</p>
+        </header>
+
+        <section class="k-create-surface" aria-labelledby="mcp-create-title">
+          <form class="grid gap-3" @submit.prevent="create">
+            <div class="k-create-body">
+            <label class="grid gap-1">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">Name</span>
+              <input v-model="draft.name" autofocus placeholder="ops" class="k-input font-mono text-[12px]" />
+            </label>
+            <label class="grid gap-1">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">Display name</span>
+              <input v-model="draft.displayName" placeholder="Ops endpoint" class="k-input text-[12px]" />
+            </label>
+            <label class="grid gap-1">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">Instructions (optional)</span>
+              <textarea v-model="draft.instructions" rows="2" placeholder="This is production — ask before destructive operations." class="k-input text-[12px]" />
+            </label>
+            <label class="flex items-center gap-2 text-[12px] text-text-secondary">
+              <input v-model="draft.readOnly" type="checkbox" class="k-checkbox" /> Read-only
+            </label>
+
+            <div v-if="mutationError" class="flex items-center gap-3 rounded-md border border-danger/30 bg-danger/5 p-3 text-[12px] text-danger" role="alert" aria-live="assertive">
+              <span class="min-w-0 flex-1">{{ mutationError }}</span>
+              <button type="button" class="k-btn k-btn--ghost shrink-0 px-2 py-1 text-danger" @click="mutationError = null">Dismiss</button>
+            </div>
+            </div>
+
+            <div class="k-create-actions">
+              <button type="button" class="k-btn k-btn--ghost px-3 py-2 text-[12px]" :disabled="busy" @click="cancelCreate">Cancel</button>
+              <button type="submit" class="k-btn k-btn--primary px-3 py-2 text-[12px]" :disabled="busy || !draft.name.trim()">
+                {{ busy ? 'Creating…' : 'Create server' }}
+              </button>
+            </div>
+          </form>
+        </section>
+      </section>
+
       <!-- ─── LIST VIEW ─────────────────────────────────────────────── -->
-      <template v-if="!selected">
+      <section v-show="!isCreate && !selected" data-mcp-route-surface="collection">
         <div class="mb-6 flex items-center justify-between">
           <div class="flex items-center gap-3">
             <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-accent/10 text-accent">
@@ -470,36 +583,11 @@ function rel(ts?: string): string {
           <button
             type="button"
             class="k-btn k-btn--primary px-3 py-2 text-[12px]"
-            @click="showCreate = !showCreate"
+            @click="openCreate"
           >
             <Plus class="h-3.5 w-3.5" :stroke-width="2" /> New server
           </button>
         </div>
-
-        <!-- Create form -->
-        <section v-if="showCreate" class="mb-5 rounded-xl border border-border-subtle bg-surface-raised p-4">
-          <div class="grid gap-3">
-            <label class="grid gap-1">
-              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">Name</span>
-              <input v-model="draft.name" placeholder="ops" class="k-input font-mono text-[12px]" />
-            </label>
-            <label class="grid gap-1">
-              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">Display name</span>
-              <input v-model="draft.displayName" placeholder="Ops endpoint" class="k-input text-[12px]" />
-            </label>
-            <label class="grid gap-1">
-              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">Instructions (optional)</span>
-              <textarea v-model="draft.instructions" rows="2" placeholder="This is production — ask before destructive operations." class="k-input text-[12px]" />
-            </label>
-            <label class="flex items-center gap-2 text-[12px] text-text-secondary">
-              <input v-model="draft.readOnly" type="checkbox" class="k-checkbox" /> Read-only
-            </label>
-            <div class="flex justify-end gap-2">
-              <button type="button" class="k-btn k-btn--ghost px-3 py-2 text-[12px]" @click="showCreate = false">Cancel</button>
-              <button type="button" class="k-btn k-btn--primary px-3 py-2 text-[12px]" :disabled="busy || !draft.name.trim()" @click="create">Create</button>
-            </div>
-          </div>
-        </section>
 
         <div v-if="mutationError" class="mb-5 flex items-center gap-3 rounded-md border border-danger/30 bg-danger/5 p-3 text-[12px] text-danger" role="alert" aria-live="assertive">
           <span class="min-w-0 flex-1">{{ mutationError }}</span>
@@ -553,10 +641,10 @@ function rel(ts?: string): string {
             </div>
           </template>
         </ResourceTable>
-      </template>
+      </section>
 
       <!-- ─── DETAIL VIEW ───────────────────────────────────────────── -->
-      <template v-else>
+      <template v-if="!isCreate && selected">
         <a
           class="k-btn k-btn--ghost k-back-action"
           href="/ui/mcp"

--- a/portal/src/pages/ProviderFrame.vue
+++ b/portal/src/pages/ProviderFrame.vue
@@ -43,6 +43,7 @@ const tagFor = (name: string) => `faros-provider-${name}`
 
 const APP_STUDIO_CREATE_ROUTE = '~new'
 const APP_STUDIO_MODELS_ROUTE = '~models'
+const APP_STUDIO_CREATE_MODEL_ROUTE = 'create/model'
 
 onMounted(() => {
   if (!providers.loaded || providers.catalogOrgUUID !== tenant.orgUUID) {
@@ -57,10 +58,10 @@ const catalogSettled = computed(() =>
 const catalogError = computed(() => providers.error)
 const catalogLoading = computed(() => !catalogError.value && !catalogSettled.value)
 const catalogMissing = computed(() => catalogSettled.value && !entry.value)
-const providerRouteSegment = computed(() => props.subPath.split('/').filter(Boolean)[0] ?? '')
+const providerRoutePath = computed(() => props.subPath.split('/').filter(Boolean).join('/'))
 const isAppStudioLandingRoute = computed(() =>
   props.providerName === 'app-studio' &&
-  ['', APP_STUDIO_CREATE_ROUTE, APP_STUDIO_MODELS_ROUTE].includes(providerRouteSegment.value),
+  ['', APP_STUDIO_CREATE_ROUTE, APP_STUDIO_MODELS_ROUTE, APP_STUDIO_CREATE_MODEL_ROUTE].includes(providerRoutePath.value),
 )
 const isFullBleedProvider = computed(() =>
   props.providerName === 'app-studio' &&
@@ -128,7 +129,7 @@ const accessAllowed = computed(() =>
 )
 
 watch(
-  () => [props.providerName, providerRouteSegment.value] as const,
+  () => [props.providerName, providerRoutePath.value] as const,
   () => { providerFullBleedOverride.value = null },
   { flush: 'sync' },
 )
@@ -344,10 +345,12 @@ function pushContext() {
 
 // Bubble faros-navigate CustomEvents up into Vue Router.
 function onNavigate(e: Event) {
-  const ce = e as CustomEvent<{ path: string }>
+  const ce = e as CustomEvent<{ path: string; replace?: boolean }>
   const p = ce.detail?.path
   if (typeof p !== 'string' || !entry.value) return
-  router.push(`/providers/${entry.value.name}/${p.replace(/^\//, '')}`)
+  const target = `/providers/${entry.value.name}/${p.replace(/^\//, '')}`
+  if (ce.detail.replace === true) void router.replace(target)
+  else void router.push(target)
 }
 
 function onLayoutChange(e: Event) {

--- a/portal/src/portalkit/faros-ui.css
+++ b/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/portal/src/router/index.ts
+++ b/portal/src/router/index.ts
@@ -68,6 +68,11 @@ const routes = [
     component: () => import('@/pages/MCPPage.vue'),
   },
   {
+    path: '/create/mcp-server',
+    name: 'mcp-create',
+    component: () => import('@/pages/MCPPage.vue'),
+  },
+  {
     path: '/mcp/:name',
     name: 'mcp-detail',
     component: () => import('@/pages/MCPPage.vue'),

--- a/provider-sdk/portalkit/faros-ui.css
+++ b/provider-sdk/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/agents/portal/src/api.ts
+++ b/providers/agents/portal/src/api.ts
@@ -65,6 +65,18 @@ export interface RunFilter {
   limit?: number
 }
 
+// ContextAuthority is the security boundary for a mounted provider. The
+// workspace selects the data scope; userKey and token select the caller that
+// is allowed to read it. A token rotation for the same known user still
+// requires a fresh client/store, but does not require throwing away the
+// user's route.
+export interface ContextAuthority {
+  usable: boolean
+  tenantKey: string
+  userKey: string | null
+  token: string | null
+}
+
 // ApiError carries the HTTP status alongside the message so callers can tell a
 // 404 (agent gone) from a 502 (upstream) without string-matching.
 export class ApiError extends Error {
@@ -93,11 +105,16 @@ export class ApiClient {
     return serviceBase(this.ctx?.basePath || '/ui/providers/agents') + path
   }
 
-  tenant(): Tenant {
+  tenant(context: FarosContext | null = this.ctx): Tenant {
     const stored = readTenant()
+    // A host-supplied tenant is authoritative even when it explicitly clears
+    // one or both fields. Falling back through null here could keep using a
+    // stale localStorage workspace after the host has made the context
+    // unusable.
+    const hasContextTenant = !!context && ('orgUUID' in context || 'workspaceUUID' in context)
     return {
-      orgUUID: this.ctx?.orgUUID ?? stored.orgUUID,
-      workspaceUUID: this.ctx?.workspaceUUID ?? stored.workspaceUUID,
+      orgUUID: hasContextTenant ? context?.orgUUID ?? null : stored.orgUUID,
+      workspaceUUID: hasContextTenant ? context?.workspaceUUID ?? null : stored.workspaceUUID,
     }
   }
 
@@ -107,9 +124,21 @@ export class ApiClient {
   }
 
   // tenantKey identifies the current workspace for change-detection (load dedupe).
-  tenantKey(): string {
-    const t = this.tenant()
+  tenantKey(context: FarosContext | null = this.ctx): string {
+    const t = this.tenant(context)
     return `${t.orgUUID || ''}/${t.workspaceUUID || ''}`
+  }
+
+  contextAuthority(context: FarosContext | null = this.ctx): ContextAuthority {
+    const tenant = this.tenant(context)
+    const user = context?.user as { sub?: unknown; userId?: unknown; email?: unknown } | null | undefined
+    const userKey = [user?.sub, user?.userId, user?.email].find((value): value is string => typeof value === 'string' && value.length > 0) || null
+    return {
+      usable: !!context?.basePath && !!tenant.orgUUID && !!tenant.workspaceUUID,
+      tenantKey: this.tenantKey(context),
+      userKey,
+      token: context?.token ?? null,
+    }
   }
 
   private headers(hasBody: boolean): Record<string, string> {
@@ -117,7 +146,9 @@ export class ApiClient {
     // Host context wins over the localStorage copy portalkit read.
     const t = this.tenant()
     if (t.orgUUID) h['X-Faros-Org'] = t.orgUUID
+    else delete h['X-Faros-Org']
     if (t.workspaceUUID) h['X-Faros-Workspace'] = t.workspaceUUID
+    else delete h['X-Faros-Workspace']
     return h
   }
 

--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -15,16 +15,19 @@
 
 import { html, nothing, type TemplateResult } from 'lit'
 import { state } from 'lit/decorators.js'
-import { ApiClient } from './api'
+import { keyed } from 'lit/directives/keyed.js'
+import type { DirectiveResult } from 'lit/directive.js'
+import { ApiClient, type ContextAuthority } from './api'
 import { AppStore } from './store'
 import { LightElement } from './ui/base'
 import { icon, type IconName } from './ui/icon'
 import { clearToasts } from './ui/toast'
 import { tabClass, tabCountClass, tabsClass } from './portalkit/tabs'
-import type { FarosContext } from './types'
-import { DEFAULT_ROUTE, MENUS, activeMenu, parseHash, syncHash, type MenuKey, type Route } from './router'
+import type { Agent, Connection, Credential, FarosContext, Toolset } from './types'
+import { DEFAULT_ROUTE, MENUS, activeMenu, hashFor, parseHash, syncHash, writeHash, type CreateSuccessDetail, type MenuKey, type Route } from './router'
 
 import './views/agents-list'
+import './views/agent-create'
 import './views/agent-detail'
 import './views/activity'
 import './views/run-detail'
@@ -45,49 +48,130 @@ export class AgentsElement extends LightElement {
   private api = new ApiClient()
   private store = new AppStore(this.api)
   private loadedTenant: string | null = null
+  private authority: ContextAuthority | null = null
+  // Every API/store rotation gets a new route generation. Keying the active
+  // route surface on this value makes authority changes remount stateful views
+  // (chat transcripts, config hydration, model probes) instead of rebinding a
+  // live child to the new store in place.
+  private authorityGeneration = 0
+  // Incremented whenever a create surface is replaced or its authority is
+  // rotated. Route-owned children receive this marker, so a success from a
+  // detached/superseded form cannot be adopted by a later create session.
+  private createSession = 0
 
   set farosContext(v: FarosContext | null) {
+    const previous = this.authority
+    const next = this.api.contextAuthority(v)
     this.ctx = v
+    const changed = previous !== null && (
+      previous.usable !== next.usable ||
+      previous.tenantKey !== next.tenantKey ||
+      previous.userKey !== next.userKey ||
+      previous.token !== next.token
+    )
+
+    if (!next.usable) {
+      if (changed || this.loadedTenant !== null || this.store.live) {
+        this.rotateContext(v, true)
+      } else {
+        this.api.setContext(v)
+        this.authority = next
+        this.requestUpdate()
+      }
+      return
+    }
+
+    if (changed) {
+      this.rotateContext(v, this.shouldResetRoute(previous, next))
+      return
+    }
+
     this.api.setContext(v)
+    this.authority = next
     this.maybeLoad()
+    this.requestUpdate()
   }
   get farosContext(): FarosContext | null {
     return this.ctx
   }
 
   private onHashChange = (): void => {
-    this.route = parseHash()
+    this.restoreRoute()
+  }
+  private onPopState = (): void => {
+    this.restoreRoute()
+  }
+  private restoreRoute(): void {
+    const next = parseHash()
+    this.advanceCreateSession(this.route, next)
+    this.route = next
+    // Keep malformed/legacy external hashes from leaving the shell rendered on
+    // one route while the URL names another. Valid hashes are unchanged, so
+    // this remains a no-op for ordinary back/forward traversal.
+    syncHash(this.route)
+    this.requestUpdate()
   }
   private onStoreChange = (): void => this.requestUpdate()
   private onNavigate = (e: Event): void => {
-    this.go((e as CustomEvent<Route>).detail)
+    if (!this.eventBelongsToCurrentStore(e)) return
+    const next = (e as CustomEvent<Route>).detail
+    // A create session owns one history entry. Picker/type/assisted subroutes
+    // replace that entry so browser Back exits to the owning collection.
+    const replaceCreateEntry = this.route.kind === 'create' && next.kind === 'create'
+    this.go(next, replaceCreateEntry ? 'replace' : 'push')
+  }
+  private onCreateSuccess = (e: Event): void => {
+    if (!this.eventBelongsToCurrentStore(e) || !this.eventBelongsToActiveCreateSession(e)) return
+    const detail = (e as CustomEvent<CreateSuccessDetail>).detail
+    if (!detail || this.route.kind !== 'create' || detail.resource !== this.route.resource) return
+    this.adoptCreateResult(detail)
+    this.go(detail.destination || this.createSuccessRoute(detail), 'replace')
+  }
+  private onCreateCancel = (e: Event): void => {
+    if (!this.eventBelongsToCurrentStore(e) || !this.eventBelongsToActiveCreateSession(e)) return
+    if (this.route.kind !== 'create') return
+    this.go(this.createOwnerRoute(this.route), 'replace')
   }
 
   connectedCallback(): void {
     super.connectedCallback()
-    this.route = parseHash()
+    const next = parseHash()
+    this.advanceCreateSession(this.route, next)
+    this.route = next
+    // Canonicalize an unknown or legacy hash once on entry. Ordinary route
+    // changes use pushState below and are never rewritten during render.
+    syncHash(this.route)
     window.addEventListener('hashchange', this.onHashChange)
+    window.addEventListener('popstate', this.onPopState)
     this.addEventListener('agents-navigate', this.onNavigate)
+    this.addEventListener('agents-create-success', this.onCreateSuccess)
+    this.addEventListener('agents-cancel', this.onCreateCancel)
     this.store.addEventListener('change', this.onStoreChange)
     this.maybeLoad()
   }
 
   disconnectedCallback(): void {
     window.removeEventListener('hashchange', this.onHashChange)
+    window.removeEventListener('popstate', this.onPopState)
     this.removeEventListener('agents-navigate', this.onNavigate)
+    this.removeEventListener('agents-create-success', this.onCreateSuccess)
+    this.removeEventListener('agents-cancel', this.onCreateCancel)
     this.store.removeEventListener('change', this.onStoreChange)
     this.store.disconnect()
     super.disconnectedCallback()
   }
 
-  private go(r: Route): void {
+  private go(r: Route, mode: 'push' | 'replace' = 'push'): void {
+    this.advanceCreateSession(this.route, r)
     this.route = r
-    syncHash(r)
+    writeHash(r, mode)
+    this.requestUpdate()
   }
 
   private maybeLoad(): void {
-    if (!this.ctx?.basePath || !this.api.hasWorkspace()) return
-    const key = this.api.tenantKey()
+    const authority = this.authority || this.api.contextAuthority()
+    if (!authority.usable) return
+    const key = authority.tenantKey
     if (key === this.loadedTenant) return
     // Switching tenants (not the first load) resets to the Agents tab so we
     // never show a stale agent from another workspace. On first load we keep
@@ -95,7 +179,7 @@ export class AgentsElement extends LightElement {
     // the components themselves — no manual reset choreography needed.
     if (this.loadedTenant !== null) {
       clearToasts()
-      this.go(DEFAULT_ROUTE)
+      this.go(DEFAULT_ROUTE, 'replace')
     }
     this.loadedTenant = key
     // A fresh store drops every slice, so views can't render another
@@ -109,23 +193,72 @@ export class AgentsElement extends LightElement {
     this.requestUpdate()
   }
 
+  private rotateContext(v: FarosContext | null, resetRoute: boolean): void {
+    this.store.removeEventListener('change', this.onStoreChange)
+    this.store.disconnect()
+    this.authorityGeneration += 1
+    this.createSession += 1
+
+    const nextApi = new ApiClient()
+    nextApi.setContext(v)
+    this.api = nextApi
+    this.store = new AppStore(nextApi)
+    this.store.addEventListener('change', this.onStoreChange)
+    this.loadedTenant = null
+    this.authority = nextApi.contextAuthority()
+    clearToasts()
+    if (resetRoute) this.go(DEFAULT_ROUTE, 'replace')
+    this.maybeLoad()
+    this.requestUpdate()
+  }
+
+  private shouldResetRoute(previous: ContextAuthority | null, next: ContextAuthority): boolean {
+    if (!previous?.usable || previous.tenantKey !== next.tenantKey) return true
+    // A route can only safely survive a token refresh when both contexts name
+    // the same known subject. If either side omits a subject, treat the change
+    // as a caller change rather than risk showing the prior caller's detail.
+    return !(previous.userKey && next.userKey && previous.userKey === next.userKey)
+  }
+
+  private eventBelongsToCurrentStore(e: Event): boolean {
+    const source = e.target as { store?: AppStore } | null
+    return !source?.store || source.store === this.store
+  }
+
+  private eventBelongsToActiveCreateSession(e: Event): boolean {
+    // Assisted connection setup is rendered below the route-owned connection
+    // surface, so its event target does not carry the marker itself. Walk up
+    // the light-DOM parent chain to find the route-owned child. This also
+    // rejects a detached child that emits after a same-tick route transition.
+    let source = e.target as (Node & { createSession?: number }) | null
+    while (source) {
+      if (typeof source.createSession === 'number') return source.createSession === this.createSession
+      source = source.parentNode as (Node & { createSession?: number }) | null
+    }
+    return false
+  }
+
+  private advanceCreateSession(previous: Route, next: Route): void {
+    if (hashFor(previous) === hashFor(next)) return
+    if (previous.kind === 'create' || next.kind === 'create') this.createSession += 1
+  }
+
   render(): TemplateResult {
     if (!this.ctx) return html`<div class="k-card agents-empty"><p class="muted" role="status">Connecting…</p></div>`
-    if (!this.api.hasWorkspace()) {
+    if (!this.authority?.usable) {
       return html`<div class="k-card agents-empty">
         <p class="muted" role="status">Select an organization and workspace in the sidebar to use your agents.</p>
       </div>`
     }
-    syncHash(this.route)
     return html`
       <div class="agents-app">
         ${this.renderNav()}
-        <div class="agents-view">${this.renderRoute()}</div>
+        <div class="agents-view">${keyed(this.authorityGeneration, this.renderRoute())}</div>
       </div>
     `
   }
 
-  private renderRoute(): TemplateResult {
+  private renderRoute(): TemplateResult | DirectiveResult {
     const bind = { store: this.store, api: this.api }
     switch (this.route.kind) {
       case 'agent':
@@ -137,6 +270,8 @@ export class AgentsElement extends LightElement {
         ></agents-agent-detail>`
       case 'run':
         return html`<agents-run-detail .store=${bind.store} .api=${bind.api} .runID=${this.route.id}></agents-run-detail>`
+      case 'create':
+        return this.renderCreateRoute(this.route)
       default:
         switch (this.route.menu) {
           case 'agents':
@@ -144,10 +279,87 @@ export class AgentsElement extends LightElement {
           case 'activity':
             return html`<agents-activity .store=${bind.store} .api=${bind.api}></agents-activity>`
           case 'connections':
-            return html`<agents-connections .store=${bind.store} .api=${bind.api}></agents-connections>`
+            return html`<agents-connections .store=${bind.store} .api=${bind.api} .routeOwned=${true}></agents-connections>`
           case 'models':
-            return html`<agents-models .store=${bind.store} .api=${bind.api}></agents-models>`
+            return html`<agents-models .store=${bind.store} .api=${bind.api} .routeOwned=${true}></agents-models>`
         }
+    }
+  }
+
+  private renderCreateRoute(route: Extract<Route, { kind: 'create' }>): TemplateResult | DirectiveResult {
+    const bind = { store: this.store, api: this.api }
+    // A context rotation can leave an in-flight mutation on the old create
+    // child. Keying the route-owned surface forces Lit to detach that child
+    // when the session changes instead of overwriting its store/session
+    // properties in place. Late events from the detached child cannot bubble;
+    // events delivered before the replacement render still fail the marker
+    // checks above.
+    const render = (view: TemplateResult): TemplateResult | DirectiveResult => keyed(this.createSession, view)
+    switch (route.resource) {
+      case 'agent':
+        return render(html`<agents-agent-create .createSession=${this.createSession} .store=${bind.store} .api=${bind.api} .routeOwned=${true}></agents-agent-create>`)
+      case 'connection':
+        return render(html`<agents-connections
+          .createSession=${this.createSession}
+          .store=${bind.store}
+          .api=${bind.api}
+          .routeOwned=${true}
+          .createRoute=${true}
+          .createType=${route.type || ''}
+        ></agents-connections>`)
+      case 'toolset':
+        return render(html`<agents-toolsets
+          .createSession=${this.createSession}
+          .store=${bind.store}
+          .api=${bind.api}
+          .routeOwned=${true}
+          .createRoute=${true}
+        ></agents-toolsets>`)
+      case 'model':
+        return render(html`<agents-models .createSession=${this.createSession} .store=${bind.store} .api=${bind.api} .routeOwned=${true} .createRoute=${true}></agents-models>`)
+    }
+  }
+
+  private createOwnerRoute(route: Extract<Route, { kind: 'create' }>): Route {
+    if (route.resource === 'model') return { kind: 'menu', menu: 'models' }
+    if (route.resource === 'connection' || route.resource === 'toolset') return { kind: 'menu', menu: 'connections' }
+    return { kind: 'menu', menu: 'agents' }
+  }
+
+  private createSuccessRoute(detail: CreateSuccessDetail): Route {
+    if (detail.resource === 'agent' && detail.name) return { kind: 'agent', name: detail.name, tab: 'config' }
+    if (detail.resource === 'model') return { kind: 'menu', menu: 'models' }
+    if (detail.resource === 'connection' || detail.resource === 'toolset') return { kind: 'menu', menu: 'connections' }
+    return { kind: 'menu', menu: 'agents' }
+  }
+
+  private adoptCreateResult(detail: CreateSuccessDetail): void {
+    if (!detail.item) return
+    switch (detail.resource) {
+      case 'agent': {
+        const item = detail.item as Agent
+        if (!item.metadata?.name) return
+        this.store.adopt('agents', item)
+        break
+      }
+      case 'connection': {
+        const item = detail.item as Connection
+        if (!item.metadata?.name) return
+        this.store.adopt('connections', item)
+        break
+      }
+      case 'toolset': {
+        const item = detail.item as Toolset
+        if (!item.metadata?.name) return
+        this.store.adopt('toolsets', item)
+        break
+      }
+      case 'model': {
+        const item = detail.item as Credential
+        if (!item.name) return
+        this.store.adopt('credentials', item)
+        break
+      }
     }
   }
 

--- a/providers/agents/portal/src/portalkit/faros-ui.css
+++ b/providers/agents/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/agents/portal/src/router.ts
+++ b/providers/agents/portal/src/router.ts
@@ -1,8 +1,7 @@
 // Hash routing for the embedded micro-frontend. The element has no server
 // routes of its own, so navigation state lives in location.hash (never sent to
-// the host). The shell mirrors the current Route to the hash on every render via
-// replaceState (which does NOT fire hashchange → no loop) and restores it on
-// load and on browser back/forward.
+// the host). The shell mirrors user navigation to the hash with pushState and
+// restores routes on load, host hash assignments, and browser back/forward.
 //
 // Scheme:
 //   #/agents                          Agents grid (default)
@@ -10,9 +9,13 @@
 //   #/activity                        run feed + approvals
 //   #/activity/<runID>                run trace
 //   #/connections #/models
+//   #/create/agent
+//   #/create/connection[/<type>]
+//   #/create/toolset #/create/model
 
 export type MenuKey = 'agents' | 'activity' | 'connections' | 'models'
 export type AgentTab = 'config' | 'runs'
+export type CreateResource = 'agent' | 'connection' | 'toolset' | 'model'
 
 export const MENUS: MenuKey[] = ['agents', 'activity', 'connections', 'models']
 const AGENT_TABS: AgentTab[] = ['config', 'runs']
@@ -21,6 +24,17 @@ export type Route =
   | { kind: 'menu'; menu: MenuKey }
   | { kind: 'agent'; name: string; tab: AgentTab }
   | { kind: 'run'; id: string }
+  | { kind: 'create'; resource: CreateResource; type?: string }
+
+// Create surfaces send this event after their API write succeeds. Keeping the
+// result on the event lets the shell make it immediately visible in the owning
+// collection while its authoritative reload is still in flight.
+export interface CreateSuccessDetail {
+  resource: CreateResource
+  name?: string
+  item?: unknown
+  destination?: Route
+}
 
 export const DEFAULT_ROUTE: Route = { kind: 'menu', menu: 'agents' }
 
@@ -30,11 +44,17 @@ export const DEFAULT_ROUTE: Route = { kind: 'menu', menu: 'agents' }
 export function parseHash(hash = location.hash): Route {
   const parts = hash.replace(/^#\/?/, '').split('/').filter(Boolean)
   const [head, second, third] = parts
-  if ((head === 'agents' || head === 'agent') && second) {
-    return { kind: 'agent', name: decodeURIComponent(second), tab: normalizeTab(third) }
+  if (head === 'create') {
+    if (second === 'agent' || second === 'toolset' || second === 'model') return { kind: 'create', resource: second }
+    if (second === 'connection') {
+      return { kind: 'create', resource: 'connection', ...(third ? { type: decodePart(third) } : {}) }
+    }
   }
-  if (head === 'activity' && second) return { kind: 'run', id: decodeURIComponent(second) }
-  if (head === 'runs' && second) return { kind: 'run', id: decodeURIComponent(second) }
+  if ((head === 'agents' || head === 'agent') && second) {
+    return { kind: 'agent', name: decodePart(second), tab: normalizeTab(third) }
+  }
+  if (head === 'activity' && second) return { kind: 'run', id: decodePart(second) }
+  if (head === 'runs' && second) return { kind: 'run', id: decodePart(second) }
   if ((MENUS as string[]).includes(head)) return { kind: 'menu', menu: head as MenuKey }
   // Legacy tabs fold into their absorbing surface.
   if (head === 'inbox' || head === 'runs') return { kind: 'menu', menu: 'activity' }
@@ -49,21 +69,36 @@ export function hashFor(route: Route): string {
       return `#/agents/${encodeURIComponent(route.name)}/${route.tab}`
     case 'run':
       return `#/activity/${encodeURIComponent(route.id)}`
+    case 'create':
+      return `#/create/${route.resource}${route.type ? `/${encodeURIComponent(route.type)}` : ''}`
     default:
       return `#/${route.menu}`
   }
 }
 
-// syncHash mirrors the route to the URL without triggering a hashchange event.
-export function syncHash(route: Route): void {
+export type HashHistoryMode = 'push' | 'replace'
+
+// writeHash mirrors the route to the URL. pushState deliberately does not fire
+// hashchange, so the caller updates its in-memory route at the same time;
+// popstate and hashchange listeners in the shell cover browser traversal and
+// host-side hash assignments respectively.
+export function writeHash(route: Route, mode: HashHistoryMode = 'push'): void {
   const h = hashFor(route)
   if (location.hash !== h) {
     try {
-      history.replaceState(null, '', h)
+      if (mode === 'replace') history.replaceState(null, '', h)
+      else history.pushState(null, '', h)
     } catch {
-      /* sandboxed history — the route just won't survive a refresh */
+      // Sandboxed history — assignment still gives the host a usable route.
+      location.hash = h
     }
   }
+}
+
+// syncHash is retained for callers that need to canonicalize an initial or
+// externally supplied hash without adding a history entry.
+export function syncHash(route: Route): void {
+  writeHash(route, 'replace')
 }
 
 // activeMenu is which nav tab lights up for a route (detail pages keep their
@@ -71,7 +106,21 @@ export function syncHash(route: Route): void {
 export function activeMenu(route: Route): MenuKey {
   if (route.kind === 'agent') return 'agents'
   if (route.kind === 'run') return 'activity'
+  if (route.kind === 'create') {
+    if (route.resource === 'model') return 'models'
+    if (route.resource === 'connection' || route.resource === 'toolset') return 'connections'
+    return 'agents'
+  }
   return route.menu
+}
+
+function decodePart(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    // A malformed external hash should not break the entire embedded portal.
+    return value
+  }
 }
 
 function normalizeTab(t: string | undefined): AgentTab {

--- a/providers/agents/portal/src/store.ts
+++ b/providers/agents/portal/src/store.ts
@@ -32,6 +32,29 @@ function slice<T>(initial: T): Slice<T> {
 
 export type SliceKey = 'agents' | 'connections' | 'toolsets' | 'schedules' | 'triggers' | 'credentials' | 'inbox'
 
+// These are the collections whose create response is returned to the shell
+// before the next list response necessarily includes it. The other slices do
+// not have a create-result adoption path, so keeping this mapping explicit
+// prevents an arbitrary list item from being treated as locally authoritative.
+export interface CreateCollectionItems {
+  agents: Agent
+  connections: Connection
+  toolsets: Toolset
+  credentials: Credential
+}
+
+export type CreateCollectionKey = keyof CreateCollectionItems
+
+interface AdoptedItem {
+  // A list request captures the collection generation when it starts. An item
+  // with a newer generation must survive that request's response if the
+  // response does not contain it.
+  generation: number
+  item: unknown
+}
+
+const CREATE_COLLECTION_KEYS: CreateCollectionKey[] = ['agents', 'connections', 'toolsets', 'credentials']
+
 // ServerEvent mirrors one /api/events push. `run` and `inbox` carry an id;
 // `schedule` and `trigger` (a background job fired) carry the source's name and
 // the run it started.
@@ -75,10 +98,26 @@ export class AppStore extends EventTarget {
   private api: ApiClient
   private abort: AbortController | null = null
   private poll: ReturnType<typeof setInterval> | null = null
+  private collectionGenerations: Record<CreateCollectionKey, number> = {
+    agents: 0,
+    connections: 0,
+    toolsets: 0,
+    credentials: 0,
+  }
+  private adoptedItems: Record<CreateCollectionKey, Map<string, AdoptedItem>> = {
+    agents: new Map(),
+    connections: new Map(),
+    toolsets: new Map(),
+    credentials: new Map(),
+  }
+  private nextLoadID = 0
+  private latestLoadID: Partial<Record<SliceKey, number>> = {}
+  private pendingLoads: Partial<Record<CreateCollectionKey, Map<number, number>>> = {}
 
   constructor(api: ApiClient) {
     super()
     this.api = api
+    for (const key of CREATE_COLLECTION_KEYS) this.pendingLoads[key] = new Map()
   }
 
   private changed(): void {
@@ -180,18 +219,84 @@ export class AppStore extends EventTarget {
   async load(key: SliceKey): Promise<void> {
     if (!this.api.hasWorkspace()) return
     const s = this[key] as Slice<unknown[]>
+    const loadID = ++this.nextLoadID
+    const requestGeneration = this.collectionGeneration(key)
+    this.latestLoadID[key] = loadID
+    this.pendingLoads[key as CreateCollectionKey]?.set(loadID, requestGeneration)
     s.loading = true
     this.changed()
     try {
-      s.data = await LOADERS[key](this.api)
-      s.error = null
-      s.hasSnapshot = true
+      const rows = await LOADERS[key](this.api)
+      // A refresh started before a successful create may return a snapshot
+      // that cannot contain the newly-created item yet. Only the latest load
+      // may replace the slice; when that load predates an adoption, merge the
+      // adopted item back in. This keeps refreshes authoritative for every
+      // other row instead of suppressing the reload altogether.
+      if (this.latestLoadID[key] === loadID) {
+        s.data = this.mergeLoadedRows(key, rows, requestGeneration)
+        s.error = null
+        s.hasSnapshot = true
+      }
     } catch (e) {
-      s.error = (e as Error).message
+      // Preserve the error from the most recent request. An older failed
+      // request must not hide a newer successful refresh (or vice versa).
+      if (this.latestLoadID[key] === loadID) s.error = (e as Error).message
+    } finally {
+      this.pendingLoads[key as CreateCollectionKey]?.delete(loadID)
+      this.pruneAdoptedItems(key)
+      if (this.latestLoadID[key] === loadID) {
+        s.loading = false
+        s.loaded = true
+      }
+      this.changed()
     }
-    s.loading = false
-    s.loaded = true
+  }
+
+  // adopt inserts the server's successful create result immediately, while
+  // recording which collection generation produced it. A list request that
+  // began at an older generation merges this item into its otherwise
+  // authoritative response instead of deleting it from the UI.
+  adopt<K extends CreateCollectionKey>(key: K, item: CreateCollectionItems[K]): void {
+    const id = createCollectionItemID(key, item)
+    if (!id) return
+
+    const generation = this.collectionGenerations[key] + 1
+    this.collectionGenerations[key] = generation
+    this.adoptedItems[key].set(id, { generation, item })
+
+    const s = this[key] as Slice<Array<CreateCollectionItems[K]>>
+    s.data = [...s.data.filter((existing) => createCollectionItemID(key, existing) !== id), item]
+    s.hasSnapshot = true
     this.changed()
+  }
+
+  private collectionGeneration(key: SliceKey): number {
+    return isCreateCollectionKey(key) ? this.collectionGenerations[key] : 0
+  }
+
+  private mergeLoadedRows(key: SliceKey, rows: unknown[], requestGeneration: number): unknown[] {
+    if (!isCreateCollectionKey(key)) return rows
+    const newer = [...this.adoptedItems[key].entries()].filter(([, adopted]) => adopted.generation > requestGeneration)
+    if (!newer.length) return rows
+
+    const present = new Set(rows.map((row) => createCollectionItemID(key, row)).filter(Boolean))
+    const merged = [...rows]
+    for (const [id, adopted] of newer) {
+      if (!present.has(id)) merged.push(adopted.item)
+    }
+    return merged
+  }
+
+  private pruneAdoptedItems(key: SliceKey): void {
+    if (!isCreateCollectionKey(key)) return
+    const pending = this.pendingLoads[key]
+    for (const [id, adopted] of this.adoptedItems[key]) {
+      // Keep the marker until every request that predates the adoption has
+      // settled. Otherwise a newer response could observe the item and then
+      // an older in-flight response could still erase it.
+      const hasOlderPendingLoad = [...(pending?.values() || [])].some((generation) => generation < adopted.generation)
+      if (!hasOlderPendingLoad) this.adoptedItems[key].delete(id)
+    }
   }
 
   async loadOAuthApps(): Promise<void> {
@@ -285,6 +390,19 @@ export class AppStore extends EventTarget {
     this.dispatchEvent(new CustomEvent<ServerEvent>('server', { detail: ev }))
     this.changed()
   }
+}
+
+function isCreateCollectionKey(key: SliceKey): key is CreateCollectionKey {
+  return CREATE_COLLECTION_KEYS.includes(key as CreateCollectionKey)
+}
+
+function createCollectionItemID(key: CreateCollectionKey, item: unknown): string {
+  if (key === 'credentials') {
+    const name = (item as Credential | null | undefined)?.name
+    return typeof name === 'string' ? name : ''
+  }
+  const name = (item as { metadata?: { name?: unknown } } | null | undefined)?.metadata?.name
+  return typeof name === 'string' ? name : ''
 }
 
 const LOADERS: Record<SliceKey, (api: ApiClient) => Promise<unknown[]>> = {

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -27,6 +27,7 @@ faros-provider-agents .agents-app { display: flex; flex-direction: column; gap: 
 faros-provider-agents .agents-view { display: flex; flex-direction: column; gap: 18px; }
 faros-provider-agents .agents-empty { display: flex; align-items: center; justify-content: center; text-align: center; min-height: 340px; }
 faros-provider-agents .agents-menu { display: flex; flex-direction: column; gap: 18px; }
+faros-provider-agents .agents-create-page { display: flex; flex-direction: column; gap: 18px; width: 100%; }
 
 /* --- top nav -------------------------------------------------------------
    Layout and tab treatment live in the canonical PortalKit recipe. Keep the

--- a/providers/agents/portal/src/test/authority-races-all.test.ts
+++ b/providers/agents/portal/src/test/authority-races-all.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '../api'
+import type { AppStore } from '../store'
+import { agentFixture, makeStore, settle, stubApi } from './helpers'
+import '../views/agents-list'
+import '../views/agent-detail'
+import '../views/agent-chat'
+import '../views/automation'
+import '../views/connections'
+import '../views/models'
+import '../views/toolsets'
+
+type Mounted = HTMLElement & Record<string, any>
+
+function hostFor(store: AppStore, api: ApiClient): HTMLElement & { store: AppStore; api: ApiClient; route: any } {
+  const host = document.createElement('faros-provider-agents') as HTMLElement & { store: AppStore; api: ApiClient; route: any }
+  host.store = store
+  host.api = api
+  host.route = { kind: 'menu', menu: 'agents' }
+  document.body.appendChild(host)
+  return host
+}
+
+async function mountChild(tag: string, props: Record<string, unknown>, store: AppStore, api: ApiClient): Promise<{ host: ReturnType<typeof hostFor>; child: Mounted }> {
+  const host = hostFor(store, api)
+  const child = document.createElement(tag) as Mounted
+  Object.assign(child, { ...props, store, api })
+  host.appendChild(child)
+  await settle(child as any)
+  return { host, child }
+}
+
+async function confirmAfterRouteRotation(action: () => Promise<unknown>, host: ReturnType<typeof hostFor>): Promise<void> {
+  const pending = action()
+  const confirm = document.querySelector<HTMLButtonElement>('[data-k-modal-confirm]')
+  expect(confirm).not.toBeNull()
+  host.route = { kind: 'menu', menu: 'connections' }
+  confirm!.click()
+  await pending
+}
+
+const usage = {
+  windowDays: 30,
+  total: { key: 'total', runs: 0, errors: 0, inputTokens: 0, outputTokens: 0, usdMicros: 0, latencyP50MS: 0, latencyP95MS: 0 },
+  byAgent: [],
+  byModel: [],
+  series: [],
+}
+
+describe('all destructive Agents confirmations are authority-bound', () => {
+  it.each([
+    {
+      label: 'agent list',
+      tag: 'agents-agents-list',
+      props: {},
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteAgent = vi.fn().mockResolvedValue(undefined)
+        api.deleteAgent = deleteAgent as ApiClient['deleteAgent']
+        store.agents.data = [agentFixture('scout')]
+        store.agents.loaded = true
+        return deleteAgent
+      },
+      action: (child: Mounted) => child.del('scout'),
+    },
+    {
+      label: 'agent detail',
+      tag: 'agents-agent-detail',
+      props: { name: 'scout', tab: 'config' },
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteAgent = vi.fn().mockResolvedValue(undefined)
+        api.deleteAgent = deleteAgent as ApiClient['deleteAgent']
+        store.agents.data = [agentFixture('scout')]
+        store.agents.loaded = true
+        return deleteAgent
+      },
+      action: (child: Mounted) => child.del(),
+    },
+    {
+      label: 'chat session',
+      tag: 'agents-agent-chat',
+      props: { name: 'scout' },
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteSession = vi.fn().mockResolvedValue(undefined)
+        api.deleteSession = deleteSession as ApiClient['deleteSession']
+        store.agents.data = [agentFixture('scout')]
+        store.agents.loaded = true
+        return deleteSession
+      },
+      action: (child: Mounted) => {
+        child.sessionID = 'session-1'
+        return child.deleteSession()
+      },
+    },
+    {
+      label: 'schedule',
+      tag: 'agents-automation',
+      props: { kind: 'schedule', agent: 'scout' },
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteSchedule = vi.fn().mockResolvedValue(undefined)
+        api.deleteSchedule = deleteSchedule as ApiClient['deleteSchedule']
+        store.schedules.data = [{ metadata: { name: 'daily' }, spec: { agentRef: 'scout', type: 'cron' } }]
+        store.schedules.loaded = true
+        return deleteSchedule
+      },
+      action: (child: Mounted) => child.del('daily'),
+    },
+    {
+      label: 'connection',
+      tag: 'agents-connections',
+      props: { routeOwned: true },
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteConnection = vi.fn().mockResolvedValue(undefined)
+        api.deleteConnection = deleteConnection as ApiClient['deleteConnection']
+        store.connections.data = [{ metadata: { name: 'search' }, spec: { type: 'websearch' } }]
+        store.connections.loaded = true
+        return deleteConnection
+      },
+      action: (child: Mounted) => child.del('search'),
+    },
+    {
+      label: 'model credential',
+      tag: 'agents-models',
+      props: {},
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteCredential = vi.fn().mockResolvedValue(undefined)
+        api.deleteCredential = deleteCredential as ApiClient['deleteCredential']
+        api.catalog = () => Promise.resolve([])
+        api.usage = () => Promise.resolve(usage)
+        store.credentials.data = [{ name: 'openai', provider: 'openai-compatible', model: 'gpt-5' }]
+        store.credentials.loaded = true
+        return deleteCredential
+      },
+      action: (child: Mounted) => child.del('openai'),
+    },
+    {
+      label: 'toolset',
+      tag: 'agents-toolsets',
+      props: {},
+      setup: (store: AppStore, api: ApiClient) => {
+        const deleteToolset = vi.fn().mockResolvedValue(undefined)
+        api.deleteToolset = deleteToolset as ApiClient['deleteToolset']
+        store.toolsets.data = [{ metadata: { name: 'dev-tools' }, spec: { connections: [] } }]
+        store.toolsets.loaded = true
+        return deleteToolset
+      },
+      action: (child: Mounted) => child.del('dev-tools'),
+    },
+  ] as const)('$label rejects confirmation after route rotation', async ({ tag, props, setup, action }) => {
+    const api = stubApi()
+    const store = makeStore(api)
+    const deletion = setup(store, api)
+    const { host, child } = await mountChild(tag, props, store, api)
+    try {
+      await confirmAfterRouteRotation(() => action(child), host)
+      expect(deletion).not.toHaveBeenCalled()
+    } finally {
+      host.remove()
+    }
+  })
+})

--- a/providers/agents/portal/src/test/authority-races.test.ts
+++ b/providers/agents/portal/src/test/authority-races.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '../api'
+import { AgentsElement } from '../element'
+import { AppStore } from '../store'
+import type { Connection, FarosContext } from '../types'
+import '../views/agents-list'
+import '../views/connections'
+import { agentFixture, makeStore, mount, settle, stubApi } from './helpers'
+
+if (!customElements.get('faros-provider-agents')) customElements.define('faros-provider-agents', AgentsElement)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function connectionFixture(name: string): Connection {
+  return { metadata: { name }, spec: { type: 'websearch', config: { provider: 'searxng', instance: name } } }
+}
+
+function configureShellApi(api: ApiClient): void {
+  const empty = () => Promise.resolve([])
+  Object.assign(api, {
+    listAgents: empty,
+    listConnections: empty,
+    listToolsets: empty,
+    listSchedules: empty,
+    listTriggers: empty,
+    listCredentials: empty,
+    listInbox: empty,
+    listSessions: empty,
+    listMessages: empty,
+    listRuns: () => Promise.resolve({ items: [] }),
+    catalog: empty,
+    usage: () =>
+      Promise.resolve({
+        windowDays: 30,
+        total: { key: 'total', runs: 0, errors: 0, inputTokens: 0, outputTokens: 0, usdMicros: 0, latencyP50MS: 0, latencyP95MS: 0 },
+        byAgent: [],
+        byModel: [],
+        series: [],
+      }),
+    oauthProviders: () => Promise.resolve({ providers: {} }),
+    capabilities: () => Promise.resolve({ providers: [] }),
+    eventStream: async function* (signal: AbortSignal) {
+      await new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }))
+    },
+  })
+}
+
+describe('authority-sensitive confirmations', () => {
+  it('does not delete after a detached view confirms', async () => {
+    const deleteAgent = vi.fn().mockResolvedValue(undefined)
+    const api = stubApi({ deleteAgent })
+    const store = makeStore(api)
+    store.agents.data = [agentFixture('scout')]
+    store.agents.loaded = true
+    const el = await mount('agents-agents-list', { store, api })
+
+    el.querySelector<HTMLButtonElement>('button[aria-label="Delete agent scout"]')!.click()
+    const confirm = document.querySelector<HTMLButtonElement>('[data-k-modal-confirm]')
+    expect(confirm).not.toBeNull()
+
+    el.remove()
+    confirm!.click()
+    await Promise.resolve()
+
+    expect(deleteAgent).not.toHaveBeenCalled()
+  })
+
+  it('does not delete after the owning shell rotates token authority', async () => {
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    try {
+      history.replaceState(null, '', '#/connections')
+      const shell = document.createElement('faros-provider-agents') as AgentsElement
+      const api = (shell as unknown as { api: ApiClient }).api
+      configureShellApi(api)
+      shell.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-a',
+        user: { sub: 'alice' },
+      }
+      document.body.appendChild(shell)
+      await settle(shell)
+
+      const oldStore = (shell as unknown as { store: AppStore }).store
+      const deleteConnection = vi.fn().mockResolvedValue(undefined)
+      api.deleteConnection = deleteConnection as ApiClient['deleteConnection']
+      oldStore.connections.data = [connectionFixture('search')]
+      oldStore.connections.loaded = true
+      oldStore.dispatchEvent(new Event('change'))
+      await settle(shell)
+
+      const deleteButton = shell.querySelector<HTMLButtonElement>('button[aria-label="Delete search"]')
+      expect(deleteButton).not.toBeNull()
+      deleteButton!.click()
+      const confirm = document.querySelector<HTMLButtonElement>('[data-k-modal-confirm]')
+      expect(confirm).not.toBeNull()
+
+      // rotateContext swaps the shell's authority synchronously; the old
+      // child remains in light DOM until the next Lit update.
+      shell.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-b',
+        user: { sub: 'alice' },
+      } satisfies FarosContext
+      confirm!.click()
+      await Promise.resolve()
+
+      expect(deleteConnection).not.toHaveBeenCalled()
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+})
+
+describe('assisted-search authority capture', () => {
+  it('keeps the initial agent and form values while busy', async () => {
+    const create = deferred<Connection>()
+    const createConnection = vi.fn(() => create.promise)
+    const patchAgent = vi.fn().mockResolvedValue(agentFixture('scout'))
+    const api = stubApi({ createConnection, patchAgent })
+    const store = makeStore(api)
+    const agents = [agentFixture('scout'), agentFixture('rover')]
+    store.agents.data = agents
+    store.agents.loaded = true
+    store.capabilities.data = { providers: ['infrastructure'] }
+    store.capabilities.loaded = true
+    store.connections.loaded = true
+    const el = await mount('agents-connections', { store, api })
+    const routes: unknown[] = []
+    document.addEventListener('agents-navigate', (e) => routes.push((e as CustomEvent).detail), { once: true })
+
+    el.querySelector<HTMLButtonElement>('.agents-assist button')!.click()
+    await settle(el)
+    const form = el.querySelector<HTMLFormElement>('.agents-dialog')!
+    const agent = form.querySelector<HTMLSelectElement>('select')!
+    const conn = form.querySelector<HTMLInputElement>('input[name=connName]')!
+    const instance = form.querySelector<HTMLInputElement>('input[name=instance]')!
+    conn.value = 'search-old'
+    conn.dispatchEvent(new Event('input'))
+    instance.value = 'searxng-old'
+    instance.dispatchEvent(new Event('input'))
+    form.querySelector<HTMLButtonElement>('.agents-modebtn:nth-child(2)')!.click()
+    await settle(el)
+
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await Promise.resolve()
+    expect(createConnection).toHaveBeenCalledTimes(1)
+    expect(agent.disabled).toBe(true)
+    expect(conn.disabled).toBe(true)
+    expect(instance.disabled).toBe(true)
+    expect([...form.querySelectorAll<HTMLButtonElement>('.agents-modebtn')].every((button) => button.disabled)).toBe(true)
+
+    // Synthetic events model a queued/stale UI event; disabled controls also
+    // prevent real pointer/keyboard events in the browser.
+    agent.value = 'rover'
+    agent.dispatchEvent(new Event('change'))
+    conn.value = 'search-new'
+    conn.dispatchEvent(new Event('input'))
+    instance.value = 'searxng-new'
+    instance.dispatchEvent(new Event('input'))
+    form.querySelector<HTMLButtonElement>('.agents-modebtn:nth-child(3)')!.dispatchEvent(new MouseEvent('click'))
+
+    create.resolve(connectionFixture('search-old'))
+    await settle(el, 8)
+
+    expect(createConnection).toHaveBeenCalledWith({
+      type: 'websearch',
+      name: 'search-old',
+      config: { provider: 'searxng', instance: 'searxng-old' },
+    })
+    expect(patchAgent).toHaveBeenCalledTimes(1)
+    expect(patchAgent.mock.calls[0][0]).toBe('scout')
+    expect(patchAgent.mock.calls[0][1].interactiveConnections).toEqual(['search-old'])
+    expect(routes).toEqual([{ kind: 'agent', name: 'scout', tab: 'config' }])
+    expect(store.takePendingPrompt('scout')).toContain('name: `searxng-old`')
+    expect(store.takePendingPrompt('scout')).toBeNull()
+    expect(store.takePendingPrompt('rover')).toBeNull()
+  })
+})

--- a/providers/agents/portal/src/test/create-routes.test.ts
+++ b/providers/agents/portal/src/test/create-routes.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentCreateWizard } from '../views/agent-create'
+import type { Connections } from '../views/connections'
+import type { Models } from '../views/models'
+import type { Toolsets } from '../views/toolsets'
+import '../views/agent-create'
+import '../views/agents-list'
+import '../views/connections'
+import '../views/models'
+import '../views/toolsets'
+import { agentFixture, makeStore, mount, settle, stubApi } from './helpers'
+
+describe('route-owned creation surfaces', () => {
+  it('renders agent creation as a page and emits its result after the API succeeds', async () => {
+    const createAgent = vi.fn().mockResolvedValue({ metadata: { name: 'nova' }, spec: { displayName: 'nova' } })
+    const api = stubApi({ createAgent })
+    const store = makeStore(api)
+    store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+    const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api, routeOwned: true })
+    let result: unknown
+    el.addEventListener('agents-create-success', (e) => (result = (e as CustomEvent).detail))
+
+    expect(el.querySelector('.agents-overlay')).toBeNull()
+    expect(el.querySelector('.agents-create-page')).not.toBeNull()
+    el.querySelector<HTMLInputElement>('input[name=name]')!.value = 'nova'
+    el.querySelector<HTMLInputElement>('input[name=name]')!.dispatchEvent(new Event('input'))
+    const model = el.querySelector('select') as HTMLSelectElement
+    model.value = 'main'
+    model.dispatchEvent(new Event('change'))
+    el.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 5)
+
+    expect(createAgent).toHaveBeenCalledWith(expect.objectContaining({ name: 'nova', modelCredential: 'main' }))
+    expect(result).toEqual(expect.objectContaining({ resource: 'agent', name: 'nova', item: expect.anything() }))
+  })
+
+  it('keeps connection type selection and creation in hash-owned surfaces', async () => {
+    const createConnection = vi.fn().mockResolvedValue({ metadata: { name: 'gh' }, spec: { type: 'github' } })
+    const api = stubApi({ createConnection })
+    const store = makeStore(api)
+    store.connections.loaded = true
+    const picker = await mount<Connections>('agents-connections', { store, api, routeOwned: true, createRoute: true, createType: '' })
+    const routes: unknown[] = []
+    picker.addEventListener('agents-navigate', (e) => routes.push((e as CustomEvent).detail))
+    expect(picker.querySelector('.agents-conn-form')).toBeNull()
+    picker.querySelector<HTMLButtonElement>('.agents-conn-tile')!.click()
+    expect(routes).toEqual([{ kind: 'create', resource: 'connection', type: 'github' }])
+
+    const formSurface = await mount<Connections>('agents-connections', { store, api, routeOwned: true, createRoute: true, createType: 'github' })
+    expect(formSurface.querySelector('.agents-conn-form')).not.toBeNull()
+    const name = formSurface.querySelector<HTMLInputElement>('input[name=name]')!
+    name.value = 'gh'
+    const token = formSurface.querySelector<HTMLInputElement>('input[name=token]')!
+    token.value = 'secret'
+    formSurface.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(formSurface, 5)
+    expect(createConnection).toHaveBeenCalledWith(expect.objectContaining({ name: 'gh', type: 'github', secret: 'secret' }))
+  })
+
+  it('renders toolset creation separately from the connections collection', async () => {
+    const createToolset = vi.fn().mockResolvedValue({ metadata: { name: 'dev-tools' }, spec: { connections: [] } })
+    const api = stubApi({ createToolset })
+    const store = makeStore(api)
+    store.connections.data = [{ metadata: { name: 'gh' }, spec: { type: 'github' } }]
+    const el = await mount<Toolsets>('agents-toolsets', { store, api, routeOwned: true, createRoute: true })
+    expect(el.querySelector('table')).toBeNull()
+    const name = el.querySelector<HTMLInputElement>('input[name=name]')!
+    name.value = 'dev-tools'
+    el.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 5)
+    expect(createToolset).toHaveBeenCalledWith(expect.objectContaining({ name: 'dev-tools', connections: [], families: ['core'] }))
+  })
+
+  it('renders model creation separately and retains the credential payload', async () => {
+    const saveCredential = vi.fn().mockResolvedValue({ name: 'main', provider: 'openai-compatible', model: 'gpt-5' })
+    const api = stubApi({ saveCredential, catalog: () => Promise.resolve([]), usage: () => Promise.resolve({ windowDays: 30, total: { key: 'total', runs: 0, errors: 0, inputTokens: 0, outputTokens: 0, usdMicros: 0, latencyP50MS: 0, latencyP95MS: 0 }, byAgent: [], byModel: [], series: [] }) })
+    const store = makeStore(api)
+    const el = await mount<Models>('agents-models', { store, api, routeOwned: true, createRoute: true })
+    expect(el.querySelector('.agents-model-create')).not.toBeNull()
+    const values: Record<string, string> = { name: 'main', model: 'gpt-5', apiKey: 'secret' }
+    for (const [field, value] of Object.entries(values)) {
+      const input = el.querySelector<HTMLInputElement>(`[name=${field}]`)!
+      input.value = value
+    }
+    el.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 5)
+    expect(saveCredential).toHaveBeenCalledWith(expect.objectContaining(values))
+  })
+})
+
+describe('route-owned collection affordances', () => {
+  it('navigates New agent instead of opening collection-local state', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    store.agents.data = [agentFixture('scout')]
+    store.agents.loaded = true
+    const el = await mount('agents-agents-list', { store, api })
+    const routes: unknown[] = []
+    el.addEventListener('agents-navigate', (e) => routes.push((e as CustomEvent).detail))
+    el.querySelector<HTMLButtonElement>('button')!.click()
+    expect(routes).toEqual([{ kind: 'create', resource: 'agent' }])
+    expect(el.querySelector('agents-agent-create')).toBeNull()
+  })
+})

--- a/providers/agents/portal/src/test/element-router.test.ts
+++ b/providers/agents/portal/src/test/element-router.test.ts
@@ -1,0 +1,558 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '../api'
+import { AgentsElement } from '../element'
+import { AppStore } from '../store'
+import type { Agent, FarosContext } from '../types'
+import { settle } from './helpers'
+
+if (!customElements.get('faros-provider-agents')) customElements.define('faros-provider-agents', AgentsElement)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function emptyApi(api: ApiClient, options: { agents?: Agent[]; providers?: string[] } = {}): void {
+  const empty = () => Promise.resolve([])
+  const emptyUsage = () =>
+    Promise.resolve({
+      windowDays: 30,
+      total: { key: 'total', runs: 0, errors: 0, inputTokens: 0, outputTokens: 0, usdMicros: 0, latencyP50MS: 0, latencyP95MS: 0 },
+      byAgent: [],
+      byModel: [],
+      series: [],
+    })
+  Object.assign(api, {
+    listAgents: () => Promise.resolve(options.agents || []),
+    listConnections: empty,
+    listToolsets: empty,
+    listSchedules: empty,
+    listTriggers: empty,
+    listCredentials: empty,
+    listInbox: empty,
+    listSessions: empty,
+    listMessages: empty,
+    listRuns: () => Promise.resolve({ items: [] }),
+    catalog: empty,
+    usage: emptyUsage,
+    oauthProviders: () => Promise.resolve({ providers: {} }),
+    capabilities: () => Promise.resolve({ providers: options.providers || [] }),
+    eventStream: async function* (signal: AbortSignal, onOpen?: () => void) {
+      onOpen?.()
+      await new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }))
+    },
+  })
+}
+
+async function mountShell(
+  hash = '#/agents',
+  options: { agents?: Agent[]; providers?: string[] } = {},
+  context: Partial<FarosContext> = {},
+): Promise<AgentsElement> {
+  history.replaceState(null, '', hash)
+  const el = document.createElement('faros-provider-agents') as AgentsElement
+  const api = (el as unknown as { api: ApiClient }).api
+  emptyApi(api, options)
+  el.farosContext = {
+    basePath: '/ui/providers/agents',
+    orgUUID: 'org',
+    workspaceUUID: 'workspace',
+    token: 'token',
+    ...context,
+  }
+  document.body.appendChild(el)
+  await settle(el)
+  return el
+}
+
+const waitForHistory = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('AgentsElement hash-owned creation navigation', () => {
+  it('pushes create, replaces on cancel, and leaves the page form in the route', async () => {
+    const el = await mountShell()
+    const before = history.length
+    const newAgent = [...el.querySelectorAll('button')].find((button) => button.textContent?.includes('New agent'))!
+    newAgent.click()
+    await settle(el)
+
+    expect(location.hash).toBe('#/create/agent')
+    expect(history.length).toBe(before + 1)
+    expect(el.querySelector('.agents-create-form')).not.toBeNull()
+    expect(el.querySelector('.agents-overlay')).toBeNull()
+
+    const cancel = [...el.querySelectorAll('button')].find((button) => button.textContent?.trim() === 'Cancel')!
+    cancel.click()
+    await settle(el)
+    expect(location.hash).toBe('#/agents')
+    expect(history.length).toBe(before + 1)
+  })
+
+  it('replaces the create entry with the new agent detail and keeps the result visible', async () => {
+    const el = await mountShell()
+    const api = (el as unknown as { api: ApiClient }).api
+    ;(el as unknown as { store: { credentials: { data: unknown[] } } }).store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+    const created = { metadata: { name: 'nova' }, spec: { displayName: 'Nova', models: { chat: 'main' } } }
+    api.createAgent = (() => Promise.resolve(created)) as ApiClient['createAgent']
+    ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('New agent'))!.click()
+    await settle(el)
+    const form = el.querySelector<HTMLFormElement>('form')!
+    const name = form.querySelector<HTMLInputElement>('input[name=name]')!
+    name.value = 'nova'
+    name.dispatchEvent(new Event('input'))
+    const model = form.querySelector<HTMLSelectElement>('select')!
+    model.value = 'main'
+    model.dispatchEvent(new Event('change'))
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 7)
+
+    expect(location.hash).toBe('#/agents/nova/config')
+    expect(el.querySelector('agents-agent-detail')).not.toBeNull()
+    expect(el.textContent).toContain('Nova')
+  })
+
+  it('restores external hash assignments and browser back traversal', async () => {
+    const el = await mountShell()
+    const before = history.length
+    const connections = [...el.querySelectorAll('button')].find((button) => button.textContent?.includes('Connections'))!
+    connections.click()
+    await settle(el)
+    expect(location.hash).toBe('#/connections')
+    expect(history.length).toBe(before + 1)
+
+    const create = [...el.querySelectorAll('button')].find((button) => button.textContent?.includes('New connection'))!
+    create.click()
+    await settle(el)
+    expect(location.hash).toBe('#/create/connection')
+    expect(el.querySelector('.agents-conn-picker')).not.toBeNull()
+
+    location.hash = '#/models'
+    await settle(el)
+    expect(location.hash).toBe('#/models')
+    expect(el.querySelector('h3')?.textContent).toContain('Models')
+
+    history.back()
+    await waitForHistory()
+    await settle(el)
+    expect(location.hash).toBe('#/create/connection')
+    expect(el.querySelector('.agents-conn-picker')).not.toBeNull()
+  })
+
+  it('keeps typed and assisted create transitions in one history entry', async () => {
+    const el = await mountShell('#/connections', {
+      agents: [{ metadata: { name: 'scout' }, spec: { displayName: 'Scout' } }],
+      providers: ['infrastructure'],
+    })
+    const pushState = vi.spyOn(history, 'pushState')
+    const replaceState = vi.spyOn(history, 'replaceState')
+    try {
+      pushState.mockClear()
+      replaceState.mockClear()
+      ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('New connection'))!.click()
+      await settle(el)
+      expect(location.hash).toBe('#/create/connection')
+      expect(pushState).toHaveBeenCalledTimes(1)
+      expect(replaceState).not.toHaveBeenCalled()
+      const createEntryLength = history.length
+
+      replaceState.mockClear()
+      el.querySelector<HTMLButtonElement>('.agents-conn-tile')!.click()
+      await settle(el)
+      expect(location.hash).toBe('#/create/connection/github')
+      expect(history.length).toBe(createEntryLength)
+      expect(replaceState).toHaveBeenCalledTimes(1)
+
+      replaceState.mockClear()
+      el.querySelector<HTMLButtonElement>('.agents-conn-form .agents-back')!.click()
+      await settle(el)
+      expect(location.hash).toBe('#/create/connection')
+      expect(history.length).toBe(createEntryLength)
+      expect(replaceState).toHaveBeenCalledTimes(1)
+
+      replaceState.mockClear()
+      el.querySelector<HTMLButtonElement>('.agents-assist .secondary')!.click()
+      await settle(el)
+      expect(location.hash).toBe('#/create/connection/assisted-search')
+      expect(history.length).toBe(createEntryLength)
+      expect(replaceState).toHaveBeenCalledTimes(1)
+
+      history.back()
+      await waitForHistory()
+      await settle(el)
+      expect(location.hash).toBe('#/connections')
+      expect(el.querySelector('.agents-create-page')).toBeNull()
+    } finally {
+      pushState.mockRestore()
+      replaceState.mockRestore()
+    }
+  })
+
+  it('replaces model creation with its collection and shows the saved credential', async () => {
+    const el = await mountShell('#/models')
+    const api = (el as unknown as { api: ApiClient }).api
+    const created = { name: 'main', provider: 'openai-compatible', model: 'gpt-5' }
+    api.saveCredential = (() => Promise.resolve(created)) as ApiClient['saveCredential']
+    ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('New model'))!.click()
+    await settle(el)
+    expect(location.hash).toBe('#/create/model')
+    const createEntryLength = history.length
+    const form = el.querySelector<HTMLFormElement>('form')!
+    for (const [field, value] of Object.entries({ name: 'main', model: 'gpt-5', apiKey: 'secret' })) {
+      form.querySelector<HTMLInputElement>(`[name=${field}]`)!.value = value
+    }
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 7)
+    expect(location.hash).toBe('#/models')
+    expect(history.length).toBe(createEntryLength)
+    expect(el.textContent).toContain('main')
+  })
+
+  it('rejects a detached create success after a same-tick create-session transition', async () => {
+    const el = await mountShell('#/create/agent', {}, { user: { sub: 'alice' } })
+    const oldCreate = el.querySelector('agents-agent-create')!
+    const store = (el as unknown as { store: AppStore }).store
+
+    // Keep the old child mounted long enough to deliver both events. This is
+    // the race that occurs when a user switches create surfaces before Lit has
+    // flushed the replacement render.
+    oldCreate.dispatchEvent(
+      new CustomEvent('agents-navigate', {
+        detail: { kind: 'menu', menu: 'agents' },
+        bubbles: true,
+        composed: true,
+      }),
+    )
+    oldCreate.dispatchEvent(
+      new CustomEvent('agents-navigate', {
+        detail: { kind: 'create', resource: 'agent' },
+        bubbles: true,
+        composed: true,
+      }),
+    )
+    oldCreate.dispatchEvent(
+      new CustomEvent('agents-create-success', {
+        detail: {
+          resource: 'agent',
+          name: 'stale',
+          item: { metadata: { name: 'stale' }, spec: {} },
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    )
+
+    expect(location.hash).toBe('#/create/agent')
+    expect(store.agents.data).toEqual([])
+    await settle(el)
+    expect(el.querySelector('agents-agent-create')).not.toBe(oldCreate)
+  })
+
+  it('does not adopt an agent result after switching directly to model creation', async () => {
+    const el = await mountShell('#/create/agent')
+    const oldCreate = el.querySelector('agents-agent-create')!
+    const store = (el as unknown as { store: AppStore }).store
+
+    oldCreate.dispatchEvent(
+      new CustomEvent('agents-navigate', {
+        detail: { kind: 'create', resource: 'model' },
+        bubbles: true,
+        composed: true,
+      }),
+    )
+    oldCreate.dispatchEvent(
+      new CustomEvent('agents-create-success', {
+        detail: {
+          resource: 'agent',
+          name: 'stale',
+          item: { metadata: { name: 'stale' }, spec: {} },
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    )
+
+    expect(location.hash).toBe('#/create/model')
+    expect(store.agents.data).toEqual([])
+    await settle(el)
+    expect(el.querySelector('agents-models')).not.toBeNull()
+  })
+
+  it('detaches a create child before a delayed mutation can finish across token refresh', async () => {
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    const pending = deferred<Agent>()
+    try {
+      const el = await mountShell('#/create/agent', {}, { user: { sub: 'alice' }, token: 'token-a' })
+      const oldCreate = el.querySelector('agents-agent-create')!
+      const oldStore = (el as unknown as { store: AppStore }).store
+      const oldApi = (el as unknown as { api: ApiClient }).api
+      oldStore.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+      await settle(el)
+      oldApi.createAgent = (() => pending.promise) as ApiClient['createAgent']
+
+      const form = el.querySelector<HTMLFormElement>('form')!
+      const name = form.querySelector<HTMLInputElement>('input[name=name]')!
+      name.value = 'stale'
+      name.dispatchEvent(new Event('input'))
+      const model = form.querySelector<HTMLSelectElement>('select')!
+      model.value = 'main'
+      model.dispatchEvent(new Event('change'))
+      form.dispatchEvent(new Event('submit', { cancelable: true }))
+      await Promise.resolve()
+
+      // The route stays on the same create resource for a same-user token
+      // refresh. A keyed session must still replace the child, because the
+      // old request's continuation will otherwise observe newly assigned
+      // store/api/session properties when it emits its success event.
+      el.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-b',
+        user: { sub: 'alice' },
+      }
+      await settle(el)
+      expect(el.querySelector('agents-agent-create')).not.toBe(oldCreate)
+      expect(location.hash).toBe('#/create/agent')
+
+      pending.resolve({ metadata: { name: 'stale' }, spec: {} })
+      await settle(el, 7)
+
+      expect(location.hash).toBe('#/create/agent')
+      expect((el as unknown as { store: AppStore }).store.agents.data).toEqual([])
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+
+  it('rotates the store and resets the route when the same workspace user changes', async () => {
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    try {
+      const el = await mountShell('#/agents/nova/config', {}, { user: { sub: 'alice' }, token: 'token-a' })
+      const oldStore = (el as unknown as { store: AppStore }).store
+      const oldDisconnect = vi.spyOn(oldStore, 'disconnect')
+      oldStore.live = true
+      oldStore.agents.data = [{ metadata: { name: 'nova' }, spec: {} }]
+
+      el.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-b',
+        user: { sub: 'bob' },
+      }
+      await settle(el)
+
+      const nextStore = (el as unknown as { store: AppStore }).store
+      expect(oldDisconnect).toHaveBeenCalled()
+      expect(nextStore).not.toBe(oldStore)
+      expect(nextStore.agents.data).toEqual([])
+      expect(location.hash).toBe('#/agents')
+      expect(loadAll).toHaveBeenCalledTimes(2)
+      expect(connect).toHaveBeenCalledTimes(2)
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+
+  it('rotates credentials and stream while preserving the route for same-user token refresh', async () => {
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    try {
+      const el = await mountShell('#/agents/nova/config', {}, { user: { sub: 'alice' }, token: 'token-a' })
+      const oldStore = (el as unknown as { store: AppStore }).store
+      const oldApi = (el as unknown as { api: ApiClient }).api
+      const oldDisconnect = vi.spyOn(oldStore, 'disconnect')
+      oldStore.live = true
+
+      el.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-b',
+        user: { sub: 'alice' },
+      }
+      await settle(el)
+
+      const nextApi = (el as unknown as { api: ApiClient }).api
+      expect(oldDisconnect).toHaveBeenCalled()
+      expect((el as unknown as { store: AppStore }).store).not.toBe(oldStore)
+      expect(nextApi).not.toBe(oldApi)
+      expect(nextApi.context()?.token).toBe('token-b')
+      expect(location.hash).toBe('#/agents/nova/config')
+      expect(loadAll).toHaveBeenCalledTimes(2)
+      expect(connect).toHaveBeenCalledTimes(2)
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+
+  it('remounts detail chat and config and detaches old store listeners on token refresh', async () => {
+    const el = await mountShell(
+      '#/agents/nova/config',
+      { agents: [{ metadata: { name: 'nova' }, spec: { displayName: 'Workspace A' } }] },
+      { user: { sub: 'alice' }, token: 'token-a' },
+    )
+    const oldStore = (el as unknown as { store: AppStore }).store
+    const oldDetail = el.querySelector('agents-agent-detail')!
+    const oldConfig = oldDetail.querySelector('agents-agent-config')!
+    const oldChat = oldDetail.querySelector('agents-agent-chat')!
+    const oldStoreRemove = vi.spyOn(oldStore, 'removeEventListener')
+    const oldChatState = oldChat as unknown as { messages: unknown[] }
+    const oldConfigState = oldConfig as unknown as { displayName: string }
+    oldChatState.messages = [{ id: 'old', role: 'assistant', content: 'workspace A secret', tools: [] }]
+    oldConfigState.displayName = 'unsaved workspace A draft'
+    ;(oldChat as unknown as { requestUpdate: () => void }).requestUpdate()
+    ;(oldConfig as unknown as { requestUpdate: () => void }).requestUpdate()
+    await settle(el)
+
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    try {
+      el.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-b',
+        user: { sub: 'alice' },
+      }
+      const nextApi = (el as unknown as { api: ApiClient }).api
+      emptyApi(nextApi)
+      await settle(el)
+
+      const nextStore = (el as unknown as { store: AppStore }).store
+      const freshAgent = { metadata: { name: 'nova' }, spec: { displayName: 'Workspace B' } }
+      nextStore.agents.data = [freshAgent]
+      nextStore.agents.loaded = true
+      nextStore.dispatchEvent(new Event('change'))
+      await settle(el)
+
+      const newDetail = el.querySelector('agents-agent-detail')!
+      const newConfig = newDetail.querySelector('agents-agent-config')!
+      const newChat = newDetail.querySelector('agents-agent-chat')!
+      expect(newDetail).not.toBe(oldDetail)
+      expect(newConfig).not.toBe(oldConfig)
+      expect(newChat).not.toBe(oldChat)
+      expect((newConfig as unknown as { displayName: string }).displayName).toBe('Workspace B')
+      expect((newChat as unknown as { messages: unknown[] }).messages).toEqual([])
+      expect((newChat as unknown as { store: AppStore }).store).toBe(nextStore)
+      expect(oldStore.live).toBe(false)
+      expect(oldStoreRemove.mock.calls.map(([type]) => type)).toContain('change')
+      expect(oldStoreRemove.mock.calls.map(([type]) => type)).toContain('server')
+
+      // A late event from the retired store must not cause the current detail
+      // surface to render or rebind back to workspace A.
+      oldStore.dispatchEvent(new Event('change'))
+      oldStore.dispatchEvent(new CustomEvent('server', { detail: { type: 'run', data: { id: 'old-run', phase: 'Succeeded' } } }))
+      await settle(el)
+      expect(el.querySelector('agents-agent-detail')).toBe(newDetail)
+      expect((newConfig as unknown as { displayName: string }).displayName).toBe('Workspace B')
+      expect((newChat as unknown as { messages: unknown[] }).messages).toEqual([])
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+
+  it('remounts models and clears local probe state on same-user token refresh', async () => {
+    const el = await mountShell('#/models', {}, { user: { sub: 'alice' }, token: 'token-a' })
+    const oldModels = el.querySelector('agents-models')!
+    const oldStore = (el as unknown as { store: AppStore }).store
+    const oldStoreRemove = vi.spyOn(oldStore, 'removeEventListener')
+    const oldState = oldModels as unknown as {
+      catalog: unknown[]
+      usage: { total?: { key?: string } } | null
+      tested: Map<string, unknown>
+      discovered: Map<string, string[]>
+      editName: string | null
+      creating: boolean
+    }
+    oldState.catalog = [{ id: 'old-catalog' }]
+    oldState.usage = { total: { key: 'old-usage' } }
+    oldState.tested = new Map([['old', { ok: true }]])
+    oldState.discovered = new Map([['old', ['old-model']]])
+    oldState.editName = 'old'
+    oldState.creating = true
+    ;(oldModels as unknown as { requestUpdate: () => void }).requestUpdate()
+    await settle(el)
+
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    try {
+      el.farosContext = {
+        basePath: '/ui/providers/agents',
+        orgUUID: 'org',
+        workspaceUUID: 'workspace',
+        token: 'token-b',
+        user: { sub: 'alice' },
+      }
+      const nextApi = (el as unknown as { api: ApiClient }).api
+      emptyApi(nextApi)
+      nextApi.catalog = () => Promise.resolve([{ id: 'new-catalog', family: 'new', label: 'New catalog', inputPer1M: 0, outputPer1M: 0 }])
+      nextApi.usage = () =>
+        Promise.resolve({
+          windowDays: 30,
+          total: { key: 'new-usage', runs: 0, errors: 0, inputTokens: 0, outputTokens: 0, usdMicros: 0, latencyP50MS: 0, latencyP95MS: 0 },
+          byAgent: [],
+          byModel: [],
+          series: [],
+        })
+      await settle(el)
+
+      const newModels = el.querySelector('agents-models')!
+      const newState = newModels as unknown as typeof oldState
+      expect(newModels).not.toBe(oldModels)
+      expect(newState.catalog).toEqual([{ id: 'new-catalog', family: 'new', label: 'New catalog', inputPer1M: 0, outputPer1M: 0 }])
+      expect(newState.usage?.total?.key).toBe('new-usage')
+      expect(newState.tested).toEqual(new Map())
+      expect(newState.discovered).toEqual(new Map())
+      expect(newState.editName).toBeNull()
+      expect(newState.creating).toBe(false)
+      expect(oldStoreRemove.mock.calls.map(([type]) => type)).toContain('change')
+
+      oldStore.dispatchEvent(new Event('change'))
+      await settle(el)
+      expect(el.querySelector('agents-models')).toBe(newModels)
+      expect((el as unknown as { store: AppStore }).store).not.toBe(oldStore)
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+
+  it('disconnects and clears the rendered workspace when context is cleared', async () => {
+    const loadAll = vi.spyOn(AppStore.prototype, 'loadAll').mockImplementation(() => undefined)
+    const connect = vi.spyOn(AppStore.prototype, 'connect').mockImplementation(() => undefined)
+    try {
+      const el = await mountShell('#/agents/nova/config', {}, { user: { sub: 'alice' }, token: 'token-a' })
+      const oldStore = (el as unknown as { store: AppStore }).store
+      const oldDisconnect = vi.spyOn(oldStore, 'disconnect')
+      oldStore.live = true
+      oldStore.agents.data = [{ metadata: { name: 'nova' }, spec: {} }]
+
+      el.farosContext = null
+      await settle(el)
+
+      const nextStore = (el as unknown as { store: AppStore }).store
+      expect(oldDisconnect).toHaveBeenCalled()
+      expect(oldStore.live).toBe(false)
+      expect(nextStore).not.toBe(oldStore)
+      expect(nextStore.agents.data).toEqual([])
+      expect(location.hash).toBe('#/agents')
+      expect(el.textContent).toContain('Connecting')
+      expect(loadAll).toHaveBeenCalledOnce()
+      expect(connect).toHaveBeenCalledOnce()
+    } finally {
+      loadAll.mockRestore()
+      connect.mockRestore()
+    }
+  })
+})

--- a/providers/agents/portal/src/test/models.test.ts
+++ b/providers/agents/portal/src/test/models.test.ts
@@ -7,7 +7,7 @@
 //      liveness was only set when a parsed event arrived and the server sends
 //      nothing but comment frames until something happens.
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import '../views/models'
 import { ApiClient } from '../api'
 import { AppStore } from '../store'
@@ -82,6 +82,30 @@ describe('api client array normalization', () => {
   it('listRuns() tolerates a null items array', async () => {
     const p = await clientWith({ items: null }).listRuns()
     expect(p.items).toEqual([])
+  })
+
+  it('does not resurrect a stored workspace after the host explicitly clears context', () => {
+    localStorage.setItem('faros:portal:tenant', JSON.stringify({ orgUUID: 'old-org', workspaceUUID: 'old-workspace' }))
+    const api = new ApiClient()
+    api.setContext({ basePath: '/ui/providers/agents', orgUUID: null, workspaceUUID: null, token: null })
+
+    expect(api.tenant()).toEqual({ orgUUID: null, workspaceUUID: null })
+    expect(api.hasWorkspace()).toBe(false)
+    expect(api.contextAuthority().usable).toBe(false)
+  })
+
+  it('omits stale tenant headers after the host explicitly clears context', async () => {
+    localStorage.setItem('faros:portal:tenant', JSON.stringify({ orgUUID: 'old-org', workspaceUUID: 'old-workspace' }))
+    const api = new ApiClient()
+    api.setContext({ basePath: '/ui/providers/agents', orgUUID: null, workspaceUUID: null, token: null })
+    const request = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ items: [] }) })
+    globalThis.fetch = request as typeof fetch
+
+    await api.get('/api/agents')
+
+    const headers = request.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(headers['X-Faros-Org']).toBeUndefined()
+    expect(headers['X-Faros-Workspace']).toBeUndefined()
   })
 })
 

--- a/providers/agents/portal/src/test/router.test.ts
+++ b/providers/agents/portal/src/test/router.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  activeMenu,
+  hashFor,
+  parseHash,
+  syncHash,
+  writeHash,
+  type Route,
+} from '../router'
+
+beforeEach(() => {
+  history.replaceState(null, '', '#/agents')
+})
+
+describe('create routes', () => {
+  it.each<[string, Route]>([
+    ['#/create/agent', { kind: 'create', resource: 'agent' }],
+    ['#/create/connection', { kind: 'create', resource: 'connection' }],
+    ['#/create/connection/github', { kind: 'create', resource: 'connection', type: 'github' }],
+    ['#/create/toolset', { kind: 'create', resource: 'toolset' }],
+    ['#/create/model', { kind: 'create', resource: 'model' }],
+  ])('parses and formats %s', (hash, route) => {
+    expect(parseHash(hash)).toEqual(route)
+    expect(hashFor(route)).toBe(hash)
+  })
+
+  it('keeps create routes highlighted under their owning menu', () => {
+    expect(activeMenu({ kind: 'create', resource: 'agent' })).toBe('agents')
+    expect(activeMenu({ kind: 'create', resource: 'connection' })).toBe('connections')
+    expect(activeMenu({ kind: 'create', resource: 'toolset' })).toBe('connections')
+    expect(activeMenu({ kind: 'create', resource: 'model' })).toBe('models')
+  })
+})
+
+describe('hash history writes', () => {
+  it('pushes ordinary navigation and replaces only an explicit terminal transition', () => {
+    const push = vi.spyOn(history, 'pushState')
+    const replace = vi.spyOn(history, 'replaceState')
+
+    writeHash({ kind: 'create', resource: 'agent' }, 'push')
+    expect(location.hash).toBe('#/create/agent')
+    expect(push).toHaveBeenCalledWith(null, '', '#/create/agent')
+
+    writeHash({ kind: 'menu', menu: 'agents' }, 'replace')
+    expect(location.hash).toBe('#/agents')
+    expect(replace).toHaveBeenCalledWith(null, '', '#/agents')
+    expect(push).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not add a second entry when canonicalizing an unchanged hash', () => {
+    const replace = vi.spyOn(history, 'replaceState')
+    replace.mockClear()
+    syncHash({ kind: 'menu', menu: 'agents' })
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('does not throw on malformed externally supplied encoded segments', () => {
+    expect(parseHash('#/agents/%E0%A4%A')).toEqual({ kind: 'agent', name: '%E0%A4%A', tab: 'config' })
+  })
+})

--- a/providers/agents/portal/src/test/store.test.ts
+++ b/providers/agents/portal/src/test/store.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { parseSSEFrame, readSSE, type SSEEvent } from '../api'
 import { makeStore, stubApi } from './helpers'
-import type { InboxItem } from '../types'
+import type { Agent, Connection, Credential, InboxItem, Toolset } from '../types'
 
 const inboxItem = (id: string, state = 'pending'): InboxItem => ({
   id,
@@ -14,6 +14,14 @@ const inboxItem = (id: string, state = 'pending'): InboxItem => ({
   prompt: 'approve?',
   createdAt: new Date().toISOString(),
 })
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
 
 describe('AppStore slices', () => {
   it('tracks loading → loaded and exposes the data', async () => {
@@ -74,6 +82,82 @@ describe('AppStore slices', () => {
     store.addEventListener('change', seen)
     await store.load('connections')
     expect(seen).toHaveBeenCalled()
+  })
+})
+
+describe('create-result adoption refresh races', () => {
+  it('merges an adopted agent into a list response that started first', async () => {
+    const pending = deferred<Agent[]>()
+    const existing: Agent = { metadata: { name: 'existing' }, spec: {} }
+    const created: Agent = { metadata: { name: 'created' }, spec: { displayName: 'Created' } }
+    const store = makeStore(stubApi({ listAgents: () => pending.promise }))
+
+    const refresh = store.load('agents')
+    store.adopt('agents', created)
+    pending.resolve([existing])
+    await refresh
+
+    expect(store.agents.data).toEqual([existing, created])
+    expect(store.agents.error).toBeNull()
+    expect(store.agents.hasSnapshot).toBe(true)
+  })
+
+  it('merges an adopted connection without preserving unrelated stale rows', async () => {
+    const pending = deferred<Connection[]>()
+    const existing: Connection = { metadata: { name: 'existing' }, spec: { type: 'slack' } }
+    const created: Connection = { metadata: { name: 'created' }, spec: { type: 'github' } }
+    const store = makeStore(stubApi({ listConnections: () => pending.promise }))
+    store.connections.data = [{ metadata: { name: 'stale' }, spec: { type: 'old' } }]
+    store.connections.hasSnapshot = true
+
+    const refresh = store.load('connections')
+    store.adopt('connections', created)
+    pending.resolve([existing])
+    await refresh
+
+    expect(store.connections.data).toEqual([existing, created])
+  })
+
+  it('merges an adopted toolset into the authoritative list result', async () => {
+    const pending = deferred<Toolset[]>()
+    const created: Toolset = { metadata: { name: 'created' }, spec: { connections: [] } }
+    const store = makeStore(stubApi({ listToolsets: () => pending.promise }))
+
+    const refresh = store.load('toolsets')
+    store.adopt('toolsets', created)
+    pending.resolve([])
+    await refresh
+
+    expect(store.toolsets.data).toEqual([created])
+  })
+
+  it('merges an adopted model credential by its non-metadata name', async () => {
+    const pending = deferred<Credential[]>()
+    const created: Credential = { name: 'created', provider: 'openai-compatible', model: 'gpt-5' }
+    const store = makeStore(stubApi({ listCredentials: () => pending.promise }))
+
+    const refresh = store.load('credentials')
+    store.adopt('credentials', created)
+    pending.resolve([])
+    await refresh
+
+    expect(store.credentials.data).toEqual([created])
+  })
+
+  it('lets a later refresh remove an adopted item once it is authoritative', async () => {
+    const pending = deferred<Agent[]>()
+    const created: Agent = { metadata: { name: 'created' }, spec: {} }
+    const listAgents = vi.fn().mockImplementationOnce(() => pending.promise).mockResolvedValueOnce([])
+    const store = makeStore(stubApi({ listAgents }))
+
+    const firstRefresh = store.load('agents')
+    store.adopt('agents', created)
+    pending.resolve([])
+    await firstRefresh
+    expect(store.agents.data).toEqual([created])
+
+    await store.load('agents')
+    expect(store.agents.data).toEqual([])
   })
 })
 

--- a/providers/agents/portal/src/ui/base.ts
+++ b/providers/agents/portal/src/ui/base.ts
@@ -9,12 +9,28 @@ import { LitElement } from 'lit'
 import { property } from 'lit/decorators.js'
 import type { ApiClient } from '../api'
 import type { AppStore } from '../store'
-import type { Route } from '../router'
+import { hashFor, type Route } from '../router'
 
 export class LightElement extends LitElement {
   protected createRenderRoot(): HTMLElement {
     return this
   }
+}
+
+// A confirmation is allowed to outlive the view that opened it. Keep the
+// authority references together so callers can verify the mounted surface
+// before starting a destructive write after the modal resolves.
+export interface AuthoritySnapshot {
+  readonly store: AppStore
+  readonly api: ApiClient
+  readonly host: HTMLElement | null
+  readonly routeKey: string | null
+}
+
+interface AgentsHost extends HTMLElement {
+  store?: AppStore
+  api?: ApiClient
+  route?: Route
 }
 
 // StoreElement is a light-DOM component wired to the shared AppStore: it
@@ -40,6 +56,29 @@ export class StoreElement extends LightElement {
 
   protected willUpdate(): void {
     this.bind()
+  }
+
+  protected captureAuthority(): AuthoritySnapshot {
+    const host = this.closest('faros-provider-agents') as AgentsHost | null
+    return {
+      store: this.store,
+      api: this.api,
+      host,
+      routeKey: host?.route ? hashFor(host.route) : null,
+    }
+  }
+
+  // A mounted child can still be connected for one turn after the shell has
+  // rotated its context. Compare against the owning shell as well as the
+  // child's properties so that same-tick token/user/tenant changes cannot
+  // turn an old confirmation into a write against the new or old authority.
+  protected authorityIsCurrent(snapshot: AuthoritySnapshot): boolean {
+    if (!this.isConnected || this.store !== snapshot.store || this.api !== snapshot.api) return false
+    const host = this.closest('faros-provider-agents') as AgentsHost | null
+    if (host !== snapshot.host) return false
+    if (!host) return true
+    if (!host.isConnected || host.store !== snapshot.store || host.api !== snapshot.api) return false
+    return (host.route ? hashFor(host.route) : null) === snapshot.routeKey
   }
 
   private bind(): void {

--- a/providers/agents/portal/src/views/agent-chat.ts
+++ b/providers/agents/portal/src/views/agent-chat.ts
@@ -257,15 +257,18 @@ export class AgentChat extends StoreElement {
   private async deleteSession(): Promise<void> {
     const id = this.sessionID
     if (!id || this.streaming) return
+    const authority = this.captureAuthority()
+    const agent = this.name
     const ok = await confirmModal({
       title: 'Delete this chat?',
       message: 'The transcript is removed from the agent’s memory for this session.',
       danger: true,
       confirmLabel: 'Delete',
     })
-    if (!ok) return
+    if (!ok || !this.authorityIsCurrent(authority)) return
     try {
-      await this.api.deleteSession(this.name, id)
+      await authority.api.deleteSession(agent, id)
+      if (!this.authorityIsCurrent(authority)) return
       toast('ok', 'Chat deleted.')
       this.sessions = this.sessions.filter((s) => s.id !== id)
       this.messages = []

--- a/providers/agents/portal/src/views/agent-create.ts
+++ b/providers/agents/portal/src/views/agent-create.ts
@@ -5,14 +5,20 @@
 // things everyone sets.
 
 import { html, nothing, type TemplateResult } from 'lit'
-import { state } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
+import { mutate } from '../mutate'
+import type { CreateSuccessDetail } from '../router'
 import type { AgentCreate } from '../types'
 
 const NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
 export class AgentCreateWizard extends StoreElement {
+  // Route-owned creation renders as a normal page surface. The default keeps
+  // the standalone element compatible with older embedders/tests that still
+  // open the compact dialog directly.
+  @property({ type: Boolean }) routeOwned = false
   @state() private name = ''
   @state() private modelCredential = ''
   @state() private systemPrompt = ''
@@ -24,13 +30,15 @@ export class AgentCreateWizard extends StoreElement {
   @state() private web = false
   @state() private fanOut = false
   @state() private errors: Record<string, string> = {}
+  @state() private busy = false
 
   firstUpdated(): void {
     this.querySelector<HTMLInputElement>('input[name=name]')?.focus()
   }
 
-  private submit(e: Event): void {
+  private async submit(e: Event): Promise<void> {
     e.preventDefault()
+    if (this.busy) return
     const errors: Record<string, string> = {}
     const name = this.name.trim()
     if (!name) errors.name = 'A name is required.'
@@ -48,27 +56,53 @@ export class AgentCreateWizard extends StoreElement {
     if (this.web) fams.push('web')
     if (this.fanOut) fams.push('spawn')
     if (fams.length > 1) body.interactiveFamilies = fams
-    this.dispatchEvent(new CustomEvent<AgentCreate>('agents-create', { detail: body }))
+    if (!this.routeOwned) {
+      this.dispatchEvent(new CustomEvent<AgentCreate>('agents-create', { detail: body }))
+      return
+    }
+
+    this.busy = true
+    const res = await mutate(this.store, {
+      run: () => this.api.createAgent(body),
+      success: `Agent “${name}” created.`,
+      failure: 'Create failed',
+      reload: ['agents'],
+    })
+    this.busy = false
+    if (!res) return
+    this.dispatchEvent(
+      new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+        detail: { resource: 'agent', name, item: res },
+        bubbles: true,
+        composed: true,
+      }),
+    )
   }
 
   private cancel(): void {
+    if (this.routeOwned) {
+      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
+      return
+    }
     this.dispatchEvent(new CustomEvent('agents-cancel'))
   }
 
   render(): TemplateResult {
     const creds = this.store.credentials.data
     const channels = this.store.channelConnections()
-    return html`<div
-      class="agents-overlay"
-      @click=${(e: Event) => e.target === e.currentTarget && this.cancel()}
-      @keydown=${(e: KeyboardEvent) => e.key === 'Escape' && this.cancel()}
+    const form = html`<form
+      class=${this.routeOwned ? 'agents-create-form k-create-surface' : 'agents-dialog'}
+      role=${this.routeOwned ? nothing : 'dialog'}
+      aria-modal=${this.routeOwned ? nothing : 'true'}
+      aria-label="Create agent"
+      @submit=${(e: Event) => void this.submit(e)}
     >
-      <form class="agents-dialog" role="dialog" aria-modal="true" aria-label="Create agent" @submit=${(e: Event) => this.submit(e)}>
-        <header class="agents-dialog-head">
+        ${this.routeOwned ? nothing : html`<header class="agents-dialog-head">
           <span class="agents-dialog-ic">${icon('bot')}</span>
           <h3>New agent</h3>
-        </header>
+        </header>`}
 
+        <div class=${this.routeOwned ? 'k-create-body' : ''}>
         <label>
           Name *
           <input class="k-input"
@@ -140,13 +174,24 @@ export class AgentCreateWizard extends StoreElement {
             <span><strong>Research fan-out</strong> <span class="muted">— work independent parts in parallel</span></span>
           </label>
         </fieldset>
-
-        <div class="agents-form-actions">
-          <button class="k-btn k-btn--primary" type="submit">${icon('check')} Create agent</button>
-          <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
         </div>
-      </form>
-    </div>`
+
+        <div class=${this.routeOwned ? 'k-create-actions' : 'agents-form-actions'}>
+          <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
+          <button class="k-btn k-btn--primary" type="submit">${icon('check')} Create agent</button>
+        </div>
+      </form>`
+    return this.routeOwned
+      ? html`<div class="agents-create-page k-create-page">
+          <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Agents</button>
+          <header class="k-create-header"><h1 class="k-create-title">Create agent</h1><p class="k-create-description">Choose the model, instructions, and optional channel this agent starts with.</p></header>
+          ${form}
+        </div>`
+      : html`<div
+          class="agents-overlay"
+          @click=${(e: Event) => e.target === e.currentTarget && this.cancel()}
+          @keydown=${(e: KeyboardEvent) => e.key === 'Escape' && this.cancel()}
+        >${form}</div>`
   }
 }
 

--- a/providers/agents/portal/src/views/agent-detail.ts
+++ b/providers/agents/portal/src/views/agent-detail.ts
@@ -28,20 +28,22 @@ export class AgentDetail extends StoreElement {
   @property({ type: String }) tab: AgentTab = 'config'
 
   private async del(): Promise<void> {
+    const authority = this.captureAuthority()
+    const name = this.name
     const ok = await confirmModal({
-      title: `Delete agent “${this.name}”?`,
+      title: `Delete agent “${name}”?`,
       message: 'This also deletes its chat history.',
       danger: true,
       confirmLabel: 'Delete',
     })
-    if (!ok) return
-    const res = await mutate(this.store, {
-      run: () => this.api.deleteAgent(this.name),
-      success: `Agent “${this.name}” deleted.`,
+    if (!ok || !this.authorityIsCurrent(authority)) return
+    const res = await mutate(authority.store, {
+      run: () => authority.api.deleteAgent(name),
+      success: `Agent “${name}” deleted.`,
       failure: 'Delete failed',
       reload: ['agents'],
     })
-    if (res !== undefined) this.navigate({ kind: 'menu', menu: 'agents' })
+    if (res !== undefined && this.authorityIsCurrent(authority)) this.navigate({ kind: 'menu', menu: 'agents' })
   }
 
   render(): TemplateResult {

--- a/providers/agents/portal/src/views/agents-list.ts
+++ b/providers/agents/portal/src/views/agents-list.ts
@@ -3,48 +3,36 @@
 // wizard, which — unlike the old bare name field — collects the model
 // credential the agent needs to be usable on arrival.
 
-import { html, nothing, type TemplateResult } from 'lit'
-import { state } from 'lit/decorators.js'
+import { html, type TemplateResult } from 'lit'
 import { repeat } from 'lit/directives/repeat.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
 import { sliceView } from '../ui/states'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
-import type { Agent, AgentCreate } from '../types'
+import type { Agent } from '../types'
 
+// Keep the element registration available to standalone consumers that import
+// only the list view; the shell also imports the route surface explicitly.
 import './agent-create'
 
 export class AgentsList extends StoreElement {
-  @state() private creating = false
-
   private async del(name: string): Promise<void> {
+    const authority = this.captureAuthority()
     const ok = await confirmModal({
       title: `Delete agent “${name}”?`,
       message: 'This also deletes its chat history.',
       danger: true,
       confirmLabel: 'Delete',
     })
-    if (!ok) return
-    await mutate(this.store, {
-      run: () => this.api.deleteAgent(name),
+    if (!ok || !this.authorityIsCurrent(authority)) return
+    await mutate(authority.store, {
+      run: () => authority.api.deleteAgent(name),
       success: `Agent “${name}” deleted.`,
       failure: 'Delete failed',
-      optimistic: () => (this.store.agents.data = this.store.agents.data.filter((a) => a.metadata.name !== name)),
+      optimistic: () => (authority.store.agents.data = authority.store.agents.data.filter((a) => a.metadata.name !== name)),
       reload: ['agents'],
     })
-  }
-
-  private async create(body: AgentCreate): Promise<void> {
-    const res = await mutate(this.store, {
-      run: () => this.api.createAgent(body),
-      success: `Agent “${body.name}” created.`,
-      failure: 'Create failed',
-      reload: ['agents'],
-    })
-    if (!res) return
-    this.creating = false
-    this.navigate({ kind: 'agent', name: body.name, tab: 'config' })
   }
 
   render(): TemplateResult {
@@ -52,7 +40,7 @@ export class AgentsList extends StoreElement {
       <div class="agents-menu">
         <div class="agents-panel-head">
           <h3>Agents</h3>
-          <button class="k-btn k-btn--primary" @click=${() => (this.creating = true)}>${icon('plus')} New agent</button>
+          <button class="k-btn k-btn--primary" @click=${() => this.navigate({ kind: 'create', resource: 'agent' })}>${icon('plus')} New agent</button>
         </div>
         ${sliceView<Agent>({
           slice: this.store.agents,
@@ -68,14 +56,6 @@ export class AgentsList extends StoreElement {
           </div>`,
         })}
       </div>
-      ${this.creating
-        ? html`<agents-agent-create
-            .store=${this.store}
-            .api=${this.api}
-            @agents-create=${(e: CustomEvent<AgentCreate>) => void this.create(e.detail)}
-            @agents-cancel=${() => (this.creating = false)}
-          ></agents-agent-create>`
-        : nothing}
     `
   }
 

--- a/providers/agents/portal/src/views/assisted-search.ts
+++ b/providers/agents/portal/src/views/assisted-search.ts
@@ -14,10 +14,11 @@
 // tool calls.
 
 import { html, nothing, type TemplateResult } from 'lit'
-import { state } from 'lit/decorators.js'
-import { StoreElement } from '../ui/base'
+import { property, state } from 'lit/decorators.js'
+import { StoreElement, type AuthoritySnapshot } from '../ui/base'
 import { icon } from '../ui/icon'
 import { mutate } from '../mutate'
+import type { CreateSuccessDetail } from '../router'
 import {
   DNS_LABEL_RE,
   INSTANCE_SIZES,
@@ -32,6 +33,8 @@ import { familiesForConns } from '../conn-defs'
 import type { ConnectionWrite } from '../types'
 
 export class AssistedSearch extends StoreElement {
+  @property({ type: Boolean }) routeOwned = false
+  @property({ type: Boolean }) page = false
   @state() private open = false
   @state() private agent = ''
   @state() private connName = 'search'
@@ -55,7 +58,16 @@ export class AssistedSearch extends StoreElement {
   }
 
   private cancel(): void {
+    if (this.busy) return
+    if (this.routeOwned || this.page) {
+      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
+      return
+    }
     this.open = false
+  }
+
+  private selectedAgent(): string {
+    return this.agent || this.store.agents.data[0]?.metadata.name || ''
   }
 
   private instanceName(): string {
@@ -79,6 +91,10 @@ export class AssistedSearch extends StoreElement {
     if (this.busy) return
     const conn = this.connName.trim()
     const inst = this.instanceName()
+    const agent = this.selectedAgent()
+    const size = this.size
+    const authority = this.captureAuthority()
+    this.agent = agent
     const errors = this.validate(conn, inst)
     this.errors = errors
     if (Object.keys(errors).length) return
@@ -93,21 +109,47 @@ export class AssistedSearch extends StoreElement {
       config: { provider: 'searxng', instance: inst },
     }
     this.busy = true
-    const res = await mutate(this.store, {
-      run: () => this.api.createConnection(body),
-      success: `Connection “${conn}” created — handing the rest to ${this.agent}.`,
-      failure: 'Create failed',
-      reload: ['connections'],
-    })
-    if (res) await this.grantToAgent(conn)
-    this.busy = false
-    if (!res) return
+    try {
+      const res = await mutate(authority.store, {
+        run: () => authority.api.createConnection(body),
+        success: `Connection “${conn}” created — handing the rest to ${agent}.`,
+        failure: 'Create failed',
+        reload: ['connections'],
+      })
+      // A context rotation can leave this light-DOM child alive until the
+      // shell's keyed route update flushes. Do not grant, hand off, or route a
+      // create response into a different authority in that gap.
+      if (!res || !this.authorityIsCurrent(authority)) return
 
-    this.store.setPendingPrompt(this.agent, searxngSetupPrompt({ connection: conn, instance: inst, size: this.size }))
-    this.open = false
-    // The chat playground lives in the agent's Config pane (right-hand split),
-    // so that is where "go to its chat" lands.
-    this.navigate({ kind: 'agent', name: this.agent, tab: 'config' })
+      await this.grantToAgent(agent, conn, authority)
+      if (!this.authorityIsCurrent(authority)) return
+
+      authority.store.setPendingPrompt(agent, searxngSetupPrompt({ connection: conn, instance: inst, size }))
+      if (this.routeOwned || this.page) {
+        this.dispatchEvent(
+          new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+            detail: {
+              resource: 'connection',
+              name: conn,
+              item: res,
+              // Assisted setup intentionally keeps its existing handoff: the
+              // agent's Config/chat surface is where the provisioning prompt is
+              // actionable and visible.
+              destination: { kind: 'agent', name: agent, tab: 'config' },
+            },
+            bubbles: true,
+            composed: true,
+          }),
+        )
+      } else {
+        this.open = false
+        // The chat playground lives in the agent's Config pane (right-hand split),
+        // so that is where "go to its chat" lands.
+        this.navigate({ kind: 'agent', name: agent, tab: 'config' })
+      }
+    } finally {
+      this.busy = false
+    }
   }
 
   // grantToAgent wires the new connection into the driving agent's interactive
@@ -116,8 +158,8 @@ export class AssistedSearch extends StoreElement {
   // granted, so the agent would provision its own backend and still answer
   // "I can't make web requests". Failure is surfaced but not fatal — the
   // connection and the instance are still worth having.
-  private async grantToAgent(conn: string): Promise<void> {
-    const agent = this.store.agents.data.find((a) => a.metadata.name === this.agent)
+  private async grantToAgent(agentName: string, conn: string, authority: AuthoritySnapshot): Promise<void> {
+    const agent = authority.store.agents.data.find((a) => a.metadata.name === agentName)
     if (!agent) return
     const current = agent.spec?.tools?.interactive?.connections || []
     if (current.includes(conn)) return
@@ -127,17 +169,29 @@ export class AssistedSearch extends StoreElement {
     // refreshed yet, and without its type the `web` family would be dropped —
     // leaving the agent with a search backend but no web_search tool.
     const families = familiesForConns(connections, (n) =>
-      n === conn ? 'websearch' : this.store.connections.data.find((c) => c.metadata.name === n)?.spec.type,
+      n === conn ? 'websearch' : authority.store.connections.data.find((c) => c.metadata.name === n)?.spec.type,
     )
-    await mutate(this.store, {
-      run: () => this.api.patchAgent(this.agent, { interactiveConnections: connections, interactiveFamilies: families }),
-      success: `Wired “${conn}” into ${this.agent}'s tools.`,
-      failure: `Created the connection, but could not wire it into ${this.agent} — add it under the agent's Tools`,
+    await mutate(authority.store, {
+      run: () => authority.api.patchAgent(agentName, { interactiveConnections: connections, interactiveFamilies: families }),
+      success: `Wired “${conn}” into ${agentName}'s tools.`,
+      failure: `Created the connection, but could not wire it into ${agentName} — add it under the agent's Tools`,
       reload: ['agents'],
     })
   }
 
   render(): TemplateResult {
+    if (this.page) {
+      // A direct/bookmarked assisted route should remain truthful when its
+      // prerequisites disappear; it must not offer a form that cannot hand
+      // work to an agent.
+      if (!this.store.hasProvider('infrastructure')) return html`<div class="agents-panel k-card agents-route-panel"><p class="muted">Infrastructure is not enabled for this workspace.</p></div>`
+      if (!this.store.agents.data.length) return html`<div class="agents-panel k-card agents-route-panel"><p class="muted">Create an agent before using assisted search setup.</p></div>`
+      if (!this.store.connections.loaded) return html`<div class="agents-panel k-card agents-route-panel" role="status"><p class="muted">Loading connections…</p></div>`
+      if (selfHostedSearchConfigured(this.store.connections.data)) {
+        return html`<div class="agents-panel k-card agents-route-panel"><p class="muted">Self-hosted search is already configured in this workspace.</p></div>`
+      }
+      return this.dialog()
+    }
     // Both gates matter: no infrastructure tools means the agent cannot
     // provision anything, no agents means there is nobody to ask.
     if (!this.store.hasProvider('infrastructure') || !this.store.agents.data.length) return html`${nothing}`
@@ -168,7 +222,11 @@ export class AssistedSearch extends StoreElement {
           >One of your agents can provision the SearXNG instance for you — instead of you hopping to Infrastructure and back.</span
         >
       </div>
-      <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.start()}>Set it up</button>
+      <button
+        type="button"
+        class="k-btn k-btn--ghost secondary"
+        @click=${() => (this.routeOwned ? this.navigate({ kind: 'create', resource: 'connection', type: 'assisted-search' }) : this.start())}
+      >Set it up</button>
       <button
         type="button"
         class="k-btn k-btn--ghost agents-iconbtn"
@@ -183,16 +241,19 @@ export class AssistedSearch extends StoreElement {
 
   private dialog(): TemplateResult {
     const agents = this.store.agents.data
-    return html`<div
-      class="agents-overlay"
-      @click=${(e: Event) => e.target === e.currentTarget && this.cancel()}
-      @keydown=${(e: KeyboardEvent) => e.key === 'Escape' && this.cancel()}
-    >
-      <form class="agents-dialog" role="dialog" aria-modal="true" aria-label="Assisted search setup" @submit=${(e: Event) => void this.submit(e)}>
-        <header class="agents-dialog-head">
+    const selected = this.selectedAgent()
+    const form = html`<form
+        class=${this.page ? 'agents-conn-form k-create-surface' : 'agents-dialog'}
+        role=${this.page ? nothing : 'dialog'}
+        aria-modal=${this.page ? nothing : 'true'}
+        aria-label="Assisted search setup"
+        @submit=${(e: Event) => void this.submit(e)}
+      >
+        ${this.page ? nothing : html`<header class="agents-dialog-head">
           <span class="agents-dialog-ic">${icon('sparkles')}</span>
           <h3>Self-hosted search, set up for you</h3>
-        </header>
+        </header>`}
+        <div class=${this.page ? 'k-create-body' : ''}>
         <p class="muted">
           We create the web-search connection pointing at an instance name, then your agent provisions the <code>searxng</code>
           instance itself. Nothing to paste back: agents reach it over the platform's internal path, so it is never published and
@@ -202,21 +263,32 @@ export class AssistedSearch extends StoreElement {
         ${agents.length > 1
           ? html`<label>
               Agent
-              <select class="k-input" aria-invalid=${this.errors.agent ? 'true' : nothing} @change=${(e: Event) => (this.agent = (e.target as HTMLSelectElement).value)}>
-                ${agents.map((a) => html`<option value=${a.metadata.name} ?selected=${a.metadata.name === this.agent}>${a.spec?.displayName || a.metadata.name}</option>`)}
+              <select
+                class="k-input"
+                ?disabled=${this.busy}
+                aria-invalid=${this.errors.agent ? 'true' : nothing}
+                @change=${(e: Event) => {
+                  if (this.busy) return
+                  this.agent = (e.target as HTMLSelectElement).value
+                }}
+              >
+                ${agents.map((a) => html`<option value=${a.metadata.name} ?selected=${a.metadata.name === selected}>${a.spec?.displayName || a.metadata.name}</option>`)}
               </select>
               ${this.errors.agent ? html`<span class="agents-fielderr">${this.errors.agent}</span>` : nothing}
             </label>`
-          : html`<p class="agents-hint">Driven by your agent <strong>${this.agent}</strong>.</p>`}
+          : html`<p class="agents-hint">Driven by your agent <strong>${selected}</strong>.</p>`}
 
         <label>
           Connection name
           <input class="k-input"
             name="connName"
             .value=${this.connName}
+            ?disabled=${this.busy}
             autocomplete="off"
             aria-invalid=${this.errors.connName ? 'true' : nothing}
-            @input=${(e: Event) => (this.connName = (e.target as HTMLInputElement).value)}
+            @input=${(e: Event) => {
+              if (!this.busy) this.connName = (e.target as HTMLInputElement).value
+            }}
           />
           ${this.errors.connName
             ? html`<span class="agents-fielderr">${this.errors.connName}</span>`
@@ -228,9 +300,11 @@ export class AssistedSearch extends StoreElement {
           <input class="k-input"
             name="instance"
             .value=${this.instanceName()}
+            ?disabled=${this.busy}
             autocomplete="off"
             aria-invalid=${this.errors.instance ? 'true' : nothing}
             @input=${(e: Event) => {
+              if (this.busy) return
               this.instanceTouched = true
               this.instance = (e.target as HTMLInputElement).value
             }}
@@ -244,17 +318,35 @@ export class AssistedSearch extends StoreElement {
           Size
           <div class="agents-modeseg" role="group" aria-label="Instance size">
             ${INSTANCE_SIZES.map(
-              (s) => html`<button type="button" class="k-btn k-btn--ghost agents-modebtn ${s === this.size ? 'sel' : ''}" @click=${() => (this.size = s)}>${s}</button>`,
+              (s) => html`<button
+                type="button"
+                ?disabled=${this.busy}
+                class="k-btn k-btn--ghost agents-modebtn ${s === this.size ? 'sel' : ''}"
+                @click=${() => {
+                  if (!this.busy) this.size = s
+                }}
+              >${s}</button>`,
             )}
           </div>
         </label>
-
-        <div class="agents-form-actions">
-          <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.busy}>${icon('sparkles')} Create and hand off</button>
-          <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
         </div>
-      </form>
-    </div>`
+
+        <div class=${this.page ? 'k-create-actions' : 'agents-form-actions'}>
+          <button type="button" ?disabled=${this.busy} class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
+          <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.busy}>${icon('sparkles')} Create and hand off</button>
+        </div>
+      </form>`
+    return this.page
+      ? html`<div class="agents-create-page k-create-page">
+          <button type="button" ?disabled=${this.busy} class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Connections</button>
+          <header class="k-create-header"><h1 class="k-create-title">Set up assisted search</h1><p class="k-create-description">Create a private search connection and let an agent provision the supporting service.</p></header>
+          ${form}
+        </div>`
+      : html`<div
+          class="agents-overlay"
+          @click=${(e: Event) => e.target === e.currentTarget && this.cancel()}
+          @keydown=${(e: KeyboardEvent) => e.key === 'Escape' && this.cancel()}
+        >${form}</div>`
   }
 }
 

--- a/providers/agents/portal/src/views/automation.ts
+++ b/providers/agents/portal/src/views/automation.ts
@@ -187,13 +187,16 @@ export class AutomationSection extends StoreElement {
   }
 
   private async del(name: string): Promise<void> {
-    const ok = await confirmModal({ title: `Delete ${this.meta.one} “${name}”?`, danger: true, confirmLabel: 'Delete' })
-    if (!ok) return
-    await mutate(this.store, {
-      run: () => (this.kind === 'schedule' ? this.api.deleteSchedule(name) : this.api.deleteTrigger(name)),
-      success: `${cap(this.meta.one)} deleted.`,
+    const authority = this.captureAuthority()
+    const kind = this.kind
+    const one = META[kind].one
+    const ok = await confirmModal({ title: `Delete ${one} “${name}”?`, danger: true, confirmLabel: 'Delete' })
+    if (!ok || !this.authorityIsCurrent(authority)) return
+    await mutate(authority.store, {
+      run: () => (kind === 'schedule' ? authority.api.deleteSchedule(name) : authority.api.deleteTrigger(name)),
+      success: `${cap(one)} deleted.`,
       failure: 'Delete failed',
-      reload: [this.kind === 'schedule' ? 'schedules' : 'triggers'],
+      reload: [kind === 'schedule' ? 'schedules' : 'triggers'],
     })
   }
 

--- a/providers/agents/portal/src/views/connections.ts
+++ b/providers/agents/portal/src/views/connections.ts
@@ -5,7 +5,7 @@
 // both are "reusable capability config".
 
 import { html, nothing, type TemplateResult } from 'lit'
-import { state } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
 import { unsafeHTML } from 'lit/directives/unsafe-html.js'
 import { StoreElement } from '../ui/base'
@@ -14,6 +14,7 @@ import { sliceView } from '../ui/states'
 import { toast } from '../ui/toast'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
+import type { CreateSuccessDetail } from '../router'
 import {
   CATEGORY_META,
   CONN_DEFS,
@@ -68,6 +69,13 @@ function unwired(c: Connection, agents: Agent[]): boolean {
 }
 
 export class Connections extends StoreElement {
+  // The collection and create surfaces share the type definitions, but only
+  // the route-owned instance renders a consequential create flow. Keeping the
+  // property explicit also leaves standalone consumers on the compact picker
+  // behaviour until they opt into hash-owned navigation.
+  @property({ type: Boolean }) routeOwned = false
+  @property({ type: Boolean }) createRoute = false
+  @property({ type: String }) createType = ''
   @state() private connType: string | null = null
   @state() private connMode = ''
   @state() private editing: string | null = null
@@ -76,13 +84,22 @@ export class Connections extends StoreElement {
     const v: Record<string, string> = {}
     form.querySelectorAll<HTMLInputElement>('input[name]').forEach((el) => (v[el.name] = el.value.trim()))
     const mode = this.connMode || def.modes?.[0].id || ''
+    const body = def.build(v, mode)
     const res = await mutate(this.store, {
-      run: () => this.api.createConnection(def.build(v, mode)),
+      run: () => this.api.createConnection(body),
       success: 'Connection created.',
       failure: 'Create failed',
       reload: ['connections'],
     })
-    if (res) {
+    if (res && this.routeOwned) {
+      this.dispatchEvent(
+        new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+          detail: { resource: 'connection', name: body.name, item: res },
+          bubbles: true,
+          composed: true,
+        }),
+      )
+    } else if (res) {
       this.connType = null
       this.connMode = ''
     }
@@ -109,10 +126,11 @@ export class Connections extends StoreElement {
   }
 
   private async del(name: string): Promise<void> {
+    const authority = this.captureAuthority()
     const ok = await confirmModal({ title: `Delete connection “${name}”?`, danger: true, confirmLabel: 'Delete' })
-    if (!ok) return
-    await mutate(this.store, {
-      run: () => this.api.deleteConnection(name),
+    if (!ok || !this.authorityIsCurrent(authority)) return
+    await mutate(authority.store, {
+      run: () => authority.api.deleteConnection(name),
       success: 'Connection deleted.',
       failure: 'Delete failed',
       reload: ['connections'],
@@ -148,10 +166,16 @@ export class Connections extends StoreElement {
   }
 
   render(): TemplateResult {
+    if (this.createRoute) return this.createRouteSurface()
     return html`
       <div class="agents-menu">
         <div class="agents-panel k-card agents-route-panel">
-          <h3>Connections</h3>
+          <div class="agents-panel-head">
+            <h3>Connections</h3>
+            ${this.routeOwned
+              ? html`<button class="k-btn k-btn--primary" @click=${() => this.navigate({ kind: 'create', resource: 'connection' })}>${icon('plus')} New connection</button>`
+              : nothing}
+          </div>
           <p class="muted">
             Shared credentials for external systems. Each is a ${icon('wrench')} <strong>Tool</strong> agents call, a
             ${icon('megaphone')} <strong>Channel</strong> they message you on, or a ${icon('plug')} generic
@@ -164,11 +188,44 @@ export class Connections extends StoreElement {
             retry: () => void this.store.load('connections'),
             content: (rows) => this.table(rows),
           })}
-          ${this.editorArea()}
+          ${this.routeOwned
+            ? this.editing
+              ? this.editorArea()
+              : html`<agents-assisted-search .store=${this.store} .api=${this.api} .routeOwned=${true}></agents-assisted-search>`
+            : this.editorArea()}
         </div>
-        <agents-toolsets .store=${this.store} .api=${this.api}></agents-toolsets>
+        <agents-toolsets .store=${this.store} .api=${this.api} .routeOwned=${this.routeOwned}></agents-toolsets>
       </div>
     `
+  }
+
+  private createRouteSurface(): TemplateResult {
+    if (!this.createType) {
+      return html`<div class="agents-menu agents-create-page k-create-page">
+        <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+        <header class="k-create-header"><h1 class="k-create-title">Create connection</h1><p class="k-create-description">Choose the tool, channel, or external service you want agents to use.</p></header>
+        <div class="k-create-surface k-create-surface--wide">
+          <div class="k-create-body">${this.picker(false)}</div>
+        </div>
+      </div>`
+    }
+    if (this.createType === 'assisted-search') {
+      return html`<div class="agents-menu agents-create-page">
+        <agents-assisted-search .store=${this.store} .api=${this.api} .routeOwned=${true} .page=${true}></agents-assisted-search>
+      </div>`
+    }
+    const def = CONN_DEFS.find((d) => d.id === this.createType)
+    if (!def) {
+      return html`<div class="agents-create-page k-create-page">
+        <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+        <header class="k-create-header"><h1 class="k-create-title">Connection type unavailable</h1><p class="k-create-description">That connection type is not available in this version of the Agents provider.</p></header>
+      </div>`
+    }
+    return html`<div class="agents-menu agents-create-page k-create-page">
+      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+      <header class="k-create-header"><h1 class="k-create-title">Connect ${def.label}</h1><p class="k-create-description">${def.desc}</p></header>
+      ${this.createForm(def)}
+    </div>`
   }
 
   private table(rows: Connection[]): TemplateResult {
@@ -269,12 +326,16 @@ export class Connections extends StoreElement {
     return this.picker()
   }
 
-  private picker(): TemplateResult {
+  private picker(showHeading = true): TemplateResult {
     const tile = (d: ConnTypeDef): TemplateResult => html`<button
       class="k-btn k-btn--ghost agents-conn-tile"
       @click=${() => {
-        this.connType = d.id
-        this.connMode = ''
+        if (this.routeOwned) {
+          this.navigate({ kind: 'create', resource: 'connection', type: d.id })
+        } else {
+          this.connType = d.id
+          this.connMode = ''
+        }
       }}
     >
       <span class="agents-conn-glyph">${icon(d.glyph)}</span>
@@ -282,7 +343,7 @@ export class Connections extends StoreElement {
       <span class="muted">${d.desc}</span>
     </button>`
     return html`<div class="agents-conn-picker">
-      <h4>Add a connection</h4>
+      ${showHeading ? html`<h4>Add a connection</h4>` : nothing}
       ${(['tool', 'channel', 'connection'] as ConnCategory[]).map((cat) => {
         const defs = CONN_DEFS.filter((d) => connCategory(d.id) === cat)
         if (!defs.length) return nothing
@@ -291,7 +352,7 @@ export class Connections extends StoreElement {
           <h5 class="agents-conn-grouphead">${icon(m.icon)} ${m.label}s <span class="muted">— ${m.blurb}</span></h5>
           <div class="agents-conn-types">${defs.map(tile)}</div>
           ${cat === 'tool'
-            ? html`<agents-assisted-search .store=${this.store} .api=${this.api}></agents-assisted-search>`
+            ? html`<agents-assisted-search .store=${this.store} .api=${this.api} .routeOwned=${this.routeOwned}></agents-assisted-search>`
             : nothing}
         </div>`
       })}
@@ -313,9 +374,12 @@ export class Connections extends StoreElement {
   }
 
   private createForm(def: ConnTypeDef): TemplateResult {
-    const mode = this.connMode || def.modes?.[0].id || ''
+    // A routed connection element can be reused while the type segment changes
+    // (for example after browser back/forward). Ignore a mode from the prior
+    // type instead of indexing an absent mode.
+    const mode = def.modes?.some((m) => m.id === this.connMode) ? this.connMode : def.modes?.[0].id || ''
     const activeMode = def.modes?.find((m) => m.id === mode)
-    let fields = def.modes ? activeMode!.fields : def.fields || []
+    let fields = def.modes ? activeMode?.fields || [] : def.fields || []
     const advanced = [...(def.advanced || []), ...(activeMode?.advanced || [])]
     // Platform OAuth app configured (operator env)? Then OAuth modes need no
     // client id/secret — drop those fields.
@@ -323,17 +387,22 @@ export class Connections extends StoreElement {
     const platformApp = isOAuthMode && this.store.oauthApps.has(def.id)
     if (platformApp) fields = fields.filter((f) => f.key !== 'clientID' && f.key !== 'clientSecret')
     return html`<form
-      class="agents-conn-form k-card"
+      class=${this.routeOwned ? 'agents-conn-form k-create-surface' : 'agents-conn-form k-card'}
       @submit=${(e: Event) => {
         e.preventDefault()
         void this.create(def, e.target as HTMLFormElement)
       }}
     >
-      <div class="agents-conn-form k-cardhead">
-        <button type="button" class="k-btn k-btn--ghost agents-back" @click=${() => (this.connType = null)}>${icon('arrow-left')} connection types</button>
-        <h4>${icon(def.glyph)} ${def.label}</h4>
+      <div class=${this.routeOwned ? 'k-create-body' : ''}>
+      <div class="agents-conn-formhead">
+        <button
+          type="button"
+          class="k-btn k-btn--ghost agents-back"
+          @click=${() => (this.routeOwned ? this.navigate({ kind: 'create', resource: 'connection' }) : (this.connType = null))}
+        >${icon('arrow-left')} connection types</button>
+        ${this.routeOwned ? nothing : html`<h4>${icon(def.glyph)} ${def.label}</h4>`}
       </div>
-      <p class="muted">${def.desc}</p>
+      ${this.routeOwned ? nothing : html`<p class="muted">${def.desc}</p>`}
       ${def.setup
         ? html`<details class="agents-setup" open>
             <summary>Before you start — setup steps</summary>
@@ -366,8 +435,20 @@ export class Connections extends StoreElement {
       ${advanced.length
         ? html`<details class="agents-adv"><summary>Advanced</summary>${advanced.map((f) => this.field(f))}</details>`
         : nothing}
-      <div><button class="k-btn k-btn--primary" type="submit">Create connection</button></div>
+      </div>
+      <div class=${this.routeOwned ? 'k-create-actions' : ''}>
+        ${this.routeOwned ? html`<button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancelCreate()}>Cancel</button>` : nothing}
+        <button class="k-btn k-btn--primary" type="submit">Create connection</button>
+      </div>
     </form>`
+  }
+
+  private cancelCreate(): void {
+    if (this.routeOwned) {
+      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
+      return
+    }
+    this.connType = null
   }
 
   private editForm(c: Connection): TemplateResult {

--- a/providers/agents/portal/src/views/models.ts
+++ b/providers/agents/portal/src/views/models.ts
@@ -10,7 +10,7 @@
 // Each credential is its own Secret (faros-agents-model-<name>).
 
 import { html, nothing, svg, type TemplateResult } from 'lit'
-import { state } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
@@ -18,6 +18,7 @@ import { errorState } from '../ui/states'
 import { toast } from '../ui/toast'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
+import type { CreateSuccessDetail } from '../router'
 import { PROVIDER_PRESETS } from '../conn-defs'
 import {
   fmtTokens,
@@ -30,6 +31,8 @@ import {
 } from '../types'
 
 export class Models extends StoreElement {
+  @property({ type: Boolean }) routeOwned = false
+  @property({ type: Boolean }) createRoute = false
   @state() private catalog: ModelInfo[] = []
   @state() private usage: UsageResponse | null = null
   @state() private usageError: string | null = null
@@ -93,15 +96,16 @@ export class Models extends StoreElement {
   }
 
   private async del(name: string): Promise<void> {
+    const authority = this.captureAuthority()
     const ok = await confirmModal({
       title: `Delete credential “${name}”?`,
       message: 'Agents using it will need reassigning.',
       danger: true,
       confirmLabel: 'Delete',
     })
-    if (!ok) return
-    await mutate(this.store, {
-      run: () => this.api.deleteCredential(name),
+    if (!ok || !this.authorityIsCurrent(authority)) return
+    await mutate(authority.store, {
+      run: () => authority.api.deleteCredential(name),
       success: 'Credential deleted.',
       failure: 'Delete failed',
       reload: ['credentials'],
@@ -109,11 +113,17 @@ export class Models extends StoreElement {
   }
 
   render(): TemplateResult {
+    if (this.createRoute) return this.createSurface()
     const creds = this.store.credentials
     return html`<div class="agents-panel k-card agents-route-panel">
       <div class="agents-panel-head">
         <h3>Models</h3>
-        ${this.creating ? nothing : html`<button class="k-btn k-btn--primary" @click=${() => (this.creating = true)}>${icon('plus')} New model</button>`}
+        ${this.creating
+          ? nothing
+          : html`<button
+              class="k-btn k-btn--primary"
+              @click=${() => (this.routeOwned ? this.navigate({ kind: 'create', resource: 'model' }) : (this.creating = true))}
+            >${icon('plus')} New model</button>`}
       </div>
       <p class="muted">
         Model credentials shared across the workspace (each is a Secret <code>faros-agents-model-&lt;name&gt;</code>). Assign them to
@@ -133,6 +143,17 @@ export class Models extends StoreElement {
               )}
             </div>`}
       ${this.creating ? this.createForm() : nothing}
+      <datalist id="agents-catalog-models">
+        ${this.catalog.map((m) => html`<option value=${m.id}>${m.label || m.id}</option>`)}
+      </datalist>
+    </div>`
+  }
+
+  private createSurface(): TemplateResult {
+    return html`<div class="agents-menu agents-create-page k-create-page">
+      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Models</button>
+      <header class="k-create-header"><h1 class="k-create-title">Add model credential</h1><p class="k-create-description">Configure a workspace model endpoint and credential for your agents.</p></header>
+      ${this.createForm()}
       <datalist id="agents-catalog-models">
         ${this.catalog.map((m) => html`<option value=${m.id}>${m.label || m.id}</option>`)}
       </datalist>
@@ -396,27 +417,41 @@ export class Models extends StoreElement {
 
   private createForm(): TemplateResult {
     return html`<form
-      class="agents-cred-form agents-model-create"
+      class=${this.createRoute ? 'agents-cred-form agents-model-create k-create-surface' : 'agents-cred-form agents-model-create'}
       @submit=${(e: Event) => {
         e.preventDefault()
         const f = e.target as HTMLFormElement
         const g = (n: string): string => (f.querySelector<HTMLInputElement>(`[name=${n}]`)?.value || '').trim()
+        const body = {
+          name: g('name'),
+          provider: 'openai-compatible',
+          baseURL: g('baseURL'),
+          model: g('model'),
+          apiKey: g('apiKey'),
+        }
         void mutate(this.store, {
-          run: () =>
-            this.api.saveCredential({
-              name: g('name'),
-              provider: 'openai-compatible',
-              baseURL: g('baseURL'),
-              model: g('model'),
-              apiKey: g('apiKey'),
-            }),
+          run: () => this.api.saveCredential(body),
           success: 'Credential saved.',
           failure: 'Save failed',
           reload: ['credentials'],
-        }).then((ok) => ok && (this.creating = false))
+        }).then((res) => {
+          if (!res) return
+          if (this.routeOwned) {
+            this.dispatchEvent(
+              new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+                detail: { resource: 'model', name: body.name, item: res },
+                bubbles: true,
+                composed: true,
+              }),
+            )
+            return
+          }
+          this.creating = false
+        })
       }}
     >
-      <h4>New model credential</h4>
+      <div class=${this.createRoute ? 'k-create-body' : ''}>
+      ${this.createRoute ? nothing : html`<h4>New model credential</h4>`}
       <div class="agents-grid2">
         <label>Name<input class="k-input" name="name" required pattern="[a-z0-9-]+" placeholder="my-openai" /></label>
         <label>
@@ -440,11 +475,20 @@ export class Models extends StoreElement {
         <label>Model<input class="k-input mono" name="model"  placeholder="gpt-4o" required list="agents-catalog-models" /></label>
       </div>
       <label>API key<input class="k-input" name="apiKey" type="password" autocomplete="off" placeholder="sk-…" required /></label>
-      <div class="agents-form-actions">
+      </div>
+      <div class=${this.createRoute ? 'k-create-actions' : 'agents-form-actions'}>
+        <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancelCreate()}>Cancel</button>
         <button class="k-btn k-btn--primary" type="submit">Add credential</button>
-        <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => (this.creating = false)}>Cancel</button>
       </div>
     </form>`
+  }
+
+  private cancelCreate(): void {
+    if (this.createRoute) {
+      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
+      return
+    }
+    this.creating = false
   }
 }
 

--- a/providers/agents/portal/src/views/toolsets.ts
+++ b/providers/agents/portal/src/views/toolsets.ts
@@ -3,23 +3,30 @@
 // families list is never hand-picked.
 
 import { html, nothing, type TemplateResult } from 'lit'
-import { state } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
 import { errorState } from '../ui/states'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
+import type { CreateSuccessDetail } from '../router'
 import type { Toolset } from '../types'
 
 export class Toolsets extends StoreElement {
-  // editing: null = closed, '' = creating, name = editing that toolset.
+  @property({ type: Boolean }) routeOwned = false
+  @property({ type: Boolean }) createRoute = false
+  // editing is null when closed, otherwise the existing toolset being edited.
   @state() private editing: string | null = null
   @state() private draftName = ''
   @state() private draftDisplay = ''
   @state() private draftConns: string[] = []
 
   private openCreate(): void {
+    if (this.routeOwned) {
+      this.navigate({ kind: 'create', resource: 'toolset' })
+      return
+    }
     this.editing = ''
     this.draftName = ''
     this.draftDisplay = ''
@@ -35,6 +42,11 @@ export class Toolsets extends StoreElement {
 
   private async save(e: Event): Promise<void> {
     e.preventDefault()
+    const form = e.currentTarget as HTMLFormElement
+    // Read the create id from the form as well as the draft state. This keeps
+    // the route surface correct for native form submission and for callers
+    // that set an input before dispatching submit in an embedded host.
+    const name = (form.querySelector<HTMLInputElement>('[name=name]')?.value || this.draftName).trim()
     const connections = this.draftConns
     const families = this.store.familiesFor(connections)
     const displayName = this.draftDisplay.trim()
@@ -47,24 +59,35 @@ export class Toolsets extends StoreElement {
           reload: ['toolsets'],
         })
       : await mutate(this.store, {
-          run: () => this.api.createToolset({ name: this.draftName.trim(), displayName, families, connections }),
+          run: () => this.api.createToolset({ name, displayName, families, connections }),
           success: 'Toolset created.',
           failure: 'Create failed',
           reload: ['toolsets'],
         })
-    if (res) this.editing = null
+    if (res && this.routeOwned && !editing) {
+      this.dispatchEvent(
+        new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+          detail: { resource: 'toolset', name, item: res },
+          bubbles: true,
+          composed: true,
+        }),
+      )
+    } else if (res) {
+      this.editing = null
+    }
   }
 
   private async del(name: string): Promise<void> {
+    const authority = this.captureAuthority()
     const ok = await confirmModal({
       title: `Delete toolset “${name}”?`,
       message: 'Agents linking it will lose those tools.',
       danger: true,
       confirmLabel: 'Delete',
     })
-    if (!ok) return
-    await mutate(this.store, {
-      run: () => this.api.deleteToolset(name),
+    if (!ok || !this.authorityIsCurrent(authority)) return
+    await mutate(authority.store, {
+      run: () => authority.api.deleteToolset(name),
       success: 'Toolset deleted.',
       failure: 'Delete failed',
       reload: ['toolsets'],
@@ -78,6 +101,7 @@ export class Toolsets extends StoreElement {
   }
 
   render(): TemplateResult {
+    if (this.createRoute) return this.createSurface()
     const slice = this.store.toolsets
     return html`<div class="agents-panel k-card agents-route-panel">
       <div class="agents-panel-head">
@@ -131,16 +155,26 @@ export class Toolsets extends StoreElement {
     </div>`
   }
 
+  private createSurface(): TemplateResult {
+    return html`<div class="agents-menu agents-create-page k-create-page">
+      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+      <header class="k-create-header"><h1 class="k-create-title">Create toolset</h1><p class="k-create-description">Bundle reusable tools once, then attach the toolset to any agent.</p></header>
+      ${this.form()}
+    </div>`
+  }
+
   private form(): TemplateResult {
     const toolConns = this.store.toolConnections()
     const isEdit = !!this.editing
-    return html`<form class="agents-toolset-form k-card" @submit=${(e: Event) => void this.save(e)}>
-      <h4>${isEdit ? html`Edit toolset <code>${this.editing}</code>` : 'New toolset'}</h4>
+    return html`<form class=${this.createRoute ? 'agents-toolset-form k-create-surface' : 'agents-toolset-form k-card'} @submit=${(e: Event) => void this.save(e)}>
+      <div class=${this.createRoute ? 'k-create-body' : ''}>
+      ${this.createRoute ? nothing : html`<h4>${isEdit ? html`Edit toolset <code>${this.editing}</code>` : 'New toolset'}</h4>`}
       ${isEdit
         ? html`<label>Display name<input class="k-input" .value=${this.draftDisplay} @input=${(e: Event) => (this.draftDisplay = (e.target as HTMLInputElement).value)} /></label>`
         : html`<div class="agents-grid2">
             <label
               >Name *<input class="k-input"
+                name="name"
                 required
                 pattern="[a-z0-9-]+"
                 placeholder="dev-tools"
@@ -177,11 +211,20 @@ export class Toolsets extends StoreElement {
         </div>
         <span class="agents-hint">Tool families are derived from these connections — never picked by hand.</span>
       </fieldset>
-      <div class="agents-form-actions">
+      </div>
+      <div class=${this.createRoute ? 'k-create-actions' : 'agents-form-actions'}>
+        <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancelCreate()}>Cancel</button>
         <button class="k-btn k-btn--primary" type="submit">${isEdit ? 'Save' : 'Create toolset'}</button>
-        <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => (this.editing = null)}>Cancel</button>
       </div>
     </form>`
+  }
+
+  private cancelCreate(): void {
+    if (this.createRoute) {
+      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
+      return
+    }
+    this.editing = null
   }
 }
 

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -3,6 +3,7 @@ import MarkdownIt from 'markdown-it'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, type Component } from 'vue'
 import {
   AppWindow,
+  ArrowLeft,
   ArrowRight,
   ArrowUp,
   BarChart3,
@@ -281,7 +282,7 @@ import type {
 
 const props = defineProps<{
   ctx: FarosContext | null
-  navigate: (path: string) => void
+  navigate: (path: string, options?: { replace?: boolean }) => void
   requestFullBleed?: (fullBleed: boolean) => void
 }>()
 
@@ -294,6 +295,12 @@ interface ProjectThumbnailRequestGuard {
   serial: number
   contextFingerprint: string
   ctx: FarosContext | null
+}
+
+interface LLMModelMutationGuard {
+  generation: number
+  contextFingerprint: string
+  routePath: string
 }
 
 function appContextFingerprint(ctx: FarosContext | null): string {
@@ -443,6 +450,7 @@ const GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com'
 const GOOGLE_CLOUD_BASE_URL = 'https://aiplatform.googleapis.com'
 const CREATE_PROJECT_ROUTE = '~new'
 const MODELS_ROUTE = '~models'
+const CREATE_MODEL_ROUTE = 'create/model'
 const appStudioSectionTabs = [
   { id: 'projects', label: 'Projects', icon: Folder },
   { id: 'models', label: 'Models', icon: Cpu },
@@ -841,6 +849,7 @@ const llmSaving = ref(false)
 const llmStatus = ref<string | null>(null)
 const llmActionError = ref<string | null>(null)
 const llmEditorOpen = ref(false)
+const llmCreateRouteSession = ref(false)
 const llmSettingsLoading = ref(false)
 const llmSettingsError = ref<string | null>(null)
 let llmSettingsLoadSerial = 0
@@ -871,6 +880,7 @@ let developmentPreviewRecoveryTimer: number | undefined
 let developmentPreviewComponentMounted = true
 let assistantThreadRequestSerial = 0
 let createReadinessLoadSerial = 0
+let llmModelMutationGeneration = 0
 const developmentPreviewRefreshController = new DevelopmentPreviewRefreshController<Project>({
   isMounted: () => developmentPreviewComponentMounted,
   selectedProjectName: () => selected.value?.name,
@@ -1001,6 +1011,29 @@ function clearPendingFirstProjectSubmission() {
   pendingFirstProjectSubmission = null
 }
 
+function invalidateLLMModelMutationState() {
+  llmModelMutationGeneration += 1
+  // A route/context transition owns the replacement busy state. The previous
+  // request remains in flight, but its finalizer is no longer allowed to
+  // touch this value.
+  llmSaving.value = false
+}
+
+function beginLLMModelMutation(): LLMModelMutationGuard {
+  return {
+    generation: ++llmModelMutationGeneration,
+    contextFingerprint: appContextFingerprint(props.ctx),
+    routePath: routePath.value,
+  }
+}
+
+function llmModelMutationIsCurrent(guard: LLMModelMutationGuard): boolean {
+  return appComponentMounted &&
+    guard.generation === llmModelMutationGeneration &&
+    guard.contextFingerprint === appContextFingerprint(props.ctx) &&
+    guard.routePath === routePath.value
+}
+
 function invalidateProjectContextState() {
   const hasToken = Boolean(props.ctx?.token)
   projectLoadSerial += 1
@@ -1021,6 +1054,7 @@ function invalidateProjectContextState() {
   projectSettingsSaveSerial += 1
   releaseLoadSerial += 1
   historyLoadSerial += 1
+  invalidateLLMModelMutationState()
 
   clearInitializationRetry()
   clearProjectThumbnailURLs()
@@ -1178,7 +1212,7 @@ function applyAssistantSkillsCatalogResponse(response: ProjectAssistantSkillsRes
 }
 
 async function loadAssistantSkills(projectName: string) {
-  if (!projectName || !props.ctx?.token || isCreateRoute.value || selected.value?.name !== projectName || selected.value.phase === 'Creating') return
+  if (!projectName || !props.ctx?.token || isCreateRoute.value || isCreateModelRoute.value || selected.value?.name !== projectName || selected.value.phase === 'Creating') return
   const serial = ++assistantSkillsLoadSerial
   assistantSkillsLoading.value = true
   assistantSkillsError.value = null
@@ -1187,12 +1221,13 @@ async function loadAssistantSkills(projectName: string) {
     if (
       serial !== assistantSkillsLoadSerial ||
       selected.value?.name !== projectName ||
-      isCreateRoute.value
+      isCreateRoute.value ||
+      isCreateModelRoute.value
     ) return
     applyAssistantSkillsCatalog(catalog.skills)
     assistantSkillsWarnings.value = catalog.warnings ?? []
   } catch (e) {
-    if (serial !== assistantSkillsLoadSerial || selected.value?.name !== projectName || isCreateRoute.value) return
+    if (serial !== assistantSkillsLoadSerial || selected.value?.name !== projectName || isCreateRoute.value || isCreateModelRoute.value) return
     // Skill discovery is intentionally scoped to the Skills workbench. A
     // stale or unavailable catalog must never make the project composer unusable.
     assistantSkillsError.value = e instanceof Error ? e.message : String(e)
@@ -1351,11 +1386,13 @@ const routeSegment = computed(() => {
     return raw
   }
 })
+const routePath = computed(() => (props.ctx?.subPath ?? '').split('/').filter(Boolean).join('/'))
 const isProjectIndexRoute = computed(() => routeSegment.value === '')
 const isCreateRoute = computed(() => routeSegment.value === CREATE_PROJECT_ROUTE)
 const isModelsRoute = computed(() => routeSegment.value === MODELS_ROUTE)
-const selectedNameFromPath = computed(() => (isCreateRoute.value || isModelsRoute.value ? '' : routeSegment.value))
-const isAppStudioLandingRoute = computed(() => isProjectIndexRoute.value || isCreateRoute.value || isModelsRoute.value)
+const isCreateModelRoute = computed(() => routePath.value === CREATE_MODEL_ROUTE)
+const selectedNameFromPath = computed(() => (isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value ? '' : routeSegment.value))
+const isAppStudioLandingRoute = computed(() => isProjectIndexRoute.value || isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value)
 const modelsReturnRoute = ref('')
 const projectRouteLoading = computed(() => Boolean(
   projectOpenLoading.value ||
@@ -1376,7 +1413,7 @@ const projectRouteShellVisible = computed(() => projectRouteLoading.value || pro
 const conversationLoading = computed(() => projectRouteLoading.value || threadHistoryLoading.value || !!selectingThreadID.value)
 const conversationInteractionBusy = computed(() => conversationLoading.value || conversationRefreshing.value || projectRouteFailure.value)
 const isBuilderVisible = computed(() =>
-  !isAppStudioLandingRoute.value || (!isModelsRoute.value && selected.value !== null),
+  !isAppStudioLandingRoute.value || (!isModelsRoute.value && !isCreateModelRoute.value && selected.value !== null),
 )
 watch(
   isBuilderVisible,
@@ -1422,12 +1459,14 @@ const canSendPrompt = computed(() =>
 )
 const threadActionsDisabled = computed(() => conversationInteractionBusy.value || messageStreaming.value || busy.value || threadMutationBusy.value)
 const settingsProject = computed(() => (isAppStudioLandingRoute.value ? null : selected.value))
-const settingsTitle = computed(() => (settingsProject.value ? 'Project settings' : 'Models'))
-const settingsDescription = computed(() =>
-  settingsProject.value
-    ? 'Update this project and manage its development preview access.'
-    : 'Configure the model credentials App Studio uses when creating and chatting in projects.',
-)
+const settingsTitle = computed(() => (
+  isCreateModelRoute.value ? 'New model' : settingsProject.value ? 'Project settings' : 'Models'
+))
+const settingsDescription = computed(() => {
+  if (isCreateModelRoute.value) return 'Configure the model credentials App Studio uses when creating and chatting in projects.'
+  if (settingsProject.value) return 'Update this project and manage its development preview access.'
+  return 'Configure the model credentials App Studio uses when creating and chatting in projects.'
+})
 const activePlanMessage = computed(() =>
   activeAssistantPlanMessage(
     messages.value,
@@ -1771,12 +1810,12 @@ const settingsInWorkbench = computed(() => !!settingsProject.value && activeWork
 const publishingInWorkbench = computed(() => activeWorkbenchTab.value?.kind === 'publishing')
 const historyInWorkbench = computed(() => activeWorkbenchTab.value?.kind === 'history')
 const projectControlSurfaceInWorkbench = computed(() => settingsInWorkbench.value || publishingInWorkbench.value || historyInWorkbench.value)
-const settingsSurfaceInline = computed(() => projectControlSurfaceInWorkbench.value || isModelsRoute.value)
+const settingsSurfaceInline = computed(() => projectControlSurfaceInWorkbench.value || isModelsRoute.value || isCreateModelRoute.value)
 const projectControlSurfaceTarget = computed(() => {
   if (publishingInWorkbench.value) return '#app-studio-publishing-host'
   if (historyInWorkbench.value) return '#app-studio-history-host'
   if (settingsInWorkbench.value) return '#app-studio-project-settings-host'
-  if (isModelsRoute.value) return '#app-studio-models-host'
+  if (isModelsRoute.value || isCreateModelRoute.value) return '#app-studio-models-host'
   return 'body'
 })
 const productionSurfaceActive = computed(() => publishingInWorkbench.value || shareDialogOpen.value)
@@ -2092,6 +2131,7 @@ onMounted(() => {
 watch(
   () => props.ctx?.subPath ?? '',
   () => {
+    invalidateLLMModelMutationState()
     // A route change can leave the previous project's stream mounted until
     // the replacement project has hydrated. Detach that stream immediately,
     // while keeping the split-pane shell visible for the replacement load.
@@ -2130,6 +2170,7 @@ watch(
     // asynchronous project/catalog response can arrive. Otherwise a pending
     // default or old project's tabs could be written under the new scope.
     invalidateProjectContextState()
+    if (isCreateModelRoute.value) openLLMEditor()
     void load()
     void loadProviders()
     void loadCreateReadiness()
@@ -2213,10 +2254,10 @@ watch(
 )
 
 watch(
-  () => [selected.value?.name ?? '', props.ctx?.token ?? '', isCreateRoute.value] as const,
-  ([projectName, _token, createRoute]) => {
+  () => [selected.value?.name ?? '', props.ctx?.token ?? '', isCreateRoute.value, isCreateModelRoute.value] as const,
+  ([projectName, _token, createRoute, createModelRoute]) => {
     resetAssistantSkillsState()
-    if (projectName && !createRoute && selected.value?.phase !== 'Creating') {
+    if (projectName && !createRoute && !createModelRoute && selected.value?.phase !== 'Creating') {
       void loadAssistantSkills(projectName)
     }
   },
@@ -2416,7 +2457,7 @@ async function load() {
     void hydrateProjectThumbnails(projectList)
     projectsLoaded.value = true
     initializing.value = false
-    if (isCreateRoute.value || isModelsRoute.value) {
+    if (isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value) {
 	  clearPendingFirstProjectSubmission()
       activeProjectContextFingerprint = ''
       resetProjectOpenLatch()
@@ -3518,6 +3559,7 @@ function selectLLMProvider(provider: string) {
 }
 
 function openLLMEditor(modelID?: string) {
+  invalidateLLMModelMutationState()
   llmStatus.value = null
   llmActionError.value = null
   const saved = llmSettings.value?.models.find((model) => model.id === modelID)
@@ -3532,13 +3574,57 @@ function openLLMEditor(modelID?: string) {
   llmEditorOpen.value = true
 }
 
+function openNewLLMModelEditor() {
+  // Keep the project-creation handoff while it is active. A model opened
+  // directly from the Models section has no stored handoff and returns there.
+  if (!modelsReturnRoute.value && isCreateRoute.value) modelsReturnRoute.value = CREATE_PROJECT_ROUTE
+  openLLMEditor()
+  props.navigate(CREATE_MODEL_ROUTE)
+}
+
+function openModelEditor(modelID?: string) {
+  if (modelID !== undefined) {
+    openLLMEditor(modelID)
+    return
+  }
+  openNewLLMModelEditor()
+}
+
 function cancelLLMEditor() {
   if (llmSaving.value) return
+  const routeOwnedCreation = isCreateModelRoute.value
+  const returnRoute = routeOwnedCreation
+    ? (modelsReturnRoute.value === CREATE_PROJECT_ROUTE ? CREATE_PROJECT_ROUTE : MODELS_ROUTE)
+    : null
+  invalidateLLMModelMutationState()
   llmStatus.value = null
   llmActionError.value = null
   llmEditorOpen.value = false
   llmEditingModelID.value = null
+  if (returnRoute) {
+    modelsReturnRoute.value = ''
+    props.navigate(returnRoute, { replace: true })
+  }
 }
+
+watch(
+  isCreateModelRoute,
+  (active, previous) => {
+    if (active) {
+      llmCreateRouteSession.value = true
+      // A direct link or a browser revisit must always start a fresh model,
+      // even if a contextual edit or a previous draft was open before the
+      // route changed.
+      openLLMEditor()
+      return
+    }
+    if (previous && llmCreateRouteSession.value) {
+      llmCreateRouteSession.value = false
+      if (!llmEditingModelID.value) llmEditorOpen.value = false
+    }
+  },
+  { immediate: true, flush: 'sync' },
+)
 
 async function applyStarterPrompt(value: string) {
   replaceAssistantComposerText(value)
@@ -3720,6 +3806,13 @@ async function saveLLMSettings() {
   llmStatus.value = null
   llmActionError.value = null
   if (llmBaseURLError.value) return
+  const routeOwnedCreation = isCreateModelRoute.value && !llmEditingModelID.value
+  const editingID = llmEditingModelID.value
+  const returnRoute = routeOwnedCreation
+    ? (modelsReturnRoute.value === CREATE_PROJECT_ROUTE ? CREATE_PROJECT_ROUTE : MODELS_ROUTE)
+    : null
+  const guard = beginLLMModelMutation()
+  const mutationContext = props.ctx
   llmSaving.value = true
   try {
     const body: { name: string; provider?: string; baseURL?: string; model: string; apiKey?: string } = {
@@ -3729,22 +3822,32 @@ async function saveLLMSettings() {
       model: normalizeLLMModelInput(llmProvider.value, llmModel.value, llmCredentialMode.value),
     }
     if (llmApiKey.value.trim()) body.apiKey = llmApiKey.value.trim()
-    const editingID = llmEditingModelID.value
     const settings = editingID
-      ? await api.patchLLMModel(props.ctx, editingID, body)
-      : await api.createLLMModel(props.ctx, body)
+      ? await api.patchLLMModel(mutationContext, editingID, body)
+      : await api.createLLMModel(mutationContext, body)
+    if (!llmModelMutationIsCurrent(guard)) return
     applyLLMSettings(settings)
     llmStatus.value = editingID ? 'Model updated.' : 'Model added.'
     llmEditorOpen.value = false
     llmEditingModelID.value = null
+    if (returnRoute) {
+      modelsReturnRoute.value = ''
+      props.navigate(returnRoute, { replace: true })
+    }
   } catch (e) {
+    if (!llmModelMutationIsCurrent(guard)) return
     llmActionError.value = e instanceof Error ? e.message : String(e)
   } finally {
-    llmSaving.value = false
+    if (llmModelMutationIsCurrent(guard)) llmSaving.value = false
   }
 }
 
 async function deleteLLMModel(modelID: string) {
+  const confirmationGuard: LLMModelMutationGuard = {
+    generation: llmModelMutationGeneration,
+    contextFingerprint: appContextFingerprint(props.ctx),
+    routePath: routePath.value,
+  }
   const saved = llmSettings.value?.models.find((model) => model.id === modelID)
   if (!saved) return
   if (!(await confirmDialog({
@@ -3753,33 +3856,45 @@ async function deleteLLMModel(modelID: string) {
     danger: true,
     confirmLabel: 'Delete model',
   }))) return
+  if (!llmModelMutationIsCurrent(confirmationGuard)) return
+  const guard = beginLLMModelMutation()
+  const mutationContext = props.ctx
   llmSaving.value = true
   llmStatus.value = null
   llmActionError.value = null
   try {
-    const settings = await api.deleteLLMModel(props.ctx, modelID)
+    const settings = await api.deleteLLMModel(mutationContext, modelID)
+    if (!llmModelMutationIsCurrent(guard)) return
     applyLLMSettings(settings)
     llmStatus.value = 'Model deleted.'
-    if (llmEditingModelID.value === modelID) cancelLLMEditor()
+    if (llmEditingModelID.value === modelID) {
+      llmEditorOpen.value = false
+      llmEditingModelID.value = null
+    }
   } catch (e) {
+    if (!llmModelMutationIsCurrent(guard)) return
     llmActionError.value = e instanceof Error ? e.message : String(e)
   } finally {
-    llmSaving.value = false
+    if (llmModelMutationIsCurrent(guard)) llmSaving.value = false
   }
 }
 
 async function setDefaultLLMModel(modelID: string) {
+  const guard = beginLLMModelMutation()
+  const mutationContext = props.ctx
   llmSaving.value = true
   llmStatus.value = null
   llmActionError.value = null
   try {
-    const settings = await api.setDefaultLLMModel(props.ctx, modelID)
+    const settings = await api.setDefaultLLMModel(mutationContext, modelID)
+    if (!llmModelMutationIsCurrent(guard)) return
     applyLLMSettings(settings)
     llmStatus.value = 'Default model updated.'
   } catch (e) {
+    if (!llmModelMutationIsCurrent(guard)) return
     llmActionError.value = e instanceof Error ? e.message : String(e)
   } finally {
-    llmSaving.value = false
+    if (llmModelMutationIsCurrent(guard)) llmSaving.value = false
   }
 }
 
@@ -3980,7 +4095,11 @@ async function openSettings() {
     openBuiltInWorkbenchTab('settings')
     await nextTick()
   } else {
-    if (!llmSettings.value?.configured) openLLMEditor()
+    if (!llmSettings.value?.configured) {
+      modelsReturnRoute.value = isCreateRoute.value ? CREATE_PROJECT_ROUTE : ''
+      openNewLLMModelEditor()
+      return
+    }
     openModelsSection()
     return
   }
@@ -3994,7 +4113,8 @@ function openProjectsSection() {
 }
 
 function openModelsSection() {
-  modelsReturnRoute.value = isCreateRoute.value ? CREATE_PROJECT_ROUTE : ''
+  if (isCreateRoute.value) modelsReturnRoute.value = CREATE_PROJECT_ROUTE
+  else if (!isCreateModelRoute.value) modelsReturnRoute.value = ''
   props.navigate(MODELS_ROUTE)
 }
 
@@ -6647,9 +6767,14 @@ function pushToolContext() {
 
 function onNestedProviderNavigate(e: Event) {
   e.stopPropagation()
-  const path = ((e as CustomEvent<{ path?: string }>).detail?.path ?? '').replace(/^\/+/, '')
+  const detail = (e as CustomEvent<{ path?: unknown; replace?: unknown }>).detail
+  const path = (typeof detail?.path === 'string' ? detail.path : '').replace(/^\/+/, '')
   const tab = activeWorkbenchTab.value
   if (!tab || tab.kind !== 'provider') return
+  // Nested provider tabs have one persisted descriptor rather than their own
+  // shell history stack. Updating that descriptor in place is therefore the
+  // equivalent of both push and replace navigation, while accepting optional
+  // replace metadata keeps the nested event contract aligned with the shell.
   workbench.value = updateWorkbenchProviderToolPath(workbench.value, tab.id, path)
   void nextTick(pushToolContext)
 }
@@ -6962,8 +7087,9 @@ function isMissingCodeConnectionError(value: string | null): boolean {
   <div v-else-if="!isBuilderVisible" class="min-h-0 bg-surface text-text-primary">
     <div class="flex min-h-full w-full flex-col gap-4">
       <Tabs
+        v-if="!isCreateModelRoute"
         :tabs="appStudioSectionTabs"
-        :active="isModelsRoute ? 'models' : 'projects'"
+        :active="isModelsRoute || isCreateModelRoute ? 'models' : 'projects'"
         aria-label="App Studio sections"
         @select="selectAppStudioSection"
       />
@@ -7338,7 +7464,14 @@ function isMissingCodeConnectionError(value: string | null): boolean {
         </main>
       </div>
 
-      <section v-else-if="isModelsRoute" class="min-h-0 pb-6">
+      <section v-else-if="isModelsRoute || isCreateModelRoute" :class="isCreateModelRoute ? 'k-create-page pb-6' : 'min-h-0 pb-6'">
+        <button v-if="isCreateModelRoute" type="button" class="k-btn k-btn--ghost k-back-action" :disabled="llmSaving" @click="cancelLLMEditor">
+          <ArrowLeft class="h-3.5 w-3.5" :stroke-width="1.75" /> Models
+        </button>
+        <header v-if="isCreateModelRoute" class="k-create-header">
+          <h1 class="k-create-title">Add model</h1>
+          <p class="k-create-description">Configure the model credentials App Studio uses when creating and chatting in projects.</p>
+        </header>
         <div id="app-studio-models-host" class="min-h-[420px]" />
       </section>
 
@@ -8655,24 +8788,26 @@ function isMissingCodeConnectionError(value: string | null): boolean {
 
   <Teleport defer :to="projectControlSurfaceTarget">
     <div
-      v-if="showSettings || publishingInWorkbench || historyInWorkbench || (isModelsRoute && !(initializing && !loading))"
+      v-if="showSettings || publishingInWorkbench || historyInWorkbench || ((isModelsRoute || isCreateModelRoute) && !(initializing && !loading))"
       :class="settingsSurfaceInline
         ? 'h-full min-h-0'
         : 'fixed inset-0 z-[100] flex items-center justify-center bg-surface/60 px-4 py-6 backdrop-blur-sm'"
       @click.self="!settingsSurfaceInline && closeSettings()"
     >
       <div
-        class="flex w-full flex-col overflow-hidden bg-surface-raised"
+        class="flex w-full flex-col"
         :class="projectControlSurfaceInWorkbench
-          ? 'h-full min-h-0'
+          ? 'h-full min-h-0 overflow-hidden bg-surface-raised'
+          : isCreateModelRoute
+            ? ''
           : isModelsRoute
             ? 'rounded-lg border border-border-subtle'
           : 'max-h-[90vh] max-w-2xl rounded-xl border border-border-subtle shadow-2xl'"
       >
-        <header v-if="!publishingInWorkbench && !historyInWorkbench" class="flex items-center justify-between gap-3 border-b border-border-subtle bg-surface-overlay/60 px-4 py-3">
+        <header v-if="!publishingInWorkbench && !historyInWorkbench && !isCreateModelRoute" class="flex items-center justify-between gap-3 border-b border-border-subtle bg-surface-overlay/60 px-4 py-3">
           <div class="min-w-0">
             <div class="flex items-center gap-2">
-              <Cpu v-if="isModelsRoute" class="h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" />
+              <Cpu v-if="isModelsRoute || isCreateModelRoute" class="h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" />
               <Settings2 v-else class="h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" />
               <h2 class="truncate text-[15px] font-semibold text-text-primary">{{ settingsTitle }}</h2>
             </div>
@@ -8681,7 +8816,7 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             </p>
           </div>
           <button
-            v-if="!settingsInWorkbench && !isModelsRoute"
+            v-if="!settingsInWorkbench && !isModelsRoute && !isCreateModelRoute"
             type="button"
             class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-muted transition hover:bg-surface-hover hover:text-text-primary"
             title="Close"
@@ -8691,7 +8826,7 @@ function isMissingCodeConnectionError(value: string | null): boolean {
           </button>
         </header>
 
-        <div class="min-h-0 overflow-auto p-4">
+        <div :class="isCreateModelRoute ? '' : 'min-h-0 overflow-auto p-4'">
           <div class="grid gap-4">
           <div
             v-if="settingsProject && !publishingInWorkbench && !historyInWorkbench"
@@ -9075,7 +9210,8 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             :saving="llmSaving"
             :status="llmStatus"
             :action-error="llmActionError"
-            :editor-open="llmEditorOpen"
+            :editor-open="llmEditorOpen || isCreateModelRoute"
+            :creation-route="isCreateModelRoute"
             :editing-model-i-d="llmEditingModelID"
             :name="llmName"
             :provider="llmProvider"
@@ -9090,7 +9226,7 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             :google-provider="isGoogleGeminiProvider"
             :google-service-account-mode="isGoogleServiceAccountMode"
             @retry="loadLLMSettings"
-            @open-editor="openLLMEditor"
+            @open-editor="openModelEditor"
             @cancel-editor="cancelLLMEditor"
             @save="saveLLMSettings"
             @delete="deleteLLMModel"

--- a/providers/app-studio/portal/src/ModelsSettings.vue
+++ b/providers/app-studio/portal/src/ModelsSettings.vue
@@ -13,6 +13,7 @@ defineProps<{
   status: string | null
   actionError: string | null
   editorOpen: boolean
+  creationRoute: boolean
   editingModelID: string | null
   name: string
   provider: string
@@ -45,16 +46,18 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <section class="grid gap-4" aria-label="Models">
-    <div class="flex flex-wrap items-start justify-between gap-3">
+  <section class="grid gap-4" :aria-label="creationRoute ? 'New model' : 'Models'">
+    <div v-if="!creationRoute" class="flex flex-wrap items-start justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="text-[14px] font-semibold text-text-primary">Models</h3>
+        <h3 class="text-[14px] font-semibold text-text-primary">{{ creationRoute ? 'New model' : 'Models' }}</h3>
         <p class="mt-1 max-w-2xl text-[12px] leading-5 text-text-muted">
-          Add workspace model connections, choose the default for project creation, and select a model per chat turn.
+          {{ creationRoute
+            ? 'Add a workspace model connection for project creation and chat.'
+            : 'Add workspace model connections, choose the default for project creation, and select a model per chat turn.' }}
         </p>
       </div>
       <button
-        v-if="!editorOpen && !(loading && !settings)"
+        v-if="!creationRoute && !editorOpen && !(loading && !settings)"
         type="button"
         class="inline-flex h-9 shrink-0 items-center gap-2 rounded-md border border-accent bg-accent px-3 text-[12px] font-semibold text-surface shadow-[0_0_16px_var(--color-accent-glow)] transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
         :disabled="(settings?.models.length ?? 0) >= 20"
@@ -65,12 +68,12 @@ const emit = defineEmits<{
       </button>
     </div>
 
-    <div v-if="loading && !settings" class="grid min-h-48 content-start gap-3 rounded-md border border-dashed border-border-subtle bg-surface p-4" role="status" aria-live="polite" aria-busy="true">
+    <div v-if="loading && !settings && !creationRoute" class="grid min-h-48 content-start gap-3 rounded-md border border-dashed border-border-subtle bg-surface p-4" role="status" aria-live="polite" aria-busy="true">
       <div class="shimmer h-4 w-36 rounded bg-surface-overlay" />
       <div class="shimmer h-24 w-full rounded bg-surface-overlay" />
       <div class="text-[12px] text-text-muted">Loading models…</div>
     </div>
-    <div v-else-if="loadError && !settings" class="flex min-h-48 flex-col items-start justify-center gap-2 rounded-md border border-danger/30 bg-danger-subtle p-4 text-[12px] text-danger" role="alert">
+    <div v-else-if="loadError && !settings && !creationRoute" class="flex min-h-48 flex-col items-start justify-center gap-2 rounded-md border border-danger/30 bg-danger-subtle p-4 text-[12px] text-danger" role="alert">
       <div>{{ loadError }}</div>
       <button type="button" class="font-medium underline underline-offset-2" @click="emit('retry')">Retry</button>
     </div>
@@ -87,7 +90,7 @@ const emit = defineEmits<{
       <div v-if="actionError" class="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] text-danger" role="alert">{{ actionError }}</div>
       <div v-else-if="status" class="rounded-md border border-success/30 bg-success-subtle px-3 py-2 text-[12px] text-success" role="status" aria-live="polite">{{ status }}</div>
 
-      <div v-if="settings?.models.length" class="grid gap-3 sm:grid-cols-2">
+      <div v-if="settings?.models.length && !creationRoute" class="grid gap-3 sm:grid-cols-2">
         <article
           v-for="saved in settings.models"
           :key="saved.id"
@@ -126,7 +129,7 @@ const emit = defineEmits<{
         </article>
       </div>
 
-      <div v-else-if="!editorOpen" class="flex min-h-44 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border-subtle bg-surface px-5 py-8 text-center">
+      <div v-else-if="!editorOpen && !creationRoute" class="flex min-h-44 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border-subtle bg-surface px-5 py-8 text-center">
         <div class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-surface-overlay text-text-muted"><Cpu class="h-5 w-5" :stroke-width="1.75" /></div>
         <div>
           <h4 class="text-[13px] font-semibold text-text-primary">No models configured</h4>
@@ -137,11 +140,12 @@ const emit = defineEmits<{
         </button>
       </div>
 
-      <form v-if="editorOpen" class="grid gap-4 rounded-lg border border-border-subtle bg-surface-overlay/40 p-4" aria-label="Model configuration form" @submit.prevent="emit('save')">
-        <div class="flex items-start gap-3">
+      <form v-if="editorOpen || creationRoute" :class="creationRoute ? 'k-create-surface k-create-surface--wide' : 'rounded-lg border border-border-subtle bg-surface-overlay/40 p-4'" aria-label="Model configuration form" @submit.prevent="emit('save')">
+        <div :class="creationRoute ? 'k-create-body' : 'grid gap-4'">
+        <div v-if="!creationRoute" class="flex items-start gap-3">
           <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-muted"><KeyRound class="h-4 w-4" :stroke-width="1.75" /></div>
           <div class="min-w-0">
-            <h4 class="text-[13px] font-semibold text-text-primary">{{ editingModelID ? 'Edit model' : 'New model' }}</h4>
+            <h4 class="text-[13px] font-semibold text-text-primary">{{ editingModelID && !creationRoute ? 'Edit model' : 'New model' }}</h4>
             <p class="mt-0.5 text-[11px] leading-4 text-text-muted">Give this connection a recognizable name, then configure its endpoint and workspace credential.</p>
           </div>
         </div>
@@ -189,15 +193,16 @@ const emit = defineEmits<{
         <section class="grid gap-2 border-t border-border-subtle pt-4" aria-labelledby="model-credential-heading">
           <h5 id="model-credential-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Credential</h5>
           <textarea v-if="googleServiceAccountMode" :value="apiKey" class="min-h-[140px] resize-y rounded-md border border-border-subtle bg-surface px-3 py-2.5 font-mono text-[12px] leading-5 text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" :placeholder="apiKeyPlaceholder" autocomplete="off" :disabled="saving" @input="emit('update:apiKey', ($event.target as HTMLTextAreaElement).value)" />
-          <input v-else :value="apiKey" class="h-10 rounded-md border border-border-subtle bg-surface px-3 text-[13px] text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" :placeholder="editingModelID ? `${apiKeyPlaceholder} (leave blank to keep current)` : apiKeyPlaceholder" type="password" autocomplete="off" :disabled="saving" @input="emit('update:apiKey', ($event.target as HTMLInputElement).value)" />
-          <p class="text-[11px] leading-4 text-text-muted">{{ apiKeyHint || (editingModelID ? 'Leave blank to keep the current credential.' : 'A credential is required before this model can be selected in chat.') }}</p>
+          <input v-else :value="apiKey" class="h-10 rounded-md border border-border-subtle bg-surface px-3 text-[13px] text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" :placeholder="editingModelID && !creationRoute ? `${apiKeyPlaceholder} (leave blank to keep current)` : apiKeyPlaceholder" type="password" autocomplete="off" :disabled="saving" @input="emit('update:apiKey', ($event.target as HTMLInputElement).value)" />
+          <p class="text-[11px] leading-4 text-text-muted">{{ apiKeyHint || (editingModelID && !creationRoute ? 'Leave blank to keep the current credential.' : 'A credential is required before this model can be selected in chat.') }}</p>
         </section>
 
-        <footer class="flex flex-wrap items-center justify-end gap-2 border-t border-border-subtle pt-3">
-          <button type="button" class="inline-flex h-9 items-center justify-center rounded-md border border-border-subtle px-3 text-[13px] font-medium text-text-secondary transition hover:bg-surface-hover" :disabled="saving" @click="emit('cancelEditor')">Cancel</button>
-          <button class="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-accent bg-accent px-3 text-[13px] font-semibold text-surface shadow-[0_0_16px_var(--color-accent-glow)] transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-none" :disabled="saving || !name.trim() || !model.trim() || Boolean(baseURLError)">
+        </div>
+        <footer :class="creationRoute ? 'k-create-actions' : 'flex flex-wrap items-center justify-end gap-2 border-t border-border-subtle pt-3'">
+          <button type="button" :class="creationRoute ? 'k-btn k-btn--ghost' : 'inline-flex h-9 items-center justify-center rounded-md border border-border-subtle px-3 text-[13px] font-medium text-text-secondary transition hover:bg-surface-hover'" :disabled="saving" @click="emit('cancelEditor')">Cancel</button>
+          <button :class="creationRoute ? 'k-btn k-btn--primary' : 'inline-flex h-9 items-center justify-center gap-2 rounded-md border border-accent bg-accent px-3 text-[13px] font-semibold text-surface shadow-[0_0_16px_var(--color-accent-glow)] transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-none'" :disabled="saving || !name.trim() || !model.trim() || Boolean(baseURLError)">
             <Loader2 v-if="saving" class="h-4 w-4 animate-spin" :stroke-width="1.75" /><Check v-else class="h-4 w-4" :stroke-width="1.75" />
-            {{ editingModelID ? 'Save changes' : 'Add model' }}
+            {{ editingModelID && !creationRoute ? 'Save changes' : 'Add model' }}
           </button>
         </footer>
       </form>

--- a/providers/app-studio/portal/src/element.ts
+++ b/providers/app-studio/portal/src/element.ts
@@ -5,6 +5,7 @@ import type { FarosContext } from './types'
 
 const TAG = 'faros-provider-app-studio'
 const TILE_TAG = 'faros-dashboard-tile-app-studio'
+type NavigationOptions = { replace?: boolean }
 
 class ProjectsElement extends HTMLElement {
   private app: VueApp | null = null
@@ -41,7 +42,7 @@ class ProjectsElement extends HTMLElement {
       render: () =>
         h(App, {
           ctx: this.state.ctx,
-          navigate: (path: string) => this.navigate(path),
+          navigate: (path: string, options?: NavigationOptions) => this.navigate(path, options),
           requestFullBleed: (fullBleed: boolean) => this.requestFullBleed(fullBleed),
         }),
     })
@@ -57,10 +58,10 @@ class ProjectsElement extends HTMLElement {
     this.overlayRoot = null
   }
 
-  private navigate(path: string): void {
+  private navigate(path: string, options: NavigationOptions = {}): void {
     this.dispatchEvent(
       new CustomEvent('faros-navigate', {
-        detail: { path },
+        detail: { path, ...(options.replace === true ? { replace: true } : {}) },
         bubbles: true,
       }),
     )

--- a/providers/app-studio/portal/src/modelsSettings.test.mjs
+++ b/providers/app-studio/portal/src/modelsSettings.test.mjs
@@ -24,6 +24,7 @@ const baseProps = {
   status: null,
   actionError: null,
   editorOpen: false,
+  creationRoute: false,
   editingModelID: null,
   name: '',
   provider: 'openai-compatible',
@@ -77,6 +78,41 @@ test('uses an explicit empty state before opening the model form', async () => {
   assert.doesNotMatch(html, /aria-label="Model configuration form"/)
 })
 
+test('route-owned model creation keeps the collection out of the form surface', async () => {
+  const html = await render({
+    creationRoute: true,
+    settings: {
+      provider: 'openai-compatible',
+      baseURL: 'https://api.openai.com/v1',
+      model: 'gpt-5.4',
+      configured: true,
+      defaultModelID: 'gpt-high',
+      models: [{ id: 'gpt-high', name: 'GPT High', provider: 'openai-compatible', baseURL: 'https://api.openai.com/v1', model: 'gpt-5.4', configured: true, default: true }],
+    },
+  })
+
+  assert.match(html, /aria-label="New model"/)
+  assert.match(html, /aria-label="Model configuration form"/)
+  assert.doesNotMatch(html, />New model</)
+  assert.doesNotMatch(html, /aria-label="Model GPT High"/)
+  assert.doesNotMatch(html, />New model<\/button>/)
+})
+
+test('route-owned model creation keeps the form actionable when settings load fails', async () => {
+  const html = await render({
+    creationRoute: true,
+    loadError: 'Could not load model settings.',
+    settings: null,
+  })
+
+  assert.match(html, /Could not load model settings\./)
+  assert.match(html, />Retry</)
+  assert.match(html, /aria-label="Model configuration form"/)
+  assert.match(html, /Display name/)
+  assert.doesNotMatch(html, />New model</)
+  assert.doesNotMatch(html, /No models configured/)
+})
+
 test('renders a guided provider, endpoint, and credential form', async () => {
   const html = await render({
     editorOpen: true,
@@ -104,11 +140,31 @@ test('renders a guided provider, endpoint, and credential form', async () => {
 test('App Studio owns save state while the extracted surface owns presentation', async () => {
   const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
 
+  assert.match(app, /const CREATE_MODEL_ROUTE = 'create\/model'/)
+  assert.match(app, /const isCreateModelRoute = computed\(\(\) => routePath\.value === CREATE_MODEL_ROUTE\)/)
+  assert.match(app, /const routePath = computed\(\(\) => \(props\.ctx\?\.subPath \?\? ''\)\.split\('\/'\)\.filter\(Boolean\)\.join\('\/'\)\)/)
+  assert.match(app, /v-if="showSettings[\s\S]*\(\(isModelsRoute \|\| isCreateModelRoute\) && !\(initializing && !loading\)\)"/)
+  assert.match(app, /<ModelsSettings[\s\S]*:creation-route="isCreateModelRoute"/)
   assert.match(app, /<ModelsSettings[\s\S]*@save="saveLLMSettings"[\s\S]*@delete="deleteLLMModel"[\s\S]*@set-default="setDefaultLLMModel"/)
   assert.match(app, /function selectLLMProvider[\s\S]*llmBaseURL\.value = GEMINI_BASE_URL[\s\S]*llmBaseURL\.value = 'https:\/\/api\.openai\.com\/v1'/)
   assert.match(app, /async function saveLLMSettings[\s\S]*api\.patchLLMModel[\s\S]*api\.createLLMModel/)
   assert.match(app, /async function deleteLLMModel[\s\S]*api\.deleteLLMModel/)
   assert.match(app, /catch \(e\)[\s\S]*llmActionError\.value = e instanceof Error/)
+})
+
+test('model creation replaces its route entry and nested navigation accepts replace metadata', async () => {
+  const [app, element] = await Promise.all([
+    readFile(new URL('./App.vue', import.meta.url), 'utf8'),
+    readFile(new URL('./element.ts', import.meta.url), 'utf8'),
+  ])
+
+  assert.match(app, /function openNewLLMModelEditor\(\)[\s\S]*props\.navigate\(CREATE_MODEL_ROUTE\)/)
+  assert.match(app, /function cancelLLMEditor\(\)[\s\S]*const returnRoute = routeOwnedCreation[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
+  assert.match(app, /const routeOwnedCreation = isCreateModelRoute\.value && !llmEditingModelID\.value[\s\S]*const returnRoute = routeOwnedCreation[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
+  assert.match(app, /const detail = \(e as CustomEvent<\{ path\?: unknown; replace\?: unknown \}>\)\.detail/)
+  assert.match(app, /Nested provider tabs have one persisted descriptor rather than their own/)
+  assert.match(element, /navigate: \(path: string, options\?: NavigationOptions\) => this\.navigate\(path, options\)/)
+  assert.match(element, /detail: \{ path, \.\.\.\(options\.replace === true \? \{ replace: true \} : \{\}\) \}/)
 })
 
 test('composer exposes the configured model picker and sends its stable ID', async () => {
@@ -122,4 +178,42 @@ test('composer exposes the configured model picker and sends its stable ID', asy
   assert.match(app, /startAssistantReview[\s\S]*modelID: payload\.modelID/)
   assert.match(picker, /aria-label="Choose model"/)
   assert.match(picker, /aria-haspopup="listbox"/)
+})
+
+test('guards delayed model mutations against context, route, and newer mutation generations', async () => {
+  const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+  const mutationStart = app.indexOf('async function saveLLMSettings')
+  const mutationEnd = app.indexOf('async function createProjectFromPrompt', mutationStart)
+  assert.ok(mutationStart >= 0 && mutationEnd > mutationStart)
+  const mutations = app.slice(mutationStart, mutationEnd)
+
+  assert.match(app, /interface LLMModelMutationGuard[\s\S]*generation: number[\s\S]*contextFingerprint: string[\s\S]*routePath: string/)
+  assert.match(app, /function invalidateLLMModelMutationState\(\)[\s\S]*llmModelMutationGeneration \+= 1/)
+  assert.match(app, /function beginLLMModelMutation\(\): LLMModelMutationGuard[\s\S]*generation: \+\+llmModelMutationGeneration/)
+  assert.match(app, /function llmModelMutationIsCurrent\(guard: LLMModelMutationGuard\): boolean[\s\S]*guard\.contextFingerprint === appContextFingerprint\(props\.ctx\)[\s\S]*guard\.routePath === routePath\.value/)
+  assert.match(app, /watch\(\s*\(\) => props\.ctx\?\.subPath \?\? ''[\s\S]*invalidateLLMModelMutationState\(\)/)
+  assert.match(app, /function invalidateProjectContextState\(\)[\s\S]*invalidateLLMModelMutationState\(\)/)
+
+  for (const operation of ['saveLLMSettings', 'deleteLLMModel', 'setDefaultLLMModel']) {
+    const start = mutations.indexOf(`async function ${operation}`)
+    assert.ok(start >= 0, `${operation} should remain App Studio-owned`)
+    const end = mutations.indexOf('\nasync function ', start + 1)
+    const block = mutations.slice(start, end < 0 ? mutations.length : end)
+    assert.match(block, /const guard = beginLLMModelMutation\(\)/)
+    assert.match(block, /if \(!llmModelMutationIsCurrent\(guard\)\) return/)
+    assert.match(block, /catch \(e\) \{[\s\S]*if \(!llmModelMutationIsCurrent\(guard\)\) return/)
+    assert.match(block, /finally \{[\s\S]*if \(llmModelMutationIsCurrent\(guard\)\) llmSaving\.value = false/)
+  }
+})
+
+test('uses the stored project-creation destination and Models fallback for route-owned creation', async () => {
+  const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+  assert.match(app, /modelsReturnRoute\.value === CREATE_PROJECT_ROUTE \? CREATE_PROJECT_ROUTE : MODELS_ROUTE/)
+  assert.match(app, /function openNewLLMModelEditor\(\)[\s\S]*if \(!modelsReturnRoute\.value && isCreateRoute\.value\) modelsReturnRoute\.value = CREATE_PROJECT_ROUTE/)
+
+  const cancelStart = app.indexOf('function cancelLLMEditor')
+  const saveStart = app.indexOf('async function saveLLMSettings')
+  const saveEnd = app.indexOf('\nasync function deleteLLMModel', saveStart)
+  assert.match(app.slice(cancelStart, saveStart), /const returnRoute = routeOwnedCreation[\s\S]*modelsReturnRoute\.value = ''[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
+  assert.match(app.slice(saveStart, saveEnd), /const returnRoute = routeOwnedCreation[\s\S]*modelsReturnRoute\.value = ''[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
 })

--- a/providers/app-studio/portal/src/portalConformance.test.mjs
+++ b/providers/app-studio/portal/src/portalConformance.test.mjs
@@ -18,7 +18,8 @@ const dashboardTile = await readFile(new URL('./DashboardTile.vue', import.meta.
 test('uses host catalog chrome on landing routes and keeps project workbenches full bleed', () => {
   assert.match(providerFrame, /const APP_STUDIO_CREATE_ROUTE = '~new'/)
   assert.match(providerFrame, /const APP_STUDIO_MODELS_ROUTE = '~models'/)
-  assert.match(providerFrame, /props\.providerName === 'app-studio' &&[\s\S]*\['', APP_STUDIO_CREATE_ROUTE, APP_STUDIO_MODELS_ROUTE\]\.includes\(providerRouteSegment\.value\)/)
+  assert.match(providerFrame, /const APP_STUDIO_CREATE_MODEL_ROUTE = 'create\/model'/)
+  assert.match(providerFrame, /props\.providerName === 'app-studio' &&[\s\S]*\['', APP_STUDIO_CREATE_ROUTE, APP_STUDIO_MODELS_ROUTE, APP_STUDIO_CREATE_MODEL_ROUTE\]\.includes\(providerRoutePath\.value\)/)
   assert.match(providerFrame, /props\.providerName === 'app-studio' &&[\s\S]*!isAppStudioLandingRoute\.value \|\| providerFullBleedOverride\.value === true/)
   assert.match(providerFrame, /<header v-if="catalogSettled && entry && !isFullBleedProvider"/)
   assert.match(app, /<h2[^>]*>Projects<\/h2>/)
@@ -57,7 +58,7 @@ test('presents Projects and Models through the shared tabs surface without a gen
   assert.match(app, /import Tabs from '\.\/portalkit\/Tabs\.vue'/)
   assert.match(app, /const appStudioSectionTabs = \[[\s\S]*id: 'projects'[\s\S]*Folder[\s\S]*id: 'models'[\s\S]*Cpu/)
   assert.match(landing, /<div class="flex min-h-full w-full flex-col gap-4">/)
-  assert.match(landing, /<Tabs[\s\S]*:tabs="appStudioSectionTabs"[\s\S]*:active="isModelsRoute \? 'models' : 'projects'"[\s\S]*aria-label="App Studio sections"[\s\S]*@select="selectAppStudioSection"/)
+  assert.match(landing, /<Tabs[\s\S]*:tabs="appStudioSectionTabs"[\s\S]*:active="isModelsRoute \|\| isCreateModelRoute \? 'models' : 'projects'"[\s\S]*aria-label="App Studio sections"[\s\S]*@select="selectAppStudioSection"/)
   assert.match(app, /function selectAppStudioSection\(id: string\)[\s\S]*openModelsSection\(\)[\s\S]*openProjectsSection\(\)/)
   assert.doesNotMatch(landing, /<nav[^>]*aria-label="App Studio sections"/)
   assert.doesNotMatch(landing, /shadow-\[0_0_14px_var\(--color-accent-glow\)\]/)
@@ -65,8 +66,8 @@ test('presents Projects and Models through the shared tabs surface without a gen
   assert.doesNotMatch(landing, /Back to projects|closeNewProjectComposer/)
   assert.doesNotMatch(landing, />\s*Settings\s*</)
   assert.match(landing, /id="app-studio-models-host"/)
-  assert.match(app, /if \(isModelsRoute\.value\) return '#app-studio-models-host'/)
-  assert.match(app, /isCreateRoute\.value \|\| isModelsRoute\.value \? '' : routeSegment\.value/)
+  assert.match(app, /if \(isModelsRoute\.value \|\| isCreateModelRoute\.value\) return '#app-studio-models-host'/)
+  assert.match(app, /isCreateRoute\.value \|\| isModelsRoute\.value \|\| isCreateModelRoute\.value \? '' : routeSegment\.value/)
 })
 
 test('uses shared confirmation and status primitives without local duplicates', () => {

--- a/providers/app-studio/portal/src/portalkit/faros-ui.css
+++ b/providers/app-studio/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/code/portal/src/App.vue
+++ b/providers/code/portal/src/App.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 import { GitBranch, Package, Plug } from 'lucide-vue-next'
 import type { FarosContext } from './types'
 import { setAPIContext, setBasePath } from './api'
 import ConnectionsView from './views/ConnectionsView.vue'
+import ConnectionCreateView from './views/ConnectionCreateView.vue'
 import ConnectionDetailView from './views/ConnectionDetailView.vue'
 import RepositoriesView from './views/RepositoriesView.vue'
+import RepositoryCreateView from './views/RepositoryCreateView.vue'
 import RepoDetailView from './views/RepoDetailView.vue'
 import PackagesView from './views/PackagesView.vue'
 import ConfirmDialog from './portalkit/ConfirmDialog.vue'
 import { resolveConfirm } from './portalkit/confirm'
 import { createResourceDeletions } from './refresh'
 import Tabs from './portalkit/Tabs.vue'
+import { contextGenerationKey } from './context'
+import { codeNavigationDetail, parseCodeSubPath, type CodeRoute } from './routes'
 
 // Sub-path routing (the shell pushes the trailing /providers/code/<sub> segment):
 //   ''  | 'connections'        → Connections
@@ -19,30 +23,14 @@ import Tabs from './portalkit/Tabs.vue'
 //   'repositories'             → Repositories
 //   'repositories/<name>'      → RepoDetail
 //   'packages'                 → Packages (workspace-wide)
+//   'create/connection/token'  → token connection creation
+//   'create/connection/github' → GitHub OAuth connection creation
+//   'create/repository'        → repository creation
 const props = defineProps<{ ctx: FarosContext | null }>()
 
-interface Route {
-  page: 'connections' | 'repositories' | 'packages'
-  repo?: string
-  connection?: string
-}
-
-function parse(sub: string | null | undefined): Route {
-  const s = (sub ?? '').replace(/^\/+|\/+$/g, '')
-  if (s === '' || s === 'connections') return { page: 'connections' }
-  if (s === 'packages') return { page: 'packages' }
-  const parts = s.split('/')
-  if (parts[0] === 'connections') {
-    return parts.length > 1 ? { page: 'connections', connection: decodeURIComponent(parts[1]) } : { page: 'connections' }
-  }
-  if (parts[0] === 'repositories') {
-    return parts.length > 1 ? { page: 'repositories', repo: decodeURIComponent(parts[1]) } : { page: 'repositories' }
-  }
-  return { page: 'connections' }
-}
-
-const route = computed(() => parse(props.ctx?.subPath))
+const route = computed<CodeRoute>(() => parseCodeSubPath(props.ctx?.subPath))
 const contextGeneration = ref(0)
+provide(contextGenerationKey, contextGeneration)
 const contextInitialized = computed(() => props.ctx !== null)
 const deletions = createResourceDeletions()
 let deletionAuthority = ''
@@ -51,8 +39,12 @@ let deletionAuthority = ''
 // authority changes. This clears actionable old-workspace state immediately and
 // lets each unmounted refresh controller reject late responses.
 watch(
-  () => [props.ctx?.basePath, props.ctx?.token, props.ctx?.tenant, props.ctx?.user?.sub] as const,
+  () => [props.ctx?.basePath, props.ctx?.token, props.ctx?.tenant, props.ctx?.user?.sub, props.ctx?.user?.email] as const,
   ([basePath, token, tenant, userSub]) => {
+    // This must run synchronously. The keyed route remount is a Vue render
+    // effect and therefore happens later; an async form continuation can
+    // otherwise commit between the context update and that unmount.
+    contextGeneration.value += 1
     // The dialog is module-global, so remounting the routed page is not enough
     // to revoke a confirmation opened under the previous authority.
     resolveConfirm(false)
@@ -60,10 +52,9 @@ watch(
     if (nextDeletionAuthority !== deletionAuthority) deletions.clear()
     deletionAuthority = nextDeletionAuthority
     setBasePath(basePath)
-    setAPIContext({ token, tenant })
-    contextGeneration.value += 1
+    setAPIContext({ token, tenant, user: userSub })
   },
-  { immediate: true },
+  { immediate: true, flush: 'sync' },
 )
 
 const hasTenant = computed(() => !!props.ctx?.tenant)
@@ -79,10 +70,10 @@ const tabs = [
 // and pushes the shell's vue-router. detail.path is the trailing segment the
 // shell appends to /providers/code/.
 const rootRef = ref<HTMLElement | null>(null)
-function navigate(path: string) {
+function navigate(path: string, options: { replace?: boolean } = {}) {
   const el = rootRef.value
   if (!el) return
-  el.dispatchEvent(new CustomEvent('faros-navigate', { detail: { path }, bubbles: true }))
+  el.dispatchEvent(new CustomEvent('faros-navigate', { detail: codeNavigationDetail(path, options), bubbles: true }))
 }
 </script>
 
@@ -104,17 +95,54 @@ function navigate(path: string) {
 
     <template v-else>
       <template v-if="!route.repo && !route.connection">
-        <Tabs :tabs="tabs" :active="route.page" aria-label="Code provider sections" @select="navigate" />
+        <template v-if="!route.create">
+          <Tabs :tabs="tabs" :active="route.page" aria-label="Code provider sections" @select="navigate" />
+        </template>
       </template>
 
       <p v-if="!hasTenant" class="empty">Select a workspace to manage code.</p>
 
       <template v-else>
+        <ConnectionCreateView
+          v-if="route.create?.resource === 'connection'"
+          :key="`${contextGeneration}:create-connection:${route.create.method}`"
+          :method="route.create.method"
+          :deletions="deletions"
+          @cancel="navigate('connections', { replace: true })"
+          @created="(n: string) => navigate('connections/' + encodeURIComponent(n), { replace: true })"
+        />
+        <RepositoryCreateView
+          v-if="route.create?.resource === 'repository'"
+          :key="`${contextGeneration}:create-repository`"
+          :deletions="deletions"
+          @cancel="navigate('repositories', { replace: true })"
+          @created="(n: string) => navigate('repositories/' + encodeURIComponent(n), { replace: true })"
+        />
         <ConnectionDetailView v-if="route.page === 'connections' && route.connection" :key="`${contextGeneration}:connection:${route.connection}`" :name="route.connection" :deletions="deletions" @back="navigate('connections')" />
-        <ConnectionsView v-else-if="route.page === 'connections'" :key="`${contextGeneration}:connections`" :deletions="deletions" @open="(n: string) => navigate('connections/' + encodeURIComponent(n))" />
-        <PackagesView v-else-if="route.page === 'packages'" :key="`${contextGeneration}:packages`" @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))" />
-        <RepoDetailView v-else-if="route.repo" :key="`${contextGeneration}:repository:${route.repo}`" :name="route.repo" :deletions="deletions" @back="navigate('repositories')" />
-        <RepositoriesView v-else :key="`${contextGeneration}:repositories`" :deletions="deletions" @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))" />
+        <RepoDetailView v-if="route.repo" :key="`${contextGeneration}:repository:${route.repo}`" :name="route.repo" :deletions="deletions" @back="navigate('repositories')" />
+        <PackagesView v-if="route.page === 'packages'" :key="`${contextGeneration}:packages`" @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))" />
+
+        <!-- Keep collection-local query/filter/page/scroll state while a routed
+             create or detail surface is active. The context key still drops the
+             cache immediately when workspace authority changes. -->
+        <KeepAlive :max="1">
+          <ConnectionsView
+            v-if="route.page === 'connections' && !route.create && !route.connection"
+            :key="`${contextGeneration}:connections`"
+            :deletions="deletions"
+            @open="(n: string) => navigate('connections/' + encodeURIComponent(n))"
+            @create="(method: 'token' | 'github') => navigate('create/connection/' + method)"
+          />
+        </KeepAlive>
+        <KeepAlive :max="1">
+          <RepositoriesView
+            v-if="route.page === 'repositories' && !route.create && !route.repo"
+            :key="`${contextGeneration}:repositories`"
+            :deletions="deletions"
+            @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))"
+            @create="navigate('create/repository')"
+          />
+        </KeepAlive>
       </template>
     </template>
 

--- a/providers/code/portal/src/api.test.ts
+++ b/providers/code/portal/src/api.test.ts
@@ -556,11 +556,54 @@ describe('Kubernetes cursor list pages', () => {
 })
 
 describe('oauthConfig', () => {
-  it('does not advertise an enabled OAuth flow without a start URL', async () => {
-    setAPIContext({ tenant: 'oauth-config', token: 'oauth-token' })
-    vi.stubGlobal('fetch', vi.fn(async () => response({ enabled: true })))
+  it('preserves a legitimate disabled response', async () => {
+    setAPIContext({ tenant: 'oauth-config-disabled', token: 'oauth-token-disabled' })
+    vi.stubGlobal('fetch', vi.fn(async () => response({ enabled: false })))
 
     await expect(api.oauthConfig()).resolves.toEqual({ enabled: false })
+  })
+
+  it('propagates transport failures so the view can offer a retry', async () => {
+    setAPIContext({ tenant: 'oauth-config-network', token: 'oauth-token-network' })
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('oauth backend unavailable')
+    }))
+
+    await expect(api.oauthConfig()).rejects.toThrow('oauth backend unavailable')
+  })
+
+  it('rejects non-success responses instead of treating them as disabled', async () => {
+    setAPIContext({ tenant: 'oauth-config-status', token: 'oauth-token-status' })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('upstream unavailable', {
+      status: 503,
+      statusText: 'Service Unavailable',
+    })))
+
+    await expect(api.oauthConfig()).rejects.toMatchObject({
+      reason: 'HTTPError',
+      message: '503: upstream unavailable',
+    })
+  })
+
+  it('rejects malformed JSON and response shapes', async () => {
+    setAPIContext({ tenant: 'oauth-config-malformed', token: 'oauth-token-malformed' })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('{', { status: 200 }))
+      .mockResolvedValueOnce(response({ enabled: 'yes' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(api.oauthConfig()).rejects.toMatchObject({ reason: 'ProtocolError' })
+    await expect(api.oauthConfig()).rejects.toMatchObject({ reason: 'ProtocolError' })
+  })
+
+  it('rejects an enabled response without a usable start URL', async () => {
+    setAPIContext({ tenant: 'oauth-config-missing-url', token: 'oauth-token-missing-url' })
+    vi.stubGlobal('fetch', vi.fn(async () => response({ enabled: true })))
+
+    await expect(api.oauthConfig()).rejects.toMatchObject({
+      reason: 'ProtocolError',
+      message: 'OAuth configuration response was enabled but missing a start URL',
+    })
   })
 
   it('preserves a configured relative OAuth start URL', async () => {
@@ -575,6 +618,89 @@ describe('oauthConfig', () => {
       enabled: true,
       startURL: '/services/providers/code/oauth/github/start',
       scopes: 'repo',
+    })
+  })
+
+  it('rejects a response that resolves after the authentication context changes', async () => {
+    setAPIContext({ tenant: 'oauth-config-old', token: 'oauth-config-old-token' })
+    let resolveResponse!: (value: Response) => void
+    const pending = new Promise<Response>(resolve => { resolveResponse = resolve })
+    vi.stubGlobal('fetch', vi.fn(() => pending))
+
+    const request = api.oauthConfig()
+    setAPIContext({ tenant: 'oauth-config-new', token: 'oauth-config-new-token' })
+    resolveResponse(response({ enabled: false }))
+
+    await expect(request).rejects.toMatchObject({ reason: 'ContextChanged' })
+  })
+})
+
+describe('connect', () => {
+  it('keeps explicit reconnect semantics: adopts the Connection and replaces its owned Secret', async () => {
+    setAPIContext({ tenant: 'connect-reconnect', token: 'connect-reconnect-token' })
+    const calls: FetchCall[] = []
+    const connection = {
+      apiVersion: 'code.faros.sh/v1alpha1',
+      kind: 'Connection',
+      metadata: { name: 'github-prod', uid: 'existing-connection-uid' },
+      spec: {
+        provider: 'github',
+        type: 'oauth',
+        owner: 'octocat',
+        secretRef: { name: 'github-prod-token', namespace: 'default', key: 'token' },
+      },
+      status: {},
+    }
+    const secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: { name: 'github-prod-token', uid: 'replacement-secret-uid' },
+      type: 'Opaque',
+      stringData: { token: 'replacement-token' },
+    }
+    vi.stubGlobal('fetch', vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const call = request(init)
+      calls.push(call)
+      const manifest = JSON.parse(String(call.variables.y)) as { kind: string }
+      return response({ data: { applyYaml: JSON.stringify(manifest.kind === 'Connection' ? connection : secret) } })
+    }))
+
+    await expect(api.connect({
+      name: ' GitHub-Prod ',
+      owner: 'octocat',
+      token: 'replacement-token',
+      type: 'oauth',
+      baseURL: 'https://github.example.com/api/v3',
+    })).resolves.toMatchObject({ name: 'github-prod', uid: 'existing-connection-uid' })
+
+    expect(calls).toHaveLength(2)
+    const connectionManifest = JSON.parse(String(calls[0].variables.y)) as Record<string, unknown>
+    expect(connectionManifest).toMatchObject({
+      apiVersion: 'code.faros.sh/v1alpha1',
+      kind: 'Connection',
+      metadata: { name: 'github-prod' },
+      spec: {
+        provider: 'github',
+        type: 'oauth',
+        owner: 'octocat',
+        baseURL: 'https://github.example.com/api/v3',
+        secretRef: { name: 'github-prod-token', namespace: 'default', key: 'token' },
+      },
+    })
+    const secretManifest = JSON.parse(String(calls[1].variables.y)) as Record<string, unknown>
+    expect(secretManifest).toMatchObject({
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'github-prod-token',
+        ownerReferences: [{
+          apiVersion: 'code.faros.sh/v1alpha1',
+          kind: 'Connection',
+          name: 'github-prod',
+          uid: 'existing-connection-uid',
+        }],
+      },
+      stringData: { token: 'replacement-token' },
     })
   })
 })

--- a/providers/code/portal/src/api.ts
+++ b/providers/code/portal/src/api.ts
@@ -30,6 +30,8 @@ const TOKEN_KEY = 'token'
 
 let bearerToken: string | null = null
 let clusterName: string | null = null
+let providerBasePath: string | null = null
+let callerUser: string | null = null
 let apiContextGeneration = 0
 
 interface APIRequestContext {
@@ -44,6 +46,7 @@ interface APIRequestContext {
 export interface APIReadContext {
   token?: string | null
   tenant?: string | null
+  user?: string | null
 }
 
 function captureRequestContext(): APIRequestContext {
@@ -60,17 +63,23 @@ function assertRequestContext(context: APIRequestContext): void {
   }
 }
 
-// setBasePath is a no-op: kcp paths are built from the cluster name, not the
-// provider basePath. Kept so App.vue's watcher type-checks.
-export function setBasePath(_ctxBasePath?: string | null) {
-  void _ctxBasePath
+// The GraphQL path is built from the cluster name, not the provider basePath,
+// but basePath is still part of the shell authority. Track it so in-flight
+// requests are fenced when the host switches provider roots.
+export function setBasePath(ctxBasePath?: string | null) {
+  const nextBasePath = ctxBasePath || null
+  if (nextBasePath === providerBasePath) return
+  providerBasePath = nextBasePath
+  apiContextGeneration += 1
 }
 export function setAPIContext(context: APIReadContext): void {
   const nextToken = context.token || null
   const nextTenant = context.tenant || null
-  if (nextToken === bearerToken && nextTenant === clusterName) return
+  const nextUser = context.user || null
+  if (nextToken === bearerToken && nextTenant === clusterName && nextUser === callerUser) return
   bearerToken = nextToken
   clusterName = nextTenant
+  callerUser = nextUser
   apiContextGeneration += 1
 }
 
@@ -868,26 +877,44 @@ export const api = {
   },
 
   // oauthConfig probes the provider backend (via the hub /services proxy) for
-  // whether the "Connect with GitHub" flow is configured. Returns enabled:false
-  // (never throws) so the view can silently fall back to the PAT form.
+  // whether the "Connect with GitHub" flow is configured. A valid disabled
+  // response is expected when no OAuth app is configured, but transport,
+  // status, and response-shape failures must reach the view so it can offer a
+  // retry instead of reporting a false "not configured" state.
   async oauthConfig(): Promise<{ enabled: boolean; startURL?: string; scopes?: string }> {
+    const context = captureRequestContext()
+    assertRequestContext(context)
+    const headers: Record<string, string> = { Accept: 'application/json' }
+    if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
+    const res = await fetch('/services/providers/code/oauth/github/config', { headers, credentials: 'same-origin' })
+    if (!res.ok) {
+      const text = await res.text()
+      assertRequestContext(context)
+      throw <ErrorResponse>{ reason: 'HTTPError', message: `${res.status}: ${text || res.statusText}` }
+    }
+    let body: unknown
     try {
-      const headers: Record<string, string> = { Accept: 'application/json' }
-      if (bearerToken) headers['Authorization'] = 'Bearer ' + bearerToken
-      const res = await fetch('/services/providers/code/oauth/github/config', { headers, credentials: 'same-origin' })
-      if (!res.ok) return { enabled: false }
-      const body: unknown = await res.json()
-      if (!isRecord(body) || typeof body.enabled !== 'boolean') return { enabled: false }
-      if ((body.startURL !== undefined && typeof body.startURL !== 'string') ||
-        (body.scopes !== undefined && typeof body.scopes !== 'string')) return { enabled: false }
-      if (body.enabled && (typeof body.startURL !== 'string' || !body.startURL.trim())) return { enabled: false }
-      return {
-        enabled: body.enabled,
-        startURL: body.startURL as string | undefined,
-        scopes: body.scopes as string | undefined,
-      }
+      body = await res.json()
     } catch {
-      return { enabled: false }
+      assertRequestContext(context)
+      throw protocolError('OAuth configuration returned malformed JSON')
+    }
+    assertRequestContext(context)
+    if (!isRecord(body) || typeof body.enabled !== 'boolean') {
+      throw protocolError('OAuth configuration response had an invalid shape')
+    }
+    if ((body.startURL !== undefined && typeof body.startURL !== 'string') ||
+      (body.scopes !== undefined && typeof body.scopes !== 'string')) {
+      throw protocolError('OAuth configuration response had an invalid shape')
+    }
+    if (body.enabled && (typeof body.startURL !== 'string' || !body.startURL.trim())) {
+      throw protocolError('OAuth configuration response was enabled but missing a start URL')
+    }
+    if (!body.enabled) return { enabled: false }
+    return {
+      enabled: true,
+      startURL: body.startURL as string,
+      scopes: body.scopes as string | undefined,
     }
   },
 

--- a/providers/code/portal/src/app-context.behavior.test.ts
+++ b/providers/code/portal/src/app-context.behavior.test.ts
@@ -1,0 +1,154 @@
+import { defineComponent, h, inject, nextTick, reactive } from 'vue'
+import { createRenderer, ssrContextKey, type RendererOptions } from '@vue/runtime-core'
+import * as VueRuntime from 'vue'
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc'
+import { describe, expect, it, vi } from 'vitest'
+
+import { contextGenerationKey } from './context'
+import type { FarosContext } from './types'
+
+const captured = vi.hoisted(() => ({ generation: undefined as Readonly<{ value: number }> | undefined }))
+
+vi.mock('./api', () => ({
+  setAPIContext: vi.fn(),
+  setBasePath: vi.fn(),
+}))
+vi.mock('./portalkit/confirm', () => ({ resolveConfirm: vi.fn() }))
+vi.mock('./portalkit/Tabs.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./portalkit/ConfirmDialog.vue', () => ({
+  default: defineComponent({
+    setup() {
+      captured.generation = inject(contextGenerationKey)
+      return () => null
+    },
+  }),
+}))
+vi.mock('./views/ConnectionCreateView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/ConnectionDetailView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/RepositoriesView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/RepositoryCreateView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/RepoDetailView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/PackagesView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/ConnectionsView.vue', () => ({
+  default: defineComponent({
+    setup() {
+      captured.generation = inject(contextGenerationKey)
+      return () => h('div')
+    },
+  }),
+}))
+vi.mock('lucide-vue-next', () => ({ GitBranch: {}, Package: {}, Plug: {} }))
+
+import App from './App.vue'
+import appSource from './App.vue?raw'
+
+function compileClientRender(source: string): (ctx: unknown, cache: unknown) => unknown {
+  const parsed = parse(source, { filename: 'App.vue' })
+  if (!parsed.descriptor.template) throw new Error('App.vue has no template')
+  const script = compileScript(parsed.descriptor, { id: 'behavior-App.vue' })
+  const compiled = compileTemplate({
+    source: parsed.descriptor.template.content,
+    filename: 'App.vue',
+    id: 'behavior-App.vue',
+    compilerOptions: { bindingMetadata: script.bindings },
+  })
+  if (compiled.errors.length) throw compiled.errors[0]
+  const code = compiled.code
+    .replace(/^import \{([^\n]+)\} from "vue"\n/, (_match, imports: string) => {
+      const bindings = imports.split(',').map(binding => {
+        const [name, alias] = binding.trim().split(/\s+as\s+/)
+        return alias ? `${name}: ${alias}` : name
+      }).join(', ')
+      return `const { ${bindings} } = VueRuntime\n`
+    })
+    .replace('export function render', 'function render')
+  return new Function('VueRuntime', `${code}\nreturn render`)(VueRuntime) as (ctx: unknown, cache: unknown) => unknown
+}
+
+;(App as unknown as { render: unknown }).render = compileClientRender(appSource)
+
+interface TreeNode {
+  type: string
+  children: TreeNode[]
+  parent: TreeNode | null
+  props: Record<string, unknown>
+  text?: string
+}
+
+function node(type: string): TreeNode {
+  return { type, children: [], parent: null, props: {} }
+}
+
+const rendererOptions: RendererOptions<TreeNode, TreeNode> = {
+  patchProp(target, key, _previous, value) {
+    target.props[key] = value
+  },
+  insert(child, parent, anchor) {
+    child.parent = parent
+    if (!anchor) {
+      parent.children.push(child)
+      return
+    }
+    const index = parent.children.indexOf(anchor)
+    parent.children.splice(index < 0 ? parent.children.length : index, 0, child)
+  },
+  remove(child) {
+    if (!child.parent) return
+    const index = child.parent.children.indexOf(child)
+    if (index >= 0) child.parent.children.splice(index, 1)
+    child.parent = null
+  },
+  createElement: type => node(type),
+  createText: text => ({ ...node('#text'), text }),
+  createComment: text => ({ ...node('#comment'), text }),
+  setText(target, text) {
+    target.text = text
+  },
+  setElementText(target, text) {
+    target.children = [{ ...node('#text'), parent: target, text }]
+  },
+  parentNode: target => target.parent,
+  nextSibling: target => {
+    if (!target.parent) return null
+    const index = target.parent.children.indexOf(target)
+    return index >= 0 ? target.parent.children[index + 1] || null : null
+  },
+}
+
+const renderer = createRenderer(rendererOptions)
+
+describe('Code App context authority generation', () => {
+  it('increments synchronously for every shell authority field before child unmount', async () => {
+    captured.generation = undefined
+    const context = reactive<FarosContext>({
+      basePath: '/ui/providers/code',
+      token: 'old-token',
+      tenant: 'old-tenant',
+      user: { sub: 'old-user', email: 'old@example.com' },
+      subPath: '',
+    })
+    const host = defineComponent({ setup: () => () => h(App, { ctx: context }) })
+    const root = node('root')
+    const app = renderer.createApp(host)
+    app.provide(ssrContextKey, { modules: new Set<string>() })
+    app.mount(root)
+
+    expect(captured.generation).toBeDefined()
+    let expected = captured.generation!.value
+    const changes: Array<() => void> = [
+      () => { context.basePath = '/ui/providers/code-v2' },
+      () => { context.token = 'new-token' },
+      () => { context.tenant = 'new-tenant' },
+      () => { context.user!.sub = 'new-user' },
+      () => { context.user!.email = 'new@example.com' },
+    ]
+    for (const change of changes) {
+      change()
+      expected += 1
+      expect(captured.generation!.value).toBe(expected)
+    }
+
+    await nextTick()
+    app.unmount()
+  })
+})

--- a/providers/code/portal/src/context.ts
+++ b/providers/code/portal/src/context.ts
@@ -1,0 +1,12 @@
+import type { InjectionKey, Ref } from 'vue'
+
+/**
+ * Shared authority generation for route-owned Code mutations.
+ *
+ * App.vue advances the provided ref synchronously whenever the shell changes
+ * the workspace, caller, token, or provider base path. Create forms capture
+ * the value before starting an async operation and compare it at every
+ * continuation, so a stale result is rejected before Vue flushes the keyed
+ * route unmount.
+ */
+export const contextGenerationKey: InjectionKey<Readonly<Ref<number>>> = Symbol('code-context-generation')

--- a/providers/code/portal/src/create-flow.regression.test.mjs
+++ b/providers/code/portal/src/create-flow.regression.test.mjs
@@ -1,0 +1,56 @@
+import fs from 'node:fs'
+import { expect, it } from 'vitest'
+
+const app = fs.readFileSync(new URL('./App.vue', import.meta.url), 'utf8')
+const connectionCollection = fs.readFileSync(new URL('./views/ConnectionsView.vue', import.meta.url), 'utf8')
+const connectionCreate = fs.readFileSync(new URL('./views/ConnectionCreateView.vue', import.meta.url), 'utf8')
+const repositoryCreate = fs.readFileSync(new URL('./views/RepositoryCreateView.vue', import.meta.url), 'utf8')
+
+it('Code collections stay cached across routed create and detail surfaces', () => {
+  expect(app).toMatch(/<KeepAlive :max="1">[\s\S]*<ConnectionsView/)
+  expect(app).toMatch(/<KeepAlive :max="1">[\s\S]*<RepositoriesView/)
+  expect(app).toMatch(/!route\.create && !route\.connection/)
+  expect(app).toMatch(/!route\.create && !route\.repo/)
+  expect(app).toMatch(/:key="`\$\{contextGeneration\}:connections`"/)
+  expect(app).toMatch(/:key="`\$\{contextGeneration\}:repositories`"/)
+})
+
+it('GitHub OAuth configuration failures settle and expose retry actions', () => {
+  for (const source of [connectionCollection, connectionCreate]) {
+    expect(source).toMatch(/async function loadOAuthConfig\(\): Promise<void>/)
+    expect(source).toMatch(/catch \(e\)/)
+    expect(source).toMatch(/oauthLoaded\.value = true/)
+    expect(source).toMatch(/@click="loadOAuthConfig"/)
+    expect(source).toMatch(/Retry GitHub sign-in/)
+  }
+})
+
+it('create routes fence every async continuation on the synchronous authority generation', () => {
+  expect(app).toMatch(/provide\(contextGenerationKey, contextGeneration\)/)
+  expect(app).toMatch(/flush: 'sync'/)
+  for (const source of [connectionCreate, repositoryCreate]) {
+    expect(source).toMatch(/inject\(contextGenerationKey, ref\(0\)\)/)
+    expect(source).toMatch(/function isCurrentMutation\(/)
+    expect(source).toMatch(/if \(!isCurrentMutation\(generation, expectedContext\)\) return/)
+    expect(source).toMatch(/if \(isCurrentMutation\(generation, expectedContext\)\) formError\.value/)
+    expect(source).toMatch(/if \(isCurrentMutation\(generation, expectedContext\)\) submitting\.value = false/)
+  }
+})
+
+it('connection creation performs an authoritative collision check before connect', () => {
+  expect(connectionCreate).toMatch(/const currentConnections = await api\.listConnections\(\)/)
+  expect(connectionCreate).toMatch(/normalizeResourceName\(connection\.name\) === desiredName/)
+  expect(connectionCreate).toMatch(/already exists\./)
+  expect(connectionCreate).toMatch(/const created = await api\.connect\(payload\)/)
+})
+
+it('route cancellation cannot hide an in-flight create mutation', () => {
+  for (const source of [connectionCreate, repositoryCreate]) {
+    expect(source).toMatch(/function cancel\(\): void \{\s+if \(submitting\.value\) return/)
+    expect(source).toMatch(/k-back-action" type="button" :disabled="submitting" @click="cancel"/)
+    expect(source).toMatch(/type="button" :disabled="submitting" @click="cancel">Cancel/)
+    expect(source).not.toMatch(/@click(?:\.prevent)?="emit\('cancel'\)"/)
+  }
+  expect(connectionCreate).toMatch(/if \(oauthBusy\.value\) clearOAuthWait\(\)/)
+  expect(connectionCreate).toMatch(/if \(popup && !popup\.closed\) popup\.close\(\)/)
+})

--- a/providers/code/portal/src/oauth-config.behavior.test.ts
+++ b/providers/code/portal/src/oauth-config.behavior.test.ts
@@ -1,0 +1,475 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRenderer, nextTick, ref, ssrContextKey, type RendererOptions } from '@vue/runtime-core'
+import * as VueRuntime from 'vue'
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc'
+import type { VNode } from 'vue'
+
+import { createResourceDeletions } from './refresh'
+import { contextGenerationKey } from './context'
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    listConnections: vi.fn(),
+    listRepositories: vi.fn(),
+    oauthConfig: vi.fn(),
+    connect: vi.fn(),
+    createRepository: vi.fn(),
+  },
+}))
+
+vi.mock('./api', () => ({
+  api: mocks.api,
+  normalizeResourceName: (value: string) => value.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 253) || 'x',
+}))
+vi.mock('./portalkit/confirm', () => ({ confirmDialog: vi.fn() }))
+vi.mock('./portalkit/ResourceTable.vue', async () => {
+  const { h } = await import('vue')
+  type StubSlots = Record<string, () => VNode[]>
+  return {
+    default: {
+      setup: (_props: unknown, { slots }: { slots: StubSlots }) => () => h('div', { class: 'resource-table-stub' }, [
+        slots.default?.(),
+      ]),
+    },
+  }
+})
+vi.mock('./portalkit/ResourceTableDeleteButton.vue', async () => {
+  const { h } = await import('vue')
+  return { default: { setup: () => () => h('button', 'Delete') } }
+})
+vi.mock('./portalkit/StatusBadge.vue', async () => {
+  const { h } = await import('vue')
+  return { default: { setup: () => () => h('span', 'status') } }
+})
+vi.mock('lucide-vue-next', async () => {
+  const { h } = await import('vue')
+  return { ArrowLeft: { setup: () => () => h('span', { 'aria-hidden': 'true' }) } }
+})
+
+import ConnectionsView from './views/ConnectionsView.vue'
+import ConnectionCreateView from './views/ConnectionCreateView.vue'
+import RepositoryCreateView from './views/RepositoryCreateView.vue'
+import connectionsSource from './views/ConnectionsView.vue?raw'
+import connectionCreateSource from './views/ConnectionCreateView.vue?raw'
+import repositoryCreateSource from './views/RepositoryCreateView.vue?raw'
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(reason?: unknown): void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+interface TreeNode {
+  type: string
+  props: Record<string, unknown>
+  children: TreeNode[]
+  options?: TreeNode[]
+  parent: TreeNode | null
+  text?: string
+  setAttribute(name: string, value: string): void
+  removeAttribute(name: string): void
+  addEventListener?(name: string, handler: unknown): void
+  removeEventListener?(name: string, handler: unknown): void
+  getRootNode?(): TreeNode
+}
+
+function textNode(text: string): TreeNode {
+  return { type: '#text', props: {}, children: [], parent: null, text, setAttribute() {}, removeAttribute() {} }
+}
+
+function createTreeElement(type: string): TreeNode {
+  const node: TreeNode = {
+    type,
+    props: {},
+    children: [],
+    options: [],
+    parent: null,
+    setAttribute(name, value) {
+      this.props[name] = value
+    },
+    removeAttribute(name) {
+      delete this.props[name]
+    },
+    addEventListener(name, handler) {
+      this.props[`listener:${name}`] = handler
+    },
+    removeEventListener(name) {
+      delete this.props[`listener:${name}`]
+    },
+    getRootNode() {
+      return this
+    },
+  }
+  return node
+}
+
+const rendererOptions: RendererOptions<TreeNode, TreeNode> = {
+  patchProp(node, key, _previous, next) {
+    node.props[key] = next
+  },
+  insert(node, parent, anchor) {
+    node.parent = parent
+    if (parent.type === 'select' && node.type === 'option') parent.options?.push(node)
+    if (anchor) {
+      const index = parent.children.indexOf(anchor)
+      parent.children.splice(index < 0 ? parent.children.length : index, 0, node)
+    } else {
+      parent.children.push(node)
+    }
+  },
+  remove(node) {
+    if (!node.parent) return
+    if (node.parent.type === 'select' && node.type === 'option') {
+      const optionIndex = node.parent.options?.indexOf(node) ?? -1
+      if (optionIndex >= 0) node.parent.options?.splice(optionIndex, 1)
+    }
+    const index = node.parent.children.indexOf(node)
+    if (index >= 0) node.parent.children.splice(index, 1)
+    node.parent = null
+  },
+  createElement: type => createTreeElement(type),
+  createText: text => textNode(text),
+  createComment: text => ({ type: '#comment', props: {}, children: [], parent: null, text, setAttribute() {}, removeAttribute() {} }),
+  setText(node, text) {
+    node.text = text
+  },
+  setElementText(node, text) {
+    node.children = [textNode(text)]
+    node.children[0].parent = node
+  },
+  parentNode: node => node.parent,
+  nextSibling: node => {
+    if (!node.parent) return null
+    const index = node.parent.children.indexOf(node)
+    return index >= 0 ? node.parent.children[index + 1] || null : null
+  },
+}
+
+const renderer = createRenderer(rendererOptions)
+
+function compileClientRender(source: string, filename: string): (ctx: unknown, cache: unknown) => unknown {
+  const parsed = parse(source, { filename })
+  if (!parsed.descriptor.template) throw new Error(`${filename} has no template`)
+  const script = compileScript(parsed.descriptor, { id: `behavior-${filename}` })
+  const compiled = compileTemplate({
+    source: parsed.descriptor.template.content,
+    filename,
+    id: `behavior-${filename}`,
+    compilerOptions: { bindingMetadata: script.bindings },
+  })
+  if (compiled.errors.length) throw compiled.errors[0]
+  const code = compiled.code
+    .replace(/^import \{([^\n]+)\} from "vue"\n/, (_match, imports: string) => {
+      const bindings = imports.split(',').map(binding => {
+        const [name, alias] = binding.trim().split(/\s+as\s+/)
+        return alias ? `${name}: ${alias}` : name
+      }).join(', ')
+      return `const { ${bindings} } = VueRuntime\n`
+    })
+    .replace('export function render', 'function render')
+  return new Function('VueRuntime', `${code}\nreturn render`)(VueRuntime) as (ctx: unknown, cache: unknown) => unknown
+}
+
+;(ConnectionsView as unknown as { render: unknown }).render = compileClientRender(connectionsSource, 'ConnectionsView.vue')
+;(ConnectionCreateView as unknown as { render: unknown }).render = compileClientRender(connectionCreateSource, 'ConnectionCreateView.vue')
+;(RepositoryCreateView as unknown as { render: unknown }).render = compileClientRender(repositoryCreateSource, 'RepositoryCreateView.vue')
+
+function allNodes(root: TreeNode): TreeNode[] {
+  return [root, ...root.children.flatMap(allNodes)]
+}
+
+function textContent(node: TreeNode): string {
+  return node.text ?? node.children.map(textContent).join('')
+}
+
+function findNode(root: TreeNode, predicate: (node: TreeNode) => boolean): TreeNode | undefined {
+  return allNodes(root).find(predicate)
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function mount(component: typeof ConnectionsView | typeof ConnectionCreateView | typeof RepositoryCreateView, props: Record<string, unknown>) {
+  const root = createTreeElement('root')
+  const app = renderer.createApp(component, props)
+  app.provide(ssrContextKey, { modules: new Set<string>() })
+  const contextGeneration = ref(0)
+  app.provide(contextGenerationKey, contextGeneration)
+  app.mount(root)
+  return { app, root, contextGeneration }
+}
+
+let previousWindow: unknown
+let previousDocument: unknown
+let previousShadowRoot: unknown
+
+beforeEach(() => {
+  previousWindow = (globalThis as typeof globalThis & { window?: unknown }).window
+  previousDocument = (globalThis as typeof globalThis & { Document?: unknown }).Document
+  previousShadowRoot = (globalThis as typeof globalThis & { ShadowRoot?: unknown }).ShadowRoot
+  Object.defineProperty(globalThis, 'Document', { configurable: true, value: class Document {} })
+  Object.defineProperty(globalThis, 'ShadowRoot', { configurable: true, value: class ShadowRoot {} })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      setInterval: () => 0,
+      clearInterval: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    },
+  })
+  mocks.api.listConnections.mockResolvedValue([])
+  mocks.api.listRepositories.mockResolvedValue([])
+  mocks.api.oauthConfig.mockResolvedValue({ enabled: false })
+  mocks.api.connect.mockResolvedValue({ name: 'created' })
+  mocks.api.createRepository.mockResolvedValue({ name: 'created-repository' })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  if (previousDocument === undefined) {
+    Reflect.deleteProperty(globalThis, 'Document')
+  } else {
+    Object.defineProperty(globalThis, 'Document', { configurable: true, value: previousDocument })
+  }
+  if (previousShadowRoot === undefined) {
+    Reflect.deleteProperty(globalThis, 'ShadowRoot')
+  } else {
+    Object.defineProperty(globalThis, 'ShadowRoot', { configurable: true, value: previousShadowRoot })
+  }
+  if (previousWindow === undefined) {
+    Reflect.deleteProperty(globalThis, 'window')
+  } else {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: previousWindow })
+  }
+})
+
+describe('OAuth configuration error states', () => {
+  it('shows a retry action on the connections collection when configuration fails', async () => {
+    const configRequest = deferred<{ enabled: boolean }>()
+    mocks.api.oauthConfig.mockReturnValue(configRequest.promise)
+    const { app, root } = mount(ConnectionsView, { deletions: createResourceDeletions() })
+    await settle()
+
+    configRequest.reject(new Error('oauth backend unavailable'))
+    await settle()
+
+    expect(textContent(root)).toContain('GitHub sign-in configuration could not be loaded: oauth backend unavailable')
+    expect(textContent(root)).toContain('Retry GitHub sign-in')
+    expect(findNode(root, node => node.props.role === 'alert')).toBeDefined()
+    app.unmount()
+  })
+
+  it('shows a retry action on the GitHub creation route when configuration fails', async () => {
+    const configRequest = deferred<{ enabled: boolean }>()
+    mocks.api.oauthConfig.mockReturnValue(configRequest.promise)
+    const { app, root } = mount(ConnectionCreateView, {
+      method: 'github',
+      deletions: createResourceDeletions(),
+    })
+    await settle()
+
+    configRequest.reject(new Error('oauth backend unavailable'))
+    await settle()
+
+    expect(textContent(root)).toContain('GitHub sign-in configuration could not be loaded: oauth backend unavailable')
+    expect(textContent(root)).toContain('Retry GitHub sign-in')
+    expect(findNode(root, node => node.props.role === 'alert')).toBeDefined()
+    app.unmount()
+  })
+})
+
+describe('connection creation authority fencing', () => {
+  const existingConnection = {
+    name: 'github-prod',
+    uid: 'github-prod-uid',
+    provider: 'github',
+    type: 'pat',
+    owner: 'octocat',
+    secretName: 'github-prod-token',
+    scopes: [],
+    validated: true,
+  }
+
+  const activeRepository = {
+    name: 'github-prod',
+    uid: 'github-prod-repository-uid',
+    connectionRef: 'github-prod',
+    repo: 'github-prod',
+    visibility: 'private',
+    ready: true,
+  }
+
+  const activeConnection = {
+    name: 'github-prod',
+    uid: 'github-prod-connection-uid',
+    provider: 'github',
+    type: 'pat',
+    owner: 'octocat',
+    secretName: 'github-prod-token',
+    scopes: [],
+    validated: true,
+  }
+
+  function setInput(root: TreeNode, placeholder: string, value: string): void {
+    const input = findNode(root, node => node.type === 'input' && node.props.placeholder === placeholder)
+    if (!input) throw new Error(`input ${placeholder} was not rendered`)
+    const update = input.props['onUpdate:modelValue'] ?? input.props.onInput
+    if (typeof update !== 'function') throw new Error(`input ${placeholder} had no v-model handler`)
+    update(typeof input.props['onUpdate:modelValue'] === 'function' ? value : { target: { value } })
+  }
+
+  async function submit(root: TreeNode): Promise<void> {
+    const form = findNode(root, node => node.type === 'form')
+    if (!form) throw new Error('connection form was not rendered')
+    const handler = form.props.onSubmit
+    if (typeof handler !== 'function') throw new Error('connection form had no submit handler')
+    await handler({ preventDefault() {} })
+  }
+
+  it('re-reads before mutation and refuses an active normalized name collision', async () => {
+    mocks.api.listConnections.mockReset()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([existingConnection])
+    mocks.api.connect.mockReset()
+
+    const created = vi.fn()
+    const { app, root } = mount(ConnectionCreateView, {
+      method: 'token',
+      deletions: createResourceDeletions(),
+      onCreated: created,
+    })
+    await settle()
+    setInput(root, 'my-github', ' GitHub-Prod ')
+    setInput(root, 'acme', 'octocat')
+    setInput(root, 'ghp_…', 'new-secret')
+
+    await submit(root)
+    expect(mocks.api.listConnections).toHaveBeenCalledTimes(2)
+    expect(mocks.api.connect).not.toHaveBeenCalled()
+    expect(created).not.toHaveBeenCalled()
+    expect(textContent(root)).toContain('Connection "github-prod" already exists.')
+    app.unmount()
+  })
+
+  it('keeps a tombstoned normalized name reserved until the resource disappears', async () => {
+    const tombstone = { ...existingConnection, deletionTimestamp: '2026-08-27T19:00:00Z' }
+    mocks.api.listConnections.mockReset()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([tombstone])
+    mocks.api.connect.mockReset()
+
+    const { app, root } = mount(ConnectionCreateView, {
+      method: 'token',
+      deletions: createResourceDeletions(),
+    })
+    await settle()
+    setInput(root, 'my-github', ' GitHub-Prod ')
+    setInput(root, 'acme', 'octocat')
+    setInput(root, 'ghp_…', 'new-secret')
+
+    await submit(root)
+    expect(mocks.api.connect).not.toHaveBeenCalled()
+    expect(textContent(root)).toContain('Connection "github-prod" is still deleting.')
+    app.unmount()
+  })
+
+  it('keeps an acknowledged delete reserved while the same UID remains visible', async () => {
+    const deletions = createResourceDeletions()
+    deletions.acknowledge('connection', existingConnection.name, existingConnection.uid)
+    mocks.api.listConnections.mockReset().mockResolvedValue([existingConnection])
+    mocks.api.connect.mockReset()
+
+    const { app, root } = mount(ConnectionCreateView, {
+      method: 'token',
+      deletions,
+    })
+    await settle()
+    setInput(root, 'my-github', ' GitHub-Prod ')
+    setInput(root, 'acme', 'octocat')
+    setInput(root, 'ghp_…', 'new-secret')
+
+    await submit(root)
+    expect(mocks.api.connect).not.toHaveBeenCalled()
+    expect(textContent(root)).toContain('Connection "github-prod" is still deleting.')
+    app.unmount()
+  })
+
+  it('rejects a stale preflight before calling the credential mutation', async () => {
+    const preflight = deferred<typeof existingConnection[]>()
+    mocks.api.listConnections.mockReset()
+      .mockResolvedValueOnce([])
+      .mockReturnValueOnce(preflight.promise)
+    mocks.api.connect.mockReset()
+
+    const created = vi.fn()
+    const { app, root, contextGeneration } = mount(ConnectionCreateView, {
+      method: 'token',
+      deletions: createResourceDeletions(),
+      onCreated: created,
+    })
+    await settle()
+    setInput(root, 'my-github', 'new-connection')
+    setInput(root, 'acme', 'octocat')
+    setInput(root, 'ghp_…', 'new-secret')
+    const pendingSubmit = submit(root)
+    await settle()
+
+    // Model a shell context update before Vue has had a chance to flush the
+    // keyed route unmount. The preflight result must not cross that boundary.
+    contextGeneration.value += 1
+    preflight.resolve([])
+    await pendingSubmit
+    await settle()
+
+    expect(mocks.api.connect).not.toHaveBeenCalled()
+    expect(created).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('rejects a repository preflight that crosses the pre-unmount authority window', async () => {
+    const preflight = deferred<typeof activeRepository[]>()
+    mocks.api.listRepositories.mockReset()
+      .mockResolvedValueOnce([])
+      .mockReturnValueOnce(preflight.promise)
+    mocks.api.listConnections.mockReset().mockResolvedValue([activeConnection])
+    mocks.api.createRepository.mockReset()
+
+    const created = vi.fn()
+    const { app, root, contextGeneration } = mount(RepositoryCreateView, {
+      deletions: createResourceDeletions(),
+      onCreated: created,
+    })
+    await settle()
+    setInput(root, 'my-service', 'new-repository')
+    const pendingSubmit = submit(root)
+    await settle()
+
+    // Model a shell context update before Vue has had a chance to flush the
+    // keyed route unmount. The complete preflight result must not commit its
+    // duplicate decision or cross into createRepository.
+    contextGeneration.value += 1
+    preflight.resolve([activeRepository])
+    await pendingSubmit
+    await settle()
+
+    expect(mocks.api.createRepository).not.toHaveBeenCalled()
+    expect(created).not.toHaveBeenCalled()
+    expect(textContent(root)).not.toContain('already exists.')
+    app.unmount()
+  })
+})

--- a/providers/code/portal/src/portalkit/faros-ui.css
+++ b/providers/code/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/code/portal/src/routes.test.ts
+++ b/providers/code/portal/src/routes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { codeNavigationDetail, parseCodeSubPath } from './routes'
+
+describe('Code provider routes', () => {
+  it('parses provider-relative connection creation routes', () => {
+    expect(parseCodeSubPath('create/connection/token')).toEqual({
+      page: 'connections',
+      create: { resource: 'connection', method: 'token' },
+    })
+    expect(parseCodeSubPath('/create/connection/github/')).toEqual({
+      page: 'connections',
+      create: { resource: 'connection', method: 'github' },
+    })
+  })
+
+  it('parses repository creation and preserves encoded detail names', () => {
+    expect(parseCodeSubPath('create/repository')).toEqual({
+      page: 'repositories',
+      create: { resource: 'repository' },
+    })
+    expect(parseCodeSubPath('repositories/acme%2Fmonorepo')).toEqual({
+      page: 'repositories',
+      repo: 'acme/monorepo',
+    })
+  })
+
+  it('falls back safely for unknown or malformed provider-relative paths', () => {
+    expect(parseCodeSubPath('create/connection/password')).toEqual({ page: 'connections' })
+    expect(parseCodeSubPath('repositories/%E0%A4%A')).toEqual({ page: 'repositories', repo: '%E0%A4%A' })
+  })
+})
+
+describe('Code provider navigation detail', () => {
+  it('strips a provider prefix and carries replace history semantics only when requested', () => {
+    expect(codeNavigationDetail('/create/repository')).toEqual({ path: 'create/repository' })
+    expect(codeNavigationDetail('/repositories/orders', { replace: true })).toEqual({
+      path: 'repositories/orders',
+      replace: true,
+    })
+  })
+})
+

--- a/providers/code/portal/src/routes.ts
+++ b/providers/code/portal/src/routes.ts
@@ -1,0 +1,66 @@
+export type ConnectionCreateMethod = 'token' | 'github'
+
+export interface CodeRoute {
+  page: 'connections' | 'repositories' | 'packages'
+  repo?: string
+  connection?: string
+  create?:
+    | { resource: 'connection'; method: ConnectionCreateMethod }
+    | { resource: 'repository' }
+}
+
+export interface CodeNavigationDetail {
+  path: string
+  replace?: boolean
+}
+
+/** Build the detail payload used by the shell's faros-navigate event. */
+export function codeNavigationDetail(path: string, options: { replace?: boolean } = {}): CodeNavigationDetail {
+  const detail: CodeNavigationDetail = { path: path.replace(/^\/+/, '') }
+  if (options.replace) detail.replace = true
+  return detail
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    // Keep an invalid escape visible instead of making an otherwise valid
+    // provider route impossible to render.
+    return value
+  }
+}
+
+/**
+ * Parse the provider-relative part of `/providers/code/<subPath>`.
+ *
+ * The shell owns the `/providers/code/` prefix and passes only its trailing
+ * segments through FarosContext.subPath. Keeping this parser provider-relative
+ * means links emitted by the provider work both from the bare provider landing
+ * page and from a deep-linked browser refresh.
+ */
+export function parseCodeSubPath(subPath: string | null | undefined): CodeRoute {
+  const normalized = (subPath ?? '').replace(/^\/+|\/+$/g, '')
+  if (normalized === '' || normalized === 'connections') return { page: 'connections' }
+  if (normalized === 'packages') return { page: 'packages' }
+  if (normalized === 'repositories') return { page: 'repositories' }
+
+  const parts = normalized.split('/')
+  if (parts[0] === 'create') {
+    if (parts[1] === 'connection' && (parts[2] === 'token' || parts[2] === 'github') && parts.length === 3) {
+      return { page: 'connections', create: { resource: 'connection', method: parts[2] } }
+    }
+    if (parts[1] === 'repository' && parts.length === 2) {
+      return { page: 'repositories', create: { resource: 'repository' } }
+    }
+    return { page: 'connections' }
+  }
+
+  if (parts[0] === 'connections' && parts.length > 1) {
+    return { page: 'connections', connection: decodeSegment(parts.slice(1).join('/')) }
+  }
+  if (parts[0] === 'repositories' && parts.length > 1) {
+    return { page: 'repositories', repo: decodeSegment(parts.slice(1).join('/')) }
+  }
+  return { page: 'connections' }
+}

--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -87,6 +87,32 @@ faros-provider-code .code-form-actions {
   flex-wrap: wrap;
   gap: 8px;
 }
+faros-provider-code .code-create__back {
+  align-items: center;
+  align-self: flex-start;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  color: var(--color-accent, #8b6bff);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 500;
+  gap: 6px;
+  margin-bottom: 8px;
+  min-height: auto;
+  padding: 0;
+}
+faros-provider-code .code-create__back:hover {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  color: var(--color-accent-hover, #a18aff);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+faros-provider-code .code-create__back:active { transform: none; }
+faros-provider-code .code-create__back svg { flex: none; }
+faros-provider-code .code-create-panel { max-width: 42rem; }
 faros-provider-code .code-row-actions {
   align-items: center;
   display: flex;

--- a/providers/code/portal/src/views/ConnectionCreateView.vue
+++ b/providers/code/portal/src/views/ConnectionCreateView.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import { computed, inject, onMounted, onUnmounted, ref } from 'vue'
+import { ArrowLeft } from 'lucide-vue-next'
+import { api, normalizeResourceName } from '../api'
+import { contextGenerationKey } from '../context'
+import type { Connection, ErrorResponse } from '../types'
+import type { ConnectionCreateMethod } from '../routes'
+import type { ResourceDeletions } from '../refresh'
+
+const props = defineProps<{
+  method: ConnectionCreateMethod
+  deletions: ResourceDeletions
+}>()
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'created', name: string): void
+}>()
+
+const connections = ref<Connection[]>([])
+const loading = ref(false)
+const loaded = ref(false)
+const readError = ref<string | null>(null)
+
+const name = ref('')
+const owner = ref('')
+const token = ref('')
+const baseURL = ref('')
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+const contextGeneration = inject(contextGenerationKey, ref(0))
+
+// GitHub OAuth is deliberately kept on the creation route. The collection
+// only chooses the creation method; this page owns the popup and the final
+// confirmation so an OAuth credential can never be lost during navigation.
+const oauthEnabled = ref(false)
+const oauthLoaded = ref(false)
+const oauthStartURL = ref('')
+const oauthConfigError = ref<string | null>(null)
+const oauthBusy = ref(false)
+const oauthAuthorized = ref(false)
+let oauthState = ''
+let oauthOrigin = ''
+let oauthPopup: Window | null = null
+let oauthPopupTimer: number | undefined
+let mounted = false
+let readGeneration = 0
+let oauthGeneration = 0
+let mutationGeneration = 0
+let oauthContextGeneration = 0
+
+const isGitHub = computed(() => props.method === 'github')
+const pageTitle = computed(() => isGitHub.value ? 'Connect with GitHub' : 'Add a token connection')
+const pageMeta = computed(() => isGitHub.value
+  ? 'Authorize GitHub, then choose the account or organization where repositories should be created.'
+  : 'Store a GitHub personal access token in this workspace and validate the connection.')
+
+function isDeleting(connection: Pick<Connection, 'name' | 'uid' | 'deletionTimestamp'>): boolean {
+  return !!connection.deletionTimestamp || props.deletions.has('connection', connection.name, connection.uid)
+}
+
+function errMessage(e: unknown): string {
+  const err = e as ErrorResponse
+  return err.reason ? `${err.reason}: ${err.message}` : err.message || String(e)
+}
+
+function isCurrentRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === readGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentOAuthRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === oauthGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentMutation(generation: number, expectedContext: number): boolean {
+  return mounted && generation === mutationGeneration && contextGeneration.value === expectedContext
+}
+
+async function loadConnections(): Promise<void> {
+  const generation = ++readGeneration
+  const expectedContext = contextGeneration.value
+  loading.value = true
+  try {
+    const next = await api.listConnections()
+    if (!isCurrentRead(generation, expectedContext)) return
+    connections.value = next
+    next
+      .filter(item => item.deletionTimestamp)
+      .forEach(item => props.deletions.acknowledge('connection', item.name, item.uid))
+    props.deletions.reconcile('connection', next)
+    loaded.value = true
+    readError.value = null
+  } catch (e) {
+    if (!isCurrentRead(generation, expectedContext)) return
+    const err = e as ErrorResponse
+    readError.value = err.reason === 'TenantMissing' ? null : errMessage(e)
+  } finally {
+    if (isCurrentRead(generation, expectedContext)) loading.value = false
+  }
+}
+
+function randomState(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+function clearOAuthWait(message?: string): void {
+  const popup = oauthPopup
+  window.clearInterval(oauthPopupTimer)
+  oauthPopupTimer = undefined
+  oauthBusy.value = false
+  oauthPopup = null
+  oauthOrigin = ''
+  oauthState = ''
+  oauthContextGeneration = 0
+  if (popup && !popup.closed) popup.close()
+  if (message) formError.value = message
+}
+
+function cancel(): void {
+  if (submitting.value) return
+  if (oauthBusy.value) clearOAuthWait()
+  emit('cancel')
+}
+
+function connectGitHub(): void {
+  if (!oauthStartURL.value) {
+    formError.value = 'GitHub sign-in is unavailable — contact a platform admin'
+    return
+  }
+  oauthBusy.value = true
+  formError.value = null
+  oauthContextGeneration = contextGeneration.value
+  oauthState = randomState()
+  let url: URL
+  try {
+    // The provider normally returns a same-origin relative path. Resolve it
+    // before recording the trusted callback origin, and reject schemes that
+    // could execute in the opener's page context.
+    url = new URL(oauthStartURL.value, window.location.href)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') throw new Error('unsupported OAuth URL scheme')
+  } catch {
+    clearOAuthWait('invalid GitHub OAuth start URL — contact a platform admin')
+    return
+  }
+  oauthOrigin = url.origin
+  url.searchParams.set('state', oauthState)
+  oauthPopup = window.open(url.toString(), 'faros-github-oauth', 'width=720,height=820')
+  if (!oauthPopup) {
+    clearOAuthWait('popup blocked — allow popups and retry')
+    return
+  }
+  oauthPopupTimer = window.setInterval(() => {
+    if (contextGeneration.value !== oauthContextGeneration) clearOAuthWait()
+    else if (oauthPopup?.closed) clearOAuthWait('GitHub sign-in window was closed — retry when ready')
+  }, 500)
+}
+
+function onMessage(ev: MessageEvent): void {
+  if (!oauthBusy.value) return
+  if (!mounted || contextGeneration.value !== oauthContextGeneration) {
+    clearOAuthWait()
+    return
+  }
+  if (!oauthPopup || ev.source !== oauthPopup || ev.origin !== oauthOrigin) return
+  const data = ev.data as { type?: string; state?: string; token?: string; login?: string; error?: string }
+  if (!data || data.type !== 'faros-github-oauth') return
+  if (data.state !== oauthState) {
+    clearOAuthWait('oauth state mismatch — please retry')
+    return
+  }
+  if (data.error || !data.token) {
+    clearOAuthWait(data.error || 'no token returned from GitHub')
+    return
+  }
+  clearOAuthWait()
+  token.value = data.token
+  owner.value = data.login || ''
+  name.value = data.login ? 'github-' + data.login : 'github'
+  oauthAuthorized.value = true
+}
+
+async function submit(): Promise<void> {
+  if (!mounted || submitting.value) return
+  const generation = ++mutationGeneration
+  const expectedContext = contextGeneration.value
+  formError.value = null
+  if (!loaded.value) {
+    formError.value = 'Connection list is still loading. Retry the read before creating a connection.'
+    return
+  }
+  if (!name.value || !owner.value || !token.value) {
+    formError.value = 'name, owner, and token are required'
+    return
+  }
+  const payload = {
+    name: name.value,
+    owner: owner.value,
+    token: token.value,
+    baseURL: baseURL.value || undefined,
+    type: isGitHub.value ? 'oauth' as const : 'pat' as const,
+  }
+  const desiredName = normalizeResourceName(payload.name)
+  submitting.value = true
+  try {
+    // The initial read only makes the form usable. Re-read the complete
+    // collection immediately before applying so an active connection with the
+    // normalized name can never be silently adopted and have its Secret
+    // overwritten by api.connect.
+    const currentConnections = await api.listConnections()
+    if (!isCurrentMutation(generation, expectedContext)) return
+    connections.value = currentConnections
+    currentConnections
+      .filter(item => item.deletionTimestamp)
+      .forEach(item => props.deletions.acknowledge('connection', item.name, item.uid))
+    props.deletions.reconcile('connection', currentConnections)
+    const existing = currentConnections.find(connection => normalizeResourceName(connection.name) === desiredName)
+    if (existing && isDeleting(existing)) {
+      formError.value = `Connection "${existing.name}" is still deleting. Wait for it to disappear before reconnecting.`
+      return
+    }
+    if (existing) {
+      formError.value = `Connection "${existing.name}" already exists.`
+      return
+    }
+    if (props.deletions.has('connection', desiredName)) {
+      formError.value = `Connection "${desiredName}" is still deleting. Wait for it to disappear before reconnecting.`
+      return
+    }
+    if (!isCurrentMutation(generation, expectedContext)) return
+    const created = await api.connect(payload)
+    if (!isCurrentMutation(generation, expectedContext)) return
+    emit('created', created.name)
+  } catch (e) {
+    if (isCurrentMutation(generation, expectedContext)) formError.value = errMessage(e)
+  } finally {
+    if (isCurrentMutation(generation, expectedContext)) submitting.value = false
+  }
+}
+
+async function loadOAuthConfig(): Promise<void> {
+  const generation = ++oauthGeneration
+  const expectedContext = contextGeneration.value
+  oauthConfigError.value = null
+  oauthLoaded.value = false
+  try {
+    const config = await api.oauthConfig()
+    if (!isCurrentOAuthRead(generation, expectedContext)) return
+    oauthEnabled.value = config.enabled
+    oauthStartURL.value = config.startURL || ''
+  } catch (e) {
+    if (!isCurrentOAuthRead(generation, expectedContext)) return
+    oauthEnabled.value = false
+    oauthStartURL.value = ''
+    oauthConfigError.value = errMessage(e)
+  } finally {
+    if (isCurrentOAuthRead(generation, expectedContext)) oauthLoaded.value = true
+  }
+}
+
+onMounted(() => {
+  mounted = true
+  void loadConnections()
+  if (isGitHub.value) void loadOAuthConfig()
+})
+onUnmounted(() => {
+  mounted = false
+  readGeneration += 1
+  oauthGeneration += 1
+  mutationGeneration += 1
+  clearOAuthWait()
+  window.removeEventListener('message', onMessage)
+})
+
+// Register the listener after setup so a popup callback cannot race a route
+// change before the component has mounted.
+onMounted(() => window.addEventListener('message', onMessage))
+</script>
+
+<template>
+  <section class="page k-create-page">
+    <button class="k-btn k-btn--ghost k-back-action" type="button" :disabled="submitting" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Connections
+    </button>
+    <header class="k-create-header">
+      <h2 class="k-create-title">{{ pageTitle }}</h2>
+      <p class="k-create-description">{{ pageMeta }}</p>
+    </header>
+
+    <div v-if="loading && !loaded" class="panel k-card" role="status" aria-live="polite">Loading connections…</div>
+    <div v-if="readError" class="error read-error" role="alert" aria-live="assertive">
+      <span>{{ readError }}</span>
+      <button class="k-btn k-btn--ghost" type="button" @click="loadConnections">Retry connections</button>
+    </div>
+
+    <div v-if="isGitHub && !oauthAuthorized" class="k-create-surface">
+      <div class="k-create-body">
+      <p class="muted">A separate GitHub window will open. After authorization, review the connection details before creating it.</p>
+      <span v-if="oauthLoaded && !oauthEnabled && !oauthConfigError" class="muted">GitHub OAuth is not configured. Use the token connection flow instead.</span>
+      <span v-else-if="!oauthLoaded" class="muted" role="status" aria-live="polite">Checking GitHub sign-in…</span>
+      <div v-if="oauthConfigError" class="error read-error" role="alert" aria-live="assertive">
+        <span>GitHub sign-in configuration could not be loaded: {{ oauthConfigError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" @click="loadOAuthConfig">Retry GitHub sign-in</button>
+      </div>
+      <p v-if="formError" class="error" role="alert">{{ formError }}</p>
+      </div>
+      <div class="k-create-actions">
+        <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
+        <button v-if="oauthEnabled" class="k-btn k-btn--primary" :disabled="oauthBusy || !oauthLoaded" type="button" @click="connectGitHub">
+          {{ oauthBusy ? 'Waiting for GitHub…' : 'Continue with GitHub' }}
+        </button>
+      </div>
+    </div>
+
+    <form v-if="method === 'token' || oauthAuthorized" class="k-create-surface" @submit.prevent="submit">
+      <div class="k-create-body">
+        <p v-if="oauthAuthorized" class="muted">
+          Authorized via GitHub<span v-if="owner"> as <code>{{ owner }}</code></span>. Pick the org/account to create repositories under, then confirm.
+        </p>
+        <label class="field"><span class="field-label">Name</span><input v-model="name" class="k-input" placeholder="my-github" autocomplete="off" /></label>
+        <label class="field"><span class="field-label">Owner (org or user)</span><input v-model="owner" class="k-input" placeholder="acme" autocomplete="off" /></label>
+        <label v-if="!oauthAuthorized" class="field"><span class="field-label">Personal access token</span><input v-model="token" class="k-input" type="password" placeholder="ghp_…" autocomplete="off" /></label>
+        <label v-else class="field"><span class="field-label">Credential</span><input class="k-input" value="GitHub OAuth — authorized" disabled /></label>
+        <label v-if="!oauthAuthorized" class="field"><span class="field-label">Base URL (GHES, optional)</span><input v-model="baseURL" class="k-input" placeholder="https://github.example.com/api/v3" autocomplete="off" /></label>
+        <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
+        <span v-if="formError" class="error" role="alert">{{ formError }}</span>
+      </div>
+      <div class="k-create-actions">
+        <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" :disabled="submitting || !loaded">{{ submitting ? 'Connecting…' : 'Create connection' }}</button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/providers/code/portal/src/views/ConnectionsView.vue
+++ b/providers/code/portal/src/views/ConnectionsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { api, normalizeResourceName } from '../api'
+import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
+import { api } from '../api'
 import type { Connection, ErrorResponse } from '../types'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
@@ -19,7 +19,10 @@ import {
 } from '../refresh'
 
 const props = defineProps<{ deletions: ResourceDeletions }>()
-const emit = defineEmits<{ (e: 'open', name: string): void }>()
+const emit = defineEmits<{
+  (e: 'open', name: string): void
+  (e: 'create', method: 'token' | 'github'): void
+}>()
 const deletionScope = 'connection'
 
 const connections = ref<Connection[]>([])
@@ -45,25 +48,10 @@ function isDeleting(connection: Pick<Connection, 'name' | 'uid' | 'deletionTimes
   return !!connection.deletionTimestamp || props.deletions.has(deletionScope, connection.name, connection.uid)
 }
 
-// connect form
-const showForm = ref(false)
-const name = ref('')
-const owner = ref('')
-const token = ref('')
-const baseURL = ref('')
-const connType = ref<'pat' | 'oauth'>('pat')
-const submitting = ref(false)
-const formError = ref<string | null>(null)
-
 // GitHub OAuth ("Connect with GitHub") — enabled when the provider is configured.
 const oauthEnabled = ref(false)
 const oauthLoaded = ref(false)
-const oauthStartURL = ref('')
-const oauthBusy = ref(false)
-let oauthState = ''
-let oauthOrigin = ''
-let oauthPopup: Window | null = null
-let oauthPopupTimer: number | undefined
+const oauthError = ref<string | null>(null)
 let mounted = false
 let refresh!: LatestRefreshController
 const refreshMode = ref<ResourceRefreshMode>('foreground')
@@ -83,74 +71,19 @@ function errMessage(e: unknown): string {
   return err.reason ? `${err.reason}: ${err.message}` : err.message || String(e)
 }
 
-function resetForm() {
-  name.value = owner.value = token.value = baseURL.value = ''
-  connType.value = 'pat'
-}
-
-function randomState(): string {
-  const a = new Uint8Array(16)
-  crypto.getRandomValues(a)
-  return Array.from(a, b => b.toString(16).padStart(2, '0')).join('')
-}
-
-function clearOAuthWait(message?: string) {
-  window.clearInterval(oauthPopupTimer)
-  oauthPopupTimer = undefined
-  oauthBusy.value = false
-  oauthPopup = null
-  oauthOrigin = ''
-  oauthState = ''
-  if (message) formError.value = message
-}
-
-function connectGitHub() {
-  if (!oauthStartURL.value) return
-  oauthBusy.value = true
-  formError.value = null
-  oauthState = randomState()
-  let url: URL
+async function loadOAuthConfig(): Promise<void> {
+  oauthError.value = null
   try {
-    // The provider normally returns a same-origin relative path. Resolve it
-    // before recording the trusted callback origin, and reject schemes that
-    // could execute in the opener's page context.
-    url = new URL(oauthStartURL.value, window.location.href)
-    if (url.protocol !== 'https:' && url.protocol !== 'http:') throw new Error('unsupported OAuth URL scheme')
-  } catch {
-    clearOAuthWait('invalid GitHub OAuth start URL — contact a platform admin')
-    return
+    const config = await api.oauthConfig()
+    if (!mounted) return
+    oauthEnabled.value = config.enabled
+  } catch (e) {
+    if (!mounted) return
+    oauthEnabled.value = false
+    oauthError.value = errMessage(e)
+  } finally {
+    if (mounted) oauthLoaded.value = true
   }
-  oauthOrigin = url.origin
-  url.searchParams.set('state', oauthState)
-  oauthPopup = window.open(url.toString(), 'faros-github-oauth', 'width=720,height=820')
-  if (!oauthPopup) {
-    clearOAuthWait('popup blocked — allow popups and retry')
-    return
-  }
-  oauthPopupTimer = window.setInterval(() => {
-    if (oauthPopup?.closed) clearOAuthWait('GitHub sign-in window was closed — retry when ready')
-  }, 500)
-}
-
-function onMessage(ev: MessageEvent) {
-  if (!oauthBusy.value) return
-  if (!oauthPopup || ev.source !== oauthPopup || ev.origin !== oauthOrigin) return
-  const d = ev.data as { type?: string; state?: string; token?: string; login?: string; error?: string }
-  if (!d || d.type !== 'faros-github-oauth') return
-  if (d.state !== oauthState) {
-    clearOAuthWait('oauth state mismatch — please retry')
-    return
-  }
-  if (d.error || !d.token) {
-    clearOAuthWait(d.error || 'no token returned from GitHub')
-    return
-  }
-  clearOAuthWait()
-  token.value = d.token
-  owner.value = d.login || ''
-  name.value = d.login ? 'github-' + d.login : 'github'
-  connType.value = 'oauth'
-  showForm.value = true
 }
 
 function load(mode: ResourceRefreshMode = 'foreground') {
@@ -164,36 +97,6 @@ function load(mode: ResourceRefreshMode = 'foreground') {
 function openConnection(row: Record<string, unknown>) {
   const resourceName = String(row.name)
   if (!row.deleting && !operations.isLocked(operationKey('connection', resourceName))) emit('open', resourceName)
-}
-
-async function submit() {
-  formError.value = null
-  if (!loaded.value) {
-    formError.value = 'Connection list is still loading. Retry the read before creating a connection.'
-    return
-  }
-  if (!name.value || !owner.value || !token.value) {
-    formError.value = 'name, owner, and token are required'
-    return
-  }
-  const existing = connections.value.find(connection => connection.name === normalizeResourceName(name.value))
-  if (existing && isDeleting(existing)) {
-    formError.value = `Connection "${existing.name}" is still deleting. Wait for it to disappear before reconnecting.`
-    return
-  }
-  submitting.value = true
-  try {
-    const created = await api.connect({ name: name.value, owner: owner.value, token: token.value, baseURL: baseURL.value || undefined, type: connType.value })
-    connections.value = [...connections.value.filter(item => item.name !== created.name), created]
-    loaded.value = true
-    resetForm()
-    showForm.value = false
-    load()
-  } catch (e) {
-    formError.value = errMessage(e)
-  } finally {
-    submitting.value = false
-  }
 }
 
 async function remove(row: Record<string, unknown>) {
@@ -243,21 +146,17 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
   }
 })
 
-onMounted(async () => {
+onMounted(() => {
   mounted = true
+  void loadOAuthConfig()
+})
+onActivated(() => {
   load()
   poller.schedule()
-  window.addEventListener('message', onMessage)
-  const cfg = await api.oauthConfig()
-  oauthEnabled.value = cfg.enabled
-  oauthStartURL.value = cfg.startURL || ''
-  oauthLoaded.value = true
 })
 onUnmounted(() => {
   mounted = false
-  clearOAuthWait()
   poller.stop()
-  window.removeEventListener('message', onMessage)
   refresh.stop()
 })
 </script>
@@ -270,38 +169,22 @@ onUnmounted(() => {
         <p class="page-meta">A connection binds your workspace to a git account. Repositories are created under it.</p>
       </div>
       <div class="code-form-actions">
-        <button v-if="oauthEnabled" class="k-btn k-btn--primary" :disabled="oauthBusy || !loaded" @click="connectGitHub">
-          {{ oauthBusy ? 'Waiting for GitHub…' : 'Connect with GitHub' }}
+        <button v-if="oauthEnabled" class="k-btn k-btn--primary" :disabled="!loaded" @click="emit('create', 'github')">
+          Connect with GitHub
         </button>
-        <button class="k-btn" :class="oauthEnabled ? 'k-btn--ghost' : 'k-btn--primary'" :disabled="!loaded" @click="showForm = !showForm">
-          {{ showForm ? 'Cancel' : 'Add token manually' }}
+        <button class="k-btn" :class="oauthEnabled ? 'k-btn--ghost' : 'k-btn--primary'" :disabled="!loaded" @click="emit('create', 'token')">
+          Add token manually
         </button>
       </div>
     </header>
 
-    <p v-if="oauthLoaded && !oauthEnabled" class="muted">
+    <p v-if="oauthError" class="error read-error" role="alert">
+      <span>GitHub sign-in configuration could not be loaded: {{ oauthError }}</span>
+      <button class="k-btn k-btn--ghost" type="button" @click="loadOAuthConfig">Retry GitHub sign-in</button>
+    </p>
+    <p v-else-if="oauthLoaded && !oauthEnabled" class="muted">
       Tip: a platform admin can enable one-click “Connect with GitHub” by configuring the provider’s GitHub OAuth app.
     </p>
-
-    <div v-if="showForm" class="panel k-card">
-      <h3 class="panel-title">{{ connType === 'oauth' ? 'Confirm GitHub connection' : 'Connect with a token' }}</h3>
-      <form class="form" @submit.prevent="submit">
-        <p v-if="connType === 'oauth'" class="muted">
-          Authorized via GitHub<span v-if="owner"> as <code>{{ owner }}</code></span>. Pick the org/account to create repositories under, then confirm.
-        </p>
-        <label class="field"><span class="field-label">Name</span><input v-model="name" class="k-input" placeholder="my-github" autocomplete="off" /></label>
-        <label class="field"><span class="field-label">Owner (org or user)</span><input v-model="owner" class="k-input" placeholder="acme" autocomplete="off" /></label>
-        <label v-if="connType === 'pat'" class="field"><span class="field-label">Personal access token</span><input v-model="token" class="k-input" type="password" placeholder="ghp_…" autocomplete="off" /></label>
-        <label v-else class="field"><span class="field-label">Credential</span><input class="k-input" value="GitHub OAuth — authorized" disabled /></label>
-        <label v-if="connType === 'pat'" class="field"><span class="field-label">Base URL (GHES, optional)</span><input v-model="baseURL" class="k-input" placeholder="https://github.example.com/api/v3" autocomplete="off" /></label>
-        <div class="code-form-actions">
-          <button class="k-btn k-btn--primary" type="submit" :disabled="submitting">{{ submitting ? 'Connecting…' : 'Create' }}</button>
-          <button class="k-btn k-btn--ghost" type="button" @click="() => { showForm = false; resetForm() }">Cancel</button>
-          <span v-if="formError" class="error" role="alert">{{ formError }}</span>
-        </div>
-        <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
-      </form>
-    </div>
 
     <p v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">{{ mutationError }}</p>
     <ResourceTable

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import { ExternalLink } from 'lucide-vue-next'
-import { api, normalizeResourceName } from '../api'
+import { api } from '../api'
 import type { Connection, ErrorResponse, Repository } from '../types'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
@@ -35,7 +35,10 @@ import {
 } from '../repositoriesPagination'
 
 const props = defineProps<{ deletions: ResourceDeletions }>()
-const emit = defineEmits<{ (e: 'open', name: string): void }>()
+const emit = defineEmits<{
+  (e: 'open', name: string): void
+  (e: 'create'): void
+}>()
 const deletionScope = 'repository'
 
 const repos = ref<Repository[]>([])
@@ -73,20 +76,7 @@ const rows = computed<Array<Record<string, unknown>>>(() => repos.value
 function isDeleting(repository: Pick<Repository, 'name' | 'uid' | 'deletionTimestamp'>): boolean {
   return !!repository.deletionTimestamp || props.deletions.has(deletionScope, repository.name, repository.uid)
 }
-const connectionChoices = computed(() => connections.value.filter(connection => (
-  !connection.deletionTimestamp && !props.deletions.has('connection', connection.name, connection.uid)
-)))
 const repositoryFilterDefinitions = computed(() => repositoryFilters(connections.value))
-
-const showForm = ref(false)
-const name = ref('')
-const repo = ref('')
-const connectionRef = ref('')
-const visibility = ref('private')
-const description = ref('')
-const autoInit = ref(true)
-const submitting = ref(false)
-const formError = ref<string | null>(null)
 
 let mounted = false
 let repoRefresh!: LatestRefreshController
@@ -246,79 +236,6 @@ function handleRepositoryChange(change: ResourceTableChange): void {
   if (transition.reload) loadRepositories()
 }
 
-async function submit() {
-  formError.value = null
-  if (!loaded.value || !connectionsLoaded.value) {
-    formError.value = 'Repository data is still loading. Retry failed reads before creating a repository.'
-    return
-  }
-  if (!name.value || !connectionRef.value) {
-    formError.value = 'name and connection are required'
-    return
-  }
-  if (!connectionChoices.value.some(connection => connection.name === connectionRef.value)) {
-    formError.value = 'Select an active connection before creating a repository.'
-    return
-  }
-  const desiredName = normalizeResourceName(name.value)
-  const lock = operationKey('repository', desiredName)
-  if (!operations.acquire(lock, 'creating')) {
-    formError.value = `Repository "${desiredName}" already has an operation in progress.`
-    return
-  }
-  submitting.value = true
-  try {
-    // The visible server page may not contain a duplicate or a repository
-    // still terminating. Resolve both decisions against a complete walk before
-    // allowing the create mutation, and only then reconcile the deletion
-    // ledger because this read is authoritative for the whole workspace.
-    // Reuse the same serialized complete-read authority as search/polling so a
-    // duplicate check cannot race another bounded walk or discard its result.
-    const allRepositories = await repositoryFullRead.read(true)
-    if (!mounted) return
-    allRepositories
-      .filter(item => item.deletionTimestamp)
-      .forEach(item => props.deletions.acknowledge(deletionScope, item.name, item.uid))
-    props.deletions.reconcile(deletionScope, allRepositories)
-    const existing = allRepositories.find(repository => repository.name === desiredName)
-    if (existing && isDeleting(existing)) {
-      formError.value = `Repository "${existing.name}" is still deleting. Wait for it to disappear before recreating it.`
-      return
-    }
-    if (existing) {
-      formError.value = `Repository "${existing.name}" already exists.`
-      return
-    }
-    if (props.deletions.has(deletionScope, desiredName)) {
-      formError.value = `Repository "${desiredName}" is still deleting. Wait for it to disappear before recreating it.`
-      return
-    }
-    const created = await api.createRepository({
-      name: name.value,
-      connectionRef: connectionRef.value,
-      repo: repo.value || undefined,
-      visibility: visibility.value,
-      description: description.value || undefined,
-      autoInit: autoInit.value,
-    })
-    if (!mounted) return
-    // Client mode has a complete source, so retain the returned UID and action
-    // row immediately. Server mode remains page-shaped and refreshes the
-    // current cursor page instead of appending an out-of-page item.
-    if (repositoryMode.value === 'client') {
-      repos.value = [...repos.value.filter(item => item.name !== created.name), created]
-    }
-    name.value = repo.value = description.value = ''
-    showForm.value = false
-    loadRepositories()
-  } catch (e) {
-    formError.value = errMessage(e)
-  } finally {
-    submitting.value = false
-    operations.release(lock)
-  }
-}
-
 async function remove(row: Record<string, unknown>) {
   const repository = row as unknown as Repository
   if (isDeleting(repository)) return
@@ -436,8 +353,6 @@ connectionRefresh = createLatestRefreshController(async (requestID, mode) => {
     props.deletions.reconcile('connection', next)
     connectionsLoaded.value = true
     connectionsError.value = null
-    const available = next.filter(item => !item.deletionTimestamp && !props.deletions.has('connection', item.name, item.uid))
-    if (!available.some(item => item.name === connectionRef.value)) connectionRef.value = available[0]?.name || ''
   } catch (e) {
     if (!connectionRefresh.isCurrent(requestID)) return
     const err = e as ErrorResponse
@@ -452,6 +367,8 @@ connectionRefresh = createLatestRefreshController(async (requestID, mode) => {
 
 onMounted(() => {
   mounted = true
+})
+onActivated(() => {
   load()
   poller.schedule()
 })
@@ -470,8 +387,8 @@ onUnmounted(() => {
         <h2 class="page-title">Repositories</h2>
         <p class="page-meta">Repositories the provider manages on the git host. Click one to manage deploy keys and collaborators.</p>
       </div>
-      <button class="k-btn k-btn--primary" :disabled="!loaded || !connectionsLoaded || !connectionChoices.length" @click="showForm = !showForm">
-        {{ showForm ? 'Cancel' : 'New repository' }}
+      <button class="k-btn k-btn--primary" :disabled="!loaded" @click="emit('create')">
+        New repository
       </button>
     </header>
 
@@ -481,36 +398,6 @@ onUnmounted(() => {
       <button class="k-btn k-btn--ghost" type="button" @click="loadConnections()">Retry connections</button>
     </div>
     <span v-else-if="connectionsLoading && connectionsLoaded" class="sr-only" role="status" aria-live="polite">Updating connections…</span>
-    <p v-if="connectionsLoaded && !connectionChoices.length" class="empty">Add a ready connection first, then create repositories under it.</p>
-
-    <div v-if="showForm" class="panel k-card">
-      <h3 class="panel-title">New repository</h3>
-      <form class="form" @submit.prevent="submit">
-        <label class="field">
-          <span class="field-label">Connection</span>
-          <select v-model="connectionRef" class="k-input" :disabled="connectionsLoading && !connectionsLoaded">
-            <option v-for="c in connectionChoices" :key="c.name" :value="c.name">{{ c.name }} ({{ c.owner }})</option>
-          </select>
-        </label>
-        <label class="field"><span class="field-label">Object name</span><input v-model="name" class="k-input" placeholder="my-service" autocomplete="off" /></label>
-        <label class="field"><span class="field-label">Repo name (defaults to object name)</span><input v-model="repo" class="k-input" placeholder="my-service" autocomplete="off" /></label>
-        <label class="field">
-          <span class="field-label">Visibility</span>
-          <select v-model="visibility" class="k-input">
-            <option value="private">private</option>
-            <option value="public">public</option>
-            <option value="internal">internal</option>
-          </select>
-        </label>
-        <label class="field"><span class="field-label">Description</span><input v-model="description" class="k-input" autocomplete="off" /></label>
-        <label class="field field-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
-        <div class="code-form-actions">
-          <button class="k-btn k-btn--primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create' }}</button>
-          <span v-if="formError" class="error" role="alert">{{ formError }}</span>
-        </div>
-      </form>
-    </div>
-
     <p v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">{{ mutationError }}</p>
     <ResourceTable
       :columns="columns"

--- a/providers/code/portal/src/views/RepositoryCreateView.vue
+++ b/providers/code/portal/src/views/RepositoryCreateView.vue
@@ -1,0 +1,266 @@
+<script setup lang="ts">
+import { computed, inject, onMounted, onUnmounted, ref } from 'vue'
+import { ArrowLeft } from 'lucide-vue-next'
+import { api, normalizeResourceName } from '../api'
+import { contextGenerationKey } from '../context'
+import type { Connection, ErrorResponse, Repository } from '../types'
+import type { ResourceDeletions } from '../refresh'
+import { createFullListReadCoordinator } from '../hybridPagination'
+import { createOperationLocks, operationKey } from '../refresh'
+
+const props = defineProps<{ deletions: ResourceDeletions }>()
+const emit = defineEmits<{
+  (e: 'cancel'): void
+  (e: 'created', name: string): void
+}>()
+
+const repositories = ref<Repository[]>([])
+const connections = ref<Connection[]>([])
+const repositoryLoaded = ref(false)
+const connectionsLoaded = ref(false)
+const repositoryLoading = ref(false)
+const connectionsLoading = ref(false)
+const repositoryError = ref<string | null>(null)
+const connectionsError = ref<string | null>(null)
+
+const name = ref('')
+const repo = ref('')
+const connectionRef = ref('')
+const visibility = ref('private')
+const description = ref('')
+const autoInit = ref(true)
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+const contextGeneration = inject(contextGenerationKey, ref(0))
+
+const repositoryFullRead = createFullListReadCoordinator(() => api.listRepositories())
+const operations = createOperationLocks()
+let mounted = false
+let repositoryReadGeneration = 0
+let connectionReadGeneration = 0
+let mutationGeneration = 0
+
+const connectionChoices = computed(() => connections.value.filter(connection => (
+  !connection.deletionTimestamp && !props.deletions.has('connection', connection.name, connection.uid)
+)))
+
+function errMessage(e: unknown): string {
+  const err = e as ErrorResponse
+  return err.reason ? `${err.reason}: ${err.message}` : err.message || String(e)
+}
+
+function isCurrentRepositoryRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === repositoryReadGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentConnectionRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === connectionReadGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentMutation(generation: number, expectedContext: number): boolean {
+  return mounted && generation === mutationGeneration && contextGeneration.value === expectedContext
+}
+
+function cancel(): void {
+  if (submitting.value) return
+  emit('cancel')
+}
+
+function reconcileConnections(next: Connection[]): void {
+  next
+    .filter(item => item.deletionTimestamp)
+    .forEach(item => props.deletions.acknowledge('connection', item.name, item.uid))
+  props.deletions.reconcile('connection', next)
+  const available = next.filter(item => !item.deletionTimestamp && !props.deletions.has('connection', item.name, item.uid))
+  if (!available.some(item => item.name === connectionRef.value)) connectionRef.value = available[0]?.name || ''
+}
+
+function reconcileRepositories(next: Repository[]): void {
+  next
+    .filter(item => item.deletionTimestamp)
+    .forEach(item => props.deletions.acknowledge('repository', item.name, item.uid))
+  props.deletions.reconcile('repository', next)
+}
+
+async function loadConnections(): Promise<void> {
+  const generation = ++connectionReadGeneration
+  const expectedContext = contextGeneration.value
+  connectionsLoading.value = true
+  try {
+    const next = await api.listConnections()
+    if (!isCurrentConnectionRead(generation, expectedContext)) return
+    connections.value = next
+    reconcileConnections(next)
+    connectionsLoaded.value = true
+    connectionsError.value = null
+  } catch (e) {
+    if (!isCurrentConnectionRead(generation, expectedContext)) return
+    const err = e as ErrorResponse
+    connectionsError.value = err.reason === 'TenantMissing' ? null : errMessage(e)
+  } finally {
+    if (isCurrentConnectionRead(generation, expectedContext)) connectionsLoading.value = false
+  }
+}
+
+async function loadRepositories(force = false): Promise<void> {
+  const generation = ++repositoryReadGeneration
+  const expectedContext = contextGeneration.value
+  repositoryLoading.value = true
+  try {
+    const next = await repositoryFullRead.read(force)
+    if (!isCurrentRepositoryRead(generation, expectedContext)) return
+    repositories.value = next
+    reconcileRepositories(next)
+    repositoryLoaded.value = true
+    repositoryError.value = null
+  } catch (e) {
+    if (!isCurrentRepositoryRead(generation, expectedContext)) return
+    const err = e as ErrorResponse
+    repositoryError.value = err.reason === 'TenantMissing' ? null : errMessage(e)
+  } finally {
+    if (isCurrentRepositoryRead(generation, expectedContext)) repositoryLoading.value = false
+  }
+}
+
+async function submit(): Promise<void> {
+  if (!mounted || submitting.value) return
+  const generation = ++mutationGeneration
+  const expectedContext = contextGeneration.value
+  formError.value = null
+  if (!repositoryLoaded.value || !connectionsLoaded.value) {
+    formError.value = 'Repository data is still loading. Retry failed reads before creating a repository.'
+    return
+  }
+  if (!name.value || !connectionRef.value) {
+    formError.value = 'name and connection are required'
+    return
+  }
+  if (!connectionChoices.value.some(connection => connection.name === connectionRef.value)) {
+    formError.value = 'Select an active connection before creating a repository.'
+    return
+  }
+  const payload = {
+    name: name.value,
+    connectionRef: connectionRef.value,
+    repo: repo.value || undefined,
+    visibility: visibility.value,
+    description: description.value || undefined,
+    autoInit: autoInit.value,
+  }
+  const desiredName = normalizeResourceName(payload.name)
+  const lock = operationKey('repository', desiredName)
+  if (!operations.acquire(lock, 'creating')) {
+    formError.value = `Repository "${desiredName}" already has an operation in progress.`
+    return
+  }
+  submitting.value = true
+  try {
+    // The initial read populates the page, but creation still performs a fresh
+    // complete walk so duplicate and terminating-name checks use current
+    // workspace authority rather than a possibly stale snapshot.
+    const [allRepositories, currentConnections] = await Promise.all([
+      repositoryFullRead.read(true),
+      api.listConnections(),
+    ])
+    if (!isCurrentMutation(generation, expectedContext)) return
+    repositories.value = allRepositories
+    reconcileRepositories(allRepositories)
+    connections.value = currentConnections
+    reconcileConnections(currentConnections)
+    connectionsLoaded.value = true
+    connectionsError.value = null
+    const existing = allRepositories.find(repository => normalizeResourceName(repository.name) === desiredName)
+    if (existing && (existing.deletionTimestamp || props.deletions.has('repository', existing.name, existing.uid))) {
+      formError.value = `Repository "${existing.name}" is still deleting. Wait for it to disappear before recreating it.`
+      return
+    }
+    if (existing) {
+      formError.value = `Repository "${existing.name}" already exists.`
+      return
+    }
+    if (props.deletions.has('repository', desiredName)) {
+      formError.value = `Repository "${desiredName}" is still deleting. Wait for it to disappear before recreating it.`
+      return
+    }
+    const currentConnection = currentConnections.find(connection => connection.name === payload.connectionRef)
+    if (!currentConnection || currentConnection.deletionTimestamp || props.deletions.has('connection', currentConnection.name, currentConnection.uid)) {
+      formError.value = `Connection "${payload.connectionRef}" is no longer active. Select another connection and retry.`
+      return
+    }
+    if (!isCurrentMutation(generation, expectedContext)) return
+    const created = await api.createRepository(payload)
+    if (!isCurrentMutation(generation, expectedContext)) return
+    emit('created', created.name)
+  } catch (e) {
+    if (isCurrentMutation(generation, expectedContext)) formError.value = errMessage(e)
+  } finally {
+    operations.release(lock)
+    if (isCurrentMutation(generation, expectedContext)) submitting.value = false
+  }
+}
+
+onMounted(() => {
+  mounted = true
+  void loadRepositories()
+  void loadConnections()
+})
+onUnmounted(() => {
+  mounted = false
+  repositoryReadGeneration += 1
+  connectionReadGeneration += 1
+  mutationGeneration += 1
+})
+</script>
+
+<template>
+  <section class="page k-create-page">
+    <button class="k-btn k-btn--ghost k-back-action" type="button" :disabled="submitting" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Repositories
+    </button>
+    <header class="k-create-header">
+      <h2 class="k-create-title">Create repository</h2>
+      <p class="k-create-description">Create a repository through one of your ready GitHub connections. Deploy keys and collaborators stay managed on the repository detail page.</p>
+    </header>
+
+    <div v-if="(repositoryLoading && !repositoryLoaded) || (connectionsLoading && !connectionsLoaded)" class="panel k-card" role="status" aria-live="polite">
+      Loading repository creation data…
+    </div>
+    <div v-if="repositoryError" class="error read-error" role="alert" aria-live="assertive">
+      <span>{{ repositoryError }}</span>
+      <button class="k-btn k-btn--ghost" type="button" @click="loadRepositories(true)">Retry repositories</button>
+    </div>
+    <div v-if="connectionsError" class="error read-error" role="alert" aria-live="assertive">
+      <span>{{ connectionsLoaded ? 'Showing cached connection choices. ' : '' }}{{ connectionsError }}</span>
+      <button class="k-btn k-btn--ghost" type="button" @click="loadConnections">Retry connections</button>
+    </div>
+    <p v-if="connectionsLoaded && !connectionChoices.length" class="empty">Add a ready connection first, then create repositories under it.</p>
+
+    <form class="k-create-surface" @submit.prevent="submit">
+      <div class="k-create-body">
+        <label class="field">
+          <span class="field-label">Connection</span>
+          <select v-model="connectionRef" class="k-input" :disabled="connectionsLoading && !connectionsLoaded">
+            <option v-for="connection in connectionChoices" :key="connection.name" :value="connection.name">{{ connection.name }} ({{ connection.owner }})</option>
+          </select>
+        </label>
+        <label class="field"><span class="field-label">Object name</span><input v-model="name" class="k-input" placeholder="my-service" autocomplete="off" /></label>
+        <label class="field"><span class="field-label">Repo name (defaults to object name)</span><input v-model="repo" class="k-input" placeholder="my-service" autocomplete="off" /></label>
+        <label class="field">
+          <span class="field-label">Visibility</span>
+          <select v-model="visibility" class="k-input">
+            <option value="private">private</option>
+            <option value="public">public</option>
+            <option value="internal">internal</option>
+          </select>
+        </label>
+        <label class="field"><span class="field-label">Description</span><input v-model="description" class="k-input" autocomplete="off" /></label>
+        <label class="field field-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
+        <span v-if="formError" class="error" role="alert">{{ formError }}</span>
+      </div>
+      <div class="k-create-actions">
+        <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create repository' }}</button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/providers/databricks/portal/package.json
+++ b/providers/databricks/portal/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "vite build",
     "test": "npm run test:portal",
-    "test:portal": "tsc -p tsconfig.test.json && node --test --test-concurrency=1 .test-dist/api.behavior.test.js .test-dist/databricksPagination.test.js .test-dist/registrationApi.test.js .test-dist/registrationFlow.test.js .test-dist/registrationTree.test.js .test-dist/refresh.test.js .test-dist/resourceName.test.js .test-dist/state.test.js .test-dist/tableRefs.test.js .test-dist/components/splitCreate.test.js src/lazyCheckboxTree.source.test.mjs src/resourceTable.ssr.test.mjs",
+    "test:portal": "tsc -p tsconfig.test.json && node --test --test-concurrency=1 .test-dist/api.behavior.test.js .test-dist/databricksPagination.test.js .test-dist/registrationApi.test.js .test-dist/registrationFlow.test.js .test-dist/registrationTree.test.js .test-dist/refresh.test.js .test-dist/resourceName.test.js .test-dist/route.test.js .test-dist/state.test.js .test-dist/tableRefs.test.js .test-dist/components/splitCreate.test.js src/lazyCheckboxTree.source.test.mjs src/resourceTable.ssr.test.mjs",
     "test:tableRefs": "tsc -p tsconfig.test.json && node .test-dist/tableRefs.test.js",
     "typecheck": "vue-tsc --noEmit"
   },

--- a/providers/databricks/portal/src/App.vue
+++ b/providers/databricks/portal/src/App.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 import { Plug, Table2, Warehouse } from 'lucide-vue-next'
 import { setBasePath, setTenant, setTenantSelection, setToken } from './api'
+import { contextGenerationKey } from './context'
+import { navigationDetail } from './navigation'
 import { setOperationContext } from './refresh'
 import ResourceImportWizard from './ResourceImportWizard.vue'
 import ConfirmDialog from './portalkit/ConfirmDialog.vue'
 import Tabs from './portalkit/Tabs.vue'
 import type { FarosContext } from './types'
+import { collectionPath, createPath, detailPath, parseSubPath, type DatabricksRoute } from './route'
 import ConnectionDetailView from './views/ConnectionDetailView.vue'
 import ConnectionsView from './views/ConnectionsView.vue'
+import CreateConnectionView from './views/CreateConnectionView.vue'
+import CreateTableView from './views/CreateTableView.vue'
+import CreateWarehouseView from './views/CreateWarehouseView.vue'
 import TableDetailView from './views/TableDetailView.vue'
 import TablesView from './views/TablesView.vue'
 import WarehouseDetailView from './views/WarehouseDetailView.vue'
@@ -16,37 +22,13 @@ import WarehousesView from './views/WarehousesView.vue'
 
 const props = defineProps<{ ctx: FarosContext | null }>()
 
-interface Route {
-  page: 'connections' | 'warehouses' | 'tables'
-  connection?: string
-  table?: string
-  warehouse?: string
-}
-
-function parse(sub: string | null | undefined): Route {
-  const s = (sub ?? '').replace(/^\/+|\/+$/g, '')
-  const parts = s.split('/')
-  if (parts[0] === 'connections') {
-    return parts.length > 1 ? { page: 'connections', connection: decodeURIComponent(parts[1]) } : { page: 'connections' }
-  }
-  if (parts[0] === 'warehouses') {
-    return parts.length > 1 ? { page: 'warehouses', warehouse: decodeURIComponent(parts[1]) } : { page: 'warehouses' }
-  }
-  if (parts[0] === 'tables') {
-    return parts.length > 1 ? { page: 'tables', table: decodeURIComponent(parts[1]) } : { page: 'tables' }
-  }
-  return { page: 'connections' }
-}
-
-const route = computed(() => parse(props.ctx?.subPath))
+const route = computed<DatabricksRoute>(() => parseSubPath(props.ctx?.subPath))
 const hasTenant = computed(() => !!props.ctx?.tenant)
 // A provider view may stay mounted while the host rotates a token or changes
 // workspaces. Keying each resource surface forces the old context's data and
 // timer out before the new context begins loading.
 const contextVersion = ref(0)
-const resourceVersion = ref(0)
-const importKind = ref<'warehouse' | 'table' | null>(null)
-const importTrigger = ref<HTMLElement | null>(null)
+provide(contextGenerationKey, contextVersion)
 const rootRef = ref<HTMLElement | null>(null)
 
 const tabs = [
@@ -69,73 +51,105 @@ watch(
     // Reads are keyed by the full context below, but mutation ownership must
     // survive token/base-path rotation within the same tenant.
     setOperationContext(JSON.stringify([tenant || '', orgUUID || '', workspaceUUID || '']))
+    // Forms compare this shared ref before committing an async result. Keep
+    // the increment synchronous so it fences a settled request before Vue's
+    // pre-flush keyed unmount runs.
     contextVersion.value += 1
-    importKind.value = null
-    importTrigger.value = null
   },
-  { immediate: true },
+  { immediate: true, flush: 'sync' },
 )
 
-function navigate(path: string) {
-  rootRef.value?.dispatchEvent(new CustomEvent('faros-navigate', { detail: { path }, bubbles: true }))
+function navigate(path: string, replace = false): void {
+  rootRef.value?.dispatchEvent(new CustomEvent('faros-navigate', {
+    detail: navigationDetail(path, replace),
+    bubbles: true,
+  }))
 }
 
-function openImport(kind: 'warehouse' | 'table', trigger?: HTMLElement) {
-  importKind.value = kind
-  importTrigger.value = trigger ?? null
+function openCreate(kind: 'connection' | 'warehouse' | 'table', mode: 'manual' | 'browse' = 'manual'): void {
+  navigate(createPath(kind, mode))
 }
 
-function restoreImportFocus(kind: 'warehouse' | 'table' | null, trigger: HTMLElement | null): void {
-  if (!kind) return
-  void nextTick(() => {
-    const target = trigger?.isConnected
-      ? trigger
-      : rootRef.value?.querySelector<HTMLElement>(`[data-split-create-trigger="${kind}"]`)
-    target?.focus()
-  })
+function cancelCreate(path: 'connections' | 'warehouses' | 'tables'): void {
+  navigate(collectionPath(path), true)
 }
 
-function focusDestination(path: 'connections' | 'warehouses'): void {
-  void nextTick(() => {
-    rootRef.value?.querySelector<HTMLElement>(`[data-k-tab-id="${path}"]`)?.focus()
-  })
+function created(kind: 'connection' | 'warehouse' | 'table', name: string): void {
+  const page = kind === 'connection' ? 'connections' : kind === 'warehouse' ? 'warehouses' : 'tables'
+  navigate(detailPath(page, name), true)
 }
 
-function closeImport(): void {
-  const kind = importKind.value
-  const trigger = importTrigger.value
-  importKind.value = null
-  importTrigger.value = null
-  restoreImportFocus(kind, trigger)
-}
-
-function importNavigate(path: 'connections' | 'warehouses') {
-  importKind.value = null
-  importTrigger.value = null
-  navigate(path)
-  focusDestination(path)
+function importNavigate(path: 'connections' | 'warehouses'): void {
+  navigate(collectionPath(path), true)
 }
 
 </script>
 
 <template>
   <div ref="rootRef" class="app">
-    <template v-if="!route.connection && !route.warehouse && !route.table">
+    <template v-if="route.page !== 'create' && !route.connection && !route.warehouse && !route.table">
       <Tabs :tabs="tabs" :active="route.page" aria-label="Databricks resource sections" @select="navigate" />
     </template>
 
     <p v-if="!hasTenant" class="empty">Select a workspace to manage Databricks resources.</p>
 
     <template v-else>
+      <CreateConnectionView
+        v-if="route.page === 'create' && route.kind === 'connection'"
+        :key="`create-connection:${contextVersion}`"
+        @cancel="cancelCreate('connections')"
+        @created="(name: string) => created('connection', name)"
+      />
+      <CreateWarehouseView
+        v-else-if="route.page === 'create' && route.kind === 'warehouse' && route.mode === 'manual'"
+        :key="`create-warehouse:${contextVersion}`"
+        @cancel="cancelCreate('warehouses')"
+        @created="(name: string) => created('warehouse', name)"
+      />
+      <CreateTableView
+        v-else-if="route.page === 'create' && route.kind === 'table' && route.mode === 'manual'"
+        :key="`create-table:${contextVersion}`"
+        @cancel="cancelCreate('tables')"
+        @created="(name: string) => created('table', name)"
+        @navigate="importNavigate"
+      />
+      <ResourceImportWizard
+        v-else-if="route.page === 'create' && (route.kind === 'warehouse' || route.kind === 'table') && route.mode === 'browse'"
+        :key="`browse-${route.kind}:${contextVersion}`"
+        :kind="route.kind"
+        route-owned
+        @close="cancelCreate(route.kind === 'warehouse' ? 'warehouses' : 'tables')"
+        @navigate="importNavigate"
+      />
       <ConnectionDetailView v-if="route.page === 'connections' && route.connection" :key="`connection-detail:${route.connection}:${contextVersion}`" :name="route.connection" @back="navigate('connections')" />
-      <ConnectionsView v-else-if="route.page === 'connections'" :key="`connections:${contextVersion}`" @open="(n: string) => navigate('connections/' + encodeURIComponent(n))" />
       <WarehouseDetailView v-else-if="route.page === 'warehouses' && route.warehouse" :key="`warehouse-detail:${route.warehouse}:${contextVersion}`" :name="route.warehouse" @back="navigate('warehouses')" />
-      <WarehousesView v-else-if="route.page === 'warehouses'" :key="`warehouses:${contextVersion}:${resourceVersion}`" @browse="(trigger) => openImport('warehouse', trigger)" @open="(n: string) => navigate('warehouses/' + encodeURIComponent(n))" />
       <TableDetailView v-else-if="route.page === 'tables' && route.table" :key="`table-detail:${route.table}:${contextVersion}`" :name="route.table" @back="navigate('tables')" />
-      <TablesView v-else :key="`tables:${contextVersion}:${resourceVersion}`" @browse="(trigger) => openImport('table', trigger)" @open="(n: string) => navigate('tables/' + encodeURIComponent(n))" />
+
+      <!-- Keep collection controls and the horizontal table scroll position
+           alive across create/detail routes. Keying the cache by the context
+           generation clears every cached tenant snapshot on rotation. -->
+      <KeepAlive :key="`collections:${contextVersion}`" :max="3">
+        <ConnectionsView
+          v-if="route.page === 'connections' && !route.connection"
+          :key="`connections:${contextVersion}`"
+          @create="openCreate('connection')"
+          @open="(n: string) => navigate(detailPath('connections', n))"
+        />
+        <WarehousesView
+          v-else-if="route.page === 'warehouses' && !route.warehouse"
+          :key="`warehouses:${contextVersion}`"
+          @create="(mode: 'manual' | 'browse') => openCreate('warehouse', mode)"
+          @open="(n: string) => navigate(detailPath('warehouses', n))"
+        />
+        <TablesView
+          v-else-if="route.page === 'tables' && !route.table"
+          :key="`tables:${contextVersion}`"
+          @create="(mode: 'manual' | 'browse') => openCreate('table', mode)"
+          @open="(n: string) => navigate(detailPath('tables', n))"
+        />
+      </KeepAlive>
     </template>
 
     <ConfirmDialog />
-    <ResourceImportWizard v-if="importKind" :kind="importKind" @close="closeImport" @registered="resourceVersion += 1" @navigate="importNavigate" />
   </div>
 </template>

--- a/providers/databricks/portal/src/ResourceImportWizard.vue
+++ b/providers/databricks/portal/src/ResourceImportWizard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { ArrowLeft, Database, LoaderCircle, X } from 'lucide-vue-next'
 import { api } from './api'
+import { contextGenerationKey } from './context'
 import LazyCheckboxTree from './LazyCheckboxTree.vue'
 import {
   REGISTRATION_LIMIT,
@@ -41,7 +42,14 @@ type Step = 'source' | 'browse' | 'review' | 'results'
 
 interface ReviewEntry { key: string; label: string; item: RegistrationItem; name: string }
 
-const props = defineProps<{ kind: Kind }>()
+interface ContinuationToken {
+  generation: number
+  context: number
+}
+
+const props = withDefaults(defineProps<{ kind: Kind; routeOwned?: boolean }>(), {
+  routeOwned: false,
+})
 const emit = defineEmits<{
   (event: 'close'): void
   (event: 'registered'): void
@@ -70,7 +78,15 @@ const error = ref<string | null>(null)
 const initializationState = reactive<InitializationState>({ connections: 'idle', warehouses: 'idle', tables: 'idle' })
 const initializationErrors = reactive<Record<InitializationResource, string | null>>({ connections: null, warehouses: null, tables: null })
 const initializationGeneration: Record<InitializationResource, number> = { connections: 0, warehouses: 0, tables: 0 }
+const contextGeneration = inject(contextGenerationKey, ref(0))
+let initializationRunGeneration = 0
 let treeGeneration = 0
+let submissionGeneration = 0
+let focusGeneration = 0
+let mounted = false
+// The host advances the shared context synchronously, then Vue flushes the
+// keyed replacement. Keep this instance inert during that scheduling window.
+let mountedContextGeneration: number | null = null
 let previousFocus: HTMLElement | null = null
 
 const plural = computed(() => props.kind === 'warehouse' ? 'warehouses' : 'tables')
@@ -96,31 +112,70 @@ function phaseLabel(resource: InitializationResource): string {
   return resource === 'connections' ? 'connections' : resource === 'warehouses' ? 'registered warehouses' : 'registered tables'
 }
 
-async function loadInitializationPhase(resource: InitializationResource): Promise<void> {
+function isMountedContextCurrent(): boolean {
+  return mounted && mountedContextGeneration !== null && contextGeneration.value === mountedContextGeneration
+}
+
+function isCurrentInitialization(resource: InitializationResource, token: ContinuationToken): boolean {
+  return isMountedContextCurrent() && initializationGeneration[resource] === token.generation && contextGeneration.value === token.context
+}
+
+function isCurrentInitializationRun(token: ContinuationToken): boolean {
+  return isMountedContextCurrent() && initializationRunGeneration === token.generation && contextGeneration.value === token.context
+}
+
+function isCurrentTree(token: ContinuationToken): boolean {
+  return isMountedContextCurrent() && treeGeneration === token.generation && contextGeneration.value === token.context
+}
+
+function isCurrentSubmission(token: ContinuationToken): boolean {
+  return isMountedContextCurrent() && submissionGeneration === token.generation && contextGeneration.value === token.context
+}
+
+function isCurrentFocus(token: ContinuationToken): boolean {
+  return focusGeneration === token.generation && mountedContextGeneration === token.context && contextGeneration.value === token.context
+}
+
+function contextChangedError(): Error {
+  return new Error('Connection changed while selecting the branch; nothing was selected.')
+}
+
+async function loadInitializationPhase(resource: InitializationResource, expectedContext = contextGeneration.value): Promise<void> {
+  if (!isMountedContextCurrent() || expectedContext !== mountedContextGeneration) return
   const generation = ++initializationGeneration[resource]
+  const token = { generation, context: expectedContext }
   initializationState[resource] = 'loading'; initializationErrors[resource] = null
   try {
     if (resource === 'connections') {
-      const list = await api.listConnections(); if (initializationGeneration[resource] !== generation) return
+      const list = await api.listConnections(); if (!isCurrentInitialization(resource, token)) return
       connections.value = list
       if (!list.some(item => item.name === connectionRef.value)) connectionRef.value = list[0]?.name ?? ''
     } else if (resource === 'warehouses') {
-      const list = await api.listWarehouses(); if (initializationGeneration[resource] !== generation) return
+      const list = await api.listWarehouses(); if (!isCurrentInitialization(resource, token)) return
       warehouses.value = list
       if (!list.some(item => item.name === warehouseRef.value && item.connectionRef === connectionRef.value)) warehouseRef.value = list.find(item => item.connectionRef === connectionRef.value)?.name ?? ''
     } else {
-      const list = await api.listTables(); if (initializationGeneration[resource] !== generation) return
+      const list = await api.listTables(); if (!isCurrentInitialization(resource, token)) return
       currentTables.value = list
     }
+    if (!isCurrentInitialization(resource, token)) return
     initializationState[resource] = 'success'
   } catch (cause) {
-    if (initializationGeneration[resource] !== generation) return
+    if (!isCurrentInitialization(resource, token)) return
     initializationState[resource] = 'error'; initializationErrors[resource] = message(cause)
   }
 }
 
-async function initialize(): Promise<void> { await Promise.all(requiredInitialization.value.map(loadInitializationPhase)) }
-function retryInitialization(resource: InitializationResource): void { if (initializationState[resource] !== 'loading') void loadInitializationPhase(resource) }
+async function initialize(): Promise<ContinuationToken | null> {
+  const token = { generation: ++initializationRunGeneration, context: contextGeneration.value }
+  await Promise.all(requiredInitialization.value.map(resource => loadInitializationPhase(resource, token.context)))
+  return isCurrentInitializationRun(token) ? token : null
+}
+function retryInitialization(resource: InitializationResource): void {
+  if (!isMountedContextCurrent() || initializationState[resource] === 'loading') return
+  initializationRunGeneration += 1
+  void loadInitializationPhase(resource)
+}
 
 function initializationBlocker(): string | null {
   const pending = requiredInitialization.value.find(resource => initializationState[resource] === 'loading')
@@ -161,50 +216,60 @@ function tableNode(item: RemoteTable, parentId: string): RegistrationTreeNode {
   return { id: `table:${item.catalog}:${item.schema}:${item.name}`, kind: 'table', label: item.name, detail: item.tableType || item.dataSourceFormat || 'Table', parentId, depth: 3, disabled, disabledReason: existing ? 'Already registered' : disabled ? item.unsupportedReason || item.reason || 'Unsupported table' : undefined, expanded: false, childrenLoaded: true, loading: false, childIds: [], catalog: item.catalog, schema: item.schema, table: item.name }
 }
 
-async function fetchChildren(parent: RegistrationTreeNode, pageToken?: string): Promise<TreePage> {
+async function fetchChildren(parent: RegistrationTreeNode, pageToken: string | undefined, token: ContinuationToken): Promise<TreePage> {
+  if (!isCurrentTree(token)) throw contextChangedError()
   if (parent.kind === 'catalog') {
     const page = await api.discoverSchemas(connectionRef.value, parent.catalog || parent.label, pageToken)
+    if (!isCurrentTree(token)) throw contextChangedError()
     return { nodes: page.items.map(item => schemaNode(item, parent.id)), nextPageToken: page.nextPageToken }
   }
   if (parent.kind === 'schema') {
     const page = await api.discoverTables(connectionRef.value, parent.catalog || '', parent.schema || parent.label, pageToken)
+    if (!isCurrentTree(token)) throw contextChangedError()
     return { nodes: page.items.map(item => tableNode(item, parent.id)), nextPageToken: page.nextPageToken }
   }
   return { nodes: [] }
 }
 
-async function loadRoot(append = false): Promise<void> {
-  if (rootLoading.value) return
-  const generation = treeGeneration
-  const token = append ? rootNextPageToken.value : undefined
+async function loadRoot(append = false): Promise<ContinuationToken | null> {
+  if (!isMountedContextCurrent() || rootLoading.value) return null
+  const treeToken = { generation: treeGeneration, context: contextGeneration.value }
+  const pageToken = append ? rootNextPageToken.value : undefined
   rootLoading.value = true; rootError.value = ''
   try {
-    const page = props.kind === 'warehouse' ? await api.discoverWarehouses(connectionRef.value, token) : await api.discoverCatalogs(connectionRef.value, token)
-    if (generation !== treeGeneration) return
+    const page = props.kind === 'warehouse' ? await api.discoverWarehouses(connectionRef.value, pageToken) : await api.discoverCatalogs(connectionRef.value, pageToken)
+    if (!isCurrentTree(treeToken)) return null
     const nodes = props.kind === 'warehouse' ? (page.items as RemoteWarehouse[]).map(warehouseNode) : (page.items as RemoteCatalog[]).map(catalogNode)
     if (!append) tree.value = emptyRegistrationTree()
     appendTreePage(tree.value, undefined, { nodes })
     rootNextPageToken.value = page.nextPageToken
-  } catch (cause) { if (generation === treeGeneration) rootError.value = message(cause) }
-  finally { if (generation === treeGeneration) rootLoading.value = false }
+    return treeToken
+  } catch (cause) {
+    if (isCurrentTree(treeToken)) {
+      rootError.value = message(cause)
+      return treeToken
+    }
+  }
+  finally { if (isCurrentTree(treeToken)) rootLoading.value = false }
+  return null
 }
 
 async function loadNodePage(id: string, append = false): Promise<void> {
   const node = tree.value.nodes[id]
-  if (!node || node.loading || isLeaf(node)) return
-  const generation = treeGeneration
+  if (!isMountedContextCurrent() || !node || node.loading || isLeaf(node)) return
+  const treeToken = { generation: treeGeneration, context: contextGeneration.value }
   node.loading = true; node.error = undefined
   try {
-    const page = await fetchChildren(node, append ? node.nextPageToken : undefined)
-    if (generation !== treeGeneration || tree.value.nodes[id] !== node) return
+    const page = await fetchChildren(node, append ? node.nextPageToken : undefined, treeToken)
+    if (!isCurrentTree(treeToken) || tree.value.nodes[id] !== node) return
     appendTreePage(tree.value, id, page)
-  } catch (cause) { if (generation === treeGeneration) node.error = message(cause) }
-  finally { if (generation === treeGeneration && tree.value.nodes[id] === node) node.loading = false }
+  } catch (cause) { if (isCurrentTree(treeToken) && tree.value.nodes[id] === node) node.error = message(cause) }
+  finally { if (isCurrentTree(treeToken) && tree.value.nodes[id] === node) node.loading = false }
 }
 
 async function expandNode(id: string): Promise<void> {
   const node = tree.value.nodes[id]
-  if (!node || node.disabled || isLeaf(node)) return
+  if (!isMountedContextCurrent() || !node || node.disabled || isLeaf(node)) return
   if (node.error) { node.expanded = true; await loadNodePage(id); return }
   node.expanded = !node.expanded
   if (node.expanded && !node.childrenLoaded) await loadNodePage(id)
@@ -212,7 +277,7 @@ async function expandNode(id: string): Promise<void> {
 
 async function toggleNode(id: string, checked: boolean): Promise<void> {
   const node = tree.value.nodes[id]
-  if (!node || node.disabled || submitting.value || branchChecking.value) return
+  if (!isMountedContextCurrent() || !node || node.disabled || submitting.value || branchChecking.value) return
   error.value = null
   if (isLeaf(node)) { error.value = updateLeafSelection(tree.value, id, checked); return }
   if (!checked) {
@@ -220,15 +285,15 @@ async function toggleNode(id: string, checked: boolean): Promise<void> {
     tree.value.selectedLeafIds = tree.value.selectedLeafIds.filter(selected => !descendants.has(selected))
     return
   }
-  const generation = treeGeneration
+  const treeToken = { generation: treeGeneration, context: contextGeneration.value }
   const remaining = REGISTRATION_LIMIT - tree.value.selectedLeafIds.length
   branchChecking.value = true
-  const result = await exhaustBranchSelection(tree.value, id, async (parent, token) => {
-    const page = await fetchChildren(parent, token)
-    if (generation !== treeGeneration) throw new Error('Connection changed while selecting the branch; nothing was selected.')
+  const result = await exhaustBranchSelection(tree.value, id, async (parent, pageToken) => {
+    const page = await fetchChildren(parent, pageToken, treeToken)
+    if (!isCurrentTree(treeToken)) throw contextChangedError()
     return page
   }, remaining)
-  if (generation === treeGeneration) {
+  if (isCurrentTree(treeToken)) {
     if (result.complete && result.state) { tree.value = result.state; tree.value.nodes[id].expanded = true }
     else error.value = result.reason || 'The complete branch could not be selected.'
     branchChecking.value = false
@@ -238,11 +303,15 @@ async function toggleNode(id: string, checked: boolean): Promise<void> {
 function loadMore(parentId?: string): void { if (parentId) void loadNodePage(parentId, true); else void loadRoot(true) }
 
 async function fromSource(): Promise<void> {
+  if (!isMountedContextCurrent()) return
+  const expectedContext = contextGeneration.value
   error.value = null
   const blocker = initializationBlocker(); if (blocker) { error.value = blocker; return }
   if (!connectionRef.value) { error.value = 'Select a connection.'; return }
   if (props.kind === 'table' && !warehouseRef.value) { error.value = 'Select a registered warehouse on this connection.'; return }
-  resetTree(); step.value = 'browse'; await loadRoot()
+  resetTree(); step.value = 'browse'
+  const treeToken = await loadRoot()
+  if (!treeToken || !isCurrentTree(treeToken) || contextGeneration.value !== expectedContext) return
   focusStep()
 }
 
@@ -260,6 +329,7 @@ function validateReviewEntries(entries: readonly ReviewEntry[]): string | null {
 const reviewValidationError = computed(() => validateReviewEntries(reviewEntries.value))
 
 function review(): void {
+  if (!isMountedContextCurrent()) return
   const entries = selectedNodes.value.map(node => { const name = suggested(node); return { key: node.id, label: node.kind === 'warehouse' ? node.label : `${node.catalog}.${node.schema}.${node.table}`, item: registrationItem(node, name), name } })
   const invalid = validateReviewEntries(entries); if (invalid) { error.value = invalid; return }
   reviewEntries.value = entries; reviewCoordinates.value = coordinates(); registrationFrozen.value = false; error.value = null; step.value = 'review'
@@ -269,49 +339,108 @@ function review(): void {
 function emitRegisteredIfNeeded(batch: readonly RegistrationResult[]): void { if (batch.some(result => result.state === 'created' || result.state === 'existing')) emit('registered') }
 
 async function register(): Promise<void> {
-  if (submitting.value) return
+  if (!isMountedContextCurrent() || submitting.value) return
+  const submissionToken = { generation: ++submissionGeneration, context: contextGeneration.value }
+  if (!isCurrentSubmission(submissionToken)) return
   const invalid = reviewValidationError.value; if (invalid) { error.value = invalid; return }
   const coordinatesSnapshot = reviewCoordinates.value ?? coordinates()
-  registrationItems.value = reviewEntries.value.map(entry => ({ ...entry.item, name: entry.name }))
+  const registrationItemsSnapshot = reviewEntries.value.map(entry => ({ ...entry.item, name: entry.name }))
+  registrationItems.value = registrationItemsSnapshot
   registrationFrozen.value = true; submitting.value = true; error.value = null
   try {
-    const response = await api.registerResources({ kind: props.kind, connectionRef: coordinatesSnapshot.connectionRef, warehouseRef: props.kind === 'table' ? coordinatesSnapshot.warehouseRef : undefined, items: registrationItems.value })
-    results.value = materializeRegistrationResults(registrationItems.value, response.results); step.value = 'results'; emitRegisteredIfNeeded(response.results); focusStep()
-    if (response.results.length !== registrationItems.value.length) error.value = `Registration returned ${response.results.length} of ${registrationItems.value.length} expected results.`
-  } catch (cause) { results.value = materializeRegistrationResults(registrationItems.value, []); step.value = 'results'; error.value = message(cause); focusStep() }
-  finally { submitting.value = false }
+    const response = await api.registerResources({ kind: props.kind, connectionRef: coordinatesSnapshot.connectionRef, warehouseRef: props.kind === 'table' ? coordinatesSnapshot.warehouseRef : undefined, items: registrationItemsSnapshot })
+    if (!isCurrentSubmission(submissionToken)) return
+    results.value = materializeRegistrationResults(registrationItemsSnapshot, response.results)
+    step.value = 'results'
+    if (!isCurrentSubmission(submissionToken)) return
+    emitRegisteredIfNeeded(response.results)
+    if (!isCurrentSubmission(submissionToken)) return
+    focusStep()
+    if (response.results.length !== registrationItemsSnapshot.length && isCurrentSubmission(submissionToken)) error.value = `Registration returned ${response.results.length} of ${registrationItemsSnapshot.length} expected results.`
+  } catch (cause) {
+    if (!isCurrentSubmission(submissionToken)) return
+    results.value = materializeRegistrationResults(registrationItemsSnapshot, [])
+    step.value = 'results'
+    if (!isCurrentSubmission(submissionToken)) return
+    error.value = message(cause)
+    focusStep()
+  }
+  finally { if (isCurrentSubmission(submissionToken)) submitting.value = false }
 }
 
 async function retryFailed(): Promise<void> {
-  if (submitting.value || !reviewCoordinates.value) return
+  if (!isMountedContextCurrent() || submitting.value || !reviewCoordinates.value) return
+  const submissionToken = { generation: ++submissionGeneration, context: contextGeneration.value }
+  if (!isCurrentSubmission(submissionToken)) return
+  const coordinatesSnapshot = reviewCoordinates.value
   const entries = retryableResults.value.map(index => ({ index, item: registrationItems.value[index] })).filter((entry): entry is { index: number; item: RegistrationItem } => !!entry.item)
   if (!entries.length) return
+  const retryItems = entries.map(entry => entry.item)
   submitting.value = true; error.value = null
   try {
-    const response = await api.registerResources({ kind: props.kind, connectionRef: reviewCoordinates.value.connectionRef, warehouseRef: props.kind === 'table' ? reviewCoordinates.value.warehouseRef : undefined, items: entries.map(entry => entry.item) })
-    results.value = mergeRegistrationResults(results.value, entries.map(entry => entry.item), response.results, entries.map(entry => entry.index)); emitRegisteredIfNeeded(response.results)
-  } catch (cause) { error.value = message(cause) }
-  finally { submitting.value = false }
+    const response = await api.registerResources({ kind: props.kind, connectionRef: coordinatesSnapshot.connectionRef, warehouseRef: props.kind === 'table' ? coordinatesSnapshot.warehouseRef : undefined, items: retryItems })
+    if (!isCurrentSubmission(submissionToken)) return
+    results.value = mergeRegistrationResults(results.value, retryItems, response.results, entries.map(entry => entry.index)); emitRegisteredIfNeeded(response.results)
+  } catch (cause) { if (isCurrentSubmission(submissionToken)) error.value = message(cause) }
+  finally { if (isCurrentSubmission(submissionToken)) submitting.value = false }
 }
 
 function back(): void {
-  if (dialogBusy.value) return
+  if (!isMountedContextCurrent() || dialogBusy.value) return
   error.value = null
   if (step.value === 'browse') { resetTree(); step.value = 'source' }
   else if (step.value === 'review') { registrationFrozen.value = false; step.value = 'browse' }
   focusStep()
 }
-function navigateTo(path: 'connections' | 'warehouses'): void { previousFocus = null; emit('navigate', path) }
-function focusStep(): void { void nextTick(() => root.value?.querySelector<HTMLElement>('.import-body button:not(:disabled),.import-body input:not(:disabled),.import-body select:not(:disabled),[role="treeitem"]')?.focus()) }
-function focusDialog(): void { void nextTick(() => root.value?.querySelector<HTMLElement>('.import-head button:not(:disabled),.import-body button:not(:disabled),.import-body input:not(:disabled),.import-body select:not(:disabled),[role="treeitem"]')?.focus()) }
-function restoreFocus(): void { const target = previousFocus; previousFocus = null; if (target) void nextTick(() => { if (target.isConnected) target.focus() }) }
-function close(): void { if (!submitting.value) { restoreFocus(); emit('close') } }
+function navigateTo(path: 'connections' | 'warehouses'): void {
+  if (!isMountedContextCurrent()) return
+  previousFocus = null
+  emit('navigate', path)
+}
+function focusStep(): void {
+  if (props.routeOwned || !mounted) return
+  if (!isMountedContextCurrent()) return
+  const token = { generation: ++focusGeneration, context: contextGeneration.value }
+  void nextTick(() => {
+    if (mounted && isCurrentFocus(token)) {
+      root.value?.querySelector<HTMLElement>('.import-body button:not(:disabled),.import-body input:not(:disabled),.import-body select:not(:disabled),[role="treeitem"]')?.focus()
+    }
+  })
+}
+function focusDialog(): void {
+  if (props.routeOwned || !mounted) return
+  if (!isMountedContextCurrent()) return
+  const token = { generation: ++focusGeneration, context: contextGeneration.value }
+  void nextTick(() => {
+    if (mounted && isCurrentFocus(token)) {
+      root.value?.querySelector<HTMLElement>('.import-head button:not(:disabled),.import-body button:not(:disabled),.import-body input:not(:disabled),.import-body select:not(:disabled),[role="treeitem"]')?.focus()
+    }
+  })
+}
+function restoreFocus(): void {
+  if (props.routeOwned) { previousFocus = null; return }
+  const target = previousFocus
+  previousFocus = null
+  if (!target) return
+  const token = { generation: ++focusGeneration, context: contextGeneration.value }
+  void nextTick(() => {
+    if (isCurrentFocus(token) && target.isConnected) target.focus()
+  })
+}
+function close(): void {
+  if (isMountedContextCurrent() && !submitting.value) { restoreFocus(); emit('close') }
+}
+function backdropPointerDown(event: PointerEvent): void {
+  if (!props.routeOwned && event.target === event.currentTarget) close()
+}
 function dialogTabStops(): HTMLElement[] {
   if (!root.value) return []
   return [...root.value.querySelectorAll<HTMLElement>('button:not(:disabled),input:not(:disabled),select:not(:disabled),[role="treeitem"][tabindex="0"]')]
     .filter(element => element.tabIndex === 0)
 }
 function keydown(event: KeyboardEvent): void {
+  if (props.routeOwned) return
+  if (!isMountedContextCurrent()) return
   if (event.key === 'Escape') { event.preventDefault(); close(); return }
   if (event.key !== 'Tab' || !root.value) return
   const focusable = dialogTabStops()
@@ -322,14 +451,33 @@ function keydown(event: KeyboardEvent): void {
 
 watch(connectionRef, (next, previous) => { if (next !== previous) { resetTree(); if (step.value !== 'source') step.value = 'source'; if (!matchingWarehouses.value.some(item => item.name === warehouseRef.value)) warehouseRef.value = matchingWarehouses.value[0]?.name ?? '' } })
 watch(warehouseRef, (next, previous) => { if (next !== previous) { resetTree(); if (step.value !== 'source') step.value = 'source' } })
-onMounted(() => { previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null; focusDialog(); void initialize().then(() => focusStep()) })
-onBeforeUnmount(restoreFocus)
+onMounted(() => {
+  mounted = true
+  mountedContextGeneration = contextGeneration.value
+  if (!props.routeOwned) {
+    previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    focusDialog()
+  }
+  void initialize().then(token => {
+    if (token && isCurrentInitializationRun(token)) focusStep()
+  })
+})
+onBeforeUnmount(() => {
+  mounted = false
+  initializationRunGeneration += 1
+  treeGeneration += 1
+  submissionGeneration += 1
+  for (const resource of ['connections', 'warehouses', 'tables'] as const) initializationGeneration[resource] += 1
+  restoreFocus()
+})
 </script>
 
 <template>
-  <div class="import-backdrop" @pointerdown.self="close">
-    <section ref="root" class="import-dialog" role="dialog" aria-modal="true" aria-labelledby="registration-title" aria-describedby="registration-description" :aria-busy="dialogBusy ? 'true' : 'false'" @keydown="keydown">
-      <header class="import-head"><div><span class="import-eyebrow">{{ stepLabel }}</span><h2 id="registration-title">New {{ kind }}</h2><p id="registration-description">Browse Databricks metadata and register selected {{ plural }}.</p></div><button class="k-btn k-btn--ghost databricks-dialog-close" type="button" aria-label="Close" :disabled="submitting" @click="close"><X :stroke-width="1.75" /></button></header>
+  <div :class="props.routeOwned ? 'k-create-page' : 'import-backdrop'" @pointerdown="backdropPointerDown">
+    <button v-if="props.routeOwned" class="k-btn k-btn--ghost k-back-action" type="button" :disabled="submitting" @click="close"><ArrowLeft :stroke-width="1.75" /> {{ kind === 'table' ? 'Tables' : 'Warehouses' }}</button>
+    <header v-if="props.routeOwned" class="k-create-header"><h2 id="registration-title" class="k-create-title">Register {{ plural }}</h2><p id="registration-description" class="k-create-description">Browse Databricks metadata and register selected {{ plural }}.</p></header>
+    <section ref="root" :class="['import-dialog', { 'k-create-surface k-create-surface--wide': props.routeOwned }]" :role="props.routeOwned ? undefined : 'dialog'" :aria-modal="props.routeOwned ? undefined : 'true'" aria-labelledby="registration-title" aria-describedby="registration-description" :aria-busy="dialogBusy ? 'true' : 'false'" @keydown="keydown">
+      <header v-if="!props.routeOwned" class="import-head"><div><span class="import-eyebrow">{{ stepLabel }}</span><h2 id="registration-title">New {{ kind }}</h2><p id="registration-description">Browse Databricks metadata and register selected {{ plural }}.</p></div><button class="k-btn k-btn--ghost databricks-dialog-close" type="button" aria-label="Close" :disabled="submitting" @click="close"><X :stroke-width="1.75" /></button></header>
       <ol class="import-steps" aria-label="Import progress"><li :aria-current="step === 'source' ? 'step' : undefined">Source</li><li :aria-current="step === 'browse' ? 'step' : undefined">Browse</li><li :aria-current="step === 'review' ? 'step' : undefined">Review</li><li :aria-current="step === 'results' ? 'step' : undefined">Results</li></ol>
       <div class="import-body">
         <div v-if="step === 'source'" class="import-stack">
@@ -346,7 +494,7 @@ onBeforeUnmount(restoreFocus)
         <p v-if="submitting" class="import-loading" role="status" aria-live="polite"><LoaderCircle class="spin" :stroke-width="1.75" /> Registering selected {{ plural }}…</p>
         <p v-if="error" class="error" role="alert" aria-live="assertive">{{ error }}</p>
       </div>
-      <footer class="import-actions"><button v-if="step === 'browse' || step === 'review'" class="k-btn k-btn--ghost icon-text" type="button" :disabled="dialogBusy" @click="back"><ArrowLeft :stroke-width="1.75" /> Back</button><span class="import-spacer" /><button v-if="step === 'source'" class="k-btn k-btn--primary" type="button" :disabled="initializationPending || submitting" @click="fromSource">Browse</button><button v-else-if="step === 'browse'" class="k-btn k-btn--primary" type="button" :disabled="!tree.selectedLeafIds.length || dialogBusy" @click="review">Review {{ tree.selectedLeafIds.length }}</button><button v-else-if="step === 'review'" class="k-btn k-btn--primary" type="button" :disabled="submitting || !!reviewValidationError" @click="register">{{ submitting ? 'Registering…' : `Register ${reviewEntries.length}` }}</button><button v-else class="k-btn k-btn--primary" type="button" @click="close">Done</button></footer>
+      <footer :class="props.routeOwned ? 'k-create-actions' : 'import-actions'"><button v-if="step === 'browse' || step === 'review'" class="k-btn k-btn--ghost icon-text" type="button" :disabled="dialogBusy" @click="back"><ArrowLeft :stroke-width="1.75" /> Back</button><span class="import-spacer" /><button v-if="props.routeOwned && step !== 'results'" class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="close">Cancel</button><button v-if="step === 'source'" class="k-btn k-btn--primary" type="button" :disabled="initializationPending || submitting" @click="fromSource">Browse</button><button v-else-if="step === 'browse'" class="k-btn k-btn--primary" type="button" :disabled="!tree.selectedLeafIds.length || dialogBusy" @click="review">Review {{ tree.selectedLeafIds.length }}</button><button v-else-if="step === 'review'" class="k-btn k-btn--primary" type="button" :disabled="submitting || !!reviewValidationError" @click="register">{{ submitting ? 'Registering…' : `Register ${reviewEntries.length}` }}</button><button v-else class="k-btn k-btn--primary" type="button" @click="close">Done</button></footer>
     </section>
   </div>
 </template>

--- a/providers/databricks/portal/src/context.ts
+++ b/providers/databricks/portal/src/context.ts
@@ -1,0 +1,11 @@
+import type { InjectionKey, Ref } from 'vue'
+
+/**
+ * Shared authority generation for route-owned resource mutations.
+ *
+ * App.vue advances the provided ref synchronously when the host context
+ * changes. Forms compare the value captured at submit/read start, so a
+ * resolved continuation is rejected even while Vue is still waiting to flush
+ * the keyed component unmount.
+ */
+export const contextGenerationKey: InjectionKey<Readonly<Ref<number>>> = Symbol('databricks-context-generation')

--- a/providers/databricks/portal/src/navigation.ts
+++ b/providers/databricks/portal/src/navigation.ts
@@ -1,0 +1,10 @@
+export interface FarosNavigationDetail {
+  path: string
+  replace?: true
+}
+
+/** Build the detail carried by the provider-to-shell navigation event. */
+export function navigationDetail(path: string, replace = false): FarosNavigationDetail {
+  const relativePath = path.replace(/^\/+/, '')
+  return replace ? { path: relativePath, replace: true } : { path: relativePath }
+}

--- a/providers/databricks/portal/src/portalkit/faros-ui.css
+++ b/providers/databricks/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/databricks/portal/src/resourceTable.ssr.test.mjs
+++ b/providers/databricks/portal/src/resourceTable.ssr.test.mjs
@@ -5,7 +5,7 @@ import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import { createRenderer, createSSRApp, h, nextTick } from 'vue'
+import { createRenderer, createSSRApp, h, nextTick, ref, watch } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
 let vite
@@ -17,6 +17,13 @@ const canonicalResourcePage = resolve(repositoryRoot, 'provider-sdk/portalkit-vu
 const canonicalPageState = resolve(repositoryRoot, 'provider-sdk/portalkit/page-state.ts')
 const canonicalFarosUIStyle = resolve(repositoryRoot, 'provider-sdk/portalkit/faros-ui.css')
 const canonicalTableHelpers = resolve(repositoryRoot, 'provider-sdk/portalkit-vue/table.ts')
+
+// The mounted SFC checks these browser constructors while applying v-model
+// updates. The host-renderer harness supplies plain objects instead of a DOM,
+// so provide inert constructors that keep that browser-only branch false.
+if (typeof globalThis.Document === 'undefined') globalThis.Document = class {}
+if (typeof globalThis.ShadowRoot === 'undefined') globalThis.ShadowRoot = class {}
+
 test.before(async () => {
   vite = await createServer({
     root: portalRoot,
@@ -70,9 +77,16 @@ function createHostRenderer() {
       node.parent = null
     },
     createElement(type) {
-      const node = { type, props: {}, children: [], parent: null }
+      const node = { type, props: {}, children: [], parent: null, addEventListener() {}, removeEventListener() {} }
+      Object.defineProperties(node, {
+        value: { get: () => node.props.value ?? '', set: value => { node.props.value = value } },
+        options: { get: () => node.children.filter(child => child.type === 'option') },
+        multiple: { get: () => !!node.props.multiple },
+        selectedIndex: { get: () => node.props.selectedIndex ?? -1, set: value => { node.props.selectedIndex = value } },
+      })
       node.removeAttribute = name => { delete node.props[name] }
       node.setAttribute = (name, value) => { node.props[name] = String(value) }
+      node.getRootNode = () => globalThis.document ?? null
       node.focus = () => {}
       return node
     },
@@ -190,7 +204,7 @@ async function loadMountedSFC(path) {
   return module.default
 }
 
-function mountDetailView(Component, props, components) {
+function mountDetailView(Component, props, components, provides = {}) {
   const previousDocument = globalThis.document
   const previousWindow = globalThis.window
   const styleNode = {
@@ -212,6 +226,7 @@ function mountDetailView(Component, props, components) {
   const { renderer, root } = createHostRenderer()
   const app = renderer.createApp(Component, props)
   for (const [name, component] of Object.entries(components ?? {})) app.component(name, component)
+  Object.assign(app._context.provides, provides)
   app._context.provides[Symbol.for('v-scx')] = { modules: new Set() }
   app.mount(root)
   return {
@@ -1201,15 +1216,15 @@ test('wizard and split-create sources preserve focus across deferred initializat
   const tableDetail = await readFile(new URL('./views/TableDetailView.vue', import.meta.url), 'utf8')
   const style = await readFile(new URL('./style.css', import.meta.url), 'utf8')
   assert.match(wizard, /focusDialog\(\)/)
-  assert.match(wizard, /void initialize\(\)\.then\(\(\) => focusStep\(\)\)/)
+  assert.match(wizard, /void initialize\(\)\.then\(token => \{[\s\S]*isCurrentInitializationRun\(token\)[\s\S]*focusStep\(\)/)
   assert.match(wizard, /function navigateTo/)
-  assert.match(app, /restoreImportFocus\(/)
-  assert.match(app, /function focusDestination/)
-  assert.match(app, /data-k-tab-id=/)
-  assert.doesNotMatch(app, /data-databricks-nav=/)
-  assert.match(app, /focusDestination\(path\)/)
-  assert.match(app, /@browse="\(trigger\) => openImport\('warehouse', trigger\)"/)
-  assert.match(app, /@browse="\(trigger\) => openImport\('table', trigger\)"/)
+  assert.match(app, /navigationDetail/)
+  assert.match(app, /function navigate\(path: string, replace = false\)/)
+  assert.match(app, /detail: navigationDetail\(path, replace\)/)
+  assert.match(app, /createPath/)
+  assert.match(app, /route-owned/)
+  assert.match(app, /@create="\(mode: 'manual' \| 'browse'\) => openCreate\('warehouse', mode\)"/)
+  assert.match(app, /@create="\(mode: 'manual' \| 'browse'\) => openCreate\('table', mode\)"/)
   assert.match(split, /data-split-create-trigger/)
   assert.match(split, /emit\('browse', trigger\)/)
   assert.match(split, /function closeMenuAfterTab/)
@@ -1237,7 +1252,9 @@ test('route tabs use PortalKit items and icons', async () => {
   assert.match(app, /\{ id: 'warehouses', label: 'Warehouses', icon: Warehouse \}/)
   assert.match(app, /\{ id: 'tables', label: 'Tables', icon: Table2 \}/)
   assert.match(app, /<Tabs :tabs="tabs" :active="route\.page" aria-label="Databricks resource sections" @select="navigate" \/>/)
-  assert.match(app, /querySelector<HTMLElement>\(`\[data-k-tab-id="\$\{path\}"\]`\)/)
+  assert.match(app, /<ConnectionsView[\s\S]*v-if="route\.page === 'connections' && !route\.connection"/)
+  assert.match(app, /<WarehousesView[\s\S]*v-else-if="route\.page === 'warehouses' && !route\.warehouse"/)
+  assert.match(app, /<TablesView[\s\S]*v-else-if="route\.page === 'tables' && !route\.table"/)
   assert.doesNotMatch(style, /faros-provider-databricks \.tabs(?:\s|\{|\.)/)
 })
 
@@ -1250,7 +1267,7 @@ test('resource detail views use the shared shell without dropping resource behav
     table: await readFile(new URL('./views/TableDetailView.vue', import.meta.url), 'utf8'),
   }
 
-  assert.match(app, /<template v-if="!route\.connection && !route\.warehouse && !route\.table">[\s\S]*<Tabs :tabs=/)
+  assert.match(app, /<template v-if="route\.page !== 'create' && !route\.connection && !route\.warehouse && !route\.table">[\s\S]*<Tabs :tabs=/)
   assert.match(app, /ConnectionDetailView v-if="route\.page === 'connections' && route\.connection"/)
   assert.match(app, /WarehouseDetailView v-else-if="route\.page === 'warehouses' && route\.warehouse"/)
   assert.match(app, /TableDetailView v-else-if="route\.page === 'tables' && route\.table"/)
@@ -1354,6 +1371,619 @@ test('Databricks resource lists use the canonical table property hierarchy', asy
   assert.match(localStyle, /\.row-actions\s*\{\s*justify-content: flex-end;/)
 })
 
+test('manual creation pages ignore rejected unrelated collection reads', async () => {
+  const [CreateWarehouseView, CreateTableView, apiModule] = await Promise.all([
+    loadMountedSFC('/src/views/CreateWarehouseView.vue'),
+    loadMountedSFC('/src/views/CreateTableView.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    listTables: apiModule.api.listTables,
+  }
+  let warehouseReads = 0
+  let tableReads = 0
+  apiModule.api.listConnections = async () => [{ name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token', secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [] }]
+  apiModule.api.listWarehouses = async () => {
+    warehouseReads += 1
+    throw new Error('warehouse collection should not load before manual creation')
+  }
+  apiModule.api.listTables = async () => {
+    tableReads += 1
+    throw new Error('table collection should not load before manual creation')
+  }
+
+  let warehouseMounted
+  let tableMounted
+  try {
+    warehouseMounted = mountDetailView(CreateWarehouseView, {}, {})
+    await flushVue()
+    assert.equal(warehouseMounted.instance.setupState.loaded, true, 'warehouse creation became ready from its connection prerequisite')
+    assert.equal(warehouseReads, 0, 'warehouse creation did not invoke the unrelated warehouse collection read')
+    warehouseMounted.unmount()
+
+    apiModule.api.listWarehouses = async () => [{ name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [] }]
+    tableMounted = mountDetailView(CreateTableView, {}, {})
+    await flushVue()
+    assert.equal(tableMounted.instance.setupState.loaded, true, 'table creation became ready from connection and warehouse prerequisites')
+    assert.equal(tableReads, 0, 'table creation did not invoke the unrelated table collection read')
+  } finally {
+    tableMounted?.unmount()
+    warehouseMounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listTables = original.listTables
+  }
+})
+
+test('manual creation attempts become inert after their route unmounts', async () => {
+  const [CreateConnectionView, CreateWarehouseView, CreateTableView, apiModule] = await Promise.all([
+    loadMountedSFC('/src/views/CreateConnectionView.vue'),
+    loadMountedSFC('/src/views/CreateWarehouseView.vue'),
+    loadMountedSFC('/src/views/CreateTableView.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    listTables: apiModule.api.listTables,
+    saveConnection: apiModule.api.saveConnection,
+    saveWarehouse: apiModule.api.saveWarehouse,
+    saveTable: apiModule.api.saveTable,
+  }
+  const connection = {
+    name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token',
+    secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [],
+  }
+  const warehouse = {
+    name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [],
+  }
+  const cases = [
+    {
+      Component: CreateConnectionView,
+      fields: { name: 'new-connection', host: 'https://dbc-new.example.com', token: 'secret-token' },
+      save: 'saveConnection',
+      result: { name: 'new-connection' },
+    },
+    {
+      Component: CreateWarehouseView,
+      fields: { name: 'new-warehouse', connectionRef: 'orders', warehouseID: 'warehouse-456' },
+      save: 'saveWarehouse',
+      result: { name: 'new-warehouse' },
+    },
+    {
+      Component: CreateTableView,
+      fields: {
+        name: 'new-table', connectionRef: 'orders', warehouseRef: 'orders-sql',
+        catalog: 'main', schema: 'sales', table: 'orders',
+      },
+      save: 'saveTable',
+      result: { name: 'new-table' },
+    },
+  ]
+
+  apiModule.api.listConnections = async () => [connection]
+  apiModule.api.listWarehouses = async () => [warehouse]
+  apiModule.api.listTables = async () => []
+  try {
+    for (const testCase of cases) {
+      let resolveSave
+      let saveStartedResolve
+      const saveStarted = new Promise(resolve => { saveStartedResolve = resolve })
+      const savePending = new Promise(resolve => { resolveSave = resolve })
+      let createdEvents = 0
+      apiModule.api[testCase.save] = async () => {
+        saveStartedResolve()
+        return savePending
+      }
+      const mounted = mountDetailView(testCase.Component, { onCreated: () => { createdEvents += 1 } }, {})
+      try {
+        await flushVue()
+        Object.assign(mounted.instance.setupState.form, testCase.fields)
+        await flushVue()
+        const submitPromise = mounted.instance.setupState.submit()
+        await saveStarted
+        await nextTick()
+        assert.equal(mounted.instance.setupState.submitting, true, `${testCase.save} marks the attempt pending`)
+
+        // A route transition unmounts the form while the server mutation is
+        // still pending. Its eventual response must not navigate or rewrite
+        // the abandoned component's state.
+        mounted.unmount()
+        resolveSave(testCase.result)
+        await submitPromise
+        await flushVue()
+
+        assert.equal(createdEvents, 0, `${testCase.save} did not emit success after unmount`)
+        assert.equal(mounted.instance.setupState.submitting, true, `${testCase.save} left abandoned state untouched after unmount`)
+      } finally {
+        mounted.unmount()
+      }
+    }
+  } finally {
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listTables = original.listTables
+    apiModule.api.saveConnection = original.saveConnection
+    apiModule.api.saveWarehouse = original.saveWarehouse
+    apiModule.api.saveTable = original.saveTable
+  }
+})
+
+test('manual creation rejects a save resolved before the context-driven unmount flush', async () => {
+  const [CreateConnectionView, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/views/CreateConnectionView.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    saveConnection: apiModule.api.saveConnection,
+  }
+  const existing = {
+    name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token',
+    secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [],
+  }
+  let resolveSave
+  let saveStartedResolve
+  const saveStarted = new Promise(resolve => { saveStartedResolve = resolve })
+  const savePending = new Promise(resolve => { resolveSave = resolve })
+  apiModule.api.listConnections = async () => [existing]
+  apiModule.api.saveConnection = async () => {
+    saveStartedResolve()
+    return savePending
+  }
+
+  const contextGeneration = ref(0)
+  let unmounted = false
+  let emittedBeforeUnmount = 0
+  const mounted = mountDetailView(
+    CreateConnectionView,
+    {
+      onCreated: () => {
+        if (!unmounted) emittedBeforeUnmount += 1
+      },
+    },
+    {},
+    { [contextModule.contextGenerationKey]: contextGeneration },
+  )
+  const originalUnmount = mounted.unmount
+  mounted.unmount = () => {
+    if (unmounted) return
+    unmounted = true
+    originalUnmount()
+  }
+  try {
+    await flushVue()
+    Object.assign(mounted.instance.setupState.form, {
+      name: 'new-connection', host: 'https://dbc-new.example.com', token: 'secret-token',
+    })
+    await flushVue()
+    const submitPromise = mounted.instance.setupState.submit()
+    await saveStarted
+
+    // Resolving the save queues its continuation first. The synchronous
+    // authority change must fence that continuation before Vue's queued
+    // keyed unmount runs in the following microtask.
+    resolveSave({ name: 'new-connection' })
+    contextGeneration.value += 1
+    queueMicrotask(() => mounted.unmount())
+    await submitPromise
+
+    assert.equal(emittedBeforeUnmount, 0, 'context change fenced success before the keyed unmount')
+    assert.equal(unmounted, true, 'the simulated keyed unmount still ran after the save continuation')
+  } finally {
+    mounted.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.saveConnection = original.saveConnection
+  }
+})
+
+test('manual creation does not focus after context changes during initial loading', async () => {
+  const [CreateConnectionView, CreateWarehouseView, CreateTableView, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/views/CreateConnectionView.vue'),
+    loadMountedSFC('/src/views/CreateWarehouseView.vue'),
+    loadMountedSFC('/src/views/CreateTableView.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+  }
+  const connection = {
+    name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token',
+    secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [],
+  }
+  const warehouse = {
+    name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [],
+  }
+  const cases = [
+    { Component: CreateConnectionView, inputID: 'connection-name' },
+    { Component: CreateWarehouseView, inputID: 'warehouse-name' },
+    { Component: CreateTableView, inputID: 'table-name' },
+  ]
+
+  try {
+    for (const testCase of cases) {
+      let resolveLoad
+      const loadPending = new Promise(resolve => { resolveLoad = resolve })
+      apiModule.api.listConnections = async () => loadPending.then(() => [connection])
+      apiModule.api.listWarehouses = async () => loadPending.then(() => [warehouse])
+      const contextGeneration = ref(0)
+      let contextChanged = false
+      let unmounted = false
+      let focused = 0
+      const mounted = mountDetailView(
+        testCase.Component,
+        {},
+        {},
+        { [contextModule.contextGenerationKey]: contextGeneration },
+      )
+      const originalUnmount = mounted.unmount
+      mounted.unmount = () => {
+        if (unmounted) return
+        unmounted = true
+        originalUnmount()
+      }
+      const input = mounted.find(node => node.props?.id === testCase.inputID)
+      assert.ok(input, `${testCase.inputID} rendered before its initial read settled`)
+      input.focus = () => { focused += 1 }
+      const stop = watch(() => mounted.instance.setupState.loaded, loaded => {
+        if (!loaded || contextChanged) return
+        contextChanged = true
+        contextGeneration.value += 1
+        // Vue's keyed unmount is queued after the resolved load continuation;
+        // the focus continuation must still observe the changed authority.
+        queueMicrotask(() => queueMicrotask(() => mounted.unmount()))
+      }, { flush: 'sync' })
+      try {
+        resolveLoad()
+        await flushVue()
+        assert.equal(contextChanged, true, `${testCase.inputID} observed the simulated context change`)
+        assert.equal(focused, 0, `${testCase.inputID} did not focus after its context changed`)
+        assert.equal(unmounted, true, `${testCase.inputID} was unmounted after the stale focus continuation`)
+      } finally {
+        stop()
+        mounted.unmount()
+      }
+    }
+  } finally {
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+  }
+})
+
+test('import wizard fences initialization before the keyed unmount flush', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+  }
+  let resolveConnections
+  let resolveWarehouses
+  apiModule.api.listConnections = async () => new Promise(resolve => { resolveConnections = resolve })
+  apiModule.api.listWarehouses = async () => new Promise(resolve => { resolveWarehouses = resolve })
+  const contextGeneration = ref(0)
+  let mounted
+  let unmounted = false
+  try {
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true },
+      {},
+      { [contextModule.contextGenerationKey]: contextGeneration },
+    )
+    assert.equal(mounted.instance.setupState.initializationState.connections, 'loading')
+    assert.equal(mounted.instance.setupState.initializationState.warehouses, 'loading')
+
+    const originalUnmount = mounted.unmount
+    mounted.unmount = () => {
+      if (unmounted) return
+      unmounted = true
+      originalUnmount()
+    }
+    resolveConnections([{ name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token', secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [] }])
+    resolveWarehouses([{ name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [] }])
+    contextGeneration.value += 1
+    // The host's keyed replacement is queued after the settled read
+    // continuations. The old wizard must still reject those continuations.
+    queueMicrotask(() => mounted.unmount())
+    await flushVue()
+
+    assert.deepEqual(mounted.instance.setupState.connections, [], 'stale connections did not populate the source state')
+    assert.deepEqual(mounted.instance.setupState.warehouses, [], 'stale warehouses did not populate the source state')
+    assert.equal(mounted.instance.setupState.initializationState.connections, 'loading', 'stale initialization did not clear busy state')
+    assert.equal(mounted.instance.setupState.initializationState.warehouses, 'loading', 'stale initialization did not clear busy state')
+    assert.equal(mounted.instance.setupState.error, null, 'stale initialization did not create an error')
+    assert.equal(unmounted, true, 'the simulated keyed unmount ran after the read continuations')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+  }
+})
+
+test('import wizard fences root and exhaustive branch discovery on context rotation', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    discoverWarehouses: apiModule.api.discoverWarehouses,
+    discoverSchemas: apiModule.api.discoverSchemas,
+    discoverTables: apiModule.api.discoverTables,
+  }
+  const connection = { name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token', secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [] }
+  apiModule.api.listConnections = async () => [connection]
+  apiModule.api.listWarehouses = async () => []
+  let resolveRoot
+  let rootStartedResolve
+  const rootStarted = new Promise(resolve => { rootStartedResolve = resolve })
+  const rootPending = new Promise(resolve => { resolveRoot = resolve })
+  apiModule.api.discoverWarehouses = async () => {
+    rootStartedResolve()
+    return rootPending
+  }
+  let resolveSchemas
+  let schemasStartedResolve
+  const schemasStarted = new Promise(resolve => { schemasStartedResolve = resolve })
+  const schemasPending = new Promise(resolve => { resolveSchemas = resolve })
+  apiModule.api.discoverSchemas = async () => {
+    schemasStartedResolve()
+    return schemasPending
+  }
+  apiModule.api.discoverTables = async () => ({ items: [] })
+  const contextGeneration = ref(0)
+  let mounted
+  let unmounted = false
+  try {
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true },
+      {},
+      { [contextModule.contextGenerationKey]: contextGeneration },
+    )
+    await flushVue()
+    const state = mounted.instance.setupState
+    const rootPromise = state.fromSource()
+    await rootStarted
+    assert.equal(state.step, 'browse')
+    assert.equal(state.rootLoading, true)
+    resolveRoot({ items: [{ id: 'warehouse-123', name: 'orders-sql', state: 'RUNNING', supported: true }] })
+    contextGeneration.value += 1
+    queueMicrotask(() => {
+      if (unmounted) return
+      unmounted = true
+      mounted.unmount()
+    })
+    await rootPromise
+    await flushVue()
+    assert.deepEqual(state.tree.roots, [], 'stale root discovery did not populate the tree')
+    assert.equal(state.rootError, '', 'stale root discovery did not create an error')
+    assert.equal(state.rootLoading, true, 'stale root discovery did not clear busy state')
+    assert.equal(state.error, null, 'stale root discovery did not create an error')
+
+    // Use a fresh keyed instance for the branch window. The branch helper
+    // resolves into a private snapshot, so an abandoned response must not
+    // select or append anything to the visible tree.
+    const branchContext = ref(0)
+    unmounted = false
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true },
+      {},
+      { [contextModule.contextGenerationKey]: branchContext },
+    )
+    await flushVue()
+    const branchState = mounted.instance.setupState
+    const branch = {
+      id: 'catalog:main', kind: 'catalog', label: 'main', depth: 1, disabled: false,
+      expanded: false, childrenLoaded: false, loading: false, childIds: [],
+      catalog: 'main',
+    }
+    branchState.tree.roots = [branch.id]
+    branchState.tree.nodes[branch.id] = branch
+    const branchPromise = branchState.toggleNode(branch.id, true)
+    await schemasStarted
+    assert.equal(branchState.branchChecking, true)
+    resolveSchemas({ items: [{ name: 'sales', catalog: 'main', supported: true }] })
+    branchContext.value += 1
+    queueMicrotask(() => {
+      if (unmounted) return
+      unmounted = true
+      mounted.unmount()
+    })
+    await branchPromise
+    await flushVue()
+    assert.deepEqual(branchState.tree.selectedLeafIds, [], 'stale branch discovery selected resources')
+    assert.deepEqual(branchState.tree.nodes[branch.id].childIds, [], 'stale branch discovery appended children')
+    assert.equal(branchState.error, null, 'stale branch discovery created an error')
+    assert.equal(branchState.branchChecking, true, 'stale branch discovery cleared busy state')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.discoverWarehouses = original.discoverWarehouses
+    apiModule.api.discoverSchemas = original.discoverSchemas
+    apiModule.api.discoverTables = original.discoverTables
+  }
+})
+
+test('import wizard fences register and retry results, errors, and finalizers', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    registerResources: apiModule.api.registerResources,
+  }
+  const connection = { name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token', secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [] }
+  apiModule.api.listConnections = async () => [connection]
+  apiModule.api.listWarehouses = async () => []
+  let mounted
+  try {
+    const registerContext = ref(0)
+    let resolveRegister
+    let registerStartedResolve
+    const registerStarted = new Promise(resolve => { registerStartedResolve = resolve })
+    const registerPending = new Promise(resolve => { resolveRegister = resolve })
+    apiModule.api.registerResources = async () => {
+      registerStartedResolve()
+      return registerPending
+    }
+    let registered = 0
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true, onRegistered: () => { registered += 1 } },
+      {},
+      { [contextModule.contextGenerationKey]: registerContext },
+    )
+    await flushVue()
+    const state = mounted.instance.setupState
+    state.step = 'review'
+    state.reviewEntries = [{ key: 'warehouse:warehouse-123', label: 'orders-sql', item: { name: 'orders-sql', warehouseID: 'warehouse-123' }, name: 'orders-sql' }]
+    state.reviewCoordinates = { connectionRef: 'orders', warehouseRef: '', catalog: '', schema: '' }
+    await flushVue()
+    const registerPromise = state.register()
+    await registerStarted
+    assert.equal(state.submitting, true)
+    resolveRegister({ results: [{ index: 0, name: 'orders-sql', state: 'created' }] })
+    registerContext.value += 1
+    queueMicrotask(() => mounted.unmount())
+    await registerPromise
+    await flushVue()
+    assert.deepEqual(state.results, [], 'stale registration did not populate results')
+    assert.equal(state.step, 'review', 'stale registration did not advance the step')
+    assert.equal(state.error, null, 'stale registration did not create an error')
+    assert.equal(state.submitting, true, 'stale registration cleared busy state')
+    assert.equal(registered, 0, 'stale registration emitted success')
+
+    const retryContext = ref(0)
+    let rejectRetry
+    let retryStartedResolve
+    const retryStarted = new Promise(resolve => { retryStartedResolve = resolve })
+    const retryPending = new Promise((_resolve, reject) => { rejectRetry = reject })
+    apiModule.api.registerResources = async () => {
+      retryStartedResolve()
+      return retryPending
+    }
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true, onRegistered: () => { registered += 1 } },
+      {},
+      { [contextModule.contextGenerationKey]: retryContext },
+    )
+    await flushVue()
+    const retryState = mounted.instance.setupState
+    retryState.step = 'results'
+    retryState.registrationItems = [{ name: 'orders-sql', warehouseID: 'warehouse-123' }]
+    retryState.results = [{ index: 0, name: 'orders-sql', state: 'failed', message: 'temporary failure' }]
+    retryState.reviewCoordinates = { connectionRef: 'orders', warehouseRef: '', catalog: '', schema: '' }
+    await flushVue()
+    const retryPromise = retryState.retryFailed()
+    await retryStarted
+    assert.equal(retryState.submitting, true)
+    rejectRetry(new Error('old context failure'))
+    retryContext.value += 1
+    queueMicrotask(() => mounted.unmount())
+    await retryPromise
+    await flushVue()
+    assert.equal(retryState.results[0].state, 'failed', 'stale retry replaced the existing result')
+    assert.equal(retryState.error, null, 'stale retry changed error state')
+    assert.equal(retryState.submitting, true, 'stale retry cleared busy state')
+    assert.equal(registered, 0, 'stale retry emitted success')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.registerResources = original.registerResources
+  }
+})
+
+test('import wizard does not focus after context changes before its nextTick continuation', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+  }
+  apiModule.api.listConnections = async () => []
+  apiModule.api.listWarehouses = async () => []
+  const previousHTMLElement = globalThis.HTMLElement
+  globalThis.HTMLElement = class {}
+  const contextGeneration = ref(0)
+  let mounted
+  let focused = 0
+  try {
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: false },
+      {},
+      { [contextModule.contextGenerationKey]: contextGeneration },
+    )
+    const section = mounted.find(node => node.type === 'section')
+    assert.ok(section, 'modal wizard rendered a section for focus assertions')
+    section.querySelector = () => ({ focus: () => { focused += 1 } })
+    // Both the initial dialog focus and the initialization focus have been
+    // scheduled, but the context changes before either nextTick runs.
+    mounted.instance.setupState.focusStep()
+    contextGeneration.value += 1
+    queueMicrotask(() => mounted.unmount())
+    await flushVue()
+    assert.equal(focused, 0, 'stale focus continuation focused the abandoned wizard')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    if (previousHTMLElement === undefined) delete globalThis.HTMLElement
+    else globalThis.HTMLElement = previousHTMLElement
+  }
+})
+
+test('route-owned import is a page while modal mode keeps modal semantics', async () => {
+  const [wizard, app] = await Promise.all([
+    readFile(new URL('./ResourceImportWizard.vue', import.meta.url), 'utf8'),
+    readFile(new URL('./App.vue', import.meta.url), 'utf8'),
+  ])
+  const Wizard = (await vite.ssrLoadModule('/src/ResourceImportWizard.vue')).default
+  const routeHTML = await renderToString(createSSRApp(Wizard, { kind: 'table', routeOwned: true }))
+  const modalHTML = await renderToString(createSSRApp(Wizard, { kind: 'table', routeOwned: false }))
+  assert.doesNotMatch(routeHTML, /role="dialog"/)
+  assert.doesNotMatch(routeHTML, /aria-modal=/)
+  assert.match(modalHTML, /role="dialog"/)
+  assert.match(modalHTML, /aria-modal="true"/)
+  assert.match(wizard, /if \(props\.routeOwned\) return/)
+  assert.match(wizard, /if \(!props\.routeOwned && event\.target === event\.currentTarget\) close\(\)/)
+  assert.match(wizard, /if \(props\.routeOwned \|\| !mounted\) return/)
+  assert.match(wizard, /if \(!props\.routeOwned\) \{[\s\S]*previousFocus = document\.activeElement/)
+  assert.match(app, /provide\(contextGenerationKey, contextVersion\)/)
+  assert.match(app, /immediate: true, flush: 'sync'/)
+  assert.match(app, /<KeepAlive :key="`collections:\$\{contextVersion\}`" :max="3">/)
+  assert.match(app, /route\.page === 'connections' && !route\.connection/)
+  assert.match(app, /route\.page === 'warehouses' && !route\.warehouse/)
+  assert.match(app, /route\.page === 'tables' && !route\.table/)
+  assert.match(app, /<ConnectionsView[\s\S]*:key="`connections:\$\{contextVersion\}`"/)
+  assert.match(app, /<WarehousesView[\s\S]*:key="`warehouses:\$\{contextVersion\}`"/)
+  assert.match(app, /<TablesView[\s\S]*:key="`tables:\$\{contextVersion\}`"/)
+  assert.doesNotMatch(app, /resourceVersion/)
+  assert.match(app, /Keying the cache by the context[\s\S]*generation clears every cached tenant snapshot/)
+})
+
 test('resource detail deletes expose pending state, truthful status, and real browser backlinks', async () => {
   const details = {
     connection: await readFile(new URL('./views/ConnectionDetailView.vue', import.meta.url), 'utf8'),
@@ -1381,6 +2011,207 @@ test('resource detail deletes expose pending state, truthful status, and real br
     assert.match(source, /:disabled="loading \|\| deleting \|\|/, `${kind} disables refresh while deleting`)
     assert.match(source, /:disabled="![^"]+ \|\| loading \|\| deleting \|\| operationLocked/, `${kind} disables delete while deleting`)
     assert.match(source, /if \(deleting\.value \|\| \(/, `${kind} guards back navigation while deleting`)
+  }
+})
+
+test('import wizard fences deep schema-to-table exhaustive selection on context rotation', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    listTables: apiModule.api.listTables,
+    discoverSchemas: apiModule.api.discoverSchemas,
+    discoverTables: apiModule.api.discoverTables,
+  }
+  const connection = {
+    name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token',
+    secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [],
+  }
+  const warehouse = {
+    name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [],
+  }
+  let tableStartedResolve
+  let resolveTables
+  const tableStarted = new Promise(resolve => { tableStartedResolve = resolve })
+  const tablePending = new Promise(resolve => { resolveTables = resolve })
+  apiModule.api.listConnections = async () => [connection]
+  apiModule.api.listWarehouses = async () => [warehouse]
+  apiModule.api.listTables = async () => []
+  apiModule.api.discoverSchemas = async () => ({ items: [{ name: 'sales', catalog: 'main', supported: true }] })
+  apiModule.api.discoverTables = async () => {
+    tableStartedResolve()
+    return tablePending
+  }
+  const contextGeneration = ref(0)
+  let mounted
+  try {
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'table', routeOwned: true },
+      {},
+      { [contextModule.contextGenerationKey]: contextGeneration },
+    )
+    await flushVue()
+    const state = mounted.instance.setupState
+    const branch = {
+      id: 'catalog:main', kind: 'catalog', label: 'main', depth: 1, disabled: false,
+      expanded: false, childrenLoaded: false, loading: false, childIds: [], catalog: 'main',
+    }
+    state.tree.roots = [branch.id]
+    state.tree.nodes[branch.id] = branch
+    const selectionPromise = state.toggleNode(branch.id, true)
+    await tableStarted
+    assert.equal(state.branchChecking, true, 'deep branch selection stays busy while table discovery is pending')
+
+    resolveTables({ items: [{ name: 'orders', catalog: 'main', schema: 'sales', supported: true }] })
+    contextGeneration.value += 1
+    queueMicrotask(() => mounted.unmount())
+    await selectionPromise
+    await flushVue()
+
+    assert.deepEqual(state.tree.selectedLeafIds, [], 'stale deep branch discovery did not select a table')
+    assert.deepEqual(state.tree.nodes[branch.id].childIds, [], 'stale deep branch discovery did not append a schema')
+    assert.equal(state.error, null, 'stale deep branch discovery did not create an error')
+    assert.equal(state.branchChecking, true, 'stale deep branch discovery did not clear busy state')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listTables = original.listTables
+    apiModule.api.discoverSchemas = original.discoverSchemas
+    apiModule.api.discoverTables = original.discoverTables
+  }
+})
+
+test('import wizard does not invoke registration after context authority changes', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    registerResources: apiModule.api.registerResources,
+  }
+  const connection = {
+    name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token',
+    secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [],
+  }
+  const warehouse = {
+    name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [],
+  }
+  let registerCalls = 0
+  apiModule.api.listConnections = async () => [connection]
+  apiModule.api.listWarehouses = async () => [warehouse]
+  apiModule.api.registerResources = async () => {
+    registerCalls += 1
+    return { results: [{ index: 0, name: 'orders-sql', state: 'created' }] }
+  }
+  const contextGeneration = ref(0)
+  let mounted
+  try {
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true },
+      {},
+      { [contextModule.contextGenerationKey]: contextGeneration },
+    )
+    await flushVue()
+    const state = mounted.instance.setupState
+    state.step = 'review'
+    state.reviewEntries = [{
+      key: 'warehouse:warehouse-123', label: 'orders-sql',
+      item: { name: 'orders-sql', warehouseID: 'warehouse-123' }, name: 'orders-sql',
+    }]
+    state.reviewCoordinates = { connectionRef: 'orders', warehouseRef: '', catalog: '', schema: '' }
+    await flushVue()
+
+    contextGeneration.value += 1
+    await state.register()
+
+    assert.equal(registerCalls, 0, 'registration did not start after the context authority changed')
+    assert.equal(state.step, 'review', 'pre-rotation registration changed the wizard step')
+    assert.deepEqual(state.results, [], 'pre-rotation registration populated results')
+    assert.equal(state.submitting, false, 'pre-rotation registration changed busy state')
+    assert.equal(state.registrationFrozen, false, 'pre-rotation registration froze the review')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.registerResources = original.registerResources
+  }
+})
+
+test('import wizard completes a successful registration and emits once', async () => {
+  const [Wizard, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/ResourceImportWizard.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    registerResources: apiModule.api.registerResources,
+  }
+  const connection = {
+    name: 'orders', host: 'https://dbc.example.com', authType: 'pat', secretName: 'orders-token',
+    secretNamespace: 'default', secretKey: 'token', status: 'Ready', conditions: [],
+  }
+  const warehouse = {
+    name: 'orders-sql', connectionRef: 'orders', warehouseID: 'warehouse-123', status: 'Ready', conditions: [],
+  }
+  let registerCalls = 0
+  let receivedPayload
+  apiModule.api.listConnections = async () => [connection]
+  apiModule.api.listWarehouses = async () => [warehouse]
+  apiModule.api.registerResources = async payload => {
+    registerCalls += 1
+    receivedPayload = payload
+    return { results: [{ index: 0, name: 'orders-sql', state: 'created', message: 'accepted' }] }
+  }
+  const contextGeneration = ref(0)
+  let registered = 0
+  let mounted
+  try {
+    mounted = mountDetailView(
+      Wizard,
+      { kind: 'warehouse', routeOwned: true, onRegistered: () => { registered += 1 } },
+      {},
+      { [contextModule.contextGenerationKey]: contextGeneration },
+    )
+    await flushVue()
+    const state = mounted.instance.setupState
+    state.step = 'review'
+    state.reviewEntries = [{
+      key: 'warehouse:warehouse-123', label: 'orders-sql',
+      item: { name: 'orders-sql', warehouseID: 'warehouse-123' }, name: 'orders-sql',
+    }]
+    state.reviewCoordinates = { connectionRef: 'orders', warehouseRef: '', catalog: '', schema: '' }
+    await flushVue()
+
+    await state.register()
+
+    assert.equal(registerCalls, 1, 'successful registration made exactly one mutation request')
+    assert.deepEqual(receivedPayload, {
+      kind: 'warehouse', connectionRef: 'orders', warehouseRef: undefined,
+      items: [{ name: 'orders-sql', warehouseID: 'warehouse-123' }],
+    }, 'successful registration used the reviewed coordinates and item')
+    assert.deepEqual(state.results, [{ index: 0, name: 'orders-sql', state: 'created', message: 'accepted' }], 'successful registration exposed the provider result')
+    assert.equal(state.step, 'results', 'successful registration advanced to results')
+    assert.equal(state.submitting, false, 'successful registration cleared busy state')
+    assert.equal(state.registrationFrozen, true, 'successful registration kept the reviewed batch frozen')
+    assert.equal(state.error, null, 'successful registration did not create an error')
+    assert.equal(registered, 1, 'successful registration emitted exactly one registered event')
+  } finally {
+    mounted?.unmount()
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.registerResources = original.registerResources
   }
 })
 

--- a/providers/databricks/portal/src/route.test.ts
+++ b/providers/databricks/portal/src/route.test.ts
@@ -1,0 +1,25 @@
+import { collectionPath, createPath, detailPath, parseSubPath } from './route.js'
+import { navigationDetail } from './navigation.js'
+
+function equal(actual: unknown, expected: unknown, label: string): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label}: ${JSON.stringify(actual)}`)
+  }
+}
+
+equal(parseSubPath(undefined), { page: 'connections' }, 'bare provider path')
+equal(parseSubPath('/create/connection/'), { page: 'create', kind: 'connection', mode: 'manual' }, 'connection create path is provider-relative')
+equal(parseSubPath('create/warehouse/manual'), { page: 'create', kind: 'warehouse', mode: 'manual' }, 'manual warehouse path')
+equal(parseSubPath('create/warehouse/browse'), { page: 'create', kind: 'warehouse', mode: 'browse' }, 'browse warehouse path')
+equal(parseSubPath('create/table/manual'), { page: 'create', kind: 'table', mode: 'manual' }, 'manual table path')
+equal(parseSubPath('create/table/browse'), { page: 'create', kind: 'table', mode: 'browse' }, 'browse table path')
+equal(parseSubPath('providers/databricks/create/table/manual'), { page: 'connections' }, 'shell prefix is not part of provider subPath')
+equal(parseSubPath('tables/orders%2Fhistory'), { page: 'tables', table: 'orders/history' }, 'detail name decoding')
+equal(createPath('connection'), 'create/connection', 'connection path stays relative')
+equal(createPath('warehouse', 'browse'), 'create/warehouse/browse', 'warehouse browse path')
+equal(createPath('table', 'manual'), 'create/table/manual', 'table manual path')
+equal(collectionPath('warehouses'), 'warehouses', 'collection path')
+equal(detailPath('tables', 'orders history'), 'tables/orders%20history', 'detail path encoding')
+equal(navigationDetail('warehouses'), { path: 'warehouses' }, 'push navigation detail')
+equal(navigationDetail('/warehouses'), { path: 'warehouses' }, 'navigation detail remains provider-relative')
+equal(navigationDetail('warehouses', true), { path: 'warehouses', replace: true }, 'replace navigation detail')

--- a/providers/databricks/portal/src/route.ts
+++ b/providers/databricks/portal/src/route.ts
@@ -1,0 +1,78 @@
+export type CollectionPage = 'connections' | 'warehouses' | 'tables'
+export type CreateKind = 'connection' | 'warehouse' | 'table'
+export type CreateMode = 'manual' | 'browse'
+
+export interface CollectionRoute {
+  page: CollectionPage
+  connection?: string
+  table?: string
+  warehouse?: string
+}
+
+export interface CreateRoute {
+  page: 'create'
+  kind: CreateKind
+  mode: CreateMode
+}
+
+export type DatabricksRoute = CollectionRoute | CreateRoute
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Parse the path after `/providers/databricks/`.
+ *
+ * The shell owns the provider prefix and passes only this relative subPath to
+ * the custom element. Keeping that boundary here prevents a provider route
+ * from accidentally dispatching a second `/providers/databricks` prefix.
+ */
+export function parseSubPath(sub: string | null | undefined): DatabricksRoute {
+  const normalized = (sub ?? '').replace(/^\/+|\/+$/g, '')
+  const parts = normalized ? normalized.split('/') : []
+
+  if (parts[0] === 'create') {
+    if (parts[1] === 'connection' && parts.length === 2) {
+      return { page: 'create', kind: 'connection', mode: 'manual' }
+    }
+    if ((parts[1] === 'warehouse' || parts[1] === 'table') &&
+      (parts[2] === 'manual' || parts[2] === 'browse') && parts.length === 3) {
+      return { page: 'create', kind: parts[1], mode: parts[2] }
+    }
+    return { page: 'connections' }
+  }
+
+  if (parts[0] === 'connections') {
+    return parts.length > 1
+      ? { page: 'connections', connection: decodeSegment(parts.slice(1).join('/')) }
+      : { page: 'connections' }
+  }
+  if (parts[0] === 'warehouses') {
+    return parts.length > 1
+      ? { page: 'warehouses', warehouse: decodeSegment(parts.slice(1).join('/')) }
+      : { page: 'warehouses' }
+  }
+  if (parts[0] === 'tables') {
+    return parts.length > 1
+      ? { page: 'tables', table: decodeSegment(parts.slice(1).join('/')) }
+      : { page: 'tables' }
+  }
+  return { page: 'connections' }
+}
+
+export function collectionPath(page: CollectionPage): string {
+  return page
+}
+
+export function createPath(kind: CreateKind, mode: CreateMode = 'manual'): string {
+  return kind === 'connection' ? 'create/connection' : `create/${kind}/${mode}`
+}
+
+export function detailPath(page: Exclude<CollectionPage, 'connections'> | 'connections', name: string): string {
+  return `${page}/${encodeURIComponent(name)}`
+}

--- a/providers/databricks/portal/src/style.css
+++ b/providers/databricks/portal/src/style.css
@@ -133,6 +133,31 @@ faros-provider-databricks .databricks-resource-panel {
   padding: 14px 16px;
 }
 
+faros-provider-databricks .databricks-create-page {
+  min-width: 0;
+}
+
+faros-provider-databricks .databricks-create-head {
+  display: block;
+}
+
+faros-provider-databricks .databricks-back-action {
+  margin-bottom: 10px;
+}
+
+faros-provider-databricks .databricks-create-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+
+faros-provider-databricks .databricks-create-card .form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 faros-provider-databricks .databricks-resource-panel-head {
   align-items: center;
   display: flex;
@@ -358,6 +383,15 @@ faros-provider-databricks .import-backdrop {
   z-index: 80;
 }
 
+/* Browse/import is a route-owned page, so it keeps the same stepper and
+ * result presentation without covering a collection or depending on modal
+ * focus restoration. */
+faros-provider-databricks .import-route {
+  display: flex;
+  min-width: 0;
+  justify-content: center;
+}
+
 faros-provider-databricks .import-dialog {
   background: var(--color-surface-raised, #111320);
   border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
@@ -368,6 +402,12 @@ faros-provider-databricks .import-dialog {
   max-height: min(760px, calc(100vh - 48px));
   overflow: hidden;
   width: min(720px, 100%);
+}
+
+faros-provider-databricks .import-dialog--route {
+  box-shadow: none;
+  max-height: none;
+  width: 100%;
 }
 
 faros-provider-databricks .import-head,

--- a/providers/databricks/portal/src/views/ConnectionsView.vue
+++ b/providers/databricks/portal/src/views/ConnectionsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ExternalLink } from 'lucide-vue-next'
-import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
@@ -20,7 +20,6 @@ import {
   type LatestRefreshController,
   type ResourceRefreshMode,
 } from '../refresh'
-import { resourceNameError } from '../resourceName'
 import {
   cloneConnectionFilters,
   CONNECTION_FILTERS,
@@ -35,7 +34,7 @@ import {
   type DatabricksPaginationMode,
 } from '../databricksPagination'
 
-const emit = defineEmits<{ (e: 'open', name: string): void }>()
+const emit = defineEmits<{ (e: 'open', name: string): void; (e: 'create'): void }>()
 
 const connections = ref<Connection[]>([])
 const loading = ref(false)
@@ -62,20 +61,12 @@ const rows = computed<Array<Record<string, unknown>>>(() => connections.value
   .filter(conn => !operations.isTombstoned(operationKey('connection', conn.name), conn.uid))
   .map(conn => ({ ...conn })))
 
-// connection form
-const showForm = ref(false)
-const name = ref('')
-const host = ref('')
-const token = ref('')
-const submitting = ref(false)
-const formError = ref<string | null>(null)
-const nameInput = ref<HTMLInputElement | null>(null)
-const formErrorRef = ref<HTMLElement | null>(null)
 let poll!: AdaptiveRefreshTimer
 let refresh!: LatestRefreshController
 let mounted = false
 let fullWalkPending = false
 let serverPageReadPending = false
+let activatedOnce = false
 let authorityGeneration = 0
 
 function invalidateCompleteAuthority(): void {
@@ -87,19 +78,6 @@ function invalidateCompleteAuthority(): void {
 function errMessage(e: unknown): string {
   const err = e as ErrorResponse
   return err.reason ? `${err.reason}: ${err.message}` : err.message || String(e)
-}
-
-function resetForm() {
-  name.value = ''
-  host.value = ''
-  token.value = ''
-  formError.value = null
-}
-
-function startCreate() {
-  resetForm()
-  showForm.value = true
-  void nextTick(() => nameInput.value?.focus())
 }
 
 const refreshMode = ref<ResourceRefreshMode>('foreground')
@@ -138,65 +116,6 @@ function operationPhase(name: string) {
 
 function openResource(name: string): void {
   if (!operationLocked(name)) emit('open', name)
-}
-
-async function focusFormError(message: string) {
-  formError.value = message
-  await nextTick()
-  formErrorRef.value?.focus()
-}
-
-async function submit() {
-  formError.value = null
-  mutationError.value = null
-  if (!loaded.value) {
-    await focusFormError('Connection list is still loading. Retry the read before creating a connection.')
-    return
-  }
-  if (!name.value || !host.value || !token.value) {
-    await focusFormError('Name, workspace host, and token are required.')
-    return
-  }
-  const nameError = resourceNameError(name.value, 'Name')
-  if (nameError) {
-    await focusFormError(nameError)
-    return
-  }
-  const desiredName = name.value.trim()
-  const lock = operationKey('connection', desiredName)
-  if (!operations.acquire(lock, 'creating')) {
-    await focusFormError(`Connection "${desiredName}" already has an update in progress.`)
-    return
-  }
-  submitting.value = true
-  try {
-    // The visible rows may be one cursor page. Duplicate protection must use a
-    // complete authoritative read before allowing the mutation.
-    const existing = await completeRead.request()
-    operations.reconcile('connection', existing.map(({ name, uid }) => ({ name, uid })))
-    if (operations.isTombstoned(lock)) {
-      await focusFormError(`Connection "${desiredName}" is still being removed. Retry after the list refresh confirms it is gone.`)
-      return
-    }
-    if (existing.some(connection => connection.name === desiredName)) {
-      await focusFormError(`Connection "${desiredName}" already exists.`)
-      return
-    }
-    await api.saveConnection({
-      name: desiredName,
-      host: host.value,
-      token: token.value,
-    })
-    invalidateCompleteAuthority()
-    resetForm()
-    showForm.value = false
-    load()
-  } catch (e) {
-    await focusFormError(errMessage(e))
-  } finally {
-    submitting.value = false
-    operations.release(lock)
-  }
 }
 
 interface ConnectionRequest {
@@ -434,6 +353,13 @@ onMounted(() => {
   mounted = true
   load()
 })
+onActivated(() => {
+  if (!activatedOnce) {
+    activatedOnce = true
+    return
+  }
+  load('foreground')
+})
 onUnmounted(() => {
   mounted = false
   invalidateCompleteAuthority()
@@ -452,38 +378,9 @@ onUnmounted(() => {
         <p class="page-meta">Databricks workspaces available to tables in this faros workspace.</p>
       </div>
       <div class="actions">
-        <button class="k-btn k-btn--primary" type="button" :disabled="submitting" @click="showForm ? (showForm = false) : startCreate()">
-          {{ showForm ? 'Cancel' : 'Add connection' }}
-        </button>
+        <button class="k-btn k-btn--primary" type="button" @click="emit('create')">Add connection</button>
       </div>
     </header>
-
-    <div v-if="showForm" class="databricks-resource-panel k-card">
-      <h3 class="databricks-resource-panel-title">Connect with a token</h3>
-      <form class="form" @submit.prevent="submit">
-        <div class="field">
-          <label class="field-label" for="connection-name">Name</label>
-          <input id="connection-name" class="k-input" ref="nameInput" v-model="name" :disabled="submitting" autocomplete="off" placeholder="orders-prod" required aria-required="true" aria-describedby="connection-name-hint connection-form-error" :aria-invalid="!!formError" />
-          <span id="connection-name-hint" class="field-hint">How this workspace is referred to from faros. Use lowercase letters, numbers, and hyphens; the name is preserved exactly.</span>
-        </div>
-        <div class="field">
-          <label class="field-label" for="connection-host">Workspace host</label>
-          <input id="connection-host" class="k-input" v-model="host" :disabled="submitting" autocomplete="url" placeholder="https://dbc-example.cloud.databricks.com" required aria-required="true" aria-describedby="connection-host-hint connection-form-error" :aria-invalid="!!formError" />
-          <span id="connection-host-hint" class="field-hint">Use the HTTPS root URL from the Databricks browser address bar (AWS, Azure, or GCP), with no path.</span>
-        </div>
-        <div class="field">
-          <label class="field-label" for="connection-token">Token</label>
-          <input id="connection-token" class="k-input" v-model="token" :disabled="submitting" type="password" autocomplete="new-password" placeholder="Paste token" required aria-required="true" aria-describedby="connection-token-hint connection-form-error" :aria-invalid="!!formError" />
-          <span id="connection-token-hint" class="field-hint">Create a personal access token in Databricks: avatar → Settings → Developer → Access tokens → Manage → Generate new token. Its identity needs SELECT on the catalogs and schemas you plan to import, plus access to a running SQL warehouse.</span>
-        </div>
-        <div class="actions">
-      <button class="k-btn k-btn--primary" type="submit" :disabled="submitting">{{ submitting ? 'Connecting...' : 'Create' }}</button>
-          <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="() => { resetForm(); showForm = false }">Cancel</button>
-          <span v-if="formError" id="connection-form-error" ref="formErrorRef" class="error" role="alert" aria-live="assertive" tabindex="-1">{{ formError }}</span>
-        </div>
-        <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the status below.</p>
-      </form>
-    </div>
 
     <div v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">
       <span>{{ mutationError }}</span>

--- a/providers/databricks/portal/src/views/CreateConnectionView.vue
+++ b/providers/databricks/portal/src/views/CreateConnectionView.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { ArrowLeft, LoaderCircle, RefreshCw } from 'lucide-vue-next'
+import { inject, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { api } from '../api'
+import { contextGenerationKey } from '../context'
+import {
+  createOperationLocks,
+  operationKey,
+} from '../refresh'
+import { resourceNameError } from '../resourceName'
+import type { ErrorResponse } from '../types'
+
+const emit = defineEmits<{
+  (event: 'cancel'): void
+  (event: 'created', name: string): void
+}>()
+
+const loading = ref(false)
+const loaded = ref(false)
+const loadError = ref<string | null>(null)
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+const nameInput = ref<HTMLInputElement | null>(null)
+const formErrorRef = ref<HTMLElement | null>(null)
+const operations = createOperationLocks()
+const contextGeneration = inject(contextGenerationKey, ref(0))
+
+// Route-owned forms can be replaced while a read or write is in flight (for
+// example when the host rotates the tenant context). Keep every async
+// continuation tied to the mounted form that started it.
+let mounted = false
+let readGeneration = 0
+let mutationGeneration = 0
+
+interface ReadToken {
+  generation: number
+  context: number
+}
+
+const form = reactive({
+  name: '',
+  host: '',
+  token: '',
+})
+
+function errMessage(error: unknown): string {
+  const response = error as Partial<ErrorResponse>
+  return response.reason ? `${response.reason}: ${response.message}` : response.message || String(error)
+}
+
+function isCurrentRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === readGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentMutation(generation: number, expectedContext: number): boolean {
+  return mounted && generation === mutationGeneration && contextGeneration.value === expectedContext
+}
+
+async function load(): Promise<ReadToken | null> {
+  const generation = ++readGeneration
+  const expectedContext = contextGeneration.value
+  loading.value = true
+  loadError.value = null
+  loaded.value = false
+  try {
+    await api.listConnections()
+    if (!isCurrentRead(generation, expectedContext)) return null
+    loaded.value = true
+    return { generation, context: expectedContext }
+  } catch (error) {
+    if (!isCurrentRead(generation, expectedContext)) return null
+    loadError.value = errMessage(error)
+    return null
+  } finally {
+    if (isCurrentRead(generation, expectedContext)) loading.value = false
+  }
+}
+
+async function focusFormError(message: string, generation: number, expectedContext: number): Promise<void> {
+  if (!isCurrentMutation(generation, expectedContext)) return
+  formError.value = message
+  await nextTick()
+  if (isCurrentMutation(generation, expectedContext)) formErrorRef.value?.focus()
+}
+
+async function submit(): Promise<void> {
+  if (!mounted || submitting.value) return
+  const generation = ++mutationGeneration
+  const expectedContext = contextGeneration.value
+  formError.value = null
+  if (!loaded.value) {
+    await focusFormError('Connection list is still loading. Retry the read before creating a connection.', generation, expectedContext)
+    return
+  }
+  if (!form.name || !form.host || !form.token) {
+    await focusFormError('Name, workspace host, and token are required.', generation, expectedContext)
+    return
+  }
+  const nameError = resourceNameError(form.name, 'Name')
+  if (nameError) {
+    await focusFormError(nameError, generation, expectedContext)
+    return
+  }
+  const desiredName = form.name.trim()
+  const payload = {
+    name: desiredName,
+    host: form.host,
+    token: form.token,
+  }
+  const lock = operationKey('connection', desiredName)
+  if (!operations.acquire(lock, 'creating')) {
+    await focusFormError(`Connection "${desiredName}" already has an update in progress.`, generation, expectedContext)
+    return
+  }
+  submitting.value = true
+  try {
+    // Re-read the complete collection immediately before applying. The page
+    // the user entered from may have become stale while the form was open.
+    const existing = await api.listConnections()
+    if (!isCurrentMutation(generation, expectedContext)) return
+    operations.reconcile('connection', existing.map(({ name, uid }) => ({ name, uid })))
+    if (operations.isTombstoned(lock)) {
+      await focusFormError(`Connection "${desiredName}" is still being removed. Retry after the list refresh confirms it is gone.`, generation, expectedContext)
+      return
+    }
+    if (existing.some(connection => connection.name === desiredName)) {
+      await focusFormError(`Connection "${desiredName}" already exists.`, generation, expectedContext)
+      return
+    }
+    const created = await api.saveConnection(payload)
+    if (!isCurrentMutation(generation, expectedContext)) return
+    emit('created', created.name)
+  } catch (error) {
+    await focusFormError(errMessage(error), generation, expectedContext)
+  } finally {
+    operations.release(lock)
+    if (isCurrentMutation(generation, expectedContext)) submitting.value = false
+  }
+}
+
+function cancel(): void {
+  if (!submitting.value) emit('cancel')
+}
+
+onMounted(() => {
+  mounted = true
+  void load().then(readToken => {
+    if (readToken && isCurrentRead(readToken.generation, readToken.context)) nameInput.value?.focus()
+  })
+})
+
+onBeforeUnmount(() => {
+  mounted = false
+  readGeneration += 1
+  mutationGeneration += 1
+})
+</script>
+
+<template>
+  <section class="page k-create-page" :aria-busy="loading || submitting ? 'true' : 'false'">
+    <button class="k-btn k-btn--ghost k-back-action" type="button" :disabled="submitting" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Connections
+    </button>
+    <header class="k-create-header">
+      <h2 class="k-create-title">Create connection</h2>
+      <p class="k-create-description">Connect a Databricks workspace for warehouse and table imports.</p>
+    </header>
+
+    <form class="k-create-surface" @submit.prevent="submit">
+      <div class="k-create-body">
+      <p v-if="loading" class="muted" role="status"><LoaderCircle class="spin" :size="14" aria-hidden="true" /> Loading existing connections…</p>
+      <p v-if="loadError" class="error" role="alert" aria-live="assertive">
+        <span>Could not load existing connections: {{ loadError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" @click="load"><RefreshCw :size="14" aria-hidden="true" /> Retry</button>
+      </p>
+        <div class="field">
+          <label class="field-label" for="connection-name">Name</label>
+          <input id="connection-name" ref="nameInput" class="k-input" v-model="form.name" :disabled="loading || submitting" autocomplete="off" placeholder="orders-prod" required aria-required="true" aria-describedby="connection-name-hint connection-form-error" :aria-invalid="!!formError" />
+          <span id="connection-name-hint" class="field-hint">How this workspace is referred to from faros. Use lowercase letters, numbers, and hyphens; the name is preserved exactly.</span>
+        </div>
+        <div class="field">
+          <label class="field-label" for="connection-host">Workspace host</label>
+          <input id="connection-host" class="k-input" v-model="form.host" :disabled="loading || submitting" autocomplete="url" placeholder="https://dbc-example.cloud.databricks.com" required aria-required="true" aria-describedby="connection-host-hint connection-form-error" :aria-invalid="!!formError" />
+          <span id="connection-host-hint" class="field-hint">Use the HTTPS root URL from the Databricks browser address bar (AWS, Azure, or GCP), with no path.</span>
+        </div>
+        <div class="field">
+          <label class="field-label" for="connection-token">Token</label>
+          <input id="connection-token" class="k-input" v-model="form.token" :disabled="loading || submitting" type="password" autocomplete="new-password" placeholder="Paste token" required aria-required="true" aria-describedby="connection-token-hint connection-form-error" :aria-invalid="!!formError" />
+          <span id="connection-token-hint" class="field-hint">Create a personal access token in Databricks: avatar → Settings → Developer → Access tokens → Manage → Generate new token. Its identity needs SELECT on the catalogs and schemas you plan to import, plus access to a running SQL warehouse.</span>
+        </div>
+        <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the status on the connection detail page.</p>
+      </div>
+      <div class="k-create-actions">
+        <span v-if="formError" id="connection-form-error" ref="formErrorRef" class="error" role="alert" aria-live="assertive" tabindex="-1">{{ formError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" :disabled="loading || submitting">{{ submitting ? 'Connecting…' : 'Create connection' }}</button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/providers/databricks/portal/src/views/CreateTableView.vue
+++ b/providers/databricks/portal/src/views/CreateTableView.vue
@@ -1,0 +1,285 @@
+<script setup lang="ts">
+import { ArrowLeft, LoaderCircle, RefreshCw } from 'lucide-vue-next'
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { api } from '../api'
+import { contextGenerationKey } from '../context'
+import {
+  createOperationLocks,
+  operationKey,
+} from '../refresh'
+import { importPrerequisiteMessage, nextValidWarehouseRef, warehousesForConnection } from '../tableRefs'
+import { resourceNameError } from '../resourceName'
+import type { Connection, ErrorResponse, Warehouse } from '../types'
+
+const emit = defineEmits<{
+  (event: 'cancel'): void
+  (event: 'created', name: string): void
+  (event: 'navigate', path: 'connections' | 'warehouses'): void
+}>()
+
+const connections = ref<Connection[]>([])
+const warehouses = ref<Warehouse[]>([])
+const loading = ref(false)
+const loaded = ref(false)
+const loadError = ref<string | null>(null)
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+const nameInput = ref<HTMLInputElement | null>(null)
+const formErrorRef = ref<HTMLElement | null>(null)
+const operations = createOperationLocks()
+const contextGeneration = inject(contextGenerationKey, ref(0))
+
+// Route-owned forms may be replaced while a read or write is in flight. Every
+// async continuation must belong to the mounted form and latest attempt that
+// started it.
+let mounted = false
+let readGeneration = 0
+let mutationGeneration = 0
+
+interface ReadToken {
+  generation: number
+  context: number
+}
+
+const form = reactive({
+  name: '',
+  connectionRef: '',
+  warehouseRef: '',
+  catalog: '',
+  schema: '',
+  table: '',
+})
+
+const tableImportBlocker = computed(() => !loaded.value ? '' : importPrerequisiteMessage(connections.value, warehouses.value))
+const formWarehouses = computed(() => warehousesForConnection(warehouses.value, form.connectionRef))
+const hasConnections = computed(() => connections.value.length > 0)
+const hasWarehouses = computed(() => warehouses.value.length > 0)
+
+function errMessage(error: unknown): string {
+  const response = error as Partial<ErrorResponse>
+  return response.reason ? `${response.reason}: ${response.message}` : response.message || String(error)
+}
+
+function isCurrentRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === readGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentMutation(generation: number, expectedContext: number): boolean {
+  return mounted && generation === mutationGeneration && contextGeneration.value === expectedContext
+}
+
+async function load(): Promise<ReadToken | null> {
+  const generation = ++readGeneration
+  const expectedContext = contextGeneration.value
+  loading.value = true
+  loaded.value = false
+  loadError.value = null
+  try {
+    const [availableConnections, availableWarehouses] = await Promise.all([
+      api.listConnections(),
+      api.listWarehouses(),
+    ])
+    if (!isCurrentRead(generation, expectedContext)) return null
+    connections.value = availableConnections
+    warehouses.value = availableWarehouses
+    if (!connections.value.some(connection => connection.name === form.connectionRef)) {
+      form.connectionRef = connections.value[0]?.name ?? ''
+    }
+    form.warehouseRef = nextValidWarehouseRef(warehouses.value, form.connectionRef, form.warehouseRef)
+    loaded.value = true
+    return { generation, context: expectedContext }
+  } catch (error) {
+    if (!isCurrentRead(generation, expectedContext)) return null
+    loadError.value = errMessage(error)
+    return null
+  } finally {
+    if (isCurrentRead(generation, expectedContext)) loading.value = false
+  }
+}
+
+async function focusFormError(message: string, generation: number, expectedContext: number): Promise<void> {
+  if (!isCurrentMutation(generation, expectedContext)) return
+  formError.value = message
+  await nextTick()
+  if (isCurrentMutation(generation, expectedContext)) formErrorRef.value?.focus()
+}
+
+// Prefill the Databricks-provided samples catalog (readable in every
+// workspace) so a first import needs no lookup: samples.nyctaxi.trips.
+function fillDemo(): void {
+  form.name = 'nyctaxi-trips'
+  form.catalog = 'samples'
+  form.schema = 'nyctaxi'
+  form.table = 'trips'
+  formError.value = null
+}
+
+async function submit(): Promise<void> {
+  if (!mounted || submitting.value) return
+  const generation = ++mutationGeneration
+  const expectedContext = contextGeneration.value
+  formError.value = null
+  if (!loaded.value) {
+    await focusFormError('Connection and warehouse lists are still loading. Retry the read before creating a table.', generation, expectedContext)
+    return
+  }
+  if (tableImportBlocker.value) {
+    await focusFormError(tableImportBlocker.value, generation, expectedContext)
+    return
+  }
+  if (!form.name || !form.connectionRef || !form.warehouseRef || !form.catalog || !form.schema || !form.table) {
+    await focusFormError('All table fields are required.', generation, expectedContext)
+    return
+  }
+  const nameError = resourceNameError(form.name, 'Name')
+  if (nameError) {
+    await focusFormError(nameError, generation, expectedContext)
+    return
+  }
+  const desiredName = form.name.trim()
+  const payload = {
+    name: desiredName,
+    connectionRef: form.connectionRef,
+    warehouseRef: form.warehouseRef,
+    catalog: form.catalog,
+    schema: form.schema,
+    table: form.table,
+  }
+  const lock = operationKey('table', desiredName)
+  if (!operations.acquire(lock, 'creating')) {
+    await focusFormError(`Table "${desiredName}" already has an update in progress.`, generation, expectedContext)
+    return
+  }
+  submitting.value = true
+  try {
+    // Resolve duplicate and foreign-key checks from complete, current reads;
+    // the collections that preceded this route may only have shown one page.
+    const [existingTables, availableConnections, availableWarehouses] = await Promise.all([
+      api.listTables(),
+      api.listConnections(),
+      api.listWarehouses(),
+    ])
+    if (!isCurrentMutation(generation, expectedContext)) return
+    operations.reconcile('table', existingTables.map(({ name, uid }) => ({ name, uid })))
+    if (operations.isTombstoned(lock)) {
+      await focusFormError(`Table "${desiredName}" is still being removed. Retry after the list refresh confirms it is gone.`, generation, expectedContext)
+      return
+    }
+    if (existingTables.some(table => table.name === desiredName)) {
+      await focusFormError(`Table "${desiredName}" already exists.`, generation, expectedContext)
+      return
+    }
+    if (!availableConnections.some(connection => connection.name === payload.connectionRef)) {
+      await focusFormError('Selected connection is no longer available in this workspace.', generation, expectedContext)
+      return
+    }
+    if (!availableWarehouses.some(warehouse => warehouse.name === payload.warehouseRef && warehouse.connectionRef === payload.connectionRef)) {
+      await focusFormError('Selected warehouse must belong to the selected connection.', generation, expectedContext)
+      return
+    }
+    const created = await api.saveTable(payload)
+    if (!isCurrentMutation(generation, expectedContext)) return
+    emit('created', created.name)
+  } catch (error) {
+    await focusFormError(errMessage(error), generation, expectedContext)
+  } finally {
+    operations.release(lock)
+    if (isCurrentMutation(generation, expectedContext)) submitting.value = false
+  }
+}
+
+function cancel(): void {
+  if (!submitting.value) emit('cancel')
+}
+
+onMounted(() => {
+  mounted = true
+  void load().then(readToken => {
+    if (readToken && isCurrentRead(readToken.generation, readToken.context)) nameInput.value?.focus()
+  })
+})
+
+onBeforeUnmount(() => {
+  mounted = false
+  readGeneration += 1
+  mutationGeneration += 1
+})
+
+watch(() => form.connectionRef, connectionRef => {
+  form.warehouseRef = nextValidWarehouseRef(warehouses.value, connectionRef, form.warehouseRef)
+})
+</script>
+
+<template>
+  <section class="page k-create-page" :aria-busy="loading || submitting ? 'true' : 'false'">
+    <button class="k-btn k-btn--ghost k-back-action" type="button" :disabled="submitting" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Tables
+    </button>
+    <header class="k-create-header">
+      <h2 class="k-create-title">Register table</h2>
+      <p class="k-create-description">Register a metadata-only Databricks table handle for App Studio and MCP.</p>
+    </header>
+
+    <form class="k-create-surface k-create-surface--wide" @submit.prevent="submit">
+      <div class="k-create-body">
+      <div class="databricks-resource-panel-head">
+        <span class="databricks-resource-panel-title">Table details</span>
+        <button class="k-btn k-btn--ghost databricks-inline-action" type="button" :disabled="loading || submitting" @click="fillDemo" title="Prefill samples.nyctaxi.trips — Databricks demo data available in every workspace">Fill with demo data</button>
+      </div>
+      <p v-if="loading" class="muted" role="status"><LoaderCircle class="spin" :size="14" aria-hidden="true" /> Loading connections and warehouses…</p>
+      <p v-if="loadError" class="error" role="alert" aria-live="assertive">
+        <span>Could not load table prerequisites: {{ loadError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" @click="load"><RefreshCw :size="14" aria-hidden="true" /> Retry</button>
+      </p>
+      <div v-if="tableImportBlocker" class="prerequisite" role="status">
+        {{ tableImportBlocker }}
+        <button v-if="!hasConnections" class="k-btn k-btn--ghost databricks-inline-action" type="button" @click="emit('navigate', 'connections')">Go to connections</button>
+        <button v-else-if="!hasWarehouses" class="k-btn k-btn--ghost databricks-inline-action" type="button" @click="emit('navigate', 'warehouses')">Go to warehouses</button>
+      </div>
+      <div class="form-grid">
+        <label class="field" for="table-name">
+          <span class="field-label">Name</span>
+          <input id="table-name" ref="nameInput" class="k-input" v-model="form.name" :disabled="loading || submitting" autocomplete="off" placeholder="order-history" required aria-required="true" aria-describedby="table-name-hint table-form-error" :aria-invalid="!!formError" />
+          <span id="table-name-hint" class="field-hint">The stable tableRef exposed to App Studio. Use lowercase letters, numbers, and hyphens; the name is preserved exactly.</span>
+        </label>
+        <label class="field" for="table-connection">
+          <span class="field-label">Connection</span>
+          <select id="table-connection" class="k-input" v-model="form.connectionRef" :disabled="loading || submitting || !hasConnections" required aria-required="true" aria-describedby="table-connection-hint table-form-error" :aria-invalid="!!formError">
+            <option value="" disabled>Select connection</option>
+            <option v-for="conn in connections" :key="conn.name" :value="conn.name">{{ conn.name }}</option>
+          </select>
+          <span id="table-connection-hint" class="field-hint">The Databricks workspace connection for this table.</span>
+        </label>
+        <label class="field" for="table-warehouse">
+          <span class="field-label">Warehouse</span>
+          <select id="table-warehouse" class="k-input" v-model="form.warehouseRef" :disabled="loading || submitting || !formWarehouses.length" required aria-required="true" aria-describedby="table-warehouse-hint table-form-error" :aria-invalid="!!formError">
+            <option value="" disabled>{{ formWarehouses.length ? 'Select warehouse' : 'No warehouses for this connection' }}</option>
+            <option v-for="wh in formWarehouses" :key="wh.name" :value="wh.name">{{ wh.name }}</option>
+          </select>
+          <span id="table-warehouse-hint" class="field-hint">A warehouse that belongs to the selected connection.</span>
+        </label>
+        <label class="field" for="table-catalog">
+          <span class="field-label">Catalog</span>
+          <input id="table-catalog" class="k-input" v-model="form.catalog" :disabled="loading || submitting" autocomplete="off" placeholder="sales" required aria-required="true" aria-describedby="table-catalog-hint table-form-error" :aria-invalid="!!formError" />
+          <span id="table-catalog-hint" class="field-hint">The Databricks catalog containing the table.</span>
+        </label>
+        <label class="field" for="table-schema">
+          <span class="field-label">Schema</span>
+          <input id="table-schema" class="k-input" v-model="form.schema" :disabled="loading || submitting" autocomplete="off" placeholder="gold" required aria-required="true" aria-describedby="table-schema-hint table-form-error" :aria-invalid="!!formError" />
+          <span id="table-schema-hint" class="field-hint">The Databricks schema containing the table.</span>
+        </label>
+        <label class="field" for="table-table">
+          <span class="field-label">Table</span>
+          <input id="table-table" class="k-input" v-model="form.table" :disabled="loading || submitting" autocomplete="off" placeholder="order_history" required aria-required="true" aria-describedby="table-table-hint table-form-error" :aria-invalid="!!formError" />
+          <span id="table-table-hint" class="field-hint">The exact table identifier in the selected catalog and schema.</span>
+        </label>
+      </div>
+      </div>
+      <div class="k-create-actions">
+        <span v-if="formError" id="table-form-error" ref="formErrorRef" class="error" role="alert" aria-live="assertive" tabindex="-1">{{ formError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" :disabled="loading || submitting || !!tableImportBlocker">{{ submitting ? 'Registering…' : 'Register table' }}</button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/providers/databricks/portal/src/views/CreateWarehouseView.vue
+++ b/providers/databricks/portal/src/views/CreateWarehouseView.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { ArrowLeft, LoaderCircle, RefreshCw } from 'lucide-vue-next'
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { api } from '../api'
+import { contextGenerationKey } from '../context'
+import {
+  createOperationLocks,
+  operationKey,
+} from '../refresh'
+import { resourceNameError } from '../resourceName'
+import type { Connection, ErrorResponse } from '../types'
+
+const emit = defineEmits<{
+  (event: 'cancel'): void
+  (event: 'created', name: string): void
+}>()
+
+const connections = ref<Connection[]>([])
+const loading = ref(false)
+const loaded = ref(false)
+const loadError = ref<string | null>(null)
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+const nameInput = ref<HTMLInputElement | null>(null)
+const formErrorRef = ref<HTMLElement | null>(null)
+const operations = createOperationLocks()
+const contextGeneration = inject(contextGenerationKey, ref(0))
+
+// Route-owned forms may be replaced while a read or write is in flight. Every
+// async continuation must belong to the mounted form and latest attempt that
+// started it.
+let mounted = false
+let readGeneration = 0
+let mutationGeneration = 0
+
+interface ReadToken {
+  generation: number
+  context: number
+}
+
+const form = reactive({
+  name: '',
+  connectionRef: '',
+  warehouseID: '',
+})
+
+const hasConnections = computed(() => connections.value.length > 0)
+
+function errMessage(error: unknown): string {
+  const response = error as Partial<ErrorResponse>
+  return response.reason ? `${response.reason}: ${response.message}` : response.message || String(error)
+}
+
+function isCurrentRead(generation: number, expectedContext: number): boolean {
+  return mounted && generation === readGeneration && contextGeneration.value === expectedContext
+}
+
+function isCurrentMutation(generation: number, expectedContext: number): boolean {
+  return mounted && generation === mutationGeneration && contextGeneration.value === expectedContext
+}
+
+async function load(): Promise<ReadToken | null> {
+  const generation = ++readGeneration
+  const expectedContext = contextGeneration.value
+  loading.value = true
+  loaded.value = false
+  loadError.value = null
+  try {
+    const availableConnections = await api.listConnections()
+    if (!isCurrentRead(generation, expectedContext)) return null
+    connections.value = availableConnections
+    if (!connections.value.some(connection => connection.name === form.connectionRef)) {
+      form.connectionRef = connections.value[0]?.name ?? ''
+    }
+    loaded.value = true
+    return { generation, context: expectedContext }
+  } catch (error) {
+    if (!isCurrentRead(generation, expectedContext)) return null
+    loadError.value = errMessage(error)
+    return null
+  } finally {
+    if (isCurrentRead(generation, expectedContext)) loading.value = false
+  }
+}
+
+async function focusFormError(message: string, generation: number, expectedContext: number): Promise<void> {
+  if (!isCurrentMutation(generation, expectedContext)) return
+  formError.value = message
+  await nextTick()
+  if (isCurrentMutation(generation, expectedContext)) formErrorRef.value?.focus()
+}
+
+async function submit(): Promise<void> {
+  if (!mounted || submitting.value) return
+  const generation = ++mutationGeneration
+  const expectedContext = contextGeneration.value
+  formError.value = null
+  if (!loaded.value) {
+    await focusFormError('Connection list is still loading. Retry the read before creating a warehouse.', generation, expectedContext)
+    return
+  }
+  if (!form.name || !form.connectionRef || !form.warehouseID) {
+    await focusFormError('Name, connection, and warehouse ID are required.', generation, expectedContext)
+    return
+  }
+  const nameError = resourceNameError(form.name, 'Name')
+  if (nameError) {
+    await focusFormError(nameError, generation, expectedContext)
+    return
+  }
+  const desiredName = form.name.trim()
+  const payload = {
+    name: desiredName,
+    connectionRef: form.connectionRef,
+    warehouseID: form.warehouseID,
+  }
+  const lock = operationKey('warehouse', desiredName)
+  if (!operations.acquire(lock, 'creating')) {
+    await focusFormError(`Warehouse "${desiredName}" already has an update in progress.`, generation, expectedContext)
+    return
+  }
+  submitting.value = true
+  try {
+    // Re-read both authoritative collections immediately before applying. A
+    // list page can be stale while this route-owned form remains open.
+    const [existing, availableConnections] = await Promise.all([
+      api.listWarehouses(),
+      api.listConnections(),
+    ])
+    if (!isCurrentMutation(generation, expectedContext)) return
+    operations.reconcile('warehouse', existing.map(({ name, uid }) => ({ name, uid })))
+    if (operations.isTombstoned(lock)) {
+      await focusFormError(`Warehouse "${desiredName}" is still being removed. Retry after the list refresh confirms it is gone.`, generation, expectedContext)
+      return
+    }
+    if (existing.some(warehouse => warehouse.name === desiredName)) {
+      await focusFormError(`Warehouse "${desiredName}" already exists.`, generation, expectedContext)
+      return
+    }
+    if (!availableConnections.some(connection => connection.name === payload.connectionRef)) {
+      await focusFormError('Selected connection is no longer available in this workspace.', generation, expectedContext)
+      return
+    }
+    const created = await api.saveWarehouse(payload)
+    if (!isCurrentMutation(generation, expectedContext)) return
+    emit('created', created.name)
+  } catch (error) {
+    await focusFormError(errMessage(error), generation, expectedContext)
+  } finally {
+    operations.release(lock)
+    if (isCurrentMutation(generation, expectedContext)) submitting.value = false
+  }
+}
+
+function cancel(): void {
+  if (!submitting.value) emit('cancel')
+}
+
+onMounted(() => {
+  mounted = true
+  void load().then(readToken => {
+    if (readToken && isCurrentRead(readToken.generation, readToken.context)) nameInput.value?.focus()
+  })
+})
+
+onBeforeUnmount(() => {
+  mounted = false
+  readGeneration += 1
+  mutationGeneration += 1
+})
+</script>
+
+<template>
+  <section class="page k-create-page" :aria-busy="loading || submitting ? 'true' : 'false'">
+    <button class="k-btn k-btn--ghost k-back-action" type="button" :disabled="submitting" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Warehouses
+    </button>
+    <header class="k-create-header">
+      <h2 class="k-create-title">Register warehouse</h2>
+      <p class="k-create-description">Register a Databricks SQL warehouse for table imports.</p>
+    </header>
+
+    <form class="k-create-surface" @submit.prevent="submit">
+      <div class="k-create-body">
+      <p v-if="loading" class="muted" role="status"><LoaderCircle class="spin" :size="14" aria-hidden="true" /> Loading connections…</p>
+      <p v-if="loadError" class="error" role="alert" aria-live="assertive">
+        <span>Could not load warehouse prerequisites: {{ loadError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" @click="load"><RefreshCw :size="14" aria-hidden="true" /> Retry</button>
+      </p>
+      <p v-if="loaded && !hasConnections" class="prerequisite" role="status">
+        Add a connection before registering a warehouse.
+      </p>
+        <div class="field">
+          <label class="field-label" for="warehouse-connection">Connection</label>
+          <select id="warehouse-connection" class="k-input" v-model="form.connectionRef" :disabled="loading || submitting || !hasConnections" required aria-required="true" aria-describedby="warehouse-connection-hint warehouse-form-error" :aria-invalid="!!formError">
+            <option value="" disabled>Select connection</option>
+            <option v-for="conn in connections" :key="conn.name" :value="conn.name">{{ conn.name }}</option>
+          </select>
+          <span id="warehouse-connection-hint" class="field-hint">The Databricks workspace connection this warehouse belongs to.</span>
+        </div>
+        <div class="field">
+          <label class="field-label" for="warehouse-name">Object name</label>
+          <input id="warehouse-name" ref="nameInput" class="k-input" v-model="form.name" :disabled="loading || submitting" placeholder="orders-sql" autocomplete="off" required aria-required="true" aria-describedby="warehouse-name-hint warehouse-form-error" :aria-invalid="!!formError" />
+          <span id="warehouse-name-hint" class="field-hint">How this warehouse is referred to from faros. Use lowercase letters, numbers, and hyphens; the name is preserved exactly.</span>
+        </div>
+        <div class="field">
+          <label class="field-label" for="warehouse-id">Warehouse ID</label>
+          <input id="warehouse-id" class="k-input" v-model="form.warehouseID" :disabled="loading || submitting" placeholder="abc123def4567890" autocomplete="off" required aria-required="true" aria-describedby="warehouse-id-hint warehouse-form-error" :aria-invalid="!!formError" />
+          <span id="warehouse-id-hint" class="field-hint">In Databricks: SQL → SQL Warehouses → open the warehouse. Use the 16-character ID from Connection details (/sql/1.0/warehouses/&lt;id&gt;), not the numeric ?o= workspace ID. The token identity needs “Can use” permission.</span>
+        </div>
+      </div>
+      <div class="k-create-actions">
+        <span v-if="formError" id="warehouse-form-error" ref="formErrorRef" class="error" role="alert" aria-live="assertive" tabindex="-1">{{ formError }}</span>
+        <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" :disabled="loading || submitting || !hasConnections">{{ submitting ? 'Registering…' : 'Register warehouse' }}</button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/providers/databricks/portal/src/views/TablesView.vue
+++ b/providers/databricks/portal/src/views/TablesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { computed, nextTick, onActivated, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { RefreshCw } from 'lucide-vue-next'
 import SplitCreateButton from '../components/SplitCreateButton.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
@@ -34,7 +34,7 @@ import {
   type TableFilterValues,
 } from '../databricksPagination'
 
-const emit = defineEmits<{ (e: 'open', name: string): void; (e: 'browse', trigger?: HTMLElement): void }>()
+const emit = defineEmits<{ (e: 'open', name: string): void; (e: 'create', mode: 'manual' | 'browse'): void }>()
 
 const connections = ref<Connection[]>([])
 const warehouses = ref<Warehouse[]>([])
@@ -76,6 +76,7 @@ let fullWalkPending = false
 let supportReadPending = false
 let serverPageReadPending = false
 let forceNextLoad = false
+let activatedOnce = false
 let authorityGeneration = 0
 
 function invalidateCompleteAuthority(): void {
@@ -123,30 +124,9 @@ function resetForm() {
   formError.value = null
 }
 
-function startCreate() {
-  resetForm()
-  showForm.value = true
-  void nextTick(() => nameInput.value?.focus())
-}
-
 function closeForm() {
   resetForm()
   showForm.value = false
-}
-
-function browseCatalog(trigger?: HTMLElement) {
-  if (showForm.value) closeForm()
-  emit('browse', trigger)
-}
-
-// Prefill the Databricks-provided samples catalog (readable in every
-// workspace) so a first import needs no lookup: samples.nyctaxi.trips.
-function fillDemo() {
-  if (!editing.value) form.name = 'nyctaxi-trips'
-  form.catalog = 'samples'
-  form.schema = 'nyctaxi'
-  form.table = 'trips'
-  formError.value = null
 }
 
 function editTable(row: Record<string, unknown>) {
@@ -514,6 +494,13 @@ onMounted(() => {
   mounted = true
   load()
 })
+onActivated(() => {
+  if (!activatedOnce) {
+    activatedOnce = true
+    return
+  }
+  load(true)
+})
 onUnmounted(() => {
   mounted = false
   invalidateCompleteAuthority()
@@ -536,7 +523,7 @@ onUnmounted(() => {
           <RefreshCw class="button-icon" :class="{ spin: loading }" :stroke-width="1.75" />
           {{ loading ? 'Refreshing…' : 'Refresh' }}
         </button>
-        <SplitCreateButton kind="table" :disabled="submitting" @manual="startCreate" @browse="browseCatalog" />
+        <SplitCreateButton kind="table" :disabled="submitting" @manual="emit('create', 'manual')" @browse="emit('create', 'browse')" />
       </div>
     </header>
 
@@ -544,8 +531,7 @@ onUnmounted(() => {
 
     <div v-if="showForm" class="databricks-resource-panel k-card">
       <div class="databricks-resource-panel-head">
-        <h3 class="databricks-resource-panel-title">{{ editing ? 'Update table' : 'Import table' }}</h3>
-        <button v-if="!editing" class="k-btn k-btn--ghost databricks-inline-action" type="button" :disabled="submitting" @click="fillDemo" title="Prefill samples.nyctaxi.trips — Databricks demo data available in every workspace">Fill with demo data</button>
+        <h3 class="databricks-resource-panel-title">Update table</h3>
       </div>
       <div v-if="tableImportBlocker" class="warning" role="status">
         {{ tableImportBlocker }}

--- a/providers/databricks/portal/src/views/WarehousesView.vue
+++ b/providers/databricks/portal/src/views/WarehousesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import SplitCreateButton from '../components/SplitCreateButton.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
@@ -20,7 +20,6 @@ import {
   type LatestRefreshController,
   type ResourceRefreshMode,
 } from '../refresh'
-import { resourceNameError } from '../resourceName'
 import {
   cloneWarehouseFilters,
   databricksHybridTransition,
@@ -35,7 +34,7 @@ import {
   warehouseFilters,
 } from '../databricksPagination'
 
-const emit = defineEmits<{ (e: 'open', name: string): void; (e: 'browse', trigger?: HTMLElement): void }>()
+const emit = defineEmits<{ (e: 'open', name: string): void; (e: 'create', mode: 'manual' | 'browse'): void }>()
 
 const connections = ref<Connection[]>([])
 const warehouses = ref<Warehouse[]>([])
@@ -61,17 +60,13 @@ const warehouseFiltersValue = ref<WarehouseFilterValues>(cloneWarehouseFilters(E
 const warehouseCursor = ref<string | null>(null)
 const warehousePageInfo = ref<ReturnType<typeof toPageInfo> | null>(null)
 
-const showForm = ref(false)
-const submitting = ref(false)
-const formError = ref<string | null>(null)
-const nameInput = ref<HTMLInputElement | null>(null)
-const formErrorRef = ref<HTMLElement | null>(null)
 let poll!: AdaptiveRefreshTimer
 let refresh!: LatestRefreshController
 let mounted = false
 let fullWalkPending = false
 let supportReadPending = false
 let serverPageReadPending = false
+let activatedOnce = false
 let authorityGeneration = 0
 
 function invalidateCompleteAuthority(): void {
@@ -97,24 +92,11 @@ function warehouseStateTone(state: unknown): 'success' | 'warning' | 'danger' | 
   }
 }
 
-const form = reactive({
-  name: '',
-  connectionRef: '',
-  warehouseID: '',
-})
-
 const filterDefinitions = computed(() => warehouseFilters(connections.value))
 
 function errMessage(e: unknown): string {
   const err = e as ErrorResponse
   return err.reason ? `${err.reason}: ${err.message}` : err.message || String(e)
-}
-
-function resetForm() {
-  form.name = ''
-  form.connectionRef = connections.value[0]?.name ?? ''
-  form.warehouseID = ''
-  formError.value = null
 }
 
 const refreshMode = ref<ResourceRefreshMode>('foreground')
@@ -153,88 +135,6 @@ function operationPhase(name: string) {
 
 function openResource(name: string): void {
   if (!operationLocked(name)) emit('open', name)
-}
-
-function startCreate() {
-  resetForm()
-  showForm.value = true
-  void nextTick(() => nameInput.value?.focus())
-}
-
-function closeForm() {
-  resetForm()
-  showForm.value = false
-}
-
-function browseCatalog(trigger?: HTMLElement) {
-  if (showForm.value) closeForm()
-  emit('browse', trigger)
-}
-
-async function focusFormError(message: string) {
-  formError.value = message
-  await nextTick()
-  formErrorRef.value?.focus()
-}
-
-async function submit() {
-  formError.value = null
-  mutationError.value = null
-  if (!loaded.value) {
-    await focusFormError('Warehouse list is still loading. Retry the read before creating a warehouse.')
-    return
-  }
-  if (!form.name || !form.connectionRef || !form.warehouseID) {
-    await focusFormError('Name, connection, and warehouse ID are required.')
-    return
-  }
-  const nameError = resourceNameError(form.name, 'Name')
-  if (nameError) {
-    await focusFormError(nameError)
-    return
-  }
-  const desiredName = form.name.trim()
-  const lock = operationKey('warehouse', desiredName)
-  if (!operations.acquire(lock, 'creating')) {
-    await focusFormError(`Warehouse "${desiredName}" already has an update in progress.`)
-    return
-  }
-  submitting.value = true
-  try {
-    // A server page is not a complete duplicate or foreign-key check. Read
-    // both authoritative collections before applying the new warehouse.
-    const [existing, availableConnections] = await Promise.all([
-      completeRead.request(),
-      api.listConnections(),
-    ])
-    operations.reconcile('warehouse', existing.map(({ name, uid }) => ({ name, uid })))
-    if (operations.isTombstoned(lock)) {
-      await focusFormError(`Warehouse "${desiredName}" is still being removed. Retry after the list refresh confirms it is gone.`)
-      return
-    }
-    if (existing.some(warehouse => warehouse.name === desiredName)) {
-      await focusFormError(`Warehouse "${desiredName}" already exists.`)
-      return
-    }
-    if (!availableConnections.some(connection => connection.name === form.connectionRef)) {
-      await focusFormError('Selected connection is no longer available in this workspace.')
-      return
-    }
-    await api.saveWarehouse({
-      name: desiredName,
-      connectionRef: form.connectionRef,
-      warehouseID: form.warehouseID,
-    })
-    invalidateCompleteAuthority()
-    resetForm()
-    showForm.value = false
-    load()
-  } catch (e) {
-    await focusFormError(errMessage(e))
-  } finally {
-    submitting.value = false
-    operations.release(lock)
-  }
 }
 
 interface WarehouseRequest {
@@ -455,9 +355,6 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
     }
     loaded.value = true
     error.value = null
-    if (connections.value.length && !connections.value.some(c => c.name === form.connectionRef)) {
-      form.connectionRef = connections.value[0].name
-    }
   } catch (e) {
     fullWalkPending = false
     supportReadPending = false
@@ -485,6 +382,13 @@ onMounted(() => {
   mounted = true
   load()
 })
+onActivated(() => {
+  if (!activatedOnce) {
+    activatedOnce = true
+    return
+  }
+  load('foreground')
+})
 onUnmounted(() => {
   mounted = false
   invalidateCompleteAuthority()
@@ -504,38 +408,10 @@ onUnmounted(() => {
         <h2 class="page-title">Warehouses</h2>
         <p class="page-meta">SQL warehouses available to imported Databricks tables. Click one to inspect status and defaults.</p>
       </div>
-      <SplitCreateButton kind="warehouse" :disabled="submitting" @manual="startCreate" @browse="browseCatalog" />
+      <SplitCreateButton kind="warehouse" @manual="emit('create', 'manual')" @browse="emit('create', 'browse')" />
     </header>
 
     <p v-if="loaded && !connections.length" class="empty">Add a connection first, then import warehouses under it.</p>
-
-    <div v-if="showForm" class="databricks-resource-panel k-card">
-      <h3 class="databricks-resource-panel-title">New warehouse</h3>
-      <form class="form" @submit.prevent="submit">
-        <div class="field">
-          <label class="field-label" for="warehouse-connection">Connection</label>
-          <select id="warehouse-connection" class="k-input" v-model="form.connectionRef" :disabled="submitting" required aria-required="true" aria-describedby="warehouse-connection-hint warehouse-form-error" :aria-invalid="!!formError">
-            <option v-for="conn in connections" :key="conn.name" :value="conn.name">{{ conn.name }}</option>
-          </select>
-          <span id="warehouse-connection-hint" class="field-hint">The Databricks workspace connection this warehouse belongs to.</span>
-        </div>
-        <div class="field">
-          <label class="field-label" for="warehouse-name">Object name</label>
-          <input id="warehouse-name" class="k-input" ref="nameInput" v-model="form.name" :disabled="submitting" placeholder="orders-sql" autocomplete="off" required aria-required="true" aria-describedby="warehouse-name-hint warehouse-form-error" :aria-invalid="!!formError" />
-          <span id="warehouse-name-hint" class="field-hint">How this warehouse is referred to from faros. Use lowercase letters, numbers, and hyphens; the name is preserved exactly.</span>
-        </div>
-        <div class="field">
-          <label class="field-label" for="warehouse-id">Warehouse ID</label>
-          <input id="warehouse-id" class="k-input" v-model="form.warehouseID" :disabled="submitting" placeholder="abc123def4567890" autocomplete="off" required aria-required="true" aria-describedby="warehouse-id-hint warehouse-form-error" :aria-invalid="!!formError" />
-          <span id="warehouse-id-hint" class="field-hint">In Databricks: SQL → SQL Warehouses → open the warehouse. Use the 16-character ID from Connection details (/sql/1.0/warehouses/&lt;id&gt;), not the numeric ?o= workspace ID. The token identity needs “Can use” permission.</span>
-        </div>
-        <div class="actions">
-          <button class="k-btn k-btn--primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create' }}</button>
-          <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="closeForm">Cancel</button>
-          <span v-if="formError" id="warehouse-form-error" ref="formErrorRef" class="error" role="alert" aria-live="assertive" tabindex="-1">{{ formError }}</span>
-        </div>
-      </form>
-    </div>
 
     <div v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">
       <span>{{ mutationError }}</span>

--- a/providers/databricks/portal/tsconfig.test.json
+++ b/providers/databricks/portal/tsconfig.test.json
@@ -24,6 +24,9 @@
     "src/resourceName.test.ts",
     "src/tableRefs.ts",
     "src/tableRefs.test.ts",
+    "src/route.ts",
+    "src/navigation.ts",
+    "src/route.test.ts",
     "src/components/splitCreate.ts",
     "src/components/splitCreate.test.ts",
     "src/types.ts"

--- a/providers/edges/portal/src/App.vue
+++ b/providers/edges/portal/src/App.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
-import { Server, Boxes, RefreshCw, Plus, Plug } from 'lucide-vue-next'
+import { Server, Boxes, Plug } from 'lucide-vue-next'
 import { setToken, setTenant, listEdges, deleteEdge } from './api'
 import Wizard from './Wizard.vue'
 import Detail from './Detail.vue'
+import EdgeCollection from './EdgeCollection.vue'
 import Workloads from './Workloads.vue'
 import Services from './Services.vue'
+import ServiceCreate from './ServiceCreate.vue'
+import WorkloadCreate from './WorkloadCreate.vue'
 import ConfirmDialog from './portalkit/ConfirmDialog.vue'
-import ResourceTable from './portalkit/ResourceTable.vue'
-import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
-import StatusBadge from './portalkit/StatusBadge.vue'
 import Tabs from './portalkit/Tabs.vue'
 import { confirmDialog } from './portalkit/confirm'
 import {
@@ -20,36 +20,23 @@ import {
   type ResourceRefreshMode,
 } from './refresh'
 import type { Edge, EdgeType, FarosContext, ErrorResponse } from './types'
+import {
+  edgeDetailPath,
+  navigationDetail,
+  parseSubPath,
+  serviceCreatePath,
+  serviceDetailPath,
+  workloadDeployPath,
+  type EdgeRoute,
+} from './routes'
 
 const props = defineProps<{ ctx: FarosContext | null }>()
 
-// Top-level view is driven by the shell route: /providers/edges → the edges
-// fleet; /providers/edges/workloads → the workloads scheduled across them. The
-// sidebar renders both as nav items (CatalogEntry ui.children), so switching
-// happens via the menu; the in-page toggle mirrors it through navigate().
-const view = computed<'edges' | 'workloads' | 'services'>(() => {
-  const sub = props.ctx?.subPath ?? ''
-  if (sub.startsWith('workloads')) return 'workloads'
-  if (sub.startsWith('services')) return 'services'
-  return 'edges'
-})
-
-// Services use a single URL-owned instance segment in addition to the
-// existing list route. Keep the encoded segment intact when decoding fails so
-// a malformed deep link reaches the instance read and reports not-found/error
-// state instead of silently falling back to the list.
-const selectedServiceName = computed<string | null>(() => {
-  const sub = props.ctx?.subPath ?? ''
-  if (!sub.startsWith('services/')) return null
-  const encodedName = sub.slice('services/'.length)
-  if (!encodedName) return ''
-  try {
-    return decodeURIComponent(encodedName)
-  } catch {
-    return encodedName
-  }
-})
-const serviceDetailRoute = computed(() => selectedServiceName.value !== null)
+// The shell owns the provider prefix and passes only the trailing path. Every
+// consequential action is represented here so browser refresh/back/forward
+// return to the same page and no stale local overlay can capture the UI.
+const route = computed<EdgeRoute>(() => parseSubPath(props.ctx?.subPath))
+const view = computed(() => route.value.page)
 
 const edgeRouteTabs = [
   { id: 'edges', label: 'Edges', icon: Server },
@@ -58,45 +45,52 @@ const edgeRouteTabs = [
 ] as const
 
 // navigate pushes the shell's router via a bubbling CustomEvent the element's
-// ProviderFrame host listens for. path is the trailing segment appended to
-// /providers/edges/ (empty = the edges list).
+// ProviderFrame host listens for. path is relative to /providers/edges/.
 const rootRef = ref<HTMLElement | null>(null)
-function navigate(path: string) {
-  rootRef.value?.dispatchEvent(new CustomEvent('faros-navigate', { detail: { path }, bubbles: true }))
+function navigate(path: string, replace = false) {
+  rootRef.value?.dispatchEvent(new CustomEvent('faros-navigate', {
+    detail: navigationDetail(path, replace),
+    bubbles: true,
+  }))
 }
 
-function onServiceNavigate(name: string | null): void {
-  navigate(name === null ? 'services' : `services/${encodeURIComponent(name)}`)
+function selectView(id: string): void {
+  // Keep the provider landing page canonical at /providers/edges; the parser
+  // also accepts the explicit `edges` collection alias for deep links.
+  navigate(id === 'edges' ? '' : id)
 }
 
-// The wizard shows automatically on first load when the workspace has no edges,
-// and on demand via "Connect edge". It closes back to the list on completion.
-const wizardOpen = ref(false)
+function onServiceNavigate(name: string | null, options?: { replace?: boolean }): void {
+  navigate(name === null ? 'services' : serviceDetailPath(name), options?.replace === true)
+}
+
+// The first empty read redirects to the same connect route users can open from
+// the collection. firstLoadDone prevents a cancel/back cycle from reopening it.
 const firstLoadDone = ref(false)
+const workloadResult = ref<string | null>(null)
 
-// Selected edge → detail view. Null = list.
-const selected = ref<{ name: string; type: EdgeType } | null>(null)
-
-function openDetail(e: Edge) {
-  selected.value = { name: e.name, type: e.type }
+function onEdgeCreated(name: string, type: EdgeType): void {
+  navigate(edgeDetailPath(type, name), true)
 }
-function closeDetail() {
-  selected.value = null
-  refresh()
+function onServiceCreated(name: string): void {
+  navigate(serviceDetailPath(name), true)
+}
+function onEdgeDeleted(): void {
+  navigate('', true)
+  void refresh()
+}
+function onWorkloadCompleted(message: string): void {
+  workloadResult.value = message
+  navigate('workloads', true)
+}
+function onWorkloadDismissResult(): void {
+  workloadResult.value = null
 }
 
-// The shell sidebar (Workloads/Services nav items) changes the route while
-// the detail or wizard overlay is open. The route must win: the template
-// gates every view on !selected/!wizardOpen, so without closing them here
-// the overlay keeps rendering and the sidebar appears dead.
-watch(view, (v) => {
-  selected.value = null
-  wizardOpen.value = false
-  if (v === 'edges') refresh()
-})
-watch(serviceDetailRoute, (isDetail) => {
-  if (isDetail) wizardOpen.value = false
-})
+function openDetail(row: Record<string, unknown>): void {
+  const type = row.type === 'server' ? 'server' : 'kubernetes'
+  navigate(edgeDetailPath(type, String(row.name)))
+}
 
 const edges = ref<Edge[]>([])
 const loading = ref(true)
@@ -107,23 +101,6 @@ const foregroundLoading = computed(() => loading.value && refreshMode.value === 
 // the shell changes tenant or token so a prior workspace's rows and cursors
 // cannot remain visible while the new context is loading.
 const contextGeneration = ref(0)
-const edgeColumns = [
-  { key: 'name', label: 'Name' },
-  { key: 'typeLabel', label: 'Type' },
-  { key: 'status', label: 'Status' },
-  { key: 'agentVersion', label: 'Agent' },
-  { key: 'lastHeartbeat', label: 'Last heartbeat' },
-  { key: 'actions', label: '' },
-]
-const edgeRows = computed<Array<Record<string, unknown>>>(() => edges.value.map(edge => ({
-  ...edge,
-  rowKey: `${edge.type}/${edge.name}`,
-  typeLabel: edge.type === 'server' ? 'Server' : 'Kubernetes',
-  status: edge.connected ? 'Connected' : (edge.phase || 'Disconnected'),
-  agentVersion: edge.agentVersion || '—',
-  lastHeartbeat: rel(edge.lastHeartbeatTime),
-  actions: '',
-})))
 
 const poller = createAdaptiveRefreshTimer(() => {
   if (props.ctx?.tenant) void refresh('background')
@@ -142,10 +119,12 @@ const edgeRefresh = createLatestRefreshController(async (requestID, mode) => {
     if (!edgeRefresh.isCurrent(requestID)) return
     edges.value = nextEdges
     error.value = null
-    // Auto-open the wizard the first time we confirm the workspace has no edges.
+    // Redirect to the route-owned wizard the first time we confirm the
+    // workspace has no edges. The flag remains set after cancellation.
     if (!firstLoadDone.value) {
       firstLoadDone.value = true
-      if (edges.value.length === 0 && !serviceDetailRoute.value) wizardOpen.value = true
+      const collectionRoute = route.value.page === 'edges' && !route.value.edge && !route.value.connect
+      if (edges.value.length === 0 && collectionRoute) navigate('connect/edge', true)
     }
   } catch (e) {
     if (!edgeRefresh.isCurrent(requestID)) return
@@ -165,9 +144,11 @@ function refresh(mode: ResourceRefreshMode | Event = 'foreground') {
   return edgeRefresh.request(requestedMode)
 }
 
-function onWizardDone() {
-  wizardOpen.value = false
-  refresh()
+function onEdgeCollectionActivated(): void {
+  // The first activation happens before the initial authoritative read, so
+  // avoid a duplicate request. Every later activation follows a detail/action
+  // route and revalidates rows without remounting ResourceTable's state.
+  if (firstLoadDone.value) void refresh('foreground')
 }
 
 async function onDelete(edge: Edge) {
@@ -192,6 +173,7 @@ watch(
       edgeRefresh.invalidate()
       edges.value = []
       firstLoadDone.value = false
+      workloadResult.value = null
       loading.value = Boolean(tenant)
       error.value = null
       if (tenant) void refresh('foreground')
@@ -210,112 +192,96 @@ onUnmounted(() => {
   poller.stop()
 })
 
-function rel(ts?: string): string {
-  if (!ts) return '—'
-  const d = new Date(ts).getTime()
-  if (Number.isNaN(d)) return '—'
-  const secs = Math.max(0, Math.floor((Date.now() - d) / 1000))
-  if (secs < 60) return `${secs}s ago`
-  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
-  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
-  return `${Math.floor(secs / 86400)}d ago`
-}
-
-function edgeRowAriaLabel(row: Record<string, unknown>): string {
-  return `Open ${row.type === 'server' ? 'server' : 'Kubernetes'} edge ${String(row.name)}`
-}
 </script>
 
 <template>
   <div ref="rootRef" class="edges-app" :key="contextGeneration">
-    <!-- Section nav: Edges | Workloads | Services. Mirrors the sidebar's sub-nav
-         items and pushes the shell route via navigate(). Hidden while the wizard
-         or a detail view is open so those flows stay focused. -->
-    <template v-if="!serviceDetailRoute">
-      <Tabs
-        v-if="!wizardOpen && !selected"
-        :tabs="edgeRouteTabs"
-        :active="view"
-        aria-label="Edges sections"
-        @select="(id) => navigate(id === 'edges' ? '' : id)"
-      />
-    </template>
-
-    <!-- Workloads view. -->
-    <Workloads v-if="view === 'workloads' && !wizardOpen && !selected" />
-
-    <!-- Services view. -->
-    <!-- The original self-closing list shape remains documented for the
-         conformance contract; the two concrete branches below keep the list
-         and URL-owned instance paths mutually exclusive. -->
-    <!-- <Services v-else-if="view === 'services' && !wizardOpen && !selected" /> -->
-    <Services
-      v-else-if="view === 'services' && !wizardOpen && !selected && !serviceDetailRoute"
-      @navigate="onServiceNavigate"
-    />
-    <Services
-      v-else-if="view === 'services' && !wizardOpen && !selected && serviceDetailRoute"
-      :selected-name="selectedServiceName"
-      @navigate="onServiceNavigate"
+    <Tabs
+      v-if="!route.edge && !route.service && !route.connect && !route.create && !route.deploy"
+      :tabs="edgeRouteTabs"
+      :active="view"
+      aria-label="Edges sections"
+      @select="selectView"
     />
 
-    <!-- Onboarding / add-edge wizard (shown on first load when empty, or on demand). -->
-    <Wizard v-else-if="wizardOpen" :cluster="props.ctx?.tenant ?? null" @connected="onWizardDone" />
-
-    <!-- Per-edge detail view. -->
+    <ServiceCreate
+      v-if="route.create?.resource === 'service'"
+      :key="`create-service:${contextGeneration}:${route.create.edgeType ?? 'any'}:${route.create.edgeName ?? ''}`"
+      :initial-edge-type="route.create.edgeType"
+      :initial-edge-name="route.create.edgeName"
+      @cancel="navigate('services', true)"
+      @created="onServiceCreated"
+    />
+    <WorkloadCreate
+      v-if="route.deploy?.resource === 'workload'"
+      :key="`deploy-workload:${contextGeneration}:${route.deploy.mode}:${route.deploy.app ?? ''}`"
+      :mode="route.deploy.mode"
+      :app-type="route.deploy.app"
+      @cancel="navigate('workloads', true)"
+      @completed="onWorkloadCompleted"
+    />
+    <Wizard
+      v-if="route.connect?.resource === 'edge'"
+      :cluster="props.ctx?.tenant ?? null"
+      @cancel="navigate('', true)"
+      @created="onEdgeCreated"
+    />
     <Detail
-      v-else-if="selected"
-      :name="selected.name"
-      :type="selected.type"
+      v-if="route.edge"
+      :key="`edge-detail:${contextGeneration}:${route.edge.type}:${route.edge.name}`"
+      :name="route.edge.name"
+      :type="route.edge.type"
       :cluster="props.ctx?.tenant ?? null"
       :token="props.ctx?.token ?? null"
-      @back="closeDetail"
-      @deleted="closeDetail"
+      @back="navigate('', true)"
+      @deleted="onEdgeDeleted"
+      @add-service="navigate(serviceCreatePath(route.edge.type, route.edge.name))"
     />
-
-    <template v-else>
-    <header class="edges-header">
-      <div>
-        <h1>Edges</h1>
-        <p>Kubernetes clusters and Linux/SSH servers connected to this workspace.</p>
-      </div>
-      <div class="header-actions">
-        <button class="k-btn k-btn--ghost" :disabled="foregroundLoading" @click="refresh">
-          <RefreshCw :size="14" :class="{ spin: foregroundLoading }" /> {{ foregroundLoading ? 'Refreshing…' : 'Refresh' }}
-        </button>
-        <button class="k-btn k-btn--primary" @click="wizardOpen = true">
-          <Plus :size="14" /> Connect edge
-        </button>
-      </div>
-    </header>
-
-    <ResourceTable
-      :columns="edgeColumns"
-      :rows="edgeRows"
-      row-key="rowKey"
-      :row-aria-label="edgeRowAriaLabel"
-      :loaded="firstLoadDone"
-      :loading="loading"
-      :refresh-mode="refreshMode"
-      :error="error"
-      retryable
-      searchable
-      search-placeholder="Search edges…"
-      :filters="[{ key: 'typeLabel', label: 'Type' }, { key: 'status', label: 'Status', allLabel: 'Any status' }]"
-      paginated
-      :page-size="10"
-      empty-text="No edges connected yet. Connect an edge to get started."
-      @retry="refresh"
-      @row-click="(row) => openDetail(row as unknown as Edge)"
-    >
-      <template #name="{ value }"><span class="name">{{ value }}</span></template>
-      <template #typeLabel="{ value, row }"><span class="k-badge k-badge--muted"><component :is="row.type === 'server' ? Server : Boxes" :size="12" />{{ value }}</span></template>
-      <template #status="{ value }"><StatusBadge :status="String(value)" /></template>
-      <template #agentVersion="{ value }"><span class="mono muted">{{ value }}</span></template>
-      <template #lastHeartbeat="{ value }"><span class="muted">{{ value }}</span></template>
-      <template #actions="{ row }"><div class="row-actions"><ResourceTableDeleteButton :label="`Delete edge ${String(row.name)}`" @click="onDelete(row as unknown as Edge)" /></div></template>
-    </ResourceTable>
-    </template>
+    <Services
+      v-if="route.page === 'services' && route.service"
+      :key="`service-detail:${contextGeneration}:${route.service}`"
+      :selected-name="route.service"
+      @navigate="onServiceNavigate"
+    />
+    <!-- Keep collection instances alive while a route-owned create/detail page
+         is active, so search/filter/page/scroll state returns unchanged. The
+         route still owns every consequential form; this only preserves the
+         read-only collection snapshot behind it. -->
+    <KeepAlive>
+      <Services
+        v-if="route.page === 'services' && !route.service && !route.create"
+        :key="`services:${contextGeneration}`"
+        @navigate="onServiceNavigate"
+        @create="navigate('create/service')"
+      />
+    </KeepAlive>
+    <KeepAlive>
+      <Workloads
+        v-if="route.page === 'workloads' && !route.deploy"
+        :key="`workloads:${contextGeneration}`"
+        :result="workloadResult"
+        @create="navigate('deploy/workload/manual')"
+        @deploy="(app) => navigate(workloadDeployPath('marketplace', app.type))"
+        @dismiss-result="onWorkloadDismissResult"
+      />
+    </KeepAlive>
+    <KeepAlive>
+      <EdgeCollection
+        v-if="route.page === 'edges' && !route.edge && !route.connect"
+        :key="`edges:${contextGeneration}`"
+        :edges="edges"
+        :loaded="firstLoadDone"
+        :loading="loading"
+        :refresh-mode="refreshMode"
+        :error="error"
+        :foreground-loading="foregroundLoading"
+        @activated="onEdgeCollectionActivated"
+        @refresh="refresh"
+        @open="openDetail"
+        @delete="onDelete"
+        @connect="navigate('connect/edge')"
+      />
+    </KeepAlive>
     <ConfirmDialog />
   </div>
 </template>

--- a/providers/edges/portal/src/Detail.vue
+++ b/providers/edges/portal/src/Detail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { ArrowLeft, ArrowUpCircle, Boxes, Cable, Check, ChevronDown, ChevronUp, Cloud, Copy, Cpu, Ellipsis, Globe2, Home, Plug, Plus, RefreshCw, Server, TerminalSquare, Trash2 } from 'lucide-vue-next'
-import { getEdge, deleteEdge, listEdgeServices, connectEdgeService, createKubeEdgeService, deleteEdgeService } from './api'
+import { getEdge, deleteEdge, listEdgeServices, connectEdgeService, deleteEdgeService } from './api'
 import { confirmDialog } from './portalkit/confirm'
 import ConditionsPanel from './portalkit/ConditionsPanel.vue'
 import ResourcePage from './portalkit/ResourcePage.vue'
@@ -19,7 +19,7 @@ import {
 import type { EdgeDetail, EdgeService, EdgeType, ErrorResponse } from './types'
 
 const props = defineProps<{ name: string; type: EdgeType; cluster: string | null; token: string | null }>()
-const emit = defineEmits<{ back: []; deleted: [] }>()
+const emit = defineEmits<{ back: []; deleted: []; addService: [] }>()
 
 // SSH terminals dock at the bottom of the host portal (survives page
 // navigation) rather than rendering inline here. The provider is an isolated
@@ -88,7 +88,7 @@ function load(mode: ResourceRefreshMode | Event = 'foreground') {
 // Retry uses the same complete snapshot so the summary and service section do
 // not disagree after an explicit recovery.
 async function refreshDetail() {
-  if (deleting.value || detailRefreshing.value || saving.value || connecting.value) return
+  if (deleting.value || detailRefreshing.value || connecting.value) return
   await load('foreground')
 }
 
@@ -311,47 +311,6 @@ function loadServices() {
   return load('foreground')
 }
 
-// Declare-service form (kube edges only).
-const adding = ref(false)
-const saving = ref(false)
-const draft = ref({ name: '', serviceType: 'home-assistant', targetNamespace: '', targetName: '', port: 8123 })
-
-function startAdd() {
-  servicesExpanded.value = true
-  adding.value = true
-  draft.value = { name: '', serviceType: 'home-assistant', targetNamespace: '', targetName: '', port: 8123 }
-}
-
-const draftValid = computed(
-  () =>
-    !!draft.value.name.trim() &&
-    !!draft.value.targetNamespace.trim() &&
-    !!draft.value.targetName.trim() &&
-    draft.value.port > 0,
-)
-
-async function submitAdd() {
-  if (!draftValid.value) return
-  saving.value = true
-  svcError.value = null
-  try {
-    await createKubeEdgeService({
-      name: draft.value.name.trim(),
-      edgeName: props.name,
-      serviceType: draft.value.serviceType,
-      targetNamespace: draft.value.targetNamespace.trim(),
-      targetName: draft.value.targetName.trim(),
-      port: Number(draft.value.port),
-    })
-    adding.value = false
-    await loadServices()
-  } catch (e) {
-    svcError.value = (e as ErrorResponse)?.message ?? 'Failed to add service'
-  } finally {
-    saving.value = false
-  }
-}
-
 async function removeService(name: string) {
   if (!(await confirmDialog({ title: `Delete service "${name}"?`, danger: true, confirmLabel: 'Delete' }))) return
   try {
@@ -474,7 +433,7 @@ onUnmounted(() => {
             <button
               type="button"
               class="k-btn k-btn--ghost"
-              :disabled="detailRefreshing || deleting || saving || connecting"
+              :disabled="detailRefreshing || deleting || connecting"
               :aria-busy="detailRefreshing || undefined"
               @click="refreshDetail"
             >
@@ -490,7 +449,7 @@ onUnmounted(() => {
                 <button
                   type="button"
                   class="edge-detail__menu-item"
-                  :disabled="!edge || deleting || detailRefreshing || saving || connecting"
+                  :disabled="!edge || deleting || detailRefreshing || connecting"
                   @click="onDelete"
                 >
                   Delete {{ type === 'server' ? 'server' : 'cluster' }}
@@ -651,39 +610,14 @@ kubectl --kubeconfig {{ name }}.kubeconfig get nodes</pre>
                     type="button"
                     class="k-btn k-btn--ghost"
                     :disabled="deleting"
-                    :aria-expanded="adding"
-                    aria-controls="edges-service-create"
-                    @click="startAdd"
+                    @click="emit('addService')"
                   ><Plus :size="14" aria-hidden="true" /> Add service</button>
                 </div>
 
-                <!-- Declare form (kube edges); opening Add service reveals it. -->
-                <div v-if="adding" id="edges-service-create" class="svc-card k-card">
-                  <div class="svc-head"><span class="svc-title"><Plus :size="15" aria-hidden="true" /> New service</span></div>
-                  <div class="svc-form">
-                    <label>Name<input v-model="draft.name" class="svc-input k-input" placeholder="home-assistant" /></label>
-                    <label>Type
-                      <select v-model="draft.serviceType" class="svc-input k-input">
-                        <option value="home-assistant">Home Assistant</option>
-                        <option value="generic">Generic (proxy only)</option>
-                      </select>
-                    </label>
-                    <label>Target namespace<input v-model="draft.targetNamespace" class="svc-input k-input" placeholder="home" /></label>
-                    <label>Target service<input v-model="draft.targetName" class="svc-input k-input" placeholder="home-assistant" /></label>
-                    <label>Port<input v-model.number="draft.port" type="number" class="svc-input k-input" placeholder="8123" /></label>
-                  </div>
-                  <div class="wiz-actions" style="justify-content: flex-start;">
-                    <button class="k-btn k-btn--primary" :disabled="saving || !draftValid" @click="submitAdd">
-                      {{ saving ? 'Adding…' : 'Add service' }}
-                    </button>
-                    <button class="k-btn k-btn--ghost" :disabled="saving" @click="adding = false">Cancel</button>
-                  </div>
-                </div>
-
-                <div v-if="!servicesLoaded && !svcError && !adding" class="muted" role="status" aria-live="polite">
+                <div v-if="!servicesLoaded && !svcError" class="muted" role="status" aria-live="polite">
                   Loading services…
                 </div>
-                <div v-else-if="servicesLoaded && services.length === 0 && !adding" class="muted">
+                <div v-else-if="servicesLoaded && services.length === 0" class="muted">
                   {{ type === 'server'
                     ? 'No services discovered yet. Discovery runs when the agent is connected.'
                     : 'No services declared yet. Add one to point at a Kubernetes Service in this cluster.' }}

--- a/providers/edges/portal/src/EdgeCollection.vue
+++ b/providers/edges/portal/src/EdgeCollection.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { computed, onActivated } from 'vue'
+import { Boxes, Plus, RefreshCw, Server } from 'lucide-vue-next'
+import ResourceTable from './portalkit/ResourceTable.vue'
+import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
+import StatusBadge from './portalkit/StatusBadge.vue'
+import type { ResourceRefreshMode } from './refresh'
+import type { Edge } from './types'
+
+const props = defineProps<{
+  edges: Edge[]
+  loaded: boolean
+  loading: boolean
+  refreshMode: ResourceRefreshMode
+  error: string | null
+  foregroundLoading: boolean
+}>()
+
+const emit = defineEmits<{
+  activated: []
+  refresh: []
+  open: [row: Record<string, unknown>]
+  delete: [edge: Edge]
+  connect: []
+}>()
+
+const edgeColumns = [
+  { key: 'name', label: 'Name' },
+  { key: 'typeLabel', label: 'Type' },
+  { key: 'status', label: 'Status' },
+  { key: 'agentVersion', label: 'Agent' },
+  { key: 'lastHeartbeat', label: 'Last heartbeat' },
+  { key: 'actions', label: '' },
+]
+
+const edgeRows = computed(() => props.edges.map(edge => ({
+  ...edge,
+  rowKey: `${edge.type}/${edge.name}`,
+  typeLabel: edge.type === 'server' ? 'Server' : 'Kubernetes',
+  status: edge.connected ? 'Connected' : (edge.phase || 'Disconnected'),
+  agentVersion: edge.agentVersion || '—',
+  lastHeartbeat: relativeTime(edge.lastHeartbeatTime),
+  actions: '',
+})))
+
+function edgeRowAriaLabel(row: Record<string, unknown>): string {
+  return `Open ${row.type === 'server' ? 'server' : 'Kubernetes'} edge ${String(row.name)}`
+}
+
+function relativeTime(timestamp?: string): string {
+  if (!timestamp) return '—'
+  const date = new Date(timestamp).getTime()
+  if (Number.isNaN(date)) return '—'
+  const seconds = Math.max(0, Math.floor((Date.now() - date) / 1000))
+  if (seconds < 60) return `${seconds}s ago`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
+  return `${Math.floor(seconds / 86400)}d ago`
+}
+
+// App keeps this component alive while detail/connect routes are active. The
+// table therefore retains its own query, filters, cursor, page, and scroll
+// state; App revalidates the authoritative rows when the collection returns.
+onActivated(() => emit('activated'))
+</script>
+
+<template>
+  <div class="edges-app">
+    <header class="edges-header">
+      <div>
+        <h1>Edges</h1>
+        <p>Kubernetes clusters and Linux/SSH servers connected to this workspace.</p>
+      </div>
+      <div class="header-actions">
+        <button class="k-btn k-btn--ghost" :disabled="props.foregroundLoading" @click="emit('refresh')">
+          <RefreshCw :size="14" :class="{ spin: props.foregroundLoading }" /> {{ props.foregroundLoading ? 'Refreshing…' : 'Refresh' }}
+        </button>
+        <button class="k-btn k-btn--primary" @click="emit('connect')">
+          <Plus :size="14" /> Connect edge
+        </button>
+      </div>
+    </header>
+
+    <ResourceTable
+      :columns="edgeColumns"
+      :rows="edgeRows"
+      row-key="rowKey"
+      :row-aria-label="edgeRowAriaLabel"
+      :loaded="props.loaded"
+      :loading="props.loading"
+      :refresh-mode="props.refreshMode"
+      :error="props.error"
+      retryable
+      searchable
+      search-placeholder="Search edges…"
+      :filters="[{ key: 'typeLabel', label: 'Type' }, { key: 'status', label: 'Status', allLabel: 'Any status' }]"
+      paginated
+      :page-size="10"
+      empty-text="No edges connected yet. Connect an edge to get started."
+      @retry="emit('refresh')"
+      @row-click="emit('open', $event)"
+    >
+      <template #name="{ value }"><span class="name">{{ value }}</span></template>
+      <template #typeLabel="{ value, row }"><span class="k-badge k-badge--muted"><component :is="row.type === 'server' ? Server : Boxes" :size="12" />{{ value }}</span></template>
+      <template #status="{ value }"><StatusBadge :status="String(value)" /></template>
+      <template #agentVersion="{ value }"><span class="mono muted">{{ value }}</span></template>
+      <template #lastHeartbeat="{ value }"><span class="muted">{{ value }}</span></template>
+      <template #actions="{ row }"><div class="row-actions"><ResourceTableDeleteButton :label="`Delete edge ${String(row.name)}`" @click="emit('delete', row as unknown as Edge)" /></div></template>
+    </ResourceTable>
+  </div>
+</template>

--- a/providers/edges/portal/src/ServiceCreate.vue
+++ b/providers/edges/portal/src/ServiceCreate.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { ArrowLeft, Globe2, Loader2, Plus } from 'lucide-vue-next'
+import { createKubeEdgeService, fetchServiceCatalog, listEdges } from './api'
+import type { CatalogEntry } from './api'
+import type { Edge, EdgeServiceDraft, EdgeType, ErrorResponse } from './types'
+
+const props = withDefaults(defineProps<{
+  initialEdgeType?: EdgeType | null
+  initialEdgeName?: string | null
+}>(), {
+  initialEdgeType: null,
+  initialEdgeName: null,
+})
+const emit = defineEmits<{
+  cancel: []
+  created: [name: string]
+}>()
+
+const catalog = ref<CatalogEntry[]>([])
+const edges = ref<Edge[]>([])
+const loading = ref(true)
+const busy = ref(false)
+const error = ref<string | null>(null)
+const selectedEdgeKey = ref('')
+
+function catalogFor(type?: string): CatalogEntry | undefined {
+  return catalog.value.find((entry) => entry.type === type)
+}
+
+const catalogGroups = computed(() => catalog.value.reduce<{ category: string; items: CatalogEntry[] }[]>((groups, entry) => {
+  const category = entry.category || 'Other'
+  let group = groups.find((item) => item.category === category)
+  if (!group) {
+    group = { category, items: [] }
+    groups.push(group)
+  }
+  group.items.push(entry)
+  return groups
+}, []))
+
+const genericFallback: CatalogEntry = {
+  type: 'generic',
+  displayName: 'Generic HTTP service',
+  category: 'Other',
+  defaultPort: 80,
+  defaultScheme: 'http',
+  auth: 'bearer',
+  credential: { optional: true, packing: 'single', fields: [{ key: 'token', label: 'Bearer token (optional)', secret: true }] },
+}
+
+const draft = ref<EdgeServiceDraft>({
+  name: '',
+  edgeName: '',
+  serviceType: 'home-assistant',
+  targetNamespace: '',
+  targetName: '',
+  scheme: 'http',
+  host: '',
+  port: 8123,
+  instructions: '',
+})
+const targetMode = ref<'host' | 'kube'>('host')
+
+function edgeKey(edge: Pick<Edge, 'type' | 'name'>): string {
+  return `${edge.type}/${edge.name}`
+}
+
+const selectedEdge = computed(() => edges.value.find((edge) => edgeKey(edge) === selectedEdgeKey.value))
+const selectedEdgeIsServer = computed(() => selectedEdge.value?.type === 'server')
+const selectedCatalogEntry = computed(() => catalogFor(draft.value.serviceType))
+const hostRequired = computed(() => !!selectedCatalogEntry.value?.hostRequired)
+const schemeLocked = computed(() => !!catalogFor(draft.value.serviceType)?.schemeLocked)
+
+function resetTargetMode(): void {
+  targetMode.value = selectedEdgeIsServer.value || hostRequired.value ? 'host' : 'kube'
+}
+
+function onEdgeChange(): void {
+  draft.value.edgeName = selectedEdge.value?.name ?? ''
+  resetTargetMode()
+}
+
+function onTypeChange(): void {
+  const entry = catalogFor(draft.value.serviceType)
+  if (entry?.defaultPort) draft.value.port = entry.defaultPort
+  if (entry?.defaultScheme) draft.value.scheme = entry.defaultScheme
+  resetTargetMode()
+}
+
+function chooseInitialEdge(): void {
+  const requested = props.initialEdgeName
+    ? edges.value.find((edge) => edge.name === props.initialEdgeName && (!props.initialEdgeType || edge.type === props.initialEdgeType))
+    : undefined
+  const matchingType = props.initialEdgeType
+    ? edges.value.find((edge) => edge.type === props.initialEdgeType)
+    : undefined
+  const initial = requested || matchingType || edges.value[0]
+  selectedEdgeKey.value = initial ? edgeKey(initial) : ''
+  draft.value.edgeName = initial?.name ?? ''
+  resetTargetMode()
+}
+
+function cancel(): void {
+  if (busy.value) return
+  emit('cancel')
+}
+
+// Accept a pasted URL for convenience, while keeping the API contract's host,
+// scheme, and port fields separate. Service proxies always dial the root path.
+function normalizeHost(value?: string): string {
+  const raw = value?.trim() ?? ''
+  if (!raw || !/^https?:\/\//i.test(raw)) return raw
+  try {
+    return new URL(raw).hostname.trim()
+  } catch {
+    return ''
+  }
+}
+
+function applyHostUrl(): void {
+  const raw = draft.value.host?.trim()
+  if (!raw || !/^https?:\/\//i.test(raw)) {
+    draft.value.host = raw || ''
+    return
+  }
+  try {
+    const url = new URL(raw)
+    draft.value.scheme = url.protocol.replace(':', '')
+    draft.value.host = url.hostname
+    draft.value.port = Number(url.port) || (url.protocol === 'https:' ? 443 : 80)
+  } catch {
+    // Leave an invalid value visible for the user to correct.
+  }
+}
+
+const normalizedHost = computed(() => normalizeHost(draft.value.host))
+const canCreate = computed(() => {
+  if (!draft.value.name.trim() || !selectedEdge.value) return false
+  if (hostRequired.value) return targetMode.value === 'host' && !!normalizedHost.value
+  return targetMode.value === 'host' || !!draft.value.targetName.trim()
+})
+
+async function onCreate(): Promise<void> {
+  if (!canCreate.value) return
+  const edge = selectedEdge.value
+  if (!edge) return
+  applyHostUrl()
+  const byHost = targetMode.value === 'host'
+  const host = byHost ? normalizeHost(draft.value.host) : ''
+  if (hostRequired.value && (!byHost || !host)) return
+  busy.value = true
+  error.value = null
+  const name = draft.value.name.trim()
+  try {
+    await createKubeEdgeService({
+      name,
+      edgeName: edge.name,
+      edgeKind: edge.type === 'server' ? 'LinuxServer' : 'KubernetesCluster',
+      serviceType: draft.value.serviceType,
+      targetNamespace: draft.value.targetNamespace.trim() || 'default',
+      targetName: byHost ? '' : draft.value.targetName.trim(),
+      scheme: draft.value.scheme || 'http',
+      host: byHost ? host || undefined : undefined,
+      port: Number(draft.value.port) || 8123,
+      instructions: draft.value.instructions?.trim() || undefined,
+    })
+    emit('created', name)
+  } catch (e) {
+    error.value = (e as ErrorResponse)?.message ?? 'Create failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+onMounted(async () => {
+  loading.value = true
+  const [catalogResult, edgesResult] = await Promise.allSettled([fetchServiceCatalog(), listEdges()])
+  if (catalogResult.status === 'fulfilled' && catalogResult.value.length) {
+    catalog.value = catalogResult.value
+    if (!catalogFor(draft.value.serviceType)) draft.value.serviceType = catalogResult.value[0].type
+  } else {
+    catalog.value = [genericFallback]
+    if (catalogResult.status === 'rejected') error.value = (catalogResult.reason as ErrorResponse)?.message ?? 'Failed to load service catalog'
+  }
+  if (edgesResult.status === 'fulfilled') {
+    edges.value = edgesResult.value
+    chooseInitialEdge()
+  } else {
+    error.value = (edgesResult.reason as ErrorResponse)?.message ?? 'Failed to load edges'
+  }
+  loading.value = false
+})
+</script>
+
+<template>
+  <div class="k-create-page">
+    <button type="button" class="k-btn k-btn--ghost k-back-action" :disabled="busy" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Services
+    </button>
+    <header class="k-create-header">
+      <h1 class="k-create-title">Create service</h1>
+      <p class="k-create-description">Declare a service on an edge and expose its tools through the Edges MCP endpoint.</p>
+    </header>
+
+    <div v-if="error" class="banner error" role="alert">{{ error }}</div>
+    <div v-if="loading" class="waiting" role="status" aria-live="polite">
+      <Loader2 :size="14" class="spin" /> Loading service types and edges…
+    </div>
+
+    <form v-else class="k-create-surface k-create-surface--wide" @submit.prevent="onCreate">
+      <div class="k-create-body">
+      <div class="row" style="gap: 12px; align-items: flex-start;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Name</span>
+          <input v-model="draft.name" class="k-input" placeholder="home-assistant" />
+        </label>
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Edge</span>
+          <select v-model="selectedEdgeKey" class="k-input" @change="onEdgeChange">
+            <option value="" disabled>Select an edge</option>
+            <option v-for="edge in edges" :key="edgeKey(edge)" :value="edgeKey(edge)">
+              {{ edge.name }} ({{ edge.type === 'server' ? 'LinuxServer' : 'KubernetesCluster' }})
+            </option>
+          </select>
+        </label>
+      </div>
+
+      <div class="row" style="gap: 12px; align-items: flex-start;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Type</span>
+          <select v-model="draft.serviceType" class="k-input" @change="onTypeChange">
+            <optgroup v-for="group in catalogGroups" :key="group.category" :label="group.category">
+              <option v-for="entry in group.items" :key="entry.type" :value="entry.type">{{ entry.displayName }}</option>
+            </optgroup>
+          </select>
+        </label>
+        <label class="fld" style="flex: 0 0 120px;">
+          <span class="lbl">Scheme</span>
+          <select v-model="draft.scheme" class="k-input" :disabled="schemeLocked" :title="schemeLocked ? 'Fixed by the service type' : ''">
+            <option value="http">http</option>
+            <option value="https">https</option>
+          </select>
+        </label>
+        <label class="fld" style="flex: 0 0 120px;">
+          <span class="lbl">Port</span>
+          <input v-model="draft.port" type="number" min="1" max="65535" class="k-input" />
+        </label>
+      </div>
+
+      <label class="fld">
+        <span class="lbl">Target</span>
+        <div class="row" style="gap: 16px;">
+          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+            <input v-model="targetMode" type="radio" value="host" /> <Globe2 :size="13" aria-hidden="true" /> Host / IP
+          </label>
+          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;" :style="{ opacity: selectedEdgeIsServer || hostRequired ? 0.5 : 1 }">
+            <input v-model="targetMode" type="radio" value="kube" :disabled="selectedEdgeIsServer || hostRequired" /> Kubernetes Service
+          </label>
+        </div>
+      </label>
+
+      <div v-if="targetMode === 'host'" class="row" style="gap: 12px; align-items: flex-start;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Host {{ catalogFor(draft.serviceType)?.hostRequired ? '(required)' : '(blank = agent loopback)' }}</span>
+          <input v-model="draft.host" class="k-input" @blur="applyHostUrl" placeholder="192.168.1.1, myui.example.com, or paste https://myui.example.com" />
+          <span v-if="catalogFor(draft.serviceType)?.hostHelp" class="muted" style="font-size: 12px; margin-top: 4px;">{{ catalogFor(draft.serviceType)?.hostHelp }}</span>
+        </label>
+      </div>
+      <div v-else class="row" style="gap: 12px; align-items: flex-start;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Target namespace</span>
+          <input v-model="draft.targetNamespace" class="k-input" placeholder="home" />
+        </label>
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Target service name</span>
+          <input v-model="draft.targetName" class="k-input" placeholder="home-assistant" />
+        </label>
+      </div>
+
+      <label class="fld">
+        <span class="lbl">AI instructions (optional)</span>
+        <textarea v-model="draft.instructions" class="k-input" rows="3" placeholder="Gates are cover.gate_main. Living room light is light.living_room." />
+      </label>
+
+      </div>
+      <div class="k-create-actions">
+        <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Cancel</button>
+        <button type="submit" class="k-btn k-btn--primary" :disabled="busy || !canCreate">
+          <Loader2 v-if="busy" :size="14" class="spin" />
+          <Plus v-else :size="14" aria-hidden="true" />
+          {{ busy ? 'Creating…' : 'Create service' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, onActivated, watch } from 'vue'
 import { RefreshCw, Plus, Check } from 'lucide-vue-next'
 import {
-  listServices, listServicesPage, createKubeEdgeService, deleteEdgeService, listEdges,
+  listServices, listServicesPage, deleteEdgeService, listEdges,
   fetchServiceCatalog,
 } from './api'
 import type { CatalogEntry } from './api'
-import type { EdgeService, EdgeServiceDraft, Edge, ErrorResponse } from './types'
+import type { EdgeService, Edge, ErrorResponse } from './types'
 import { confirmDialog } from './portalkit/confirm'
 import ResourceTable from './portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
@@ -24,7 +24,10 @@ import {
 } from './refresh'
 
 const props = defineProps<{ selectedName?: string | null }>()
-const emit = defineEmits<{ navigate: [name: string | null] }>()
+const emit = defineEmits<{
+  navigate: [name: string | null, options?: { replace?: boolean }]
+  create: []
+}>()
 
 // Service type catalog — fetched from the backend (svccatalog.All()) so the form
 // never drifts from the provider's auth/probe knowledge. Each entry seeds the
@@ -33,16 +36,6 @@ const catalog = ref<CatalogEntry[]>([])
 function catalogFor(t?: string): CatalogEntry | undefined {
   return catalog.value.find((c) => c.type === t)
 }
-// Types grouped by category (first-seen order) for <optgroup> rendering.
-const CATALOG_GROUPS = computed(() =>
-  catalog.value.reduce<{ category: string; items: CatalogEntry[] }[]>((groups, c) => {
-    const cat = c.category || 'Other'
-    let g = groups.find((x) => x.category === cat)
-    if (!g) { g = { category: cat, items: [] }; groups.push(g) }
-    g.items.push(c)
-    return groups
-  }, []),
-)
 // A one-entry fallback so the form still works if the catalog fetch fails.
 const GENERIC_FALLBACK: CatalogEntry = {
   type: 'generic', displayName: 'Generic HTTP service', category: 'Other',
@@ -57,17 +50,6 @@ async function loadCatalog() {
     if (!catalog.value.length) catalog.value = [GENERIC_FALLBACK]
   }
 }
-// schemeLocked types (e.g. UniFi is always https) pin the scheme select.
-const createSchemeLocked = computed(() => !!catalogFor(draft.value.serviceType)?.schemeLocked)
-function onTypeChange() {
-  const c = catalogFor(draft.value.serviceType)
-  if (c) {
-    if (c.defaultPort) draft.value.port = c.defaultPort
-    if (c.defaultScheme) draft.value.scheme = c.defaultScheme
-  }
-  resetTargetMode()
-}
-
 const services = ref<EdgeService[]>([])
 const edges = ref<Edge[]>([])
 const loading = ref(true)
@@ -151,61 +133,6 @@ const serviceFilters = computed<TableFilterDefinition[]>(() => {
   ]
 })
 
-const showCreate = ref(false)
-const busy = ref(false)
-const draft = ref<EdgeServiceDraft>({
-  name: '',
-  edgeName: '',
-  serviceType: 'home-assistant',
-  targetNamespace: '',
-  targetName: '',
-  scheme: 'http',
-  host: '',
-  port: 8123,
-  instructions: '',
-})
-
-// How the service is reached is an explicit choice, independent of the edge kind:
-//   host — dial an address directly (agent loopback, or a LAN device like a UniFi
-//          console). Works on either edge kind.
-//   kube — reach a named Kubernetes Service by cluster DNS (KubernetesCluster only).
-const targetMode = ref<'host' | 'kube'>('host')
-
-const selectedEdgeIsServer = computed(
-  () => edges.value.find((e) => e.name === draft.value.edgeName)?.type === 'server',
-)
-
-// Sensible default target mode when the edge or type changes: LAN-style services
-// (UniFi) and LinuxServer edges default to host; KubernetesCluster edges default
-// to a cluster Service. The user can override with the toggle.
-function resetTargetMode() {
-  // Types flagged hostRequired live on the edge LAN (e.g. a UniFi console), not
-  // on the agent loopback, so they default to host addressing.
-  const needsHost = !!catalogFor(draft.value.serviceType)?.hostRequired
-  targetMode.value = selectedEdgeIsServer.value || needsHost ? 'host' : 'kube'
-}
-
-function toggleCreate() {
-  showCreate.value = !showCreate.value
-  if (showCreate.value) resetTargetMode()
-}
-
-// spec.host is a bare hostname/IP (scheme + port are separate fields). If the
-// user pastes a full URL, split it into host + scheme + port for convenience.
-// Any path is dropped — services proxy at the root.
-function applyHostUrl() {
-  const raw = draft.value.host?.trim()
-  if (!raw || !/^https?:\/\//i.test(raw)) return
-  try {
-    const u = new URL(raw)
-    draft.value.scheme = u.protocol.replace(':', '')
-    draft.value.host = u.hostname
-    draft.value.port = Number(u.port) || (u.protocol === 'https:' ? 443 : 80)
-  } catch {
-    /* not a valid URL — leave the field as typed */
-  }
-}
-
 // The selected resource identity is URL-owned by App.vue. Keep the list's
 // table/search/pagination state local, and only retain a row snapshot as an
 // optimistic seed while ServiceEdit performs its exact getService read.
@@ -214,9 +141,9 @@ function openEdit(s: EdgeService) {
   editing.value = s
   emit('navigate', s.name)
 }
-function closeEdit() {
+function closeEdit(replace = false) {
   editing.value = null
-  emit('navigate', null)
+  emit('navigate', null, replace ? { replace: true } : undefined)
 }
 function syncRouteSelection() {
   if (props.selectedName === undefined || props.selectedName === null) {
@@ -239,7 +166,7 @@ async function onEditSaved() {
 async function onEditDeleted() {
   const name = props.selectedName ?? editing.value?.name
   await refresh('foreground', true)
-  if (name && props.selectedName === name) closeEdit()
+  if (name && props.selectedName === name) closeEdit(true)
 }
 
 type ServiceTableRequest = Omit<TableRequestState, 'filters'> & { filters: ServiceFilterValues }
@@ -361,7 +288,6 @@ const serviceRefresh = createLatestRefreshController(async (requestID, mode) => 
     }
     loaded.value = true
     error.value = null
-    if (!draft.value.edgeName && edges.value.length) draft.value.edgeName = edges.value[0].name
   } catch (e) {
     const current = request.mode === 'client' && request.active
       ? serviceClientReadIsCurrent(requestID, request, readGeneration)
@@ -453,43 +379,6 @@ function handleServiceTableChange(change: ResourceTableChange) {
   void refresh()
 }
 
-const canCreate = computed(
-  () =>
-    !!draft.value.name.trim() &&
-    !!draft.value.edgeName &&
-    // host mode: host optional (empty = agent loopback). kube mode: need a target.
-    (targetMode.value === 'host' || !!draft.value.targetName.trim()),
-)
-
-async function onCreate() {
-  if (!canCreate.value) return
-  if (targetMode.value === 'host') applyHostUrl() // normalize a pasted URL
-  busy.value = true
-  error.value = null
-  try {
-    const byHost = targetMode.value === 'host'
-    await createKubeEdgeService({
-      name: draft.value.name.trim(),
-      edgeName: draft.value.edgeName,
-      edgeKind: selectedEdgeIsServer.value ? 'LinuxServer' : 'KubernetesCluster',
-      serviceType: draft.value.serviceType,
-      targetNamespace: draft.value.targetNamespace.trim() || 'default',
-      targetName: byHost ? '' : draft.value.targetName.trim(),
-      scheme: draft.value.scheme || 'http',
-      host: byHost ? draft.value.host?.trim() || undefined : undefined,
-      port: Number(draft.value.port) || 8123,
-      instructions: draft.value.instructions?.trim() || undefined,
-    })
-    showCreate.value = false
-    draft.value = { name: '', edgeName: edges.value[0]?.name ?? '', serviceType: 'home-assistant', targetNamespace: '', targetName: '', scheme: 'http', host: '', port: 8123, instructions: '' }
-    await refresh('foreground', true)
-  } catch (e) {
-    error.value = (e as ErrorResponse)?.message ?? 'Create failed'
-  } finally {
-    busy.value = false
-  }
-}
-
 async function onDelete(s: EdgeService) {
   if (!(await confirmDialog({ title: `Delete service "${s.name}"?`, message: 'Its MCP tools stop being exposed.', danger: true, confirmLabel: 'Delete' }))) return
   try {
@@ -503,6 +392,12 @@ async function onDelete(s: EdgeService) {
 onMounted(() => {
   loadCatalog()
   refresh()
+})
+// The collection stays cached while a route-owned create/detail page is open.
+// Revalidate on return so a successful mutation is visible without discarding
+// the user's query, filters, cursor, or page state.
+onActivated(() => {
+  if (!stopped) void refresh('foreground', true)
 })
 onUnmounted(() => {
   stopped = true
@@ -539,91 +434,12 @@ function serviceRowAriaLabel(row: Record<string, unknown>): string {
         <button
           type="button"
           class="k-btn k-btn--primary"
-          :aria-expanded="showCreate"
-          aria-controls="edges-service-create"
-          @click="toggleCreate"
+          @click="emit('create')"
         >
           <Plus :size="14" aria-hidden="true" /> New service
         </button>
       </div>
     </header>
-
-    <!-- Create form -->
-    <div v-if="showCreate" id="edges-service-create" class="wiz-card k-card">
-      <h3>New service</h3>
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Name</span>
-          <input v-model="draft.name" class="k-input" placeholder="ha" />
-        </label>
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Edge</span>
-          <select v-model="draft.edgeName" class="k-input" @change="resetTargetMode">
-            <option v-for="e in edges" :key="e.name" :value="e.name">{{ e.name }} ({{ e.type === 'server' ? 'LinuxServer' : 'KubernetesCluster' }})</option>
-          </select>
-        </label>
-      </div>
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Type</span>
-          <select v-model="draft.serviceType" class="k-input" @change="onTypeChange">
-            <optgroup v-for="g in CATALOG_GROUPS" :key="g.category" :label="g.category">
-              <option v-for="c in g.items" :key="c.type" :value="c.type">{{ c.displayName }}</option>
-            </optgroup>
-          </select>
-        </label>
-        <label class="fld" style="flex: 0 0 120px;">
-          <span class="lbl">Scheme</span>
-          <select v-model="draft.scheme" class="k-input" :disabled="createSchemeLocked" :title="createSchemeLocked ? 'Fixed by the service type' : ''">
-            <option value="http">http</option>
-            <option value="https">https</option>
-          </select>
-        </label>
-        <label class="fld" style="flex: 0 0 120px;">
-          <span class="lbl">Port</span>
-          <input v-model="draft.port" type="number" min="1" max="65535" class="k-input" />
-        </label>
-      </div>
-      <!-- Target: an explicit choice, independent of the edge kind. -->
-      <label class="fld">
-        <span class="lbl">Target</span>
-        <div class="row" style="gap: 16px;">
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
-            <input type="radio" value="host" v-model="targetMode" /> Host / IP
-          </label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;" :style="{ opacity: selectedEdgeIsServer ? 0.5 : 1 }">
-            <input type="radio" value="kube" v-model="targetMode" :disabled="selectedEdgeIsServer" /> Kubernetes Service
-          </label>
-        </div>
-      </label>
-      <!-- Host: dial an address directly (loopback, or a LAN device like UniFi). -->
-      <div v-if="targetMode === 'host'" class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Host {{ catalogFor(draft.serviceType)?.hostRequired ? '(required)' : '(blank = agent loopback)' }}</span>
-          <input v-model="draft.host" class="k-input" @blur="applyHostUrl" placeholder="192.168.1.1, myui.example.com, or paste https://myui.example.com — blank = 127.0.0.1" />
-          <span v-if="catalogFor(draft.serviceType)?.hostHelp" class="muted" style="font-size: 12px; margin-top: 4px;">{{ catalogFor(draft.serviceType)?.hostHelp }}</span>
-        </label>
-      </div>
-      <!-- Kubernetes Service: reach it by cluster DNS. -->
-      <div v-else class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Target namespace</span>
-          <input v-model="draft.targetNamespace" class="k-input" placeholder="home" />
-        </label>
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Target service name</span>
-          <input v-model="draft.targetName" class="k-input" placeholder="home-assistant" />
-        </label>
-      </div>
-      <label class="fld">
-        <span class="lbl">AI instructions (optional)</span>
-        <textarea v-model="draft.instructions" class="k-input" rows="3" placeholder="Gates are cover.gate_main. Living room light is light.living_room."></textarea>
-      </label>
-      <div class="wiz-actions">
-        <button class="k-btn k-btn--ghost" @click="showCreate = false">Cancel</button>
-        <button class="k-btn k-btn--primary" :disabled="busy || !canCreate" @click="onCreate">Create</button>
-      </div>
-    </div>
 
     <ResourceTable
       :columns="serviceColumns"

--- a/providers/edges/portal/src/Wizard.vue
+++ b/providers/edges/portal/src/Wizard.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { ref, computed, onUnmounted } from 'vue'
-import { Boxes, Server, ArrowRight, Copy, Check, Loader2, CircleDot, PartyPopper } from 'lucide-vue-next'
+import { ArrowLeft, Boxes, Server, ArrowRight, Copy, Check, Loader2, CircleDot, PartyPopper } from 'lucide-vue-next'
 import { createEdge, probeEdge } from './api'
 import type { EdgeType, ErrorResponse } from './types'
 
 const props = defineProps<{ cluster: string | null }>()
-const emit = defineEmits<{ connected: [] }>()
+const emit = defineEmits<{
+  cancel: []
+  created: [name: string, type: EdgeType]
+}>()
 
 type Step = 1 | 2 | 3
 const step = ref<Step>(1)
@@ -154,6 +157,9 @@ function fmt(s: number) {
       <input v-model="labels" class="k-input" placeholder="env=prod, region=us-east" />
 
       <div class="wiz-actions">
+        <button class="k-btn k-btn--ghost" @click="emit('cancel')">
+          <ArrowLeft :size="14" aria-hidden="true" /> Back to edges
+        </button>
         <button class="k-btn k-btn--primary" :disabled="!canContinue" @click="handleCreate">
           <Loader2 v-if="saving" :size="14" class="spin" />
           {{ saving ? 'Creating…' : 'Create & continue' }}
@@ -192,7 +198,8 @@ function fmt(s: number) {
 
       <div class="waiting"><Loader2 :size="14" class="spin" /> Waiting for <b>{{ trimmed }}</b> to connect… <span class="muted">({{ fmt(elapsed) }})</span></div>
       <div class="wiz-actions">
-        <button class="k-btn k-btn--ghost" @click="emit('connected')">Skip — I'll come back later</button>
+        <button class="k-btn k-btn--ghost" @click="emit('cancel')">Back to edges</button>
+        <button class="k-btn k-btn--ghost" @click="emit('created', trimmed, edgeType)">Skip — view edge details</button>
       </div>
     </div>
 
@@ -202,7 +209,7 @@ function fmt(s: number) {
       <h3><b>{{ trimmed }}</b> is online</h3>
       <p class="muted">Agent {{ agentVersion || '—' }} · connected after {{ fmt(elapsed) }}</p>
       <div class="wiz-actions">
-        <button class="k-btn k-btn--primary" @click="emit('connected')">View edges <ArrowRight :size="14" /></button>
+        <button class="k-btn k-btn--primary" @click="emit('created', trimmed, edgeType)">View edge details <ArrowRight :size="14" /></button>
       </div>
     </div>
   </div>

--- a/providers/edges/portal/src/WorkloadCreate.vue
+++ b/providers/edges/portal/src/WorkloadCreate.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { ArrowLeft, Loader2, Rocket } from 'lucide-vue-next'
+import { createWorkload, deployMarketplaceApp, listEdges, type WorkloadDraft } from './api'
+import { MARKETPLACE, type MarketplaceApp } from './marketplace'
+import type { Edge, ErrorResponse } from './types'
+
+const props = defineProps<{
+  mode: 'manual' | 'marketplace'
+  appType?: string
+}>()
+const emit = defineEmits<{
+  cancel: []
+  completed: [message: string]
+}>()
+
+const edges = ref<Edge[]>([])
+const loading = ref(true)
+const busy = ref(false)
+const error = ref<string | null>(null)
+const draft = ref({
+  name: '',
+  image: 'nginx:latest',
+  replicas: 1,
+  strategy: 'Spread' as 'Spread' | 'Singleton',
+  selector: 'env=dev',
+})
+const deployName = ref('')
+const deployEdge = ref('')
+
+// A route-owned form can disappear while an API read or mutation is still in
+// flight. Keep a local lifecycle fence so a canceled/unmounted deployment
+// cannot update the old form or start a mutation after its target preflight.
+let active = true
+let lifecycleGeneration = 0
+
+function isCurrent(generation: number): boolean {
+  return active && generation === lifecycleGeneration
+}
+
+function cancel(): void {
+  if (busy.value) return
+  active = false
+  lifecycleGeneration += 1
+  emit('cancel')
+}
+
+const app = computed<MarketplaceApp | null>(() =>
+  props.mode === 'marketplace' ? MARKETPLACE.find((entry) => entry.type === props.appType) ?? null : null,
+)
+// Marketplace charts expose a Kubernetes Service target in the second step
+// of deployMarketplaceApp. Keep LinuxServer edges out of this choice rather
+// than allowing a workload target that the follow-up Service cannot reach.
+const kubernetesEdges = computed(() => edges.value.filter((edge) => edge.type === 'kubernetes'))
+const title = computed(() => app.value ? `Deploy ${app.value.label}` : 'New workload')
+const credentialHint: Record<string, string> = {
+  'api-key': 'API key (mint it in the app, paste on the Services tab)',
+  'user-pass': '"username:password" (paste on the Services tab)',
+  password: 'web password (paste on the Services tab)',
+  optional: 'no token needed',
+}
+
+function parseSelector(value: string): Record<string, string> {
+  const selector: Record<string, string> = {}
+  for (const pair of value.split(',')) {
+    const [key, val] = pair.split('=').map((part) => part.trim())
+    if (key && val) selector[key] = val
+  }
+  return selector
+}
+
+const canSubmit = computed(() => {
+  if (!active || loading.value || busy.value) return false
+  if (props.mode === 'marketplace') {
+    return !!app.value && !!deployName.value.trim() && kubernetesEdges.value.some((edge) => edge.name === deployEdge.value)
+  }
+  return !!draft.value.name.trim() && !!draft.value.image.trim()
+})
+
+async function submit(): Promise<void> {
+  if (!active || !canSubmit.value) return
+  const generation = ++lifecycleGeneration
+  busy.value = true
+  error.value = null
+  try {
+    if (props.mode === 'marketplace') {
+      const selected = app.value
+      if (!selected) {
+        error.value = 'That marketplace app is no longer available.'
+        return
+      }
+      const selectedEdge = kubernetesEdges.value.find((edge) => edge.name === deployEdge.value)
+      if (!selectedEdge) {
+        error.value = 'Select a KubernetesCluster edge before deploying a marketplace app.'
+        return
+      }
+      // The form's edge list is only a snapshot. Re-read it immediately before
+      // the first marketplace mutation so a disconnected/deleted target cannot
+      // receive a workload (and its follow-up Service) after the form loaded.
+      const latestEdges = await listEdges()
+      if (!isCurrent(generation)) return
+      const latestEdge = latestEdges.find((edge) => edge.name === selectedEdge.name && edge.type === 'kubernetes')
+      edges.value = latestEdges
+      if (!latestEdge) {
+        deployEdge.value = kubernetesEdges.value[0]?.name ?? ''
+        error.value = 'The selected KubernetesCluster edge is no longer available. Choose another edge.'
+        return
+      }
+      await deployMarketplaceApp({
+        name: deployName.value.trim(),
+        edgeName: latestEdge.name,
+        chart: selected.chart,
+        values: selected.values,
+        serviceType: selected.type,
+        port: selected.port,
+      })
+      if (!isCurrent(generation)) return
+      emit('completed', `${selected.label} deployment started as ${deployName.value.trim()}.`)
+      return
+    }
+
+    const workload: WorkloadDraft = {
+      name: draft.value.name.trim(),
+      image: draft.value.image.trim(),
+      replicas: Number(draft.value.replicas) || 1,
+      strategy: draft.value.strategy,
+      selector: parseSelector(draft.value.selector),
+    }
+    await createWorkload(workload)
+    if (!isCurrent(generation)) return
+    emit('completed', `Workload ${workload.name} created.`)
+  } catch (e) {
+    if (!isCurrent(generation)) return
+    error.value = (e as ErrorResponse)?.message ?? (props.mode === 'marketplace' ? 'Deploy failed' : 'Create failed')
+  } finally {
+    if (isCurrent(generation)) busy.value = false
+  }
+}
+
+onMounted(async () => {
+  const generation = lifecycleGeneration
+  const result = await listEdges().then((value) => ({ value }), (reason) => ({ reason }))
+  if (!isCurrent(generation)) return
+  if ('value' in result) {
+    edges.value = result.value
+    if (props.mode === 'marketplace' && app.value) {
+      deployName.value = app.value.type
+    }
+    deployEdge.value = (props.mode === 'marketplace' ? kubernetesEdges.value : edges.value)[0]?.name ?? ''
+  } else {
+    error.value = (result.reason as ErrorResponse)?.message ?? 'Failed to load edges'
+  }
+  loading.value = false
+})
+
+onUnmounted(() => {
+  active = false
+  lifecycleGeneration += 1
+})
+</script>
+
+<template>
+  <div class="k-create-page">
+    <button type="button" class="k-btn k-btn--ghost k-back-action" :disabled="busy" @click="cancel">
+      <ArrowLeft :size="14" aria-hidden="true" /> Workloads
+    </button>
+    <header class="k-create-header">
+      <h1 class="k-create-title">{{ title }}</h1>
+      <p v-if="app" class="k-create-description">Deploy a pinned Helm chart onto one KubernetesCluster edge and wire its Edges service.</p>
+      <p v-else class="k-create-description">Deploy a workload across matching Kubernetes edges.</p>
+    </header>
+
+    <div v-if="error" class="banner error" role="alert">{{ error }}</div>
+    <div v-if="loading" class="waiting" role="status" aria-live="polite">
+      <Loader2 :size="14" class="spin" /> Loading edges…
+    </div>
+
+    <form v-else-if="app && props.mode === 'marketplace'" class="k-create-surface k-create-surface--wide" @submit.prevent="submit">
+      <div class="k-create-body">
+      <label class="fld">
+        <span class="lbl">Workload name</span>
+        <input v-model="deployName" class="k-input" :placeholder="app.type" />
+      </label>
+      <label class="fld">
+        <span class="lbl">Edge</span>
+        <select v-model="deployEdge" class="k-input" :disabled="kubernetesEdges.length === 0">
+          <option value="" disabled>Select an edge</option>
+          <option v-for="edge in kubernetesEdges" :key="edge.name" :value="edge.name">{{ edge.name }} (KubernetesCluster)</option>
+        </select>
+      </label>
+      <p v-if="kubernetesEdges.length === 0" class="banner warn" role="status">Connect a KubernetesCluster edge before deploying a marketplace app.</p>
+      <p class="muted">Deploys <span class="mono">{{ app.chart.chart }}@{{ app.chart.version }}</span> onto <b>{{ deployEdge || '—' }}</b> and wires an Edges Service on port {{ app.port }}. Auth: {{ credentialHint[app.credential] }}.</p>
+      </div>
+      <div class="k-create-actions">
+        <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Cancel</button>
+        <button type="submit" class="k-btn k-btn--primary" :disabled="!canSubmit">
+          <Loader2 v-if="busy" :size="14" class="spin" />
+          <Rocket v-else :size="14" aria-hidden="true" />
+          {{ busy ? 'Deploying…' : 'Deploy' }}
+        </button>
+      </div>
+    </form>
+
+    <div v-else-if="props.mode === 'marketplace'" class="k-create-surface">
+      <div class="k-create-body">
+      <p class="banner error" role="alert">That marketplace app is not available.</p>
+      </div>
+      <div class="k-create-actions"><button class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Back to workloads</button></div>
+    </div>
+
+    <form v-else class="k-create-surface k-create-surface--wide" @submit.prevent="submit">
+      <div class="k-create-body">
+      <label class="fld">
+        <span class="lbl">Name</span>
+        <input v-model="draft.name" class="k-input" placeholder="nginx-demo" />
+      </label>
+      <label class="fld">
+        <span class="lbl">Image</span>
+        <input v-model="draft.image" class="k-input" placeholder="nginx:latest" />
+      </label>
+      <div class="row" style="gap: 12px; align-items: flex-start;">
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Replicas</span>
+          <input v-model="draft.replicas" type="number" min="1" class="k-input" />
+        </label>
+        <label class="fld" style="flex: 1;">
+          <span class="lbl">Strategy</span>
+          <select v-model="draft.strategy" class="k-input">
+            <option value="Spread">Spread (all matching edges)</option>
+            <option value="Singleton">Singleton (one edge)</option>
+          </select>
+        </label>
+      </div>
+      <label class="fld">
+        <span class="lbl">Edge selector (key=value, comma-separated)</span>
+        <input v-model="draft.selector" class="k-input" placeholder="env=dev" />
+      </label>
+      </div>
+      <div class="k-create-actions">
+        <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Cancel</button>
+        <button type="submit" class="k-btn k-btn--primary" :disabled="!canSubmit">
+          <Loader2 v-if="busy" :size="14" class="spin" />
+          {{ busy ? 'Creating…' : 'Create workload' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/providers/edges/portal/src/Workloads.vue
+++ b/providers/edges/portal/src/Workloads.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { computed, ref, onMounted, onUnmounted, onActivated } from 'vue'
 import { RefreshCw, Plus, ChevronRight, ChevronDown, Store, Rocket } from 'lucide-vue-next'
-import { listWorkloads, listWorkloadsPage, createWorkload, deleteWorkload, deployMarketplaceApp, listEdges, type WorkloadDraft } from './api'
+import { listWorkloads, listWorkloadsPage, deleteWorkload, listEdges } from './api'
 import type { Workload, Edge, ErrorResponse } from './types'
 import { confirmDialog } from './portalkit/confirm'
 import ResourceTable from './portalkit/ResourceTable.vue'
@@ -17,6 +17,13 @@ import {
   createLatestRefreshController,
   type ResourceRefreshMode,
 } from './refresh'
+
+const props = defineProps<{ result?: string | null }>()
+const emit = defineEmits<{
+  create: []
+  deploy: [app: MarketplaceApp]
+  dismissResult: []
+}>()
 
 const workloads = ref<Workload[]>([])
 const edges = ref<Edge[]>([])
@@ -86,58 +93,7 @@ const workloadFilters: TableFilterDefinition[] = [
   { key: 'status', label: 'Status', allLabel: 'Any status', options: WORKLOAD_STATUS_OPTIONS },
 ]
 
-// Marketplace deploy state.
 const showMarket = ref(true)
-const deployApp = ref<MarketplaceApp | null>(null)
-const deployName = ref('')
-const deployEdge = ref('')
-function openDeploy(app: MarketplaceApp) {
-  deployApp.value = app
-  deployName.value = app.type
-  deployEdge.value = edges.value[0]?.name ?? ''
-  error.value = null
-}
-function closeDeploy() {
-  deployApp.value = null
-}
-async function onDeploy() {
-  const app = deployApp.value
-  if (!app || !deployName.value.trim() || !deployEdge.value) return
-  busy.value = true
-  error.value = null
-  try {
-    await deployMarketplaceApp({
-      name: deployName.value.trim(),
-      edgeName: deployEdge.value,
-      chart: app.chart,
-      values: app.values,
-      serviceType: app.type,
-      port: app.port,
-    })
-    closeDeploy()
-    await refresh('foreground', true)
-  } catch (e) {
-    error.value = (e as ErrorResponse)?.message ?? 'Deploy failed'
-  } finally {
-    busy.value = false
-  }
-}
-const credentialHint: Record<string, string> = {
-  'api-key': 'API key (mint it in the app, paste on the Services tab)',
-  'user-pass': '"username:password" (paste on the Services tab)',
-  password: 'web password (paste on the Services tab)',
-  optional: 'no token needed',
-}
-
-const showCreate = ref(false)
-const busy = ref(false)
-const draft = ref<{ name: string; image: string; replicas: number; strategy: 'Spread' | 'Singleton'; selector: string }>({
-  name: '',
-  image: 'nginx:latest',
-  replicas: 1,
-  strategy: 'Spread',
-  selector: 'env=dev',
-})
 
 const expanded = ref<string | null>(null)
 function toggle(name: string) {
@@ -263,7 +219,6 @@ const workloadRefresh = createLatestRefreshController(async (requestID, mode) =>
     }
     loaded.value = true
     error.value = null
-    if (!deployEdge.value && edges.value.length) deployEdge.value = edges.value[0].name
   } catch (e) {
     const current = request.mode === 'client' && request.active
       ? workloadClientReadIsCurrent(requestID, request, readGeneration)
@@ -354,38 +309,6 @@ function handleWorkloadTableChange(change: ResourceTableChange) {
   void refresh()
 }
 
-function parseSelector(s: string): Record<string, string> {
-  const out: Record<string, string> = {}
-  for (const pair of s.split(',')) {
-    const [k, v] = pair.split('=').map((x) => x.trim())
-    if (k && v) out[k] = v
-  }
-  return out
-}
-
-async function onCreate() {
-  if (!draft.value.name.trim() || !draft.value.image.trim()) return
-  busy.value = true
-  error.value = null
-  try {
-    const d: WorkloadDraft = {
-      name: draft.value.name.trim(),
-      image: draft.value.image.trim(),
-      replicas: Number(draft.value.replicas) || 1,
-      strategy: draft.value.strategy,
-      selector: parseSelector(draft.value.selector),
-    }
-    await createWorkload(d)
-    showCreate.value = false
-    draft.value = { name: '', image: 'nginx:latest', replicas: 1, strategy: 'Spread', selector: 'env=dev' }
-    await refresh('foreground', true)
-  } catch (e) {
-    error.value = (e as ErrorResponse)?.message ?? 'Create failed'
-  } finally {
-    busy.value = false
-  }
-}
-
 async function onDelete(w: Workload) {
   if (!(await confirmDialog({ title: `Delete workload "${w.name}"?`, message: 'Its Deployments on every edge are removed.', danger: true, confirmLabel: 'Delete' }))) return
   try {
@@ -397,6 +320,12 @@ async function onDelete(w: Workload) {
 }
 
 onMounted(() => { void refresh('foreground') })
+// Workload create/deploy is route-owned while this collection remains cached.
+// Refresh on return to reconcile the newly submitted workload immediately and
+// retain the table's current query/filter/page state during that read.
+onActivated(() => {
+  if (!stopped) void refresh('foreground', true)
+})
 onUnmounted(() => {
   stopped = true
   workloadRefresh.stop()
@@ -436,14 +365,17 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
         <button
           type="button"
           class="k-btn k-btn--primary"
-          :aria-expanded="showCreate"
-          aria-controls="edges-workload-create"
-          @click="showCreate = !showCreate"
+          @click="emit('create')"
         >
           <Plus :size="14" aria-hidden="true" /> New workload
         </button>
       </div>
     </header>
+
+    <div v-if="props.result" class="banner success" role="status" aria-live="polite">
+      {{ props.result }}
+      <button type="button" class="k-btn k-btn--ghost compact-control" @click="emit('dismissResult')">Dismiss</button>
+    </div>
 
     <!-- Marketplace -->
     <div class="market k-card">
@@ -473,73 +405,12 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
               </div>
               <p class="market-desc">{{ app.description }}</p>
               <div class="market-meta muted mono">{{ app.chart.chart }}@{{ app.chart.version }} · :{{ app.port }}</div>
-              <button class="k-btn k-btn--primary compact-control" :disabled="edges.length === 0" @click="openDeploy(app)">
+              <button class="k-btn k-btn--primary compact-control" :disabled="edges.length === 0" @click="emit('deploy', app)">
                 <Rocket :size="13" /> Deploy
               </button>
             </div>
           </div>
         </div>
-      </div>
-    </div>
-
-    <!-- Deploy dialog -->
-    <div v-if="deployApp" class="wiz-card k-card">
-      <h3>Deploy {{ deployApp.label }}</h3>
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Name</span>
-          <input v-model="deployName" class="k-input" :placeholder="deployApp.type" />
-        </label>
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Edge</span>
-          <select v-model="deployEdge" class="k-input">
-            <option v-for="e in edges" :key="e.name" :value="e.name">{{ e.name }}</option>
-          </select>
-        </label>
-      </div>
-      <div class="muted" style="margin: 4px 0 12px;">
-        Deploys the chart onto <b>{{ deployEdge || '—' }}</b> and wires an edges Service.
-        Auth: {{ credentialHint[deployApp.credential] }}.
-      </div>
-      <div class="wiz-actions">
-        <button class="k-btn k-btn--ghost" @click="closeDeploy">Cancel</button>
-        <button class="k-btn k-btn--primary" :disabled="busy || !deployName.trim() || !deployEdge" @click="onDeploy">
-          <Rocket :size="14" /> Deploy
-        </button>
-      </div>
-    </div>
-
-    <!-- Create form -->
-    <div v-if="showCreate" id="edges-workload-create" class="wiz-card k-card">
-      <h3>New workload</h3>
-      <label class="fld">
-        <span class="lbl">Name</span>
-        <input v-model="draft.name" class="k-input" placeholder="nginx-demo" />
-      </label>
-      <label class="fld">
-        <span class="lbl">Image</span>
-        <input v-model="draft.image" class="k-input" placeholder="nginx:latest" />
-      </label>
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Replicas</span>
-          <input v-model="draft.replicas" type="number" min="1" class="k-input" />
-        </label>
-        <label class="fld" style="flex: 1;">
-          <span class="lbl">Strategy</span>
-          <select v-model="draft.strategy" class="k-input">
-            <option value="Spread">Spread (all matching edges)</option>
-            <option value="Singleton">Singleton (one edge)</option>
-          </select>
-        </label>
-      </div>
-      <label class="fld">
-        <span class="lbl">Edge selector (key=value, comma-separated)</span>
-        <input v-model="draft.selector" class="k-input" placeholder="env=dev" />
-      </label>
-      <div class="wiz-actions">
-        <button class="k-btn k-btn--ghost" @click="showCreate = false">Cancel</button>
-        <button class="k-btn k-btn--primary" :disabled="busy || !draft.name.trim() || !draft.image.trim()" @click="onCreate">Create</button>
       </div>
     </div>
 

--- a/providers/edges/portal/src/edge-collection.regression.test.mjs
+++ b/providers/edges/portal/src/edge-collection.regression.test.mjs
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readSource = (file) => readFileSync(resolve(process.cwd(), 'src', file), 'utf8')
+const app = readSource('App.vue')
+const collection = readSource('EdgeCollection.vue')
+
+describe('Edges collection route-state regression', () => {
+  it('keeps the collection instance alive and revalidates when returning from routes', () => {
+    const cachedCollection = app.match(/<KeepAlive>\s*<EdgeCollection[\s\S]*?<\/KeepAlive>/)?.[0]
+    expect(cachedCollection).toBeTruthy()
+    expect(cachedCollection).toMatch(/:key="`edges:\$\{contextGeneration\}`"/)
+    expect(cachedCollection).toMatch(/@activated="onEdgeCollectionActivated"/)
+    expect(cachedCollection).toMatch(/@refresh="refresh"/)
+    expect(collection).toMatch(/onActivated\(\(\) => emit\('activated'\)\)/)
+    expect(collection).toMatch(/<ResourceTable[\s\S]*searchable[\s\S]*paginated/)
+    expect(app).toMatch(/function onEdgeCollectionActivated\(\): void \{[\s\S]*if \(firstLoadDone\.value\) void refresh\('foreground'\)/)
+  })
+
+  it('replaces the detail route on Back so browser Back does not reopen it', () => {
+    expect(app).toMatch(/<Detail[\s\S]*@back="navigate\('', true\)"/)
+  })
+})

--- a/providers/edges/portal/src/portalkit/faros-ui.css
+++ b/providers/edges/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/edges/portal/src/routes.test.ts
+++ b/providers/edges/portal/src/routes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  edgeDetailPath,
+  navigationDetail,
+  parseSubPath,
+  serviceCreatePath,
+  serviceDetailPath,
+  workloadDeployPath,
+} from './routes'
+
+describe('Edges provider routes', () => {
+  it('parses provider-relative collection, action, and detail paths', () => {
+    expect(parseSubPath(undefined)).toEqual({ page: 'edges' })
+    expect(parseSubPath('connect/edge')).toEqual({ page: 'edges', connect: { resource: 'edge' } })
+    expect(parseSubPath('/create/service/')).toEqual({ page: 'services', create: { resource: 'service' } })
+    expect(parseSubPath('create/service/server/edge%2Fa')).toEqual({
+      page: 'services',
+      create: { resource: 'service', edgeType: 'server', edgeName: 'edge/a' },
+    })
+    expect(parseSubPath('create/service/kubernetes/prod/us')).toEqual({
+      page: 'services',
+      create: { resource: 'service', edgeType: 'kubernetes', edgeName: 'prod/us' },
+    })
+    expect(parseSubPath('deploy/workload/manual')).toEqual({
+      page: 'workloads',
+      deploy: { resource: 'workload', mode: 'manual' },
+    })
+    expect(parseSubPath('deploy/workload/marketplace/grafana')).toEqual({
+      page: 'workloads',
+      deploy: { resource: 'workload', mode: 'marketplace', app: 'grafana' },
+    })
+    expect(parseSubPath('edges/kubernetes/prod%2Fus')).toEqual({
+      page: 'edges', edge: { type: 'kubernetes', name: 'prod/us' },
+    })
+    expect(parseSubPath('services/home%2Dassistant')).toEqual({ page: 'services', service: 'home-assistant' })
+  })
+
+  it('normalizes a shell-prefixed debug path without changing provider output paths', () => {
+    expect(parseSubPath('/providers/edges/edges/server/edge-a')).toEqual({
+      page: 'edges', edge: { type: 'server', name: 'edge-a' },
+    })
+    expect(navigationDetail('/create/service')).toEqual({ path: 'create/service' })
+    expect(navigationDetail('services/svc', true)).toEqual({ path: 'services/svc', replace: true })
+  })
+
+  it('builds collision-safe paths and preserves encoded names', () => {
+    expect(edgeDetailPath('kubernetes', 'prod/us')).toBe('edges/kubernetes/prod%2Fus')
+    expect(serviceDetailPath('home assistant')).toBe('services/home%20assistant')
+    expect(serviceCreatePath('server', 'edge-a')).toBe('create/service/server/edge-a')
+    expect(serviceCreatePath()).toBe('create/service')
+    expect(workloadDeployPath('manual')).toBe('deploy/workload/manual')
+    expect(workloadDeployPath('marketplace', 'grafana')).toBe('deploy/workload/marketplace/grafana')
+  })
+})

--- a/providers/edges/portal/src/routes.ts
+++ b/providers/edges/portal/src/routes.ts
@@ -1,0 +1,135 @@
+import type { EdgeType } from './types'
+
+export type EdgeCollectionPage = 'edges' | 'services' | 'workloads'
+export type ServiceCreateRoute = {
+  resource: 'service'
+  edgeType?: EdgeType
+  edgeName?: string
+}
+export type WorkloadDeployRoute = {
+  resource: 'workload'
+  mode: 'manual' | 'marketplace'
+  app?: string
+}
+
+export interface EdgeRoute {
+  page: EdgeCollectionPage
+  edge?: { type: EdgeType; name: string }
+  service?: string
+  connect?: { resource: 'edge' }
+  create?: ServiceCreateRoute
+  deploy?: WorkloadDeployRoute
+}
+
+export interface EdgeNavigationDetail {
+  path: string
+  replace?: boolean
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    // Keep malformed escapes visible so a bad deep link remains addressable and
+    // the eventual resource read can report a useful not-found/error state.
+    return value
+  }
+}
+
+function normalizeSubPath(subPath: string | null | undefined): string {
+  let normalized = (subPath ?? '').replace(/^\/+|\/+$/g, '')
+  // FarosContext is provider-relative, but accepting the shell prefix here is
+  // harmless and makes standalone/debug harness context easier to diagnose.
+  if (normalized === 'providers/edges') return ''
+  if (normalized.startsWith('providers/edges/')) normalized = normalized.slice('providers/edges/'.length)
+  return normalized
+}
+
+/** Parse the provider-relative path after `/providers/edges/`. */
+export function parseSubPath(subPath: string | null | undefined): EdgeRoute {
+  const normalized = normalizeSubPath(subPath)
+  const parts = normalized ? normalized.split('/') : []
+
+  if (normalized === '' || normalized === 'edges') return { page: 'edges' }
+  if (normalized === 'services') return { page: 'services' }
+  if (normalized === 'workloads') return { page: 'workloads' }
+
+  if (parts[0] === 'connect' && parts[1] === 'edge' && parts.length === 2) {
+    return { page: 'edges', connect: { resource: 'edge' } }
+  }
+
+  if (parts[0] === 'create' && parts[1] === 'service') {
+    if (parts.length === 2) return { page: 'services', create: { resource: 'service' } }
+    if (
+      parts.length >= 4 &&
+      (parts[2] === 'kubernetes' || parts[2] === 'server') &&
+      parts[3] !== ''
+    ) {
+      return {
+        page: 'services',
+        create: {
+          resource: 'service',
+          edgeType: parts[2],
+          edgeName: decodeSegment(parts.slice(3).join('/')),
+        },
+      }
+    }
+    return { page: 'services' }
+  }
+
+  if (parts[0] === 'deploy' && parts[1] === 'workload') {
+    if (parts.length === 3 && parts[2] === 'manual') {
+      return { page: 'workloads', deploy: { resource: 'workload', mode: 'manual' } }
+    }
+    if (parts.length === 4 && parts[2] === 'marketplace' && parts[3] !== '') {
+      return {
+        page: 'workloads',
+        deploy: { resource: 'workload', mode: 'marketplace', app: decodeSegment(parts.slice(3).join('/')) },
+      }
+    }
+    return { page: 'workloads' }
+  }
+
+  if (parts[0] === 'edges' && parts.length >= 3 && (parts[1] === 'kubernetes' || parts[1] === 'server')) {
+    return {
+      page: 'edges',
+      edge: { type: parts[1], name: decodeSegment(parts.slice(2).join('/')) },
+    }
+  }
+  if (parts[0] === 'services' && parts.length > 1) {
+    return { page: 'services', service: decodeSegment(parts.slice(1).join('/')) }
+  }
+
+  // Unknown provider paths land on the default collection rather than leaving
+  // a stale action surface mounted.
+  return { page: 'edges' }
+}
+
+// The explicit alias keeps the provider name visible at call sites and gives
+// route tests a stable, discoverable parser name.
+export const parseEdgesSubPath = parseSubPath
+
+export function navigationDetail(path: string, replace = false): EdgeNavigationDetail {
+  const detail: EdgeNavigationDetail = { path: path.replace(/^\/+/, '') }
+  if (replace) detail.replace = true
+  return detail
+}
+
+export function edgeDetailPath(type: EdgeType, name: string): string {
+  return `edges/${type}/${encodeURIComponent(name)}`
+}
+
+export function serviceDetailPath(name: string): string {
+  return `services/${encodeURIComponent(name)}`
+}
+
+export function serviceCreatePath(edgeType?: EdgeType, edgeName?: string): string {
+  if (edgeType && edgeName) return `create/service/${edgeType}/${encodeURIComponent(edgeName)}`
+  return 'create/service'
+}
+
+export function workloadDeployPath(mode: 'manual' | 'marketplace', app?: string): string {
+  return mode === 'marketplace' && app
+    ? `deploy/workload/marketplace/${encodeURIComponent(app)}`
+    : 'deploy/workload/manual'
+}

--- a/providers/edges/portal/src/style.css
+++ b/providers/edges/portal/src/style.css
@@ -86,6 +86,7 @@ faros-provider-edges .copy:disabled { opacity: .4; cursor: default; }
 faros-provider-edges .waiting { display: flex; align-items: center; gap: 8px; font-size: 12px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--color-accent, #8b6bff) 20%, transparent); background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-radius: 6px; color: var(--color-text-secondary, #8a8ca6); }
 faros-provider-edges .banner.warn { border: 1px solid color-mix(in srgb, var(--color-warning, #f0a63a) 30%, transparent); background: var(--color-warning-subtle, rgba(240, 166, 58, 0.12)); color: var(--color-warning, #f0a63a); padding: 10px 12px; border-radius: 6px; font-size: 12px; }
 faros-provider-edges .banner.error { border: 1px solid color-mix(in srgb, var(--color-danger, #ff5d5d) 30%, transparent); background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); padding: 10px 12px; border-radius: 6px; margin-bottom: 14px; font-size: 12px; }
+faros-provider-edges .banner.success { display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 1px solid color-mix(in srgb, var(--color-success) 30%, transparent); background: var(--color-success-subtle); color: var(--color-success); padding: 10px 12px; border-radius: 6px; margin-bottom: 14px; font-size: 12px; }
 
 /* ── Misc text ── */
 faros-provider-edges .row { display: flex; align-items: center; gap: 8px; }

--- a/providers/edges/portal/src/tabs.test.mjs
+++ b/providers/edges/portal/src/tabs.test.mjs
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 const readSource = (file) => readFileSync(resolve(process.cwd(), 'src', file), 'utf8')
 const app = readSource('App.vue')
+const edgeCollection = readSource('EdgeCollection.vue')
 const services = readSource('Services.vue')
 const workloads = readSource('Workloads.vue')
 const styles = readSource('style.css')
@@ -13,21 +14,24 @@ describe('Edges portal conformance', () => {
     expect(app).toMatch(/import Tabs from '\.\/portalkit\/Tabs\.vue'/)
     expect(app).toMatch(/const edgeRouteTabs = \[[\s\S]*id: 'edges'[\s\S]*Server[\s\S]*id: 'workloads'[\s\S]*Boxes[\s\S]*id: 'services'[\s\S]*Plug/)
 
-    const routeTabs = app.match(/<Tabs[\s\S]*?@select="\(id\) => navigate\(id === 'edges' \? '' : id\)"\s*\/>/)?.[0]
+    const routeTabs = app.match(/<Tabs[\s\S]*?@select="selectView"\s*\/>/)?.[0]
     expect(routeTabs).toBeTruthy()
-    expect(routeTabs).toMatch(/v-if="!wizardOpen && !selected"/)
+    expect(routeTabs).toMatch(/v-if="!route\.edge && !route\.service && !route\.connect && !route\.create && !route\.deploy"/)
     expect(routeTabs).toMatch(/:tabs="edgeRouteTabs"/)
     expect(routeTabs).toMatch(/:active="view"/)
     expect(routeTabs).toMatch(/aria-label="Edges sections"/)
     expect(routeTabs).not.toMatch(/wiz-steps|wiz-step|style=/)
   })
 
-  it('keeps wizard progression styling and overlay route guards intact', () => {
+  it('keeps route-owned creation and detail surfaces out of collection overlays', () => {
     expect(styles).toMatch(/faros-provider-edges \.edges-app \{[^}]*display: flex;[^}]*flex-direction: column;[^}]*gap: 16px;/)
-    expect(app).toMatch(/<Workloads v-if="view === 'workloads' && !wizardOpen && !selected" \/>/)
-    expect(app).toMatch(/<Services v-else-if="view === 'services' && !wizardOpen && !selected" \/>/)
-    expect(app).toMatch(/<Wizard v-else-if="wizardOpen"/)
-    expect(app).toMatch(/<Detail[\s\S]*v-else-if="selected"/)
+    expect(app).toMatch(/<WorkloadCreate[\s\S]*route\.deploy\?\.resource === 'workload'/)
+    expect(app).toMatch(/<ServiceCreate[\s\S]*route\.create\?\.resource === 'service'/)
+    expect(app).toMatch(/<Wizard[\s\S]*route\.connect\?\.resource === 'edge'/)
+    expect(app).toMatch(/<Detail[\s\S]*v-if="route\.edge"/)
+    expect(app).not.toMatch(/const selected = ref/)
+    expect(services).not.toMatch(/const showCreate = ref/)
+    expect(workloads).not.toMatch(/const showCreate = ref/)
     expect(styles).toMatch(/\.wiz-steps\s*\{[\s\S]*\.wiz-step\s*\{[\s\S]*\.wiz-step\.active\s*\{[\s\S]*\.wiz-step\.done\s*\{/)
   })
 
@@ -40,7 +44,7 @@ describe('Edges portal conformance', () => {
 
   it('keeps interactive table rows labeled and nested actions explicit', () => {
     for (const [source, labelFunction] of [
-      [app, 'edgeRowAriaLabel'],
+      [edgeCollection, 'edgeRowAriaLabel'],
       [services, 'serviceRowAriaLabel'],
       [workloads, 'workloadRowAriaLabel'],
     ]) {
@@ -49,7 +53,7 @@ describe('Edges portal conformance', () => {
       expect(source).toMatch(/@row-click=/)
     }
 
-    expect(app).toMatch(/ResourceTableDeleteButton/)
+    expect(edgeCollection).toMatch(/ResourceTableDeleteButton/)
     expect(services).toMatch(/ResourceTableEditButton/)
     expect(services).toMatch(/ResourceTableDeleteButton/)
     expect(workloads).toMatch(/ResourceTableDeleteButton/)

--- a/providers/edges/portal/src/views.behavior.test.ts
+++ b/providers/edges/portal/src/views.behavior.test.ts
@@ -27,7 +27,9 @@ vi.mock('./portalkit/confirm', () => confirm)
 
 import Services from './Services.vue'
 import ServiceEdit from './ServiceEdit.vue'
+import ServiceCreate from './ServiceCreate.vue'
 import Workloads from './Workloads.vue'
+import WorkloadCreate from './WorkloadCreate.vue'
 
 type HostNode = {
   type: string
@@ -544,6 +546,162 @@ describe('edge list views', () => {
           { value: 'Failed', label: 'Failed' }, { value: 'Unknown', label: 'Unknown' },
         ] },
       ])
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('revalidates a marketplace target before mutation when the selected edge disappears', async () => {
+    const latestEdges = deferred<unknown[]>()
+    api.listEdges.mockReset()
+    api.listEdges.mockResolvedValueOnce([edge]).mockImplementationOnce(() => latestEdges.promise)
+    const mounted = await mount(WorkloadCreate, { mode: 'marketplace', appType: 'grafana' })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      expect(state.deployEdge).toBe('edge-a')
+      expect(state.canSubmit).toBe(true)
+
+      const submit = state.submit()
+      await flush()
+      expect(api.listEdges).toHaveBeenCalledTimes(2)
+      expect(state.busy).toBe(true)
+      expect(api.deployMarketplaceApp).not.toHaveBeenCalled()
+
+      // The edge was present when the form loaded but is gone by the time the
+      // mutation would begin. The stale target must never reach the workload or
+      // follow-up Service API, and the form should expose the refreshed state.
+      latestEdges.resolve([])
+      await submit
+      await flush()
+      expect(api.deployMarketplaceApp).not.toHaveBeenCalled()
+      expect(state.deployEdge).toBe('')
+      expect(state.error).toBe('The selected KubernetesCluster edge is no longer available. Choose another edge.')
+      expect(state.busy).toBe(false)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('does not start marketplace mutation after unmount during edge preflight', async () => {
+    const freshEdges = deferred<unknown[]>()
+    api.listEdges.mockReset()
+    api.listEdges.mockResolvedValueOnce([edge]).mockImplementationOnce(() => freshEdges.promise)
+    const mounted = await mount(WorkloadCreate, { mode: 'marketplace', appType: 'grafana' })
+    const state = mounted.instance.setupState
+    await flush()
+    const submit = state.submit()
+    await flush()
+    expect(api.listEdges).toHaveBeenCalledTimes(2)
+    expect(api.deployMarketplaceApp).not.toHaveBeenCalled()
+
+    mounted.unmount()
+    freshEdges.resolve([edge])
+    await submit
+    await flush()
+
+    expect(api.deployMarketplaceApp).not.toHaveBeenCalled()
+    expect(state.error).toBeNull()
+    expect(state.edges).toEqual([edge])
+  })
+
+  it('keeps cancellation disabled while a marketplace deployment is in flight', async () => {
+    const freshEdges = deferred<unknown[]>()
+    const canceled = vi.fn()
+    api.listEdges.mockReset()
+    api.listEdges.mockResolvedValueOnce([edge]).mockImplementationOnce(() => freshEdges.promise)
+    const mounted = await mount(WorkloadCreate, { mode: 'marketplace', appType: 'grafana', onCancel: canceled })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      const submit = state.submit()
+      await flush()
+
+      state.cancel()
+      expect(canceled).not.toHaveBeenCalled()
+      expect(state.busy).toBe(true)
+
+      freshEdges.resolve([edge])
+      await submit
+      expect(api.deployMarketplaceApp).toHaveBeenCalledTimes(1)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('ignores the initial marketplace edge read after the route unmounts', async () => {
+    const initialEdges = deferred<unknown[]>()
+    api.listEdges.mockReset().mockImplementation(() => initialEdges.promise)
+    const mounted = await mount(WorkloadCreate, { mode: 'marketplace', appType: 'grafana' })
+    const state = mounted.instance.setupState
+    mounted.unmount()
+    initialEdges.resolve([edge])
+    await flush()
+
+    expect(state.edges).toEqual([])
+    expect(state.loading).toBe(true)
+    expect(state.error).toBeNull()
+    expect(api.deployMarketplaceApp).not.toHaveBeenCalled()
+  })
+
+  it('requires host mode and a normalized host for host-required catalog entries', async () => {
+    api.fetchServiceCatalog.mockResolvedValue([{
+      type: 'unifi-network', displayName: 'UniFi Network', category: 'Network',
+      defaultPort: 443, defaultScheme: 'https', schemeLocked: true, hostRequired: true,
+      credential: { fields: [{ key: 'apiKey', label: 'API key', secret: true }] }, auth: 'apiKeyHeader',
+    }])
+    const mounted = await mount(ServiceCreate)
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      state.draft.name = 'unifi'
+      expect(state.targetMode).toBe('host')
+
+      // A malicious/stale target-mode value must not bypass catalog policy by
+      // supplying a Kubernetes Service target instead of a LAN host.
+      state.targetMode = 'kube'
+      state.draft.targetName = 'network'
+      expect(state.canCreate).toBe(false)
+      await state.onCreate()
+      expect(api.createKubeEdgeService).not.toHaveBeenCalled()
+
+      state.targetMode = 'host'
+      state.draft.host = '   '
+      expect(state.canCreate).toBe(false)
+      await state.onCreate()
+      expect(api.createKubeEdgeService).not.toHaveBeenCalled()
+
+      state.draft.host = '  https://192.168.1.1:443/  '
+      expect(state.canCreate).toBe(true)
+      await state.onCreate()
+      expect(api.createKubeEdgeService).toHaveBeenCalledWith(expect.objectContaining({
+        host: '192.168.1.1',
+        targetName: '',
+        edgeKind: 'KubernetesCluster',
+      }))
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('preserves edge kind when KubernetesCluster and LinuxServer share a name', async () => {
+    api.listEdges.mockResolvedValue([
+      { ...edge, name: 'shared', type: 'kubernetes' },
+      { ...edge, name: 'shared', type: 'server' },
+    ])
+    const mounted = await mount(ServiceCreate, { initialEdgeName: 'shared', initialEdgeType: 'server' })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      expect(state.selectedEdgeKey).toBe('server/shared')
+      expect(state.selectedEdge.type).toBe('server')
+
+      state.draft.name = 'shared-service'
+      await state.onCreate()
+      expect(api.createKubeEdgeService).toHaveBeenCalledWith(expect.objectContaining({
+        edgeName: 'shared',
+        edgeKind: 'LinuxServer',
+      }))
     } finally {
       mounted.unmount()
     }

--- a/providers/edges/portal/src/workload-create.regression.test.mjs
+++ b/providers/edges/portal/src/workload-create.regression.test.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(resolve(process.cwd(), 'src', 'WorkloadCreate.vue'), 'utf8')
+
+describe('Marketplace workload target regression', () => {
+  it('offers and validates only KubernetesCluster edges for the Kubernetes Service follow-up', () => {
+    expect(source).toMatch(/const kubernetesEdges = computed\(\(\) => edges\.value\.filter\(\(edge\) => edge\.type === 'kubernetes'\)\)/)
+    expect(source).toMatch(/kubernetesEdges\.value\.some\(\(edge\) => edge\.name === deployEdge\.value\)/)
+    expect(source).toMatch(/const selectedEdge = kubernetesEdges\.value\.find\(\(edge\) => edge\.name === deployEdge\.value\)/)
+    expect(source).toMatch(/v-for="edge in kubernetesEdges"/)
+    expect(source).not.toMatch(/v-for="edge in edges"/)
+    expect(source).toMatch(/Connect a KubernetesCluster edge before deploying a marketplace app\./)
+  })
+
+  it('fences route teardown and disables cancellation while deployment is in flight', () => {
+    expect(source).toMatch(/import \{ computed, onMounted, onUnmounted, ref \} from 'vue'/)
+    expect(source).toMatch(/let active = true\s+let lifecycleGeneration = 0/)
+    expect(source).toMatch(/function cancel\(\): void \{\s+if \(busy\.value\) return[\s\S]*active = false[\s\S]*emit\('cancel'\)/)
+    expect(source).toMatch(/const latestEdges = await listEdges\(\)\s+if \(!isCurrent\(generation\)\) return/)
+    expect(source).toMatch(/await deployMarketplaceApp\(\{[\s\S]*\}\)\s+if \(!isCurrent\(generation\)\) return\s+emit\('completed'/)
+    expect(source).toMatch(/onUnmounted\(\(\) => \{[\s\S]*active = false[\s\S]*lifecycleGeneration \+= 1/)
+    expect(source).toMatch(/k-back-action" :disabled="busy" @click="cancel"/)
+    expect(source).toMatch(/>Cancel<\/button>/)
+    expect(source).not.toMatch(/@click(?:\.prevent)?="emit\('cancel'\)"/)
+  })
+})

--- a/providers/infrastructure/portal/src/portalkit/faros-ui.css
+++ b/providers/infrastructure/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/infrastructure/portal/src/views/ProvisionPage.vue
+++ b/providers/infrastructure/portal/src/views/ProvisionPage.vue
@@ -101,7 +101,7 @@ async function submit() {
 </script>
 
 <template>
-  <section class="page">
+  <section class="page k-create-page">
     <button type="button" class="k-btn k-btn--ghost k-back-action" :disabled="submitting" @click="emit('navigate', 'catalog')"><ArrowLeft :size="14" aria-hidden="true" /> Back to templates</button>
     <div v-if="loading && !loaded" class="page-loading-shell" role="status" aria-live="polite" aria-busy="true">
       <span>Loading template…</span>
@@ -113,18 +113,17 @@ async function submit() {
       <button type="button" class="k-btn k-btn--ghost" @click="load">Retry</button>
     </div>
     <template v-else-if="template">
-      <header class="page-head">
-        <div>
-          <h2 class="page-title">Provision {{ template.displayName }}</h2>
-          <p class="page-meta">{{ template.description }}</p>
-        </div>
+      <header class="k-create-header">
+        <h2 class="k-create-title">Provision {{ template.displayName }}</h2>
+        <p class="k-create-description">{{ template.description }}</p>
       </header>
       <div v-if="readError" class="stale-banner" role="alert" aria-live="assertive">
         <span>Showing the last successful template. {{ readError }}</span>
         <button type="button" class="k-btn k-btn--ghost" @click="load">Retry</button>
       </div>
       <span v-if="loading" class="sr-only" role="status" aria-live="polite">Rechecking template…</span>
-      <form class="form" :aria-busy="submitting || loading" @submit.prevent="submit">
+      <form class="k-create-surface k-create-surface--wide" :aria-busy="submitting || loading" @submit.prevent="submit">
+        <div class="k-create-body">
         <div class="dynform-row">
           <label for="infrastructure-instance-name">
             <span class="dynform-label">Instance name<span class="required">*</span></span>
@@ -135,11 +134,12 @@ async function submit() {
         <DynamicForm :schema="template.inputsSchema" v-model:values="values" />
         <div v-if="mutationError" class="read-error" role="alert" aria-live="assertive">{{ mutationError }}</div>
         <span v-if="submitting" class="sr-only" role="status" aria-live="polite">Provisioning instance…</span>
-        <div class="actions">
+        </div>
+        <div class="k-create-actions">
+          <button type="button" class="k-btn k-btn--ghost" :disabled="submitting" @click="emit('navigate', 'catalog')">Cancel</button>
           <button type="submit" class="k-btn k-btn--primary" :disabled="submitting || loading">
             {{ submitting ? 'Provisioning…' : 'Provision' }}
           </button>
-          <button type="button" class="k-btn k-btn--ghost" :disabled="submitting" @click="emit('navigate', 'catalog')">Cancel</button>
         </div>
       </form>
     </template>

--- a/providers/kuery/portal/src/portalkit/faros-ui.css
+++ b/providers/kuery/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);

--- a/providers/quickstart/portal/src/portalkit/faros-ui.css
+++ b/providers/quickstart/portal/src/portalkit/faros-ui.css
@@ -228,6 +228,73 @@ html.light .k-card {
 }
 .k-back-action:active { transform: none; }
 .k-back-action svg { flex: none; }
+
+/* ── Route-owned create page ──────────────────────────────────────────────
+ * One hierarchy across providers: back action, one page heading, one form
+ * surface, and a right-aligned Cancel → primary footer. Providers own field
+ * content and may opt into the wide surface for dense provisioning tasks. */
+.k-create-page {
+  width: 100%;
+  min-width: 0;
+}
+.k-create-header {
+  margin-block: 14px 22px;
+}
+.k-create-title {
+  margin: 0;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.k-create-description {
+  max-width: 42rem;
+  margin: 6px 0 0;
+  color: var(--color-text-muted, #5d5f78);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.k-create-surface {
+  width: 100%;
+  max-width: 42rem;
+  overflow: clip;
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+}
+html.light .k-create-surface {
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 4%, transparent);
+}
+.k-create-surface--wide { max-width: none; }
+.k-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+.k-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  background: color-mix(in srgb, var(--color-surface, #0a0b12) 44%, var(--color-surface-raised, #111320));
+}
+.k-create-actions > [role="alert"] {
+  flex: 1 1 100%;
+  order: -1;
+}
+
+@media (max-width: 620px) {
+  .k-create-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+  }
+}
 .k-btn--danger {
   background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
   color: var(--color-danger, #ff5d5d);


### PR DESCRIPTION
## Summary

- codify concise design-book guidance for route-owned creation of consequential resources
- add one shared create-page skeleton and apply it across MCP, Agents, App Studio, Code, Databricks, Edges, and Infrastructure where the task warrants a dedicated route
- preserve contextual creation for compact subordinate actions
- add readable provider-owned routes, lifecycle and authority fencing, cached-list refresh behavior, and cross-provider conformance coverage

## Verification

- `make verify-portalkit verify-ui-conformance`
- Code portal: `npm test`, `npm run typecheck`, `npm run build`
- Edges portal: `npm test`, `npm run typecheck`, `npm run build`
- Databricks portal: `npm test`, `npm run typecheck`, `npm run build`
- `git diff --check`
